### PR TITLE
PAE-289: Update design docs for event-driven summary log flow

### DIFF
--- a/docs/architecture/discovery/pepr-hld.md
+++ b/docs/architecture/discovery/pepr-hld.md
@@ -243,9 +243,9 @@ Note that updating an entity _may_ include changing its `status`. See a summary 
 ### Summary Log
 
 1. `created`: summary log has been created (after upload by User) but has not yet been ingested by the service
-2. `upload-failed`: summary log file failed virus scan
+2. `upload_failed`: summary log file failed virus scan
 3. `validating`: summary log is being validated by the backend worker
-4. `validation-failed`: summary log validation failed
+4. `validation_failed`: summary log validation failed
 5. `ingested`: summary log has been ingested by the service and the prospective modifications to waste records can be reviewed by the user
 6. `approved`: summary log has been approved by the user and modifications applied to waste records
 

--- a/docs/architecture/discovery/pepr-hld.md
+++ b/docs/architecture/discovery/pepr-hld.md
@@ -242,11 +242,11 @@ Note that updating an entity _may_ include changing its `status`. See a summary 
 
 ### Summary Log
 
-1. `created`: summary log has been created (after upload by User) but has not yet been ingested by the service
+1. `created`: summary log has been created (after upload by User) but has not yet been validated by the service
 2. `upload_failed`: summary log file failed virus scan
 3. `validating`: summary log is being validated by the backend worker
 4. `validation_failed`: summary log validation failed
-5. `ingested`: summary log has been ingested by the service and the prospective modifications to waste records can be reviewed by the user
+5. `validation_succeeded`: summary log has been successfully validated and the prospective modifications to waste records can be reviewed by the user
 6. `approved`: summary log has been approved by the user and modifications applied to waste records
 
 ### Waste Record Version
@@ -447,8 +447,10 @@ sequenceDiagram
 
     User->>Frontend: select activity, site & material
     User->>Frontend: initiate upload
-    Frontend->>CDP: request upload URL
-    CDP-->>Frontend: uploadUrl
+    Frontend->>Backend: request upload URL
+    Backend->>CDP: request upload URL
+    CDP-->>Backend: uploadUrl
+    Backend-->>Frontend: uploadUrl
     User->>CDP: upload summaryLog.xlsx
     CDP->>S3: store file
     CDP->>Backend: callback with S3 details
@@ -457,7 +459,7 @@ sequenceDiagram
     SQS->>Worker: trigger validation
     Worker->>S3: fetch summaryLog.xlsx
     Note over Worker: parse summary log + compare against WASTE-RECORDS
-    Worker->>Backend: update SUMMARY-LOG entity (status: ingested)
+    Worker->>Backend: update SUMMARY-LOG entity (status: validation_succeeded)
     User->>Frontend: view progress page
     Frontend->>Backend: GET summary log
     Backend-->>Frontend: status & validation results

--- a/docs/architecture/discovery/pepr-hld.md
+++ b/docs/architecture/discovery/pepr-hld.md
@@ -252,10 +252,10 @@ stateDiagram-v2
     uploaded --> validating: Validation started
     validating --> validation_failed: Validation errors found
     validating --> validated: Validation completed successfully
-    validated --> submitted: User submitted changes
+    validated --> submitted: Summary log submitted
     upload_failed --> [*]: User must restart
     validation_failed --> [*]: User must restart
-    submitted --> [*]: Changes applied
+    submitted --> [*]
 ```
 
 1. `awaiting_upload`: entity created and upload process started, awaiting file upload from user

--- a/docs/architecture/discovery/pepr-hld.md
+++ b/docs/architecture/discovery/pepr-hld.md
@@ -253,8 +253,8 @@ stateDiagram-v2
     validating --> validation_failed: Validation errors found
     validating --> validated: Validation completed successfully
     validated --> submitted: Summary log submitted
-    upload_failed --> [*]
-    validation_failed --> [*]
+    upload_failed --> [*]: User must restart
+    validation_failed --> [*]: User must restart
     submitted --> [*]
 ```
 

--- a/docs/architecture/discovery/pepr-hld.md
+++ b/docs/architecture/discovery/pepr-hld.md
@@ -253,8 +253,8 @@ stateDiagram-v2
     validating --> validation_failed: Validation errors found
     validating --> validated: Validation completed successfully
     validated --> submitted: Summary log submitted
-    upload_failed --> [*]: User must restart
-    validation_failed --> [*]: User must restart
+    upload_failed --> [*]
+    validation_failed --> [*]
     submitted --> [*]
 ```
 

--- a/docs/architecture/discovery/pepr-lld.md
+++ b/docs/architecture/discovery/pepr-lld.md
@@ -126,7 +126,7 @@ Request body matches CDP's callback payload:
 }
 ```
 
-Updates the existing SUMMARY-LOG entity with S3 details and sets status to `created` (if upload succeeded) or `upload-failed` (if virus scan failed). If successful, sends a message to SQS to trigger validation.
+Updates the existing SUMMARY-LOG entity with S3 details and sets status to `created` (if upload succeeded) or `upload_failed` (if virus scan failed). If successful, sends a message to SQS to trigger validation.
 
 #### `POST /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/submit`
 
@@ -135,7 +135,7 @@ Used to submit a summary log to a registration, applying the validated changes t
 > [!NOTE]
 > To prevent race conditions and ensure data integrity, this endpoint should validate:
 >
-> - Summary log status must be `ingested` (reject `created`, `validating`, `validation-failed`, `upload-failed`, or `approved`)
+> - Summary log status must be `ingested` (reject `created`, `validating`, `validation_failed`, `upload_failed`, or `approved`)
 > - Summary log must be the most recently uploaded for the given site + material (reject if a newer summary log exists)
 
 ### Waste Records
@@ -611,8 +611,8 @@ sequenceDiagram
       alt status: created or validating
         Backend-->>Frontend: 200: { status: 'created' | 'validating' }
         Frontend-->>Op: <html>Processing...</html>
-      else status: validation-failed
-        Backend-->>Frontend: 200: { status: 'validation-failed', errors }
+      else status: validation_failed
+        Backend-->>Frontend: 200: { status: 'validation_failed', errors }
         Frontend-->>Op: <html>Validation failed...</html>
         Note over Op: End Journey
       else status: ingested
@@ -623,7 +623,7 @@ sequenceDiagram
     end
   else FileStatus: rejected
     CDP->>Backend: PUT /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/upload-completed<br>{ uploadStatus: 'ready', form: { file: { fileStatus: 'rejected', ... } }, numberOfRejectedFiles: 1 }
-    Note over Backend: update SUMMARY-LOG entity<br>{ status: 'upload-failed', failureReason }
+    Note over Backend: update SUMMARY-LOG entity<br>{ status: 'upload_failed', failureReason }
     Backend-->>CDP: 200
 
     loop polling until final state
@@ -631,7 +631,7 @@ sequenceDiagram
       Op->>Frontend: GET /organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}
       Note over Frontend: Read session<br>[{ organisationId, registrationId, summaryLogId, uploadId }]
       Frontend->>Backend: GET /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}
-      Backend-->>Frontend: 200: { status: 'upload-failed', failureReason }
+      Backend-->>Frontend: 200: { status: 'upload_failed', failureReason }
       Frontend-->>Op: <html>Upload failed...</html>
       Note over Op: End Journey
     end

--- a/docs/architecture/discovery/pepr-lld.md
+++ b/docs/architecture/discovery/pepr-lld.md
@@ -568,7 +568,8 @@ sequenceDiagram
     Backend->>SQS: send message { summaryLogId, organisationId, registrationId }
     Backend-->>CDP: 200
     Note over BackendWorker: START async file validation
-    SQS->>BackendWorker: poll message
+    BackendWorker->>SQS: poll for messages
+    SQS-->>BackendWorker: message { summaryLogId, organisationId, registrationId }
     BackendWorker->>Backend: update SUMMARY-LOG<br>{ status: 'validating' }
     BackendWorker->>S3: fetch: s3Key/fileId
     S3-->>BackendWorker: S3 file

--- a/docs/architecture/discovery/pepr-lld.md
+++ b/docs/architecture/discovery/pepr-lld.md
@@ -11,8 +11,9 @@
       * [`GET /v1/organisations`](#get-v1organisations)
       * [`GET /v1/organisations/{id}`](#get-v1organisationsid)
     * [Summary Logs](#summary-logs)
-      * [`POST /v1/organisations/{id}/registrations/{id}/summary-logs/validate`](#post-v1organisationsidregistrationsidsummary-logsvalidate)
-      * [`POST /v1/organisations/{id}/registrations/{id}/summary-logs/{id}/submit`](#post-v1organisationsidregistrationsidsummary-logsidsubmit)
+      * [`GET /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}`](#get-v1organisationsidregistrationsidsummary-logssummarylogid)
+      * [`PUT /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/upload-completed`](#put-v1organisationsidregistrationsidsummary-logssummarylogidupload-completed)
+      * [`POST /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/submit`](#post-v1organisationsidregistrationsidsummary-logssummarylogidsubmit)
     * [Waste Records](#waste-records)
       * [`GET /v1/organisations/{id}/registrations/{id}/waste-records`](#get-v1organisationsidregistrationsidwaste-records)
       * [`GET /v1/organisations/{id}/registrations/{id}/waste-records/{id}`](#get-v1organisationsidregistrationsidwaste-recordsid)
@@ -87,7 +88,7 @@ Cancelled/Suspended accreditations will result in changed permissions for PRNs a
 
 Used to retrieve the current state and data of a summary log.
 
-#### `PUT /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/cdp-callback`
+#### `PUT /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/upload-completed`
 
 Internal endpoint used by CDP to notify the backend when a file upload is complete or has failed virus scan.
 
@@ -515,6 +516,9 @@ TBD
 
 ### Summary Log upload & ingest
 
+> [!NOTE]
+> The frontend only needs a single page to handle the entire upload and validation flow. The page polls the backend state document and updates the UI based on the current status, without requiring redirects between different URLs.
+
 #### Phase 1: upload & async processes: virus scan, file parsing & data validation
 
 ```mermaid
@@ -541,7 +545,7 @@ sequenceDiagram
   Note over CDP: END async virus scan
 
   alt FileStatus: complete
-    CDP->>Backend: PUT /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/cdp-callback<br>TODO: request body TBC
+    CDP->>Backend: PUT /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/upload-completed<br>TODO: request body TBC
     Note over Backend: create SUMMARY-LOG entity<br>{ status: 'created', s3 details }
     Backend->>SQS: send message { summaryLogId, organisationId, registrationId }
     Backend-->>CDP: 200
@@ -576,7 +580,7 @@ sequenceDiagram
       end
     end
   else FileStatus: rejected
-    CDP->>Backend: PUT /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/cdp-callback<br>TODO: request body TBC
+    CDP->>Backend: PUT /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/upload-completed<br>TODO: request body TBC
     Note over Backend: create SUMMARY-LOG entity<br>{ status: 'upload-failed', failure details }
     Backend-->>CDP: 200
 

--- a/docs/architecture/discovery/pepr-lld.md
+++ b/docs/architecture/discovery/pepr-lld.md
@@ -588,13 +588,13 @@ sequenceDiagram
   alt FileStatus: complete
     CDP->>Backend: PUT /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/upload-completed<br>{ uploadStatus: 'ready', form: { file: { fileStatus: 'complete', s3Bucket, s3Key, ... } } }
     Note over Backend: update SUMMARY-LOG entity<br>{ status: 'created', s3Bucket, s3Key }
-    Backend->>SQS: send message { summaryLogId, organisationId, registrationId }
+    Backend->>SQS: send ValidateSummaryLog command<br>{ summaryLogId, organisationId, registrationId, s3Bucket, s3Key }
     Backend-->>CDP: 200
     Note over BackendWorker: START async file validation
     BackendWorker->>SQS: poll for messages
-    SQS-->>BackendWorker: message { summaryLogId, organisationId, registrationId }
+    SQS-->>BackendWorker: ValidateSummaryLog command<br>{ summaryLogId, organisationId, registrationId, s3Bucket, s3Key }
     BackendWorker->>Backend: update SUMMARY-LOG<br>{ status: 'validating' }
-    BackendWorker->>S3: fetch: s3Key/fileId
+    BackendWorker->>S3: fetch: s3Bucket/s3Key
     S3-->>BackendWorker: S3 file
     loop each row
       Note over BackendWorker: parse row<br>compare to WASTE-RECORD for ourReference<br>update SUMMARY-LOG.data in batches

--- a/docs/architecture/discovery/pepr-lld.md
+++ b/docs/architecture/discovery/pepr-lld.md
@@ -132,6 +132,12 @@ Updates the existing SUMMARY-LOG entity with S3 details and sets status to `crea
 
 Used to submit a summary log to a registration, applying the validated changes to waste records.
 
+> [!NOTE]
+> To prevent race conditions and ensure data integrity, this endpoint should validate:
+>
+> - Summary log status must be `ingested` (reject `created`, `validating`, `validation-failed`, `upload-failed`, or `approved`)
+> - Summary log must be the most recently uploaded for the given site + material (reject if a newer summary log exists)
+
 ### Waste Records
 
 #### `GET /v1/organisations/{id}/registrations/{id}/waste-records`
@@ -663,10 +669,3 @@ sequenceDiagram
   Backend-->>Frontend: 200: { status: 'approved', data: [ ... ] }
   Frontend-->>Op: <html>Submission complete</html>
 ```
-
-> [!IMPORTANT]
-> To avoid race-conditions / multiple uploads of a summary log to the same site + material before approving a previously uploaded summary log, the epr-backend API should:
->
-> 1. fail any attempt to submit a `created` summary log
-> 2. fail any attempt to submit an `ingested` summary log when that summary log is the not the most recently uploaded for the given site + material
-> 3. fail any attempt to submit an `approved` summary log

--- a/docs/architecture/discovery/pepr-lld.md
+++ b/docs/architecture/discovery/pepr-lld.md
@@ -533,7 +533,7 @@ sequenceDiagram
 
   Op->>Frontend: GET /organisations/{id}/registrations/{id}/summary-logs/upload
   Note over Frontend: generate summaryLogId
-  Frontend->>CDP: POST /initiate<br>redirectUrl: `{eprFrontend}/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/progress`
+  Frontend->>CDP: POST /initiate<br>redirectUrl: `{eprFrontend}/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}`
   CDP-->>Frontend: 200: { uploadId, uploadUrl }
   Note over Frontend: Write session<br>[{ organisationId, registrationId, summaryLogId, uploadId }]
   Frontend-->>Op: <html><h2>upload a summary log</h2><form>...</form></html>
@@ -562,7 +562,7 @@ sequenceDiagram
 
     loop polling until final state
       Note over Op: Poll using<br> <meta http-equiv="refresh" content="3">
-      Op->>Frontend: GET .../summary-logs/{summaryLogId}/progress
+      Op->>Frontend: GET /organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}
       Note over Frontend: Read session<br>[{ organisationId, registrationId, summaryLogId, uploadId }]
       Frontend->>Backend: GET /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}
       Note over Backend: lookup SUMMARY-LOG entity
@@ -575,7 +575,7 @@ sequenceDiagram
         Note over Op: End Journey
       else status: ingested
         Backend-->>Frontend: 200: { status: 'ingested', data }
-        Frontend-->>Op: 302: /organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/result
+        Frontend-->>Op: <html>Summary of changes...<button>Submit</button></html>
         Note over Op: End Journey
       end
     end
@@ -586,7 +586,7 @@ sequenceDiagram
 
     loop polling until final state
       Note over Op: Poll using<br> <meta http-equiv="refresh" content="3">
-      Op->>Frontend: GET .../summary-logs/{summaryLogId}/progress
+      Op->>Frontend: GET /organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}
       Note over Frontend: Read session<br>[{ organisationId, registrationId, summaryLogId, uploadId }]
       Frontend->>Backend: GET /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}
       Backend-->>Frontend: 200: { status: 'upload-failed', failureReason }
@@ -608,8 +608,8 @@ sequenceDiagram
   participant S3
 
 
-  Op->>Frontend: GET .../summary-logs/{summaryLogId}/result
-  Note over Frontend: Read session<br>[{ summaryLogStatus }]
+  Op->>Frontend: GET /organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}
+  Note over Frontend: Read session<br>[{ organisationId, registrationId, summaryLogId }]
   Frontend->>Backend: GET /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}
   Note over Backend: lookup SUMMARY-LOG entity
   Backend-->>Frontend: 200: { status: 'ingested', data: [ ... ] }
@@ -617,15 +617,15 @@ sequenceDiagram
 
   Note over Op: Review changes
 
-  Op->>Frontend: POST .../summary-logs/{summaryLogId}/submit
-  Note over Frontend: Read session<br>[{ summaryLogStatus }]
+  Op->>Frontend: POST /organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/submit
+  Note over Frontend: Read session<br>[{ organisationId, registrationId, summaryLogId }]
   Frontend->>Backend: POST /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/submit
   Note over Backend: lookup SUMMARY-LOG entity
   Note over Backend: apply SUMMARY-LOG.data to WASTE-RECORD entities
   Note over Backend: update WASTE-BALANCE
   Note over Backend: update SUMMARY-LOG<br>{ status: 'approved' }
   Backend-->>Frontend: 200: { status: 'approved', data: [ ... ] }
-  Frontend-->>Op: 302: /organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/complete
+  Frontend-->>Op: <html>Submission complete</html>
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
Ticket: [PAE-289](https://eaflood.atlassian.net/browse/PAE-289)

## Summary

Updates HLD and LLD to replace polling-based file upload flow with event-driven architecture using CDP callbacks and SQS queue.

## Changes

### HLD (pepr-hld.md)
- Added new Summary Log states: `upload-failed`, `validating`, `validation-failed`
- Updated workflow diagram to show CDP callback → SQS → worker validation flow

### LLD (pepr-lld.md)

**New endpoints:**
- `POST /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/initiate` - Backend creates SUMMARY-LOG document, proxies CDP initiate request, returns upload credentials
- `GET /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}` - Retrieve summary log state
- `PUT /v1/organisations/{id}/registrations/{id}/summary-logs/{summaryLogId}/upload-completed` - CDP callback endpoint (includes full callback payload schema from CDP docs)

**Architecture improvements:**
- Frontend initiates upload via backend instead of calling CDP directly, ensuring SUMMARY-LOG document exists before upload starts (alternative simpler approach documented: handle 404s gracefully)
- CDP callback triggers `ValidateSummaryLog` command sent to SQS queue (includes s3Bucket and s3Key so worker doesn't need database lookup)
- Worker polls SQS (not push-based), processes validation, updates SUMMARY-LOG status
- Frontend stays on single URL throughout entire flow - no redirects between /upload, /progress, /result
- Submit endpoint validation rules moved from IMPORTANT callout to endpoint documentation

**Details filled in:**
- Complete CDP callback payload structure based on CDP uploader documentation
- Proper SQS polling flow (worker polls queue, not queue pushes to worker)
- Named SQS message as `ValidateSummaryLog` command to clarify it's a directive

## Why

- Eliminates frontend dependency on CDP polling
- Centralizes state management in backend MongoDB
- Enables reliable asynchronous validation via SQS queue
- Prevents race conditions where upload completes before state document exists
- Improves observability and resilience of upload process

[PAE-289]: https://eaflood.atlassian.net/browse/PAE-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ