### PR TITLE
PAE-120-investigate-dxt-api-email-limitation

### DIFF
--- a/postman/epr-backend.postman_collection.json
+++ b/postman/epr-backend.postman_collection.json
@@ -67,6 +67,28 @@
         }
       },
       "response": []
+    },
+    {
+      "name": "/test-endpoint-dxt",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"meta\": {\n    \"schemaVersion\": \"2\",\n    \"timestamp\": \"2025-03-25T10:00:00Z\"\n  },\n  \"data\": {\n    \"main\": {\n      \"componentName\": \"Some value from the form\",\n      \"richComponentName\": { \"foo\": \"bar\", \"baz\": true }\n    },\n    \"repeaters\": {\n      \"repeaterName\": [\n        { \"textComponentName\": \"First repeater value\" },\n        { \"richComponentName\": { \"foo\": \"bar\", \"baz\": true } }\n      ]\n    },\n    \"files\": {\n      \"fileComponentName\": [\n        {\n          \"fileId\": \"123-456-789\",\n          \"link\": \"https://forms-designer/file-download/123-456-789\"\n        }\n      ]\n    }\n  }\n}"
+        },
+        "url": {
+          "raw": "{{host}}/test-endpoint-dxt",
+          "host": ["{{host}}"],
+          "path": ["send-email"]
+        }
+      },
+      "response": []
     }
   ]
 }

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -1,12 +1,12 @@
 import { health } from '../routes/health.js'
 import { example } from '../routes/example.js'
 import { notify } from '../routes/notify.js'
-
+import { testEndpointDXT } from '../routes/testEndpointDXT.js'
 const router = {
   plugin: {
     name: 'router',
     register: (server, _options) => {
-      server.route([health, notify, ...example])
+      server.route([health, notify, testEndpointDXT, ...example])
     }
   }
 }

--- a/src/routes/testEndpointDXT.js
+++ b/src/routes/testEndpointDXT.js
@@ -1,0 +1,34 @@
+import Boom from '@hapi/boom'
+import { createLogger } from '../common/helpers/logging/logger.js'
+
+/**
+ * Test endpoint to receive payloads and respond with status.
+ * No external integrations.
+ */
+const testEndpointDXT = {
+  method: 'POST',
+  path: '/test-endpoint-dxt',
+  options: {
+    validate: {
+      payload: (value, _options) => {
+        if (!value || typeof value !== 'object') {
+          throw Boom.badRequest('Invalid payload — must be JSON object')
+        }
+        return value
+      }
+    }
+  },
+  handler: async (request, h) => {
+    const logger = createLogger()
+
+    logger.info('Received test-endpoint-dxt payload:', request.payload)
+
+    return h.response({
+      success: true,
+      receivedAt: new Date().toISOString(),
+      originalPayload: request.payload
+    })
+  }
+}
+
+export { testEndpointDXT }

--- a/src/routes/testEndpointDXT.test.js
+++ b/src/routes/testEndpointDXT.test.js
@@ -1,0 +1,69 @@
+const mockLoggerInfo = vi.fn()
+const mockLoggerError = vi.fn()
+const mockLoggerWarn = vi.fn()
+
+vi.mock('../common/helpers/logging/logger.js', () => ({
+  createLogger: () => ({
+    info: (...args) => mockLoggerInfo(...args),
+    error: (...args) => mockLoggerError(...args),
+    warn: (...args) => mockLoggerWarn(...args)
+  })
+}))
+
+let server
+
+describe('/test-endpoint-dxt route', () => {
+  beforeAll(async () => {
+    const { createServer } = await import('../server.js')
+    server = await createServer()
+    await server.initialize()
+  })
+
+  it('returns 200 and echoes back payload on valid request', async () => {
+    const payload = {
+      email: 'test@example.com',
+      template: 'test-template',
+      personalisation: { name: 'Test' }
+    }
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/test-endpoint-dxt',
+      payload
+    })
+
+    expect(response.statusCode).toEqual(200)
+
+    const body = JSON.parse(response.payload)
+    expect(body.success).toBe(true)
+    expect(body.originalPayload).toEqual(payload)
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      'Received test-endpoint-dxt payload:',
+      payload
+    )
+  })
+
+  it('returns 400 if payload is not an object', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/test-endpoint-dxt',
+      payload: 'not-an-object'
+    })
+
+    expect(response.statusCode).toEqual(400)
+    const body = JSON.parse(response.payload)
+    expect(body.message).toMatch(/Invalid request payload JSON format/)
+  })
+
+  it('returns 400 if payload is null', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/test-endpoint-dxt',
+      payload: null
+    })
+
+    expect(response.statusCode).toEqual(400)
+    const body = JSON.parse(response.payload)
+    expect(body.message).toMatch(/Invalid payload/)
+  })
+})


### PR DESCRIPTION
## Description

- Created a new POST endpoint /test-endpoint-dxt to accept any JSON payload, log it, and return a success status with the original payload.

- Added validation to ensure the payload is a non-null object.

- Implemented unit tests for valid and invalid payloads.

- Provided Postman collection for manual testing.

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).
