### PR TITLE
PAE-276: Add logs when reg/accreditation fails due to mongo validation

### DIFF
--- a/src/routes/v1/apply/accreditation.test.js
+++ b/src/routes/v1/apply/accreditation.test.js
@@ -191,7 +191,42 @@ describe(`${url} route`, () => {
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(`An internal server error occurred`)
     expect(mockLoggerError).toHaveBeenCalledWith(error, {
-      message: `Failure on ${accreditationPath}`,
+      message: `Failure on ${accreditationPath} for orgId: 500000 and referenceNumber: 68a66ec3dabf09f3e442b2da, mongo validation failures: `,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+      },
+      http: {
+        response: {
+          status_code: statusCode
+        }
+      }
+    })
+  })
+
+  it('returns 500 if insertOne fails with mongo validation failures', async () => {
+    const statusCode = 500
+    const error = Object.assign(new Error('db.collection.insertOne failed'), {
+      errInfo: JSON.parse(
+        '{"failingDocumentId":"68da86a39a36abfab162b707","details":{"operatorName":"$jsonSchema","title":"Registration Validation","schemaRulesNotSatisfied":[{"operatorName":"properties","propertiesNotSatisfied":[{"propertyName":"orgId","description":"\'orgId\' must be a positive integer above 500000 and is required","details":[{"operatorName":"minimum","specifiedAs":{"minimum":500000},"reason":"comparison failed","consideredValue":100000}]}]}]}}'
+      )
+    })
+
+    mockInsertOne.mockImplementationOnce(() => {
+      throw error
+    })
+
+    const response = await server.inject({
+      method: 'POST',
+      url,
+      payload: accreditationFixture
+    })
+
+    expect(response.statusCode).toEqual(statusCode)
+    const body = JSON.parse(response.payload)
+    expect(body.message).toMatch(`An internal server error occurred`)
+    expect(mockLoggerError).toHaveBeenCalledWith(error, {
+      message: `Failure on ${accreditationPath} for orgId: 500000 and referenceNumber: 68a66ec3dabf09f3e442b2da, mongo validation failures: orgId - 'orgId' must be a positive integer above 500000 and is required`,
       event: {
         category: LOGGING_EVENT_CATEGORIES.SERVER,
         action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE


### PR DESCRIPTION
Ticket: [PAE-276](https://eaflood.atlassian.net/browse/PAE-276)
## Description

PAGE-276: Add logs when reg/accreditation fails due to mongo validation
---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-276]: https://eaflood.atlassian.net/browse/PAE-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ