### PR TITLE
PAE-226: Update axios/pino dependency and ignore-scripts

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -65,7 +65,7 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run format:check
           npm run lint
           npm test

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -28,7 +28,7 @@ jobs:
           cache: npm
 
       # Ensure tests pass. Add more checks if required
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm test
 
       - name: Publish Hot Fix

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run format:check
           npm run lint
           npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ USER node
 COPY --from=development /home/node/package*.json ./
 COPY --from=development /home/node/src ./src/
 
-RUN npm ci --omit=dev
+RUN npm ci --ignore-scripts --omit=dev
 
 ARG PORT
 ENV PORT=${PORT}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "node-fetch": "3.3.2",
         "notifications-node-client": "8.2.1",
         "obfuscate-mail": "1.5.1",
-        "pino": "9.9.5",
+        "pino": "9.10.0",
         "pino-pretty": "13.1.1",
         "undici": "7.16.0"
       },
@@ -9430,9 +9430,9 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.9.5",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.9.5.tgz",
-      "integrity": "sha512-d1s98p8/4TfYhsJ09r/Azt30aYELRi6NNnZtEbqFw6BoGsdPVf5lKNK3kUwH8BmJJfpTLNuicjUQjaMbd93dVg==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.10.0.tgz",
+      "integrity": "sha512-VOFxoNnxICtxaN8S3E73pR66c5MTFC+rwRcNRyHV/bV/c90dXvJqMfjkeRFsGBDXmlUN3LccJQPqGIufnaJePA==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4451,9 +4451,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node-fetch": "3.3.2",
     "notifications-node-client": "8.2.1",
     "obfuscate-mail": "1.5.1",
-    "pino": "9.9.5",
+    "pino": "9.10.0",
     "pino-pretty": "13.1.1",
     "undici": "7.16.0"
   },


### PR DESCRIPTION
Ticket: [PAE-226](https://eaflood.atlassian.net/browse/PAE-226)

[PAE-207]: https://eaflood.atlassian.net/browse/PAE-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



[PAE-226]: https://eaflood.atlassian.net/browse/PAE-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#Description
- Fix for https://security.snyk.io/vuln/SNYK-JS-AXIOS-12613773
- add ignore-scripts to npm ci
- upgrade pino version