### PR TITLE
PAE-196: send audit log for database inserts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "mongodb": "6.18.0",
         "node-fetch": "3.3.2",
         "notifications-node-client": "8.2.1",
+        "obfuscate-mail": "1.5.1",
         "pino": "9.9.0",
         "pino-pretty": "13.1.1",
         "undici": "7.14.0"
@@ -9149,6 +9150,15 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/obfuscate-mail": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/obfuscate-mail/-/obfuscate-mail-1.5.1.tgz",
+      "integrity": "sha512-TFhD3ovYSZu6zXzYOUNm9SzRZo9yo1qebiczM0LKKczBjJ9SavX4OCUTWY3OtwD2BMOurs6huC+w254wnLuRoA==",
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mongodb": "6.18.0",
     "node-fetch": "3.3.2",
     "notifications-node-client": "8.2.1",
+    "obfuscate-mail": "1.5.1",
     "pino": "9.9.0",
     "pino-pretty": "13.1.1",
     "undici": "7.14.0"

--- a/src/common/enums/event.js
+++ b/src/common/enums/event.js
@@ -25,9 +25,11 @@ export const LOGGING_EVENT_ACTIONS = {
 }
 
 export const AUDIT_EVENT_CATEGORIES = {
-  EMAIL: 'email'
+  EMAIL: 'email',
+  DB: 'database'
 }
 
 export const AUDIT_EVENT_ACTIONS = {
-  EMAIL_SENT: 'email_sent'
+  EMAIL_SENT: 'email_sent',
+  DB_INSERT: 'database_insert'
 }

--- a/src/common/helpers/apply/handler.js
+++ b/src/common/helpers/apply/handler.js
@@ -1,5 +1,8 @@
+import { audit } from '@defra/cdp-auditing'
 import Boom from '@hapi/boom'
 import {
+  AUDIT_EVENT_ACTIONS,
+  AUDIT_EVENT_CATEGORIES,
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '../../enums/index.js'
@@ -19,6 +22,17 @@ export function registrationAndAccreditationHandler(name, path, factory) {
           rawSubmissionData
         })
       )
+
+      audit({
+        event: {
+          category: AUDIT_EVENT_CATEGORIES.DB,
+          action: AUDIT_EVENT_ACTIONS.DB_INSERT
+        },
+        context: {
+          orgId,
+          referenceNumber
+        }
+      })
 
       logger.info({
         message: `Stored ${name} data for orgId: ${orgId} and referenceNumber: ${referenceNumber}`,

--- a/src/common/helpers/notify.js
+++ b/src/common/helpers/notify.js
@@ -1,5 +1,7 @@
-import { audit } from '@defra/cdp-auditing'
+import obfuscateEmail from 'obfuscate-mail'
+
 import { NotifyClient } from 'notifications-node-client'
+import { audit } from '@defra/cdp-auditing'
 import { createLogger } from './logging/logger.js'
 import { getLocalSecret } from './get-local-secret.js'
 import {
@@ -41,8 +43,15 @@ async function sendEmail(templateId, emailAddress, personalisation = {}) {
         action: AUDIT_EVENT_ACTIONS.EMAIL_SENT
       },
       context: {
-        template_id: templateId,
-        email_address: emailAddress
+        templateId,
+        emailAddress: obfuscateEmail(emailAddress, {
+          asterisksLength: 8,
+          showDomainName: false,
+          minimumNameObfuscationLength: 3,
+          visibleCharactersEndLength: 4,
+          visibleCharactersStartLength: 4
+        }),
+        personalisation
       }
     })
   } catch (err) {

--- a/src/common/helpers/notify.test.js
+++ b/src/common/helpers/notify.test.js
@@ -34,7 +34,7 @@ vi.mock('./get-local-secret.js')
 
 describe('sendEmail', () => {
   const templateId = 'template-id'
-  const emailAddress = 'test@example.com'
+  const emailAddress = 'testing@example.com'
   const personalisation = { name: 'Test' }
 
   beforeEach(() => {
@@ -81,15 +81,21 @@ describe('sendEmail', () => {
   })
 
   it('calls audit when notifyClient.sendEmail succeeds', async () => {
+    const emailFirstFourChars = emailAddress.slice(0, 4)
+    const emailLastFourChars = emailAddress.slice(-4)
     await sendEmail(templateId, emailAddress)
+
     expect(mockAudit).toHaveBeenCalledWith({
       event: {
         category: AUDIT_EVENT_CATEGORIES.EMAIL,
         action: AUDIT_EVENT_ACTIONS.EMAIL_SENT
       },
       context: {
-        template_id: templateId,
-        email_address: emailAddress
+        templateId,
+        emailAddress: expect.stringMatching(
+          new RegExp(`^${emailFirstFourChars}[*@]+${emailLastFourChars}$`)
+        ),
+        personalisation: expect.any(Object)
       }
     })
   })

--- a/src/routes/v1/apply/accreditation.test.js
+++ b/src/routes/v1/apply/accreditation.test.js
@@ -1,4 +1,6 @@
 import {
+  AUDIT_EVENT_ACTIONS,
+  AUDIT_EVENT_CATEGORIES,
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '../../../common/enums/event.js'
@@ -9,6 +11,7 @@ import { accreditationPath } from './accreditation.js'
 const mockLoggerInfo = vi.fn()
 const mockLoggerError = vi.fn()
 const mockLoggerWarn = vi.fn()
+const mockAudit = vi.fn()
 
 const mockInsertOne = vi.fn()
 
@@ -18,6 +21,10 @@ vi.mock('../../../common/helpers/logging/logger.js', () => ({
     error: (...args) => mockLoggerError(...args),
     warn: (...args) => mockLoggerWarn(...args)
   })
+}))
+
+vi.mock('@defra/cdp-auditing', () => ({
+  audit: (...args) => mockAudit(...args)
 }))
 
 const url = accreditationPath
@@ -47,6 +54,17 @@ describe(`${url} route`, () => {
     })
 
     expect(response.statusCode).toEqual(201)
+
+    expect(mockAudit).toHaveBeenCalledWith({
+      event: {
+        category: AUDIT_EVENT_CATEGORIES.DB,
+        action: AUDIT_EVENT_ACTIONS.DB_INSERT
+      },
+      context: {
+        orgId: expect.any(Number),
+        referenceNumber: expect.any(String)
+      }
+    })
 
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/routes/v1/apply/organisation.js
+++ b/src/routes/v1/apply/organisation.js
@@ -1,6 +1,9 @@
+import { audit } from '@defra/cdp-auditing'
 import Boom from '@hapi/boom'
 import { createLogger } from '../../../common/helpers/logging/logger.js'
 import {
+  AUDIT_EVENT_ACTIONS,
+  AUDIT_EVENT_CATEGORIES,
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES,
   ORG_ID_START_NUMBER,
@@ -86,6 +89,18 @@ export const organisation = {
       )
 
       const referenceNumber = insertedId.toString()
+
+      audit({
+        event: {
+          category: AUDIT_EVENT_CATEGORIES.DB,
+          action: AUDIT_EVENT_ACTIONS.DB_INSERT
+        },
+        context: {
+          orgId,
+          orgName,
+          referenceNumber
+        }
+      })
 
       logger.info({
         message: `Stored organisation data for orgId: ${orgId} and referenceNumber: ${referenceNumber}`,

--- a/src/routes/v1/apply/registration.test.js
+++ b/src/routes/v1/apply/registration.test.js
@@ -1,4 +1,6 @@
 import {
+  AUDIT_EVENT_ACTIONS,
+  AUDIT_EVENT_CATEGORIES,
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '../../../common/enums/event.js'
@@ -9,6 +11,7 @@ import { registrationPath } from './registration.js'
 const mockLoggerInfo = vi.fn()
 const mockLoggerError = vi.fn()
 const mockLoggerWarn = vi.fn()
+const mockAudit = vi.fn()
 
 const mockInsertOne = vi.fn()
 
@@ -18,6 +21,10 @@ vi.mock('../../../common/helpers/logging/logger.js', () => ({
     error: (...args) => mockLoggerError(...args),
     warn: (...args) => mockLoggerWarn(...args)
   })
+}))
+
+vi.mock('@defra/cdp-auditing', () => ({
+  audit: (...args) => mockAudit(...args)
 }))
 
 const url = registrationPath
@@ -47,6 +54,17 @@ describe(`${url} route`, () => {
     })
 
     expect(response.statusCode).toEqual(201)
+
+    expect(mockAudit).toHaveBeenCalledWith({
+      event: {
+        category: AUDIT_EVENT_CATEGORIES.DB,
+        action: AUDIT_EVENT_ACTIONS.DB_INSERT
+      },
+      context: {
+        orgId: expect.any(Number),
+        referenceNumber: expect.any(String)
+      }
+    })
 
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
Ticket: [PAE-196](https://eaflood.atlassian.net/browse/PAE-196)
## Description

1. Add email obfuscation lib
2. Add email obfuscation to audit logs
3. Audit DB inserts on each endpoint

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-196]: https://eaflood.atlassian.net/browse/PAE-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ