### PR TITLE
PAE-283: Fix orgId validation to match MongoDB constraints

### DIFF
--- a/src/common/helpers/apply/payload.js
+++ b/src/common/helpers/apply/payload.js
@@ -1,9 +1,15 @@
 import Boom from '@hapi/boom'
 import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES,
+  ORG_ID_START_NUMBER
+} from '../../enums/index.js'
+import {
   extractAnswers,
   extractOrgId,
   extractReferenceNumber
 } from './extract-answers.js'
+import { logger } from '../logging/logger.js'
 
 export function registrationAndAccreditationPayload(data, _options) {
   if (!data || typeof data !== 'object') {
@@ -16,6 +22,24 @@ export function registrationAndAccreditationPayload(data, _options) {
 
   if (!orgId) {
     throw Boom.badData('Could not extract orgId from answers')
+  }
+
+  if (orgId < ORG_ID_START_NUMBER) {
+    logger.warn({
+      message: `orgId: ${orgId}, referenceNumber: ${referenceNumber} - Organisation ID must be at least ${ORG_ID_START_NUMBER}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+      },
+      http: {
+        response: {
+          status_code: 422
+        }
+      }
+    })
+    throw Boom.badData(
+      `Organisation ID must be at least ${ORG_ID_START_NUMBER}`
+    )
   }
 
   if (!referenceNumber) {

--- a/src/routes/v1/apply/registration.test.js
+++ b/src/routes/v1/apply/registration.test.js
@@ -204,7 +204,7 @@ describe(`${url} route`, () => {
         },
         data: {
           main: {
-            orgIdField: '5000',
+            orgIdField: '499999',
             refField: 'abcdef123456fedcba654321'
           }
         }
@@ -218,7 +218,7 @@ describe(`${url} route`, () => {
     expect(body.message).toEqual(message)
     expect(mockLoggerWarn).toHaveBeenCalledWith({
       message:
-        'orgId: 5000, referenceNumber: abcdef123456fedcba654321 - Organisation ID must be at least 500000',
+        'orgId: 499999, referenceNumber: abcdef123456fedcba654321 - Organisation ID must be at least 500000',
       event: {
         category: LOGGING_EVENT_CATEGORIES.SERVER,
         action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE

--- a/src/routes/v1/apply/registration.test.js
+++ b/src/routes/v1/apply/registration.test.js
@@ -174,6 +174,63 @@ describe(`${url} route`, () => {
     expect(body.message).toEqual(message)
   })
 
+  it('returns 422 if orgId is below minimum value', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url,
+      payload: {
+        meta: {
+          definition: {
+            pages: [
+              {
+                components: [
+                  {
+                    name: 'orgIdField',
+                    shortDescription: FORM_FIELDS_SHORT_DESCRIPTIONS.ORG_ID,
+                    title: 'What is your Organisation ID number?',
+                    type: 'TextField'
+                  },
+                  {
+                    name: 'refField',
+                    shortDescription:
+                      FORM_FIELDS_SHORT_DESCRIPTIONS.REFERENCE_NUMBER,
+                    title: 'What is your System Reference number?',
+                    type: 'TextField'
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        data: {
+          main: {
+            orgIdField: '5000',
+            refField: 'abcdef123456fedcba654321'
+          }
+        }
+      }
+    })
+
+    const message = 'Organisation ID must be at least 500000'
+    const body = JSON.parse(response.payload)
+
+    expect(response.statusCode).toEqual(422)
+    expect(body.message).toEqual(message)
+    expect(mockLoggerWarn).toHaveBeenCalledWith({
+      message:
+        'orgId: 5000, referenceNumber: abcdef123456fedcba654321 - Organisation ID must be at least 500000',
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+      },
+      http: {
+        response: {
+          status_code: 422
+        }
+      }
+    })
+  })
+
   it('returns 500 if error is thrown by insertOne', async () => {
     const statusCode = 500
     const error = new Error('db.collection.insertOne failed')


### PR DESCRIPTION
Ticket: [PAE-283](https://eaflood.atlassian.net/browse/PAE-283)
## Summary
- Added minimum value validation (500000) for orgId to match MongoDB constraints
- Returns 422 with error message: "Organisation ID must be at least 500000"
- Logs orgId and referenceNumber for debugging: "orgId: {orgId}, referenceNumber: {referenceNumber} - Organisation ID must be at least 500000"
- Prevents invalid orgId values that would cause database errors

## Dependencies
**Merge order:** This PR must be merged **SECOND**, after https://github.com/DEFRA/epr-backend-journey-tests/pull/65

Journey test updates in https://github.com/DEFRA/epr-backend-journey-tests/pull/65 must be merged first to avoid test failures in CI.

## Test plan
- Added test cases for orgId validation including boundary conditions (499999)
- All tests pass with 100% coverage
- Journey tests updated and pass

[PAE-283]: https://eaflood.atlassian.net/browse/PAE-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ