### PR TITLE
PAE-226: Ignore scripts on npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PORT=${PORT}
 EXPOSE ${PORT} ${PORT_DEBUG}
 
 COPY --chown=node:node package*.json ./
-RUN npm install
+RUN npm install --ignore-scripts
 COPY --chown=node:node ./src ./src
 
 CMD [ "npm", "run", "docker:dev" ]


### PR DESCRIPTION
Ticket: [PAE-226](https://eaflood.atlassian.net/browse/PAE-226)
## Description

PAE-226: Ignore scripts on npm install
---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-226]: https://eaflood.atlassian.net/browse/PAE-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ