### PR TITLE
PAE-296: Replace HTTP status codes with named constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "global-agent": "3.0.0",
         "hapi-pino": "13.0.0",
         "hapi-pulse": "3.0.1",
+        "http-status-codes": "2.3.0",
         "https-proxy-agent": "7.0.6",
         "joi": "17.13.3",
         "mongo-locks": "3.0.2",
@@ -6904,6 +6905,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
       "license": "MIT"
     },
     "node_modules/https-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "global-agent": "3.0.0",
     "hapi-pino": "13.0.0",
     "hapi-pulse": "3.0.1",
+    "http-status-codes": "2.3.0",
     "https-proxy-agent": "7.0.6",
     "joi": "17.13.3",
     "mongo-locks": "3.0.2",

--- a/src/common/helpers/apply/handler.js
+++ b/src/common/helpers/apply/handler.js
@@ -1,5 +1,6 @@
 import { audit } from '@defra/cdp-auditing'
 import Boom from '@hapi/boom'
+import { StatusCodes } from 'http-status-codes'
 import {
   AUDIT_EVENT_ACTIONS,
   AUDIT_EVENT_CATEGORIES,
@@ -40,7 +41,7 @@ export function registrationAndAccreditationHandler(name, path, factory) {
           action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
         }
       })
-      return h.response().code(201)
+      return h.response().code(StatusCodes.CREATED)
     } catch (err) {
       const validationFailedForFields = getValidationFailedFields(err)
       const message = `Failure on ${path} for orgId: ${orgId} and referenceNumber: ${referenceNumber}, mongo validation failures: ${validationFailedForFields}`
@@ -52,7 +53,7 @@ export function registrationAndAccreditationHandler(name, path, factory) {
         },
         http: {
           response: {
-            status_code: 500
+            status_code: StatusCodes.INTERNAL_SERVER_ERROR
           }
         }
       })

--- a/src/common/helpers/apply/payload.js
+++ b/src/common/helpers/apply/payload.js
@@ -1,4 +1,5 @@
 import Boom from '@hapi/boom'
+import { StatusCodes } from 'http-status-codes'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES,
@@ -33,7 +34,7 @@ export function registrationAndAccreditationPayload(data, _options) {
       },
       http: {
         response: {
-          status_code: 422
+          status_code: StatusCodes.UNPROCESSABLE_ENTITY
         }
       }
     })

--- a/src/common/helpers/fail-action.js
+++ b/src/common/helpers/fail-action.js
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
@@ -13,7 +14,7 @@ export function failAction(_request, _h, error) {
     },
     http: {
       response: {
-        status_code: error?.output?.statusCode ?? 400
+        status_code: error?.output?.statusCode ?? StatusCodes.BAD_REQUEST
       }
     }
   })

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import process from 'node:process'
+import { StatusCodes } from 'http-status-codes'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
@@ -18,7 +19,8 @@ process.on('unhandledRejection', (error) => {
     },
     http: {
       response: {
-        status_code: error?.output?.status_code ?? 500
+        status_code:
+          error?.output?.status_code ?? StatusCodes.INTERNAL_SERVER_ERROR
       }
     }
   })

--- a/src/routes/v1/apply/accreditation.test.js
+++ b/src/routes/v1/apply/accreditation.test.js
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes'
 import {
   AUDIT_EVENT_ACTIONS,
   AUDIT_EVENT_CATEGORIES,
@@ -53,7 +54,7 @@ describe(`${url} route`, () => {
       payload: accreditationFixture
     })
 
-    expect(response.statusCode).toEqual(201)
+    expect(response.statusCode).toEqual(StatusCodes.CREATED)
 
     expect(mockAudit).toHaveBeenCalledWith({
       event: {
@@ -84,7 +85,7 @@ describe(`${url} route`, () => {
       payload: 'not-an-object'
     })
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(/Invalid request payload JSON format/)
   })
@@ -96,7 +97,7 @@ describe(`${url} route`, () => {
       payload: null
     })
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(/Invalid payload/)
   })
@@ -134,7 +135,7 @@ describe(`${url} route`, () => {
     const message = 'Could not extract orgId from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(422)
+    expect(response.statusCode).toEqual(StatusCodes.UNPROCESSABLE_ENTITY)
     expect(body.message).toEqual(message)
   })
 
@@ -170,12 +171,12 @@ describe(`${url} route`, () => {
     const message = 'Could not extract referenceNumber from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(422)
+    expect(response.statusCode).toEqual(StatusCodes.UNPROCESSABLE_ENTITY)
     expect(body.message).toEqual(message)
   })
 
   it('returns 500 if error is thrown by insertOne', async () => {
-    const statusCode = 500
+    const statusCode = StatusCodes.INTERNAL_SERVER_ERROR
     const error = new Error('db.collection.insertOne failed')
     mockInsertOne.mockImplementationOnce(() => {
       throw error
@@ -205,7 +206,7 @@ describe(`${url} route`, () => {
   })
 
   it('returns 500 if insertOne fails with mongo validation failures', async () => {
-    const statusCode = 500
+    const statusCode = StatusCodes.INTERNAL_SERVER_ERROR
     const error = Object.assign(new Error('db.collection.insertOne failed'), {
       errInfo: JSON.parse(
         '{"failingDocumentId":"68da86a39a36abfab162b707","details":{"operatorName":"$jsonSchema","title":"Registration Validation","schemaRulesNotSatisfied":[{"operatorName":"properties","propertiesNotSatisfied":[{"propertyName":"orgId","description":"\'orgId\' must be a positive integer above 500000 and is required","details":[{"operatorName":"minimum","specifiedAs":{"minimum":500000},"reason":"comparison failed","consideredValue":100000}]}]}]}}'

--- a/src/routes/v1/apply/organisation.js
+++ b/src/routes/v1/apply/organisation.js
@@ -1,5 +1,6 @@
 import { audit } from '@defra/cdp-auditing'
 import Boom from '@hapi/boom'
+import { StatusCodes } from 'http-status-codes'
 import { logger } from '#common/helpers/logging/logger.js'
 import {
   AUDIT_EVENT_ACTIONS,
@@ -143,7 +144,7 @@ export const organisation = {
         },
         http: {
           response: {
-            status_code: 500
+            status_code: StatusCodes.INTERNAL_SERVER_ERROR
           }
         }
       })

--- a/src/routes/v1/apply/organisation.test.js
+++ b/src/routes/v1/apply/organisation.test.js
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes'
 import {
   AUDIT_EVENT_ACTIONS,
   AUDIT_EVENT_CATEGORIES,
@@ -67,7 +68,7 @@ describe(`${url} route`, () => {
     const orgId = 500002
     const orgName = 'ACME ltd'
 
-    expect(response.statusCode).toEqual(200)
+    expect(response.statusCode).toEqual(StatusCodes.OK)
 
     expect(mockAudit).toHaveBeenCalledWith({
       event: {
@@ -116,7 +117,7 @@ describe(`${url} route`, () => {
       payload: 'not-an-object'
     })
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(/Invalid request payload JSON format/)
   })
@@ -128,7 +129,7 @@ describe(`${url} route`, () => {
       payload: null
     })
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(/Invalid payload/)
   })
@@ -166,7 +167,7 @@ describe(`${url} route`, () => {
     const message = 'Could not extract email from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(422)
+    expect(response.statusCode).toEqual(StatusCodes.UNPROCESSABLE_ENTITY)
     expect(body.message).toEqual(message)
   })
 
@@ -203,7 +204,7 @@ describe(`${url} route`, () => {
     const message = 'Could not extract organisation name from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(422)
+    expect(response.statusCode).toEqual(StatusCodes.UNPROCESSABLE_ENTITY)
     expect(body.message).toEqual(message)
   })
 
@@ -226,12 +227,12 @@ describe(`${url} route`, () => {
     const message = 'Could not get regulator name from data'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(422)
+    expect(response.statusCode).toEqual(StatusCodes.UNPROCESSABLE_ENTITY)
     expect(body.message).toEqual(message)
   })
 
   it('returns 500 if error is thrown by insertOne', async () => {
-    const statusCode = 500
+    const statusCode = StatusCodes.INTERNAL_SERVER_ERROR
     const error = new Error('db.collection.insertOne failed')
     mockInsertOne.mockImplementationOnce(() => {
       throw error
@@ -261,7 +262,7 @@ describe(`${url} route`, () => {
   })
 
   it('returns 500 if error is thrown by sendEmail', async () => {
-    const statusCode = 500
+    const statusCode = StatusCodes.INTERNAL_SERVER_ERROR
     const error = new Error('Notify API failed')
     sendEmail.mockRejectedValueOnce(error)
 

--- a/src/routes/v1/apply/registration.test.js
+++ b/src/routes/v1/apply/registration.test.js
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes'
 import {
   AUDIT_EVENT_ACTIONS,
   AUDIT_EVENT_CATEGORIES,
@@ -53,7 +54,7 @@ describe(`${url} route`, () => {
       payload: registrationFixture
     })
 
-    expect(response.statusCode).toEqual(201)
+    expect(response.statusCode).toEqual(StatusCodes.CREATED)
 
     expect(mockAudit).toHaveBeenCalledWith({
       event: {
@@ -84,7 +85,7 @@ describe(`${url} route`, () => {
       payload: 'not-an-object'
     })
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(/Invalid request payload JSON format/)
   })
@@ -96,7 +97,7 @@ describe(`${url} route`, () => {
       payload: null
     })
 
-    expect(response.statusCode).toEqual(400)
+    expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(/Invalid payload/)
   })
@@ -134,7 +135,7 @@ describe(`${url} route`, () => {
     const message = 'Could not extract orgId from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(422)
+    expect(response.statusCode).toEqual(StatusCodes.UNPROCESSABLE_ENTITY)
     expect(body.message).toEqual(message)
   })
 
@@ -170,7 +171,7 @@ describe(`${url} route`, () => {
     const message = 'Could not extract referenceNumber from answers'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(422)
+    expect(response.statusCode).toEqual(StatusCodes.UNPROCESSABLE_ENTITY)
     expect(body.message).toEqual(message)
   })
 
@@ -214,7 +215,7 @@ describe(`${url} route`, () => {
     const message = 'Organisation ID must be at least 500000'
     const body = JSON.parse(response.payload)
 
-    expect(response.statusCode).toEqual(422)
+    expect(response.statusCode).toEqual(StatusCodes.UNPROCESSABLE_ENTITY)
     expect(body.message).toEqual(message)
     expect(mockLoggerWarn).toHaveBeenCalledWith({
       message:
@@ -225,14 +226,14 @@ describe(`${url} route`, () => {
       },
       http: {
         response: {
-          status_code: 422
+          status_code: StatusCodes.UNPROCESSABLE_ENTITY
         }
       }
     })
   })
 
   it('returns 500 if error is thrown by insertOne', async () => {
-    const statusCode = 500
+    const statusCode = StatusCodes.INTERNAL_SERVER_ERROR
     const error = new Error('db.collection.insertOne failed')
     mockInsertOne.mockImplementationOnce(() => {
       throw error
@@ -262,7 +263,7 @@ describe(`${url} route`, () => {
   })
 
   it('returns 500 if insertOne fails with mongo validation failures', async () => {
-    const statusCode = 500
+    const statusCode = StatusCodes.INTERNAL_SERVER_ERROR
     const error = Object.assign(new Error('db.collection.insertOne failed'), {
       errInfo: JSON.parse(
         '{"failingDocumentId":"68da86a39a36abfab162b707","details":{"operatorName":"$jsonSchema","title":"Registration Validation","schemaRulesNotSatisfied":[{"operatorName":"properties","propertiesNotSatisfied":[{"propertyName":"orgId","description":"\'orgId\' must be a positive integer above 500000 and is required","details":[{"operatorName":"minimum","specifiedAs":{"minimum":500000},"reason":"comparison failed","consideredValue":100000}]}]}]}}'

--- a/src/routes/v1/organisations/registrations/summary-logs/validate.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/validate.js
@@ -1,4 +1,5 @@
 import Boom from '@hapi/boom'
+import { StatusCodes } from 'http-status-codes'
 import { logger } from '#common/helpers/logging/logger.js'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -85,7 +86,7 @@ export const summaryLogsValidate = {
         .response({
           status: 'validating'
         })
-        .code(202)
+        .code(StatusCodes.ACCEPTED)
     } catch (err) {
       const message = `Failure on ${summaryLogsValidatePath}`
 
@@ -97,7 +98,7 @@ export const summaryLogsValidate = {
         },
         http: {
           response: {
-            status_code: 500
+            status_code: StatusCodes.INTERNAL_SERVER_ERROR
           }
         }
       })

--- a/src/routes/v1/organisations/registrations/summary-logs/validate.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/validate.test.js
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
@@ -50,7 +51,7 @@ describe(`${url} route`, () => {
       payload
     })
 
-    expect(response.statusCode).toBe(202)
+    expect(response.statusCode).toBe(StatusCodes.ACCEPTED)
 
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -70,7 +71,7 @@ describe(`${url} route`, () => {
       payload: 'not-an-object'
     })
 
-    expect(response.statusCode).toBe(400)
+    expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(/Invalid request payload JSON format/)
   })
@@ -82,7 +83,7 @@ describe(`${url} route`, () => {
       payload: null
     })
 
-    expect(response.statusCode).toBe(400)
+    expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(/Invalid payload/)
   })
@@ -101,13 +102,13 @@ describe(`${url} route`, () => {
 
       const body = JSON.parse(response.payload)
 
-      expect(response.statusCode).toBe(422)
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
       expect(body.message).toEqual(`${key} is missing in body.data`)
     }
   )
 
   it('returns 500 if error is thrown', async () => {
-    const statusCode = 500
+    const statusCode = StatusCodes.INTERNAL_SERVER_ERROR
     const error = new Error('logging failed')
     mockLoggerInfo.mockImplementationOnce(() => {
       throw error


### PR DESCRIPTION
## Summary

Replaced all hard-coded HTTP status code numbers with named constants from the `http-status-codes` package to improve code readability and maintainability.

## Changes

- Added `http-status-codes` package as a dependency
- Replaced numeric status codes throughout the codebase:
  - `200` → `StatusCodes.OK`
  - `201` → `StatusCodes.CREATED`
  - `202` → `StatusCodes.ACCEPTED`
  - `400` → `StatusCodes.BAD_REQUEST`
  - `422` → `StatusCodes.UNPROCESSABLE_ENTITY`
  - `500` → `StatusCodes.INTERNAL_SERVER_ERROR`
- Updated source files: `index.js`, `fail-action.js`, `handler.js`, `payload.js`, `organisation.js`, `validate.js`
- Updated test files: `registration.test.js`, `organisation.test.js`, `accreditation.test.js`, `validate.test.js`

## Why

Using named constants instead of magic numbers makes the code more self-documenting and reduces the risk of errors. When developers see `StatusCodes.UNPROCESSABLE_ENTITY`, the intent is immediately clear, whereas `422` requires domain knowledge to understand.

## Test Results

All 99 tests passing with 100% code coverage maintained.