### PR TITLE
Pae 200 internal only documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@
     * [Access](#access)
     * [Using Templates](#using-templates)
     * [Development Notes](#development-notes)
+  * [Further Documentation](#further-documentation)
 <!-- TOC -->
 
 <!-- prettier-ignore-end -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -530,3 +530,11 @@ We use [GOV.UK Notify](https://www.notifications.service.gov.uk/) to send automa
 - API keys are stored securely in CDP — never commit them to the repo. See [Secrets](#secrets) for how to handle them.
 - New templates must be created in GOV.UK Notify and their IDs updated in code.
 - In non-live mode, only approved recipient email addresses can be used.
+
+## Further Documentation
+
+This `CONTRIBUTING.md` focuses on repository-specific guidance such as setup, development, and deployment.
+
+For wider engineering documentation (including runbooks, hotfix process, non-technical resources, and dummy data assets), please see our Confluence space:
+
+[Engineering Documentation Home](https://eaflood.atlassian.net/wiki/spaces/MWR/folder/5874122814?atlOrigin=eyJpIjoiY2Q5Y2ViNTUzNmY4NDI0NWE4ODZmMGZiMGQ3NTZlYjkiLCJwIjoiYyJ9)


### PR DESCRIPTION
## Description

Storing documentation that can’t be shared in the public domain. Extending on existing runbooks by adding hotfix process and add some non technical documentation as well as dummy data for different reports and summary logs

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).
