### PR TITLE
PAE-127: add convict config and docker compose settings

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -87,6 +87,7 @@ services:
       LOCALSTACK_ENDPOINT: http://localstack:4566
       MONGO_URI: mongodb://mongodb:27017/
       GOVUK_NOTIFY_API_KEY: /run/secrets/govuk_notify_api_key
+      AUDIT_ENABLED: false
     secrets:
       - govuk_notify_api_key
     networks:

--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,7 @@ convict.addFormats(convictFormatWithValidator)
 const isProduction = process.env.NODE_ENV === 'production'
 const isTest = process.env.NODE_ENV === 'test'
 
-const config = convict({
+const baseConfig = {
   serviceVersion: {
     doc: 'The service version, this variable is injected into your docker container in CDP environments',
     format: String,
@@ -48,6 +48,14 @@ const config = convict({
     ],
     default: 'local',
     env: 'ENVIRONMENT'
+  },
+  audit: {
+    isEnabled: {
+      doc: 'Is auditing enabled',
+      format: Boolean,
+      default: true,
+      env: 'AUDIT_ENABLED'
+    }
   },
   log: {
     isEnabled: {
@@ -129,8 +137,14 @@ const config = convict({
       env: 'TRACING_HEADER'
     }
   }
-})
+}
+
+const config = convict(baseConfig)
 
 config.validate({ allowed: 'strict' })
 
-export { config }
+function getConfig(overrides) {
+  return convict(baseConfig, overrides)
+}
+
+export { config, getConfig }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import process from 'node:process'
 
 import { createLogger } from './common/helpers/logging/logger.js'
-import { startServer } from './common/helpers/start-server.js'
+import { startServer } from './start-server.js'
 
 await startServer()
 

--- a/src/routes/notify.test.js
+++ b/src/routes/notify.test.js
@@ -14,6 +14,8 @@ vi.mock('../common/helpers/logging/logger.js', () => ({
   })
 }))
 
+vi.mock('./common/helpers/mongodb.js')
+
 let server
 
 describe('/send-email route', () => {

--- a/src/routes/v1/apply/accreditation.test.js
+++ b/src/routes/v1/apply/accreditation.test.js
@@ -16,6 +16,8 @@ vi.mock('../../../common/helpers/logging/logger.js', () => ({
   })
 }))
 
+vi.mock('./common/helpers/mongodb.js')
+
 let server
 
 describe('/accreditation route', () => {

--- a/src/routes/v1/apply/organisation.test.js
+++ b/src/routes/v1/apply/organisation.test.js
@@ -16,6 +16,8 @@ vi.mock('../../../common/helpers/logging/logger.js', () => ({
   })
 }))
 
+vi.mock('./common/helpers/mongodb.js')
+
 let server
 
 describe('/v1/apply/organisation route', () => {

--- a/src/routes/v1/apply/registration.test.js
+++ b/src/routes/v1/apply/registration.test.js
@@ -16,6 +16,8 @@ vi.mock('../../../common/helpers/logging/logger.js', () => ({
   })
 }))
 
+vi.mock('./common/helpers/mongodb.js')
+
 let server
 
 describe('/registration route', () => {

--- a/src/server.js
+++ b/src/server.js
@@ -2,7 +2,7 @@ import Hapi from '@hapi/hapi'
 
 import { secureContext } from '@defra/hapi-secure-context'
 
-import { config } from './config.js'
+import { getConfig } from './config.js'
 import { router } from './plugins/router.js'
 import { requestLogger } from './common/helpers/logging/request-logger.js'
 import { mongoDb } from './common/helpers/mongodb.js'
@@ -13,6 +13,7 @@ import { setupProxy } from './common/helpers/proxy/setup-proxy.js'
 
 async function createServer() {
   setupProxy()
+  const config = getConfig()
   const server = Hapi.server({
     host: config.get('host'),
     port: config.get('port'),

--- a/src/start-server.js
+++ b/src/start-server.js
@@ -1,17 +1,19 @@
-import { config } from '../../config.js'
+import { getConfig } from './config.js'
 
-import { createServer } from '../../server.js'
-import { createLogger } from './logging/logger.js'
+import { createServer } from './server.js'
+import { createLogger } from './common/helpers/logging/logger.js'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
-} from '../enums/event.js'
+} from './common/enums/event.js'
 import { enableAuditing } from '@defra/cdp-auditing'
 
 async function startServer() {
+  const config = getConfig()
+  const auditConfig = config.get('audit')
   let server
 
-  enableAuditing(process.env.AUDIT_ENABLED !== 'false')
+  enableAuditing(auditConfig.isEnabled)
 
   try {
     server = await createServer()

--- a/src/start-server.test.js
+++ b/src/start-server.test.js
@@ -6,9 +6,9 @@ import {
 } from './common/enums/event.js'
 import { getConfig } from './config.js'
 
-const mockLoggerInfo = vi.fn(console.log)
-const mockLoggerError = vi.fn(console.error)
-const mockLoggerWarn = vi.fn(console.warn)
+const mockLoggerInfo = vi.fn()
+const mockLoggerError = vi.fn()
+const mockLoggerWarn = vi.fn()
 
 const mockHapiLoggerInfo = vi.fn()
 const mockHapiLoggerError = vi.fn()

--- a/src/start-server.test.js
+++ b/src/start-server.test.js
@@ -3,7 +3,8 @@ import hapi from '@hapi/hapi'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
-} from '../enums/event.js'
+} from './common/enums/event.js'
+import { getConfig } from './config.js'
 
 const mockLoggerInfo = vi.fn()
 const mockLoggerError = vi.fn()
@@ -13,6 +14,22 @@ const mockHapiLoggerInfo = vi.fn()
 const mockHapiLoggerError = vi.fn()
 
 const mockEnabledAuditing = vi.fn()
+
+const configOverrides = { env: { PORT: '3098' } }
+
+vi.mock('./config.js', async (importOriginal) => {
+  const configOriginal = await importOriginal()
+
+  return {
+    ...configOriginal,
+    getConfig: vi.fn((overrides) =>
+      configOriginal.getConfig({
+        ...configOverrides,
+        ...overrides
+      })
+    )
+  }
+})
 
 vi.mock('hapi-pino', () => ({
   default: {
@@ -25,7 +42,7 @@ vi.mock('hapi-pino', () => ({
     name: 'mock-hapi-pino'
   }
 }))
-vi.mock('./logging/logger.js', () => ({
+vi.mock('./common/helpers/logging/logger.js', () => ({
   createLogger: () => ({
     info: (...args) => mockLoggerInfo(...args),
     error: (...args) => mockLoggerError(...args),
@@ -44,41 +61,31 @@ describe('#startServer', () => {
   let hapiServerSpy
   let startServerImport
   let createServerImport
+  let server
 
   beforeAll(async () => {
-    vi.stubEnv('PORT', '3098')
-
-    createServerImport = await import('../../server.js')
+    createServerImport = await import('./server.js')
     startServerImport = await import('./start-server.js')
 
     createServerSpy = vi.spyOn(createServerImport, 'createServer')
     hapiServerSpy = vi.spyOn(hapi, 'server')
+
+    server = await startServerImport.startServer()
   })
 
-  afterAll(() => {
+  afterAll(async () => {
     vi.resetAllMocks()
   })
 
   describe('When server starts', () => {
-    test('Should start up server as expected', async () => {
-      await startServerImport.startServer()
+    beforeEach(async () => {
+      await server.stop()
+      server = await startServerImport.startServer()
+    })
 
+    test('Should start up server as expected', async () => {
       expect(createServerSpy).toHaveBeenCalled()
       expect(hapiServerSpy).toHaveBeenCalled()
-      expect(mockHapiLoggerInfo).toHaveBeenCalledWith({
-        message: 'Setting up MongoDb',
-        event: expect.objectContaining({
-          category: LOGGING_EVENT_CATEGORIES.DB,
-          action: LOGGING_EVENT_ACTIONS.CONNECTION_INITIALISING
-        })
-      })
-      expect(mockHapiLoggerInfo).toHaveBeenCalledWith({
-        message: 'MongoDb connected to epr-backend',
-        event: expect.objectContaining({
-          category: LOGGING_EVENT_CATEGORIES.DB,
-          action: LOGGING_EVENT_ACTIONS.CONNECTION_SUCCESS
-        })
-      })
       expect(mockHapiLoggerInfo).toHaveBeenCalledWith({
         message: expect.stringMatching(
           /^Server started successfully at http:\/\/localhost:[0-9]+/
@@ -91,26 +98,38 @@ describe('#startServer', () => {
     })
 
     test('Should enable auditing by default', async () => {
-      vi.stubEnv('AUDIT_ENABLED', undefined)
-      await startServerImport.startServer()
       expect(mockEnabledAuditing).toHaveBeenCalledWith(true)
     })
 
-    test('Should disable auditing if AUDIT_ENBLED env var is "false"', async () => {
-      vi.stubEnv('AUDIT_ENABLED', 'false')
-      await startServerImport.startServer()
+    test('Should disable auditing if audit.isEnabled config is false', async () => {
+      const config = getConfig()
+
+      getConfig.mockImplementationOnce(() => ({
+        ...config,
+        get: (item) => {
+          return item === 'audit'
+            ? {
+                isEnabled: false
+              }
+            : config.get(item)
+        }
+      }))
+
+      await server.stop()
+      server = await startServerImport.startServer()
+
       expect(mockEnabledAuditing).toHaveBeenCalledWith(false)
     })
   })
 
-  describe('When server start fails', () => {
-    beforeAll(() => {
+  describe('When server start fails', async () => {
+    beforeEach(async () => {
+      await server.stop()
       createServerSpy.mockRejectedValue(new Error('Server failed to start'))
+      server = await startServerImport.startServer()
     })
 
     test('Should log failed startup message', async () => {
-      await startServerImport.startServer()
-
       expect(mockLoggerError).toHaveBeenCalledWith(
         Error('Server failed to start'),
         {


### PR DESCRIPTION
Ticket: [PAE-127](https://eaflood.atlassian.net/browse/PAE-127)
## Description

1. Use convict config management for `AUDIT_ENABLED` env var
2. Allow config to be overridden for testing purposes
3. Move `start-server.js` to same dir as `server.js` because:
    1. It is the first thing called from the application entry point
    2. It depends on `server.js` at the root of the `src` dir
    3. It simplifies mocking paths in tests
4. Mock config in `start-server.js` integration tests
5. Remove assertions that were only passing because of mocking path issues fixed by item 3.3 above
6. Add a testing approach that allows us to start and stop the server so that we can mock function return values and assert the behaviour we are testing

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-127]: https://eaflood.atlassian.net/browse/PAE-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ