### PR TITLE
PAE-288: Run tests sequentially in CI to avoid MongoDB race condition

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: 'node',
     clearMocks: true,
     hookTimeout: 60000,
+    fileParallelism: !process.env.CI,
     coverage: {
       provider: 'v8',
       reportsDirectory: './coverage',


### PR DESCRIPTION
Ticket: [PAE-288](https://eaflood.atlassian.net/browse/PAE-288)
## What changed

Modified vitest config to run test files sequentially only in CI environments by setting `fileParallelism: !process.env.CI`.

## Why

The MongoDB memory server has a race condition when multiple test files try to download or access the binary simultaneously. Even with caching and increased timeouts, the lockfile management causes intermittent failures in CI.

Running tests sequentially in CI (where the race condition occurs) while keeping parallel execution for local development (where it typically doesn't) provides the best balance of reliability and developer experience.

**Performance impact:**
- Local: ~5s (parallel, unchanged)
- CI: ~18s (sequential, but reliable)

[PAE-288]: https://eaflood.atlassian.net/browse/PAE-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ