### PR TITLE
PAE-166: submit accreditation data

### DIFF
--- a/postman/CDP-Dev.postman_environment.json
+++ b/postman/CDP-Dev.postman_environment.json
@@ -1,0 +1,15 @@
+{
+  "id": "8d24bec9-ed91-4374-be2f-ec6ca7be48ac",
+  "name": "CDP: Dev",
+  "values": [
+    {
+      "key": "host",
+      "value": " https://epr-backend.dev.cdp-int.defra.cloud",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2025-08-25T11:58:07.378Z",
+  "_postman_exported_using": "Postman/11.38.4"
+}

--- a/postman/CDP-Test.postman_environment.json
+++ b/postman/CDP-Test.postman_environment.json
@@ -1,0 +1,15 @@
+{
+  "id": "2a5dd853-6440-4356-9bd4-fb8de36a9f1a",
+  "name": "CDP: Test",
+  "values": [
+    {
+      "key": "host",
+      "value": " https://epr-backend.test.cdp-int.defra.cloud",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2025-08-25T11:58:27.374Z",
+  "_postman_exported_using": "Postman/11.38.4"
+}

--- a/src/common/helpers/apply/handler.js
+++ b/src/common/helpers/apply/handler.js
@@ -1,0 +1,45 @@
+import Boom from '@hapi/boom'
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '../../enums/index.js'
+import { createLogger } from '../logging/logger.js'
+
+export function registrationAndAccreditationHandler(name, path, factory) {
+  return async ({ db, payload }, h) => {
+    const { answers, orgId, rawSubmissionData, referenceNumber } = payload
+    const logger = createLogger()
+
+    try {
+      await db.collection(name).insertOne(
+        factory({
+          orgId,
+          referenceNumber,
+          answers,
+          rawSubmissionData
+        })
+      )
+
+      logger.info({
+        message: `Stored ${name} data for orgId: ${orgId} and referenceNumber: ${referenceNumber}`,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.SERVER,
+          action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
+        }
+      })
+      return h.response().code(201)
+    } catch (err) {
+      const message = `Failure on ${path}`
+
+      logger.error(err, {
+        message,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.SERVER,
+          action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+        }
+      })
+
+      throw Boom.badImplementation(message)
+    }
+  }
+}

--- a/src/common/helpers/apply/payload.js
+++ b/src/common/helpers/apply/payload.js
@@ -1,0 +1,26 @@
+import Boom from '@hapi/boom'
+import {
+  extractAnswers,
+  extractOrgId,
+  extractReferenceNumber
+} from './extract-answers.js'
+
+export function registrationAndAccreditationPayload(data, _options) {
+  if (!data || typeof data !== 'object') {
+    throw Boom.badRequest('Invalid payload')
+  }
+
+  const answers = extractAnswers(data)
+  const orgId = extractOrgId(answers)
+  const referenceNumber = extractReferenceNumber(answers)
+
+  if (!orgId) {
+    throw Boom.badRequest('Could not extract orgId from answers')
+  }
+
+  if (!referenceNumber) {
+    throw Boom.badRequest('Could not extract referenceNumber from answers')
+  }
+
+  return { answers, orgId, rawSubmissionData: data, referenceNumber }
+}

--- a/src/routes/v1/apply/accreditation.js
+++ b/src/routes/v1/apply/accreditation.js
@@ -1,4 +1,10 @@
 import Boom from '@hapi/boom'
+import {
+  extractAnswers,
+  extractOrgId,
+  extractReferenceNumber
+} from '../../../common/helpers/apply/extract-answers.js'
+import { accreditationFactory } from '../../../common/helpers/collections/factories/index.js'
 import { createLogger } from '../../../common/helpers/logging/logger.js'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -7,39 +13,76 @@ import {
 
 const path = '/v1/apply/accreditation'
 
+const accreditationPath = path
+
 /**
  * Apply: Accreditation
- * Stores accreditation data an activity/site/material combinations against an organisation.
+ * Stores accreditation data an activity/site/material combinations against an orgId and referenceNumber.
  */
 const accreditation = {
   method: 'POST',
   path,
   options: {
     validate: {
-      payload: (value, _options) => {
-        if (!value || typeof value !== 'object') {
-          throw Boom.badRequest('Invalid payload — must be JSON object')
+      payload: (data, _options) => {
+        if (!data || typeof data !== 'object') {
+          throw Boom.badRequest('Invalid payload')
         }
-        return value
+
+        const answers = extractAnswers(data)
+        const orgId = extractOrgId(answers)
+        const referenceNumber = extractReferenceNumber(answers)
+
+        if (!orgId) {
+          throw Boom.badRequest('Could not extract orgId from answers')
+        }
+
+        if (!referenceNumber) {
+          throw Boom.badRequest(
+            'Could not extract referenceNumber from answers'
+          )
+        }
+
+        return { answers, orgId, rawSubmissionData: data, referenceNumber }
       }
     }
   },
-  handler: async ({ payload }, h) => {
+  handler: async ({ db, payload }, h) => {
+    const { answers, orgId, rawSubmissionData, referenceNumber } = payload
     const logger = createLogger()
 
-    logger.info({
-      message: 'Received accreditation payload',
-      data: payload, // @fixme: remove!!!
-      event: {
-        category: LOGGING_EVENT_CATEGORIES.SERVER,
-        action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
-      }
-    })
+    try {
+      await db.collection('accreditation').insertOne(
+        accreditationFactory({
+          orgId,
+          referenceNumber,
+          answers,
+          rawSubmissionData
+        })
+      )
 
-    return h.response()
+      logger.info({
+        message: `Stored accreditation data for orgId: ${orgId} and referenceNumber: ${referenceNumber}`,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.SERVER,
+          action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
+        }
+      })
+      return h.response().code(201)
+    } catch (err) {
+      const message = `Failure on ${accreditationPath}`
+
+      logger.error(err, {
+        message,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.SERVER,
+          action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+        }
+      })
+
+      throw Boom.badImplementation(message)
+    }
   }
 }
-
-const accreditationPath = path
 
 export { accreditation, accreditationPath }

--- a/src/routes/v1/apply/accreditation.js
+++ b/src/routes/v1/apply/accreditation.js
@@ -1,88 +1,24 @@
-import Boom from '@hapi/boom'
-import {
-  extractAnswers,
-  extractOrgId,
-  extractReferenceNumber
-} from '../../../common/helpers/apply/extract-answers.js'
+import { registrationAndAccreditationPayload } from '../../../common/helpers/apply/payload.js'
+import { registrationAndAccreditationHandler } from '../../../common/helpers/apply/handler.js'
 import { accreditationFactory } from '../../../common/helpers/collections/factories/index.js'
-import { createLogger } from '../../../common/helpers/logging/logger.js'
-import {
-  LOGGING_EVENT_ACTIONS,
-  LOGGING_EVENT_CATEGORIES
-} from '../../../common/enums/event.js'
 
-const path = '/v1/apply/accreditation'
-
-const accreditationPath = path
+export const accreditationPath = '/v1/apply/accreditation'
 
 /**
  * Apply: Accreditation
  * Stores accreditation data an activity/site/material combinations against an orgId and referenceNumber.
  */
-const accreditation = {
+export const accreditation = {
   method: 'POST',
-  path,
+  path: accreditationPath,
   options: {
     validate: {
-      payload: (data, _options) => {
-        if (!data || typeof data !== 'object') {
-          throw Boom.badRequest('Invalid payload')
-        }
-
-        const answers = extractAnswers(data)
-        const orgId = extractOrgId(answers)
-        const referenceNumber = extractReferenceNumber(answers)
-
-        if (!orgId) {
-          throw Boom.badRequest('Could not extract orgId from answers')
-        }
-
-        if (!referenceNumber) {
-          throw Boom.badRequest(
-            'Could not extract referenceNumber from answers'
-          )
-        }
-
-        return { answers, orgId, rawSubmissionData: data, referenceNumber }
-      }
+      payload: registrationAndAccreditationPayload
     }
   },
-  handler: async ({ db, payload }, h) => {
-    const { answers, orgId, rawSubmissionData, referenceNumber } = payload
-    const logger = createLogger()
-
-    try {
-      await db.collection('accreditation').insertOne(
-        accreditationFactory({
-          orgId,
-          referenceNumber,
-          answers,
-          rawSubmissionData
-        })
-      )
-
-      logger.info({
-        message: `Stored accreditation data for orgId: ${orgId} and referenceNumber: ${referenceNumber}`,
-        event: {
-          category: LOGGING_EVENT_CATEGORIES.SERVER,
-          action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
-        }
-      })
-      return h.response().code(201)
-    } catch (err) {
-      const message = `Failure on ${accreditationPath}`
-
-      logger.error(err, {
-        message,
-        event: {
-          category: LOGGING_EVENT_CATEGORIES.SERVER,
-          action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
-        }
-      })
-
-      throw Boom.badImplementation(message)
-    }
-  }
+  handler: registrationAndAccreditationHandler(
+    'accreditation',
+    accreditationPath,
+    accreditationFactory
+  )
 }
-
-export { accreditation, accreditationPath }

--- a/src/routes/v1/apply/organisation.js
+++ b/src/routes/v1/apply/organisation.js
@@ -15,17 +15,15 @@ import {
 import { organisationFactory } from '../../../common/helpers/collections/factories/index.js'
 import { sendEmail } from '../../../common/helpers/notify.js'
 
-const path = '/v1/apply/organisation'
-
-const organisationPath = path
+export const organisationPath = '/v1/apply/organisation'
 
 /**
  * Apply: Organisation
  * Stores organisation data.
  */
-const organisation = {
+export const organisation = {
   method: 'POST',
-  path,
+  path: organisationPath,
   options: {
     validate: {
       payload: (data, _options) => {
@@ -116,5 +114,3 @@ const organisation = {
     }
   }
 }
-
-export { organisation, organisationPath }

--- a/src/routes/v1/apply/registration.js
+++ b/src/routes/v1/apply/registration.js
@@ -47,8 +47,7 @@ const registration = {
       }
     }
   },
-  handler: async (req, h) => {
-    const { db, payload } = req
+  handler: async ({ db, payload }, h) => {
     const { answers, orgId, rawSubmissionData, referenceNumber } = payload
     const logger = createLogger()
 


### PR DESCRIPTION
Ticket: [PAE-166](https://eaflood.atlassian.net/browse/PAE-166)
## Description

1. Add request validation for Accreditation endpoint
2. Write Accreditation data to database
3. Add Postman environments to include Dev & Test 
---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-166]: https://eaflood.atlassian.net/browse/PAE-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ