### PR TITLE
PAE-205: Add github actions to run backend journey tests on each PR

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -82,3 +82,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  test-journey:
+    name: Run Journey Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: docker build -t defradigital/epr-backend:${{github.sha}} .
+      - uses: DEFRA/epr-backend-journey-tests/run-journey-tests@main
+        with:
+          epr-backend: ${{github.sha}}
+          branch: main


### PR DESCRIPTION
## Description

This PR would enforce the backend journey tests to run on each Pull Request that is made. This is to ensure that the integration tests are not failing prior to merging to main.