### PR TITLE
PAE-197: fix incorrectly located options object in runCommand

### DIFF
--- a/src/common/helpers/collections/create-update-accreditation.js
+++ b/src/common/helpers/collections/create-update-accreditation.js
@@ -38,6 +38,6 @@ export async function createOrUpdateAccreditationCollection(db, collections) {
   if (!collections.find(({ name }) => name === collectionName)) {
     await db.createCollection(collectionName, options)
   } else {
-    await db.command({ collMod: collectionName }, options)
+    await db.command({ collMod: collectionName, ...options })
   }
 }

--- a/src/common/helpers/collections/create-update-organisation.js
+++ b/src/common/helpers/collections/create-update-organisation.js
@@ -41,6 +41,6 @@ export async function createOrUpdateOrganisationCollection(db, collections) {
   if (!collections.find(({ name }) => name === collectionName)) {
     await db.createCollection(collectionName, options)
   } else {
-    await db.command({ collMod: collectionName }, options)
+    await db.command({ collMod: collectionName, ...options })
   }
 }

--- a/src/common/helpers/collections/create-update-registration.js
+++ b/src/common/helpers/collections/create-update-registration.js
@@ -38,6 +38,6 @@ export async function createOrUpdateRegistrationCollection(db, collections) {
   if (!collections.find(({ name }) => name === collectionName)) {
     await db.createCollection(collectionName, options)
   } else {
-    await db.command({ collMod: collectionName }, options)
+    await db.command({ collMod: collectionName, ...options })
   }
 }


### PR DESCRIPTION
Ticket: [PAE-197](https://eaflood.atlassian.net/browse/PAE-197)
## Description

Move options object

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-197]: https://eaflood.atlassian.net/browse/PAE-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ