### PR TITLE
PAE-182: add http.response.status_code to endpoints that call logger.error in catch clause

### DIFF
--- a/src/common/helpers/apply/handler.js
+++ b/src/common/helpers/apply/handler.js
@@ -50,6 +50,11 @@ export function registrationAndAccreditationHandler(name, path, factory) {
         event: {
           category: LOGGING_EVENT_CATEGORIES.SERVER,
           action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+        },
+        http: {
+          response: {
+            status_code: 500
+          }
         }
       })
 

--- a/src/routes/v1/apply/accreditation.test.js
+++ b/src/routes/v1/apply/accreditation.test.js
@@ -175,6 +175,7 @@ describe(`${url} route`, () => {
   })
 
   it('returns 500 if error is thrown by insertOne', async () => {
+    const statusCode = 500
     const error = new Error('db.collection.insertOne failed')
     mockInsertOne.mockImplementationOnce(() => {
       throw error
@@ -186,7 +187,7 @@ describe(`${url} route`, () => {
       payload: accreditationFixture
     })
 
-    expect(response.statusCode).toEqual(500)
+    expect(response.statusCode).toEqual(statusCode)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(`An internal server error occurred`)
     expect(mockLoggerError).toHaveBeenCalledWith(error, {
@@ -194,6 +195,11 @@ describe(`${url} route`, () => {
       event: {
         category: LOGGING_EVENT_CATEGORIES.SERVER,
         action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+      },
+      http: {
+        response: {
+          status_code: statusCode
+        }
       }
     })
   })

--- a/src/routes/v1/apply/organisation.js
+++ b/src/routes/v1/apply/organisation.js
@@ -141,6 +141,11 @@ export const organisation = {
         event: {
           category: LOGGING_EVENT_CATEGORIES.SERVER,
           action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+        },
+        http: {
+          response: {
+            status_code: 500
+          }
         }
       })
 

--- a/src/routes/v1/apply/organisation.test.js
+++ b/src/routes/v1/apply/organisation.test.js
@@ -231,6 +231,7 @@ describe(`${url} route`, () => {
   })
 
   it('returns 500 if error is thrown by insertOne', async () => {
+    const statusCode = 500
     const error = new Error('db.collection.insertOne failed')
     mockInsertOne.mockImplementationOnce(() => {
       throw error
@@ -242,7 +243,7 @@ describe(`${url} route`, () => {
       payload: organisationFixture
     })
 
-    expect(response.statusCode).toEqual(500)
+    expect(response.statusCode).toEqual(statusCode)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(`An internal server error occurred`)
     expect(mockLoggerError).toHaveBeenCalledWith(error, {
@@ -250,11 +251,17 @@ describe(`${url} route`, () => {
       event: {
         category: LOGGING_EVENT_CATEGORIES.SERVER,
         action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+      },
+      http: {
+        response: {
+          status_code: statusCode
+        }
       }
     })
   })
 
   it('returns 500 if error is thrown by sendEmail', async () => {
+    const statusCode = 500
     const error = new Error('Notify API failed')
     sendEmail.mockRejectedValueOnce(error)
 
@@ -264,7 +271,7 @@ describe(`${url} route`, () => {
       payload: organisationFixture
     })
 
-    expect(response.statusCode).toEqual(500)
+    expect(response.statusCode).toEqual(statusCode)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(`An internal server error occurred`)
     expect(mockLoggerError).toHaveBeenCalledWith(error, {
@@ -272,6 +279,11 @@ describe(`${url} route`, () => {
       event: {
         category: LOGGING_EVENT_CATEGORIES.SERVER,
         action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+      },
+      http: {
+        response: {
+          status_code: statusCode
+        }
       }
     })
   })

--- a/src/routes/v1/apply/registration.test.js
+++ b/src/routes/v1/apply/registration.test.js
@@ -77,7 +77,7 @@ describe(`${url} route`, () => {
     )
   })
 
-  it('returns 422 if payload is not an object', async () => {
+  it('returns 400 if payload is not an object', async () => {
     const response = await server.inject({
       method: 'POST',
       url,
@@ -175,6 +175,7 @@ describe(`${url} route`, () => {
   })
 
   it('returns 500 if error is thrown by insertOne', async () => {
+    const statusCode = 500
     const error = new Error('db.collection.insertOne failed')
     mockInsertOne.mockImplementationOnce(() => {
       throw error
@@ -186,7 +187,7 @@ describe(`${url} route`, () => {
       payload: registrationFixture
     })
 
-    expect(response.statusCode).toEqual(500)
+    expect(response.statusCode).toEqual(statusCode)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(`An internal server error occurred`)
     expect(mockLoggerError).toHaveBeenCalledWith(error, {
@@ -194,6 +195,11 @@ describe(`${url} route`, () => {
       event: {
         category: LOGGING_EVENT_CATEGORIES.SERVER,
         action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+      },
+      http: {
+        response: {
+          status_code: statusCode
+        }
       }
     })
   })


### PR DESCRIPTION
Ticket: [PAE-182](https://eaflood.atlassian.net/browse/PAE-182)
## Description


---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-182]: https://eaflood.atlassian.net/browse/PAE-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ