### PR TITLE
PAE-182: improve logger.warn and logger.error for alerting purposes

### DIFF
--- a/src/common/helpers/apply/payload.js
+++ b/src/common/helpers/apply/payload.js
@@ -15,11 +15,11 @@ export function registrationAndAccreditationPayload(data, _options) {
   const referenceNumber = extractReferenceNumber(answers)
 
   if (!orgId) {
-    throw Boom.badRequest('Could not extract orgId from answers')
+    throw Boom.badData('Could not extract orgId from answers')
   }
 
   if (!referenceNumber) {
-    throw Boom.badRequest('Could not extract referenceNumber from answers')
+    throw Boom.badData('Could not extract referenceNumber from answers')
   }
 
   return { answers, orgId, rawSubmissionData: data, referenceNumber }

--- a/src/common/helpers/fail-action.js
+++ b/src/common/helpers/fail-action.js
@@ -1,8 +1,23 @@
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '../enums/index.js'
 import { createLogger } from './logging/logger.js'
 
 const logger = createLogger()
 
 export function failAction(_request, _h, error) {
-  logger.warn(error, error?.message)
+  logger.warn({
+    message: error?.message ?? error.toString(),
+    event: {
+      category: LOGGING_EVENT_CATEGORIES.SERVER,
+      action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+    },
+    http: {
+      response: {
+        status_code: error?.output?.statusCode ?? 400
+      }
+    }
+  })
   throw error
 }

--- a/src/common/helpers/fail-action.test.js
+++ b/src/common/helpers/fail-action.test.js
@@ -1,10 +1,20 @@
 import { failAction } from './fail-action.js'
 
 describe('#fail-action', () => {
-  test('Should throw expected error', () => {
+  test('Should throw expected error object', () => {
     const mockRequest = {}
     const mockToolkit = {}
     const mockError = Error('Something terrible has happened!')
+
+    expect(() => failAction(mockRequest, mockToolkit, mockError)).toThrow(
+      'Something terrible has happened!'
+    )
+  })
+
+  test('Should throw expected error string', () => {
+    const mockRequest = {}
+    const mockToolkit = {}
+    const mockError = 'Something terrible has happened!'
 
     expect(() => failAction(mockRequest, mockToolkit, mockError)).toThrow(
       'Something terrible has happened!'

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,8 @@
 import process from 'node:process'
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from './common/enums/index.js'
 
 import { createLogger } from './common/helpers/logging/logger.js'
 import { startServer } from './start-server.js'
@@ -7,7 +11,17 @@ await startServer()
 
 process.on('unhandledRejection', (error) => {
   const logger = createLogger()
-  logger.info('Unhandled rejection')
-  logger.error(error)
+  logger.error(error, {
+    message: 'Unhandled rejection',
+    event: {
+      category: LOGGING_EVENT_CATEGORIES.HTTP,
+      action: LOGGING_EVENT_ACTIONS.REQUEST_FAILURE
+    },
+    http: {
+      response: {
+        status_code: error?.output?.status_code ?? 500
+      }
+    }
+  })
   process.exitCode = 1
 })

--- a/src/routes/v1/apply/accreditation.test.js
+++ b/src/routes/v1/apply/accreditation.test.js
@@ -101,7 +101,7 @@ describe(`${url} route`, () => {
     expect(body.message).toMatch(/Invalid payload/)
   })
 
-  it('returns 400 if payload is missing orgId', async () => {
+  it('returns 422 if payload is missing orgId', async () => {
     const response = await server.inject({
       method: 'POST',
       url,
@@ -134,11 +134,11 @@ describe(`${url} route`, () => {
     const message = 'Could not extract orgId from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(422)
     expect(body.message).toEqual(message)
   })
 
-  it('returns 400 if payload is missing reference number', async () => {
+  it('returns 422 if payload is missing reference number', async () => {
     const response = await server.inject({
       method: 'POST',
       url,
@@ -170,7 +170,7 @@ describe(`${url} route`, () => {
     const message = 'Could not extract referenceNumber from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(422)
     expect(body.message).toEqual(message)
   })
 

--- a/src/routes/v1/apply/organisation.js
+++ b/src/routes/v1/apply/organisation.js
@@ -41,17 +41,15 @@ export const organisation = {
         const regulatorEmail = getRegulatorEmail(data)
 
         if (!regulatorEmail) {
-          throw Boom.badRequest('Could not get regulator name from data')
+          throw Boom.badData('Could not get regulator name from data')
         }
 
         if (!email) {
-          throw Boom.badRequest('Could not extract email from answers')
+          throw Boom.badData('Could not extract email from answers')
         }
 
         if (!orgName) {
-          throw Boom.badRequest(
-            'Could not extract organisation name from answers'
-          )
+          throw Boom.badData('Could not extract organisation name from answers')
         }
 
         return {

--- a/src/routes/v1/apply/organisation.test.js
+++ b/src/routes/v1/apply/organisation.test.js
@@ -133,7 +133,7 @@ describe(`${url} route`, () => {
     expect(body.message).toMatch(/Invalid payload/)
   })
 
-  it('returns 400 if payload is missing email', async () => {
+  it('returns 422 if payload is missing email', async () => {
     const response = await server.inject({
       method: 'POST',
       url,
@@ -166,11 +166,11 @@ describe(`${url} route`, () => {
     const message = 'Could not extract email from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(422)
     expect(body.message).toEqual(message)
   })
 
-  it('returns 400 if payload is missing orgName', async () => {
+  it('returns 422 if payload is missing orgName', async () => {
     const response = await server.inject({
       method: 'POST',
       url,
@@ -203,11 +203,11 @@ describe(`${url} route`, () => {
     const message = 'Could not extract organisation name from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(422)
     expect(body.message).toEqual(message)
   })
 
-  it('returns 400 if payload is missing regulatorEmail', async () => {
+  it('returns 422 if payload is missing regulatorEmail', async () => {
     const response = await server.inject({
       method: 'POST',
       url,
@@ -226,7 +226,7 @@ describe(`${url} route`, () => {
     const message = 'Could not get regulator name from data'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(422)
     expect(body.message).toEqual(message)
   })
 

--- a/src/routes/v1/apply/registration.test.js
+++ b/src/routes/v1/apply/registration.test.js
@@ -77,7 +77,7 @@ describe(`${url} route`, () => {
     )
   })
 
-  it('returns 400 if payload is not an object', async () => {
+  it('returns 422 if payload is not an object', async () => {
     const response = await server.inject({
       method: 'POST',
       url,
@@ -101,7 +101,7 @@ describe(`${url} route`, () => {
     expect(body.message).toMatch(/Invalid payload/)
   })
 
-  it('returns 400 if payload is missing orgId', async () => {
+  it('returns 422 if payload is missing orgId', async () => {
     const response = await server.inject({
       method: 'POST',
       url,
@@ -134,11 +134,11 @@ describe(`${url} route`, () => {
     const message = 'Could not extract orgId from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(422)
     expect(body.message).toEqual(message)
   })
 
-  it('returns 400 if payload is missing reference number', async () => {
+  it('returns 422 if payload is missing reference number', async () => {
     const response = await server.inject({
       method: 'POST',
       url,
@@ -170,7 +170,7 @@ describe(`${url} route`, () => {
     const message = 'Could not extract referenceNumber from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(422)
     expect(body.message).toEqual(message)
   })
 


### PR DESCRIPTION
Ticket: [PAE-182](https://eaflood.atlassian.net/browse/PAE-182)
## Description

1. Update request field validation Boom errors to `badData`, which will result in `422` instead of `400`
2. Update `failAction` to use structured logging with `http.response.status_code` for alerting purposes
3. Update unhandledRejection as per the item above

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-182]: https://eaflood.atlassian.net/browse/PAE-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ