### PR TITLE
PAE-121: setup code coverage rules

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
   "*.{js,json,md}": "npm run format",
-  "src/**/*.js": ["npm run format", "npm run lint:fix", "npm test"],
+  "src/**/*.js": ["npm run lint:fix", "npm test -- --passWithNoTests"],
   "docs/architecture/decisions/*.md": "npm run adr:generate:toc"
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,8 +14,19 @@ export default {
   coveragePathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/.server',
-    'index.js'
+    'index.js',
+    'config.js',
+    'example-find.js',
+    'routes/example.js'
   ],
+  coverageThreshold: {
+    global: {
+      lines: 100,
+      statements: 100,
+      branches: 100,
+      functions: 100
+    }
+  },
   coverageDirectory: '<rootDir>/coverage',
   transform: {
     '^.+\\.js$': 'babel-jest'

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "npm run lint -- --fix",
     "postversion": "git add package.json package-lock.json && git commit -m $npm_package_version",
     "test": "node --no-experimental-require-module ./node_modules/jest/bin/jest.js --coverage --verbose --runInBand",
-    "test:watch": "node --no-experimental-require-module ./node_modules/jest/bin/jest.js --watch",
+    "test:watch": "npm run test -- --watch",
     "server:watch": "nodemon --inspect=0.0.0.0 --ext js,json --legacy-watch ./src",
     "server:debug": "nodemon --inspect-brk=0.0.0.0 --ext js,json --legacy-watch ./src",
     "start": "NODE_ENV=production node --use-strict .",

--- a/src/common/helpers/logging/logger-options.js
+++ b/src/common/helpers/logging/logger-options.js
@@ -26,6 +26,8 @@ export const loggerOptions = {
   level: logConfig.level,
   ...formatters[logConfig.format],
   nesting: true,
+  // @fixme: add coverage
+  /* istanbul ignore next */
   mixin() {
     const mixinValues = {}
     const traceId = getTraceId()

--- a/src/common/helpers/mongo-lock.js
+++ b/src/common/helpers/mongo-lock.js
@@ -1,6 +1,8 @@
 async function acquireLock(locker, resource, logger) {
   const lock = await locker.lock(resource)
   if (!lock) {
+    // @fixme: add coverage
+    /* istanbul ignore next */
     if (logger) {
       logger.error(`Failed to acquire lock for ${resource}`)
     }

--- a/src/common/helpers/mongodb.js
+++ b/src/common/helpers/mongodb.js
@@ -15,7 +15,10 @@ export const mongoDb = {
       const client = await MongoClient.connect(options.mongoUri, {
         retryWrites: options.retryWrites,
         readPreference: options.readPreference,
-        ...(server.secureContext && { secureContext: server.secureContext })
+        ...(server.secureContext &&
+          // @fixme: add coverage
+          /* istanbul ignore next */
+          { secureContext: server.secureContext })
       })
 
       const databaseName = options.databaseName
@@ -29,7 +32,11 @@ export const mongoDb = {
       server.decorate('server', 'mongoClient', client)
       server.decorate('server', 'db', db)
       server.decorate('server', 'locker', locker)
+      // @fixme: add coverage
+      /* istanbul ignore next */
       server.decorate('request', 'db', () => db, { apply: true })
+      // @fixme: add coverage
+      /* istanbul ignore next */
       server.decorate('request', 'locker', () => locker, { apply: true })
 
       server.events.on('stop', async () => {

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -1,3 +1,5 @@
+// @fixme: add coverage
+/* istanbul ignore file */
 const health = {
   method: 'GET',
   path: '/health',


### PR DESCRIPTION
Ticket: [PAE-XXX](https://eaflood.atlassian.net/browse/PAE-XXX)

## Description

1. Removes duplicate prettier formatting for JS files
2. Removes duplication in `npm test:watch` script
3. Adds `coverageThreshold`
4. Excludes example files from coverage
5. Adds `istanbul ignore` for scaffolded code

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).
