### PR TITLE
PAE-165: submit registration data

### DIFF
--- a/src/common/enums/form-fields.js
+++ b/src/common/enums/form-fields.js
@@ -1,5 +1,7 @@
 export const FORM_FIELDS_SHORT_DESCRIPTIONS = {
   EMAIL: 'Submitter email address',
   NATIONS: 'Nations with sites',
-  ORG_NAME: 'Organisation name'
+  ORG_NAME: 'Organisation name',
+  ORG_ID: 'Organisation ID',
+  REFERENCE_NUMBER: 'System Reference'
 }

--- a/src/common/helpers/apply/extract-answers.js
+++ b/src/common/helpers/apply/extract-answers.js
@@ -50,9 +50,28 @@ export function extractNations(answers) {
   }, [])
 }
 
+export function extractOrgId(answers) {
+  const { value } =
+    answers.find(
+      ({ shortDescription }) =>
+        shortDescription === FORM_FIELDS_SHORT_DESCRIPTIONS.ORG_ID
+    ) ?? {}
+
+  const orgId = parseInt(value, 10)
+
+  return isNaN(orgId) ? undefined : orgId
+}
+
 export function extractOrgName(answers) {
   return answers.find(
     ({ shortDescription }) =>
       shortDescription === FORM_FIELDS_SHORT_DESCRIPTIONS.ORG_NAME
+  )?.value
+}
+
+export function extractReferenceNumber(answers) {
+  return answers.find(
+    ({ shortDescription }) =>
+      shortDescription === FORM_FIELDS_SHORT_DESCRIPTIONS.REFERENCE_NUMBER
   )?.value
 }

--- a/src/common/helpers/apply/extract-answers.test.js
+++ b/src/common/helpers/apply/extract-answers.test.js
@@ -3,7 +3,9 @@ import {
   extractAnswers,
   extractEmail,
   extractNations,
-  extractOrgName
+  extractOrgId,
+  extractOrgName,
+  extractReferenceNumber
 } from './extract-answers.js'
 import { FORM_FIELDS_SHORT_DESCRIPTIONS, NATION } from '../../enums/index.js'
 
@@ -79,8 +81,24 @@ describe('extractNations', () => {
   })
 })
 
+describe('extractOrgId', () => {
+  it('should extract organisation id from answers', () => {
+    const answers = [
+      {
+        shortDescription: FORM_FIELDS_SHORT_DESCRIPTIONS.ORG_ID,
+        value: '500019'
+      }
+    ]
+    expect(extractOrgId(answers)).toBe(500019)
+  })
+
+  it('should return undefined if organisation id not found', () => {
+    expect(extractOrgId([])).toBeUndefined()
+  })
+})
+
 describe('extractOrgName', () => {
-  it('should extract organization name from answers', () => {
+  it('should extract organisation name from answers', () => {
     const answers = [
       {
         shortDescription: FORM_FIELDS_SHORT_DESCRIPTIONS.ORG_NAME,
@@ -90,7 +108,23 @@ describe('extractOrgName', () => {
     expect(extractOrgName(answers)).toBe('Test Org')
   })
 
-  it('should return undefined if organization name not found', () => {
+  it('should return undefined if organisation name not found', () => {
     expect(extractOrgName([])).toBeUndefined()
+  })
+})
+
+describe('extractReferenceNumber', () => {
+  it('should extract reference number from answers', () => {
+    const answers = [
+      {
+        shortDescription: FORM_FIELDS_SHORT_DESCRIPTIONS.REFERENCE_NUMBER,
+        value: '68a66ec3dabf09f3e442b2da'
+      }
+    ]
+    expect(extractReferenceNumber(answers)).toBe('68a66ec3dabf09f3e442b2da')
+  })
+
+  it('should return undefined if organisation name not found', () => {
+    expect(extractReferenceNumber([])).toBeUndefined()
   })
 })

--- a/src/routes/v1/apply/organisation.js
+++ b/src/routes/v1/apply/organisation.js
@@ -17,6 +17,8 @@ import { sendEmail } from '../../../common/helpers/notify.js'
 
 const path = '/v1/apply/organisation'
 
+const organisationPath = path
+
 /**
  * Apply: Organisation
  * Stores organisation data.
@@ -81,7 +83,7 @@ const organisation = {
       const referenceNumber = insertedId.toString()
 
       logger.info({
-        message: `Stored organisation data for orgId: ${orgId}`,
+        message: `Stored organisation data for orgId: ${orgId} and referenceNumber: ${referenceNumber}`,
         event: {
           category: LOGGING_EVENT_CATEGORIES.SERVER,
           action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
@@ -114,7 +116,5 @@ const organisation = {
     }
   }
 }
-
-const organisationPath = path
 
 export { organisation, organisationPath }

--- a/src/routes/v1/apply/registration.js
+++ b/src/routes/v1/apply/registration.js
@@ -1,4 +1,10 @@
 import Boom from '@hapi/boom'
+import {
+  extractAnswers,
+  extractOrgId,
+  extractReferenceNumber
+} from '../../../common/helpers/apply/extract-answers.js'
+import { registrationFactory } from '../../../common/helpers/collections/factories/index.js'
 import { createLogger } from '../../../common/helpers/logging/logger.js'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -7,37 +13,77 @@ import {
 
 const path = '/v1/apply/registration'
 
+const registrationPath = path
+
 /**
  * Apply: Registration
- * Stores registration data an activity/site/material combinations against an organisation.
+ * Stores registration data an activity/site/material combinations against an orgId and referenceNumber.
  */
 const registration = {
   method: 'POST',
   path,
   options: {
     validate: {
-      payload: (value, _options) => {
-        if (!value || typeof value !== 'object') {
-          throw Boom.badRequest('Invalid payload — must be JSON object')
+      payload: (data, _options) => {
+        if (!data || typeof data !== 'object') {
+          throw Boom.badRequest('Invalid payload')
         }
-        return value
+
+        const answers = extractAnswers(data)
+        const orgId = extractOrgId(answers)
+        const referenceNumber = extractReferenceNumber(answers)
+
+        if (!orgId) {
+          throw Boom.badRequest('Could not extract orgId from answers')
+        }
+
+        if (!referenceNumber) {
+          throw Boom.badRequest(
+            'Could not extract referenceNumber from answers'
+          )
+        }
+
+        return { answers, orgId, rawSubmissionData: data, referenceNumber }
       }
     }
   },
-  handler: async (_request, h) => {
+  handler: async (req, h) => {
+    const { db, payload } = req
+    const { answers, orgId, rawSubmissionData, referenceNumber } = payload
     const logger = createLogger()
 
-    logger.info({
-      message: 'Received registration payload',
-      event: {
-        category: LOGGING_EVENT_CATEGORIES.SERVER,
-        action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
-      }
-    })
-    return h.response()
+    try {
+      await db.collection('registration').insertOne(
+        registrationFactory({
+          orgId,
+          referenceNumber,
+          answers,
+          rawSubmissionData
+        })
+      )
+
+      logger.info({
+        message: `Stored registration data for orgId: ${orgId} and referenceNumber: ${referenceNumber}`,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.SERVER,
+          action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
+        }
+      })
+      return h.response().code(201)
+    } catch (err) {
+      const message = `Failure on ${registrationPath}`
+
+      logger.error(err, {
+        message,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.SERVER,
+          action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+        }
+      })
+
+      throw Boom.badImplementation(message)
+    }
   }
 }
-
-const registrationPath = path
 
 export { registration, registrationPath }

--- a/src/routes/v1/apply/registration.test.js
+++ b/src/routes/v1/apply/registration.test.js
@@ -2,12 +2,15 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '../../../common/enums/event.js'
+import { FORM_FIELDS_SHORT_DESCRIPTIONS } from '../../../common/enums/index.js'
 import registrationFixture from '../../../data/fixtures/registration.json'
 import { registrationPath } from './registration.js'
 
 const mockLoggerInfo = vi.fn()
 const mockLoggerError = vi.fn()
 const mockLoggerWarn = vi.fn()
+
+const mockInsertOne = vi.fn()
 
 vi.mock('../../../common/helpers/logging/logger.js', () => ({
   createLogger: () => ({
@@ -16,8 +19,6 @@ vi.mock('../../../common/helpers/logging/logger.js', () => ({
     warn: (...args) => mockLoggerWarn(...args)
   })
 }))
-
-vi.mock('./common/helpers/mongodb.js')
 
 const url = registrationPath
 let server
@@ -29,14 +30,23 @@ describe(`${url} route`, () => {
     await server.initialize()
   })
 
-  it('returns 200 and echoes back payload on valid request', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const collectionSpy = vi.spyOn(server.db, 'collection')
+
+    collectionSpy.mockReturnValue({
+      insertOne: mockInsertOne
+    })
+  })
+
+  it('returns 201 and echoes back payload on valid request', async () => {
     const response = await server.inject({
       method: 'POST',
       url,
       payload: registrationFixture
     })
 
-    expect(response.statusCode).toEqual(204)
+    expect(response.statusCode).toEqual(201)
 
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -71,5 +81,102 @@ describe(`${url} route`, () => {
     expect(response.statusCode).toEqual(400)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(/Invalid payload/)
+  })
+
+  it('returns 400 if payload is missing orgId', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url,
+      payload: {
+        meta: {
+          definition: {
+            pages: [
+              {
+                components: [
+                  {
+                    name: 'asd123',
+                    shortDescription:
+                      FORM_FIELDS_SHORT_DESCRIPTIONS.REFERENCE_NUMBER,
+                    title: 'What is your System Reference number?',
+                    type: 'TextField'
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        data: {
+          main: {
+            asd123: '68a66ec3dabf09f3e442b2da'
+          }
+        }
+      }
+    })
+
+    const message = 'Could not extract orgId from answers'
+    const body = JSON.parse(response.payload)
+
+    expect(response.statusCode).toEqual(400)
+    expect(body.message).toEqual(message)
+  })
+
+  it('returns 400 if payload is missing reference number', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url,
+      payload: {
+        meta: {
+          definition: {
+            pages: [
+              {
+                components: [
+                  {
+                    name: 'asd456',
+                    shortDescription: FORM_FIELDS_SHORT_DESCRIPTIONS.ORG_ID,
+                    title: 'What is your Organisation ID number?',
+                    type: 'TextField'
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        data: {
+          main: {
+            asd456: '500019'
+          }
+        }
+      }
+    })
+
+    const message = 'Could not extract referenceNumber from answers'
+    const body = JSON.parse(response.payload)
+
+    expect(response.statusCode).toEqual(400)
+    expect(body.message).toEqual(message)
+  })
+
+  it('returns 500 if error is thrown by insertOne', async () => {
+    const error = new Error('db.collection.insertOne failed')
+    mockInsertOne.mockImplementationOnce(() => {
+      throw error
+    })
+
+    const response = await server.inject({
+      method: 'POST',
+      url,
+      payload: registrationFixture
+    })
+
+    expect(response.statusCode).toEqual(500)
+    const body = JSON.parse(response.payload)
+    expect(body.message).toMatch(`An internal server error occurred`)
+    expect(mockLoggerError).toHaveBeenCalledWith(error, {
+      message: `Failure on ${registrationPath}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+      }
+    })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-165](https://eaflood.atlassian.net/browse/PAE-165)
## Description

1. Add extraction functions
2. Add request validation for Registration endpoint
3. Write Registration data to database
4. Update Organisation endpoint and tests in line with Registration changes

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-165]: https://eaflood.atlassian.net/browse/PAE-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ