### PR TITLE
PAE-296: Make S3 fields conditionally required based on file status

### DIFF
--- a/src/repositories/summary-logs-repository.contract.js
+++ b/src/repositories/summary-logs-repository.contract.js
@@ -66,8 +66,8 @@ const testInsertBehaviour = (getRepository) => {
   })
 }
 
-const testFindBySummaryLogIdBehaviour = (getRepository) => {
-  describe('findBySummaryLogId', () => {
+const testFindBySummaryLogIdNotFound = (getRepository) => {
+  describe('findBySummaryLogId - not found', () => {
     const repository = () => getRepository()
 
     it('returns null when summary log ID not found', async () => {
@@ -113,6 +113,12 @@ const testFindBySummaryLogIdBehaviour = (getRepository) => {
       expect(result.summaryLogId).toBe(summaryLogIdA)
       expect(result.organisationId).toBe('org-1')
     })
+  })
+}
+
+const testFindBySummaryLogIdRetrieval = (getRepository) => {
+  describe('findBySummaryLogId - retrieval', () => {
+    const repository = () => getRepository()
 
     it('can retrieve a log by summary log ID after insert', async () => {
       const summaryLogId = `contract-summary-${randomUUID()}`
@@ -180,8 +186,8 @@ const testInsertValidationRequiredFields = (getRepository) => {
   })
 }
 
-const testInsertValidationFieldRules = (getRepository) => {
-  describe('insert validation - field rules', () => {
+const testInsertValidationFieldHandling = (getRepository) => {
+  describe('insert validation - field handling', () => {
     const repository = () => getRepository()
 
     it('rejects insert with invalid file.status', async () => {
@@ -242,6 +248,12 @@ const testInsertValidationFieldRules = (getRepository) => {
         'insertedId'
       )
     })
+  })
+}
+
+const testInsertValidationStatusBasedS3 = (getRepository) => {
+  describe('insert validation - status-based S3 requirements', () => {
+    const repository = () => getRepository()
 
     it('accepts rejected file without S3 info', async () => {
       const summaryLogId = `contract-rejected-no-s3-${randomUUID()}`
@@ -306,8 +318,10 @@ export const testSummaryLogsRepositoryContract = (createRepository) => {
     })
 
     testInsertBehaviour(() => repository)
-    testFindBySummaryLogIdBehaviour(() => repository)
+    testFindBySummaryLogIdNotFound(() => repository)
+    testFindBySummaryLogIdRetrieval(() => repository)
     testInsertValidationRequiredFields(() => repository)
-    testInsertValidationFieldRules(() => repository)
+    testInsertValidationFieldHandling(() => repository)
+    testInsertValidationStatusBasedS3(() => repository)
   })
 }

--- a/src/repositories/summary-logs-repository.contract.js
+++ b/src/repositories/summary-logs-repository.contract.js
@@ -275,6 +275,25 @@ const testInsertValidationFieldRules = (getRepository) => {
         /Invalid summary log data.*s3/
       )
     })
+
+    it('accepts pending file without S3 info', async () => {
+      const summaryLogId = `contract-pending-no-s3-${randomUUID()}`
+      const pendingLog = {
+        summaryLogId,
+        file: {
+          id: `file-pending-${randomUUID()}`,
+          name: 'scanning.xlsx',
+          status: 'pending'
+        }
+      }
+
+      const result = await repository().insert(pendingLog)
+      expect(result.insertedId).toBeTruthy()
+
+      const found = await repository().findBySummaryLogId(summaryLogId)
+      expect(found.file.status).toBe('pending')
+      expect(found.file.s3).toBeUndefined()
+    })
   })
 }
 

--- a/src/repositories/summary-logs-repository.contract.js
+++ b/src/repositories/summary-logs-repository.contract.js
@@ -16,8 +16,6 @@ const buildMinimalSummaryLog = (fileOverrides = {}) => ({
 
 const testInsertBehaviour = (getRepository) => {
   describe('insert', () => {
-    const repository = () => getRepository()
-
     it('inserts a summary log and returns result with insertedId', async () => {
       const fileId = `contract-insert-${randomUUID()}`
       const summaryLog = {
@@ -33,7 +31,7 @@ const testInsertBehaviour = (getRepository) => {
         }
       }
 
-      const result = await repository().insert(summaryLog)
+      const result = await getRepository().insert(summaryLog)
 
       expect(result).toHaveProperty('insertedId')
       expect(result.insertedId).toBeTruthy()
@@ -55,8 +53,8 @@ const testInsertBehaviour = (getRepository) => {
         }
       }
 
-      await repository().insert(summaryLog)
-      const found = await repository().findBySummaryLogId(summaryLogId)
+      await getRepository().insert(summaryLog)
+      const found = await getRepository().findBySummaryLogId(summaryLogId)
 
       expect(found).toBeTruthy()
       expect(found.summaryLogId).toBe(summaryLogId)
@@ -68,11 +66,9 @@ const testInsertBehaviour = (getRepository) => {
 
 const testFindBySummaryLogIdNotFound = (getRepository) => {
   describe('findBySummaryLogId - not found', () => {
-    const repository = () => getRepository()
-
     it('returns null when summary log ID not found', async () => {
       const summaryLogId = `contract-nonexistent-${randomUUID()}`
-      const result = await repository().findBySummaryLogId(summaryLogId)
+      const result = await getRepository().findBySummaryLogId(summaryLogId)
 
       expect(result).toBeNull()
     })
@@ -81,7 +77,7 @@ const testFindBySummaryLogIdNotFound = (getRepository) => {
       const summaryLogIdA = `contract-summary-a-${randomUUID()}`
       const summaryLogIdB = `contract-summary-b-${randomUUID()}`
 
-      await repository().insert({
+      await getRepository().insert({
         summaryLogId: summaryLogIdA,
         organisationId: 'org-1',
         registrationId: 'reg-1',
@@ -94,7 +90,7 @@ const testFindBySummaryLogIdNotFound = (getRepository) => {
           }
         }
       })
-      await repository().insert({
+      await getRepository().insert({
         summaryLogId: summaryLogIdB,
         organisationId: 'org-2',
         registrationId: 'reg-2',
@@ -108,7 +104,7 @@ const testFindBySummaryLogIdNotFound = (getRepository) => {
         }
       })
 
-      const result = await repository().findBySummaryLogId(summaryLogIdA)
+      const result = await getRepository().findBySummaryLogId(summaryLogIdA)
 
       expect(result.summaryLogId).toBe(summaryLogIdA)
       expect(result.organisationId).toBe('org-1')
@@ -118,13 +114,11 @@ const testFindBySummaryLogIdNotFound = (getRepository) => {
 
 const testFindBySummaryLogIdRetrieval = (getRepository) => {
   describe('findBySummaryLogId - retrieval', () => {
-    const repository = () => getRepository()
-
     it('can retrieve a log by summary log ID after insert', async () => {
       const summaryLogId = `contract-summary-${randomUUID()}`
       const fileId = `contract-file-${randomUUID()}`
 
-      await repository().insert({
+      await getRepository().insert({
         summaryLogId,
         file: {
           id: fileId,
@@ -137,7 +131,7 @@ const testFindBySummaryLogIdRetrieval = (getRepository) => {
         }
       })
 
-      const result = await repository().findBySummaryLogId(summaryLogId)
+      const result = await getRepository().findBySummaryLogId(summaryLogId)
 
       expect(result).toBeTruthy()
       expect(result.summaryLogId).toBe(summaryLogId)
@@ -150,18 +144,16 @@ const testFindBySummaryLogIdRetrieval = (getRepository) => {
 
 const testInsertValidationRequiredFields = (getRepository) => {
   describe('insert validation - required fields', () => {
-    const repository = () => getRepository()
-
     it('rejects insert with missing file.id', async () => {
       const logWithMissingId = buildMinimalSummaryLog({ id: null })
-      await expect(repository().insert(logWithMissingId)).rejects.toThrow(
+      await expect(getRepository().insert(logWithMissingId)).rejects.toThrow(
         /Invalid summary log data.*id/
       )
     })
 
     it('rejects insert with missing file.name', async () => {
       const logWithMissingName = buildMinimalSummaryLog({ name: null })
-      await expect(repository().insert(logWithMissingName)).rejects.toThrow(
+      await expect(getRepository().insert(logWithMissingName)).rejects.toThrow(
         /Invalid summary log data.*name/
       )
     })
@@ -170,16 +162,16 @@ const testInsertValidationRequiredFields = (getRepository) => {
       const logWithMissingBucket = buildMinimalSummaryLog({
         s3: { bucket: null, key: 'key' }
       })
-      await expect(repository().insert(logWithMissingBucket)).rejects.toThrow(
-        /Invalid summary log data.*bucket/
-      )
+      await expect(
+        getRepository().insert(logWithMissingBucket)
+      ).rejects.toThrow(/Invalid summary log data.*bucket/)
     })
 
     it('rejects insert with missing file.s3.key', async () => {
       const logWithMissingKey = buildMinimalSummaryLog({
         s3: { bucket: 'bucket', key: null }
       })
-      await expect(repository().insert(logWithMissingKey)).rejects.toThrow(
+      await expect(getRepository().insert(logWithMissingKey)).rejects.toThrow(
         /Invalid summary log data.*key/
       )
     })
@@ -188,16 +180,14 @@ const testInsertValidationRequiredFields = (getRepository) => {
 
 const testInsertValidationFieldHandling = (getRepository) => {
   describe('insert validation - field handling', () => {
-    const repository = () => getRepository()
-
     it('rejects insert with invalid file.status', async () => {
       const logWithInvalidStatus = buildMinimalSummaryLog({
         id: `contract-invalid-status-${randomUUID()}`,
         status: 'invalid-status'
       })
-      await expect(repository().insert(logWithInvalidStatus)).rejects.toThrow(
-        /Invalid summary log data.*status/
-      )
+      await expect(
+        getRepository().insert(logWithInvalidStatus)
+      ).rejects.toThrow(/Invalid summary log data.*status/)
     })
 
     it('strips unknown fields from insert', async () => {
@@ -211,8 +201,8 @@ const testInsertValidationFieldHandling = (getRepository) => {
         })
       }
 
-      await repository().insert(logWithUnknownFields)
-      const found = await repository().findBySummaryLogId(summaryLogId)
+      await getRepository().insert(logWithUnknownFields)
+      const found = await getRepository().findBySummaryLogId(summaryLogId)
 
       expect(found.hackerField).toBeUndefined()
       expect(found.anotherBadField).toBeUndefined()
@@ -222,7 +212,7 @@ const testInsertValidationFieldHandling = (getRepository) => {
       const fileId = `contract-minimal-${randomUUID()}`
       const minimalLog = buildMinimalSummaryLog({ id: fileId })
 
-      const result = await repository().insert(minimalLog)
+      const result = await getRepository().insert(minimalLog)
       expect(result.insertedId).toBeTruthy()
     })
 
@@ -241,10 +231,10 @@ const testInsertValidationFieldHandling = (getRepository) => {
         }
       }
 
-      await expect(repository().insert(completeLog)).resolves.toHaveProperty(
+      await expect(getRepository().insert(completeLog)).resolves.toHaveProperty(
         'insertedId'
       )
-      await expect(repository().insert(rejectedLog)).resolves.toHaveProperty(
+      await expect(getRepository().insert(rejectedLog)).resolves.toHaveProperty(
         'insertedId'
       )
     })
@@ -253,8 +243,6 @@ const testInsertValidationFieldHandling = (getRepository) => {
 
 const testInsertValidationStatusBasedS3 = (getRepository) => {
   describe('insert validation - status-based S3 requirements', () => {
-    const repository = () => getRepository()
-
     it('accepts rejected file without S3 info', async () => {
       const summaryLogId = `contract-rejected-no-s3-${randomUUID()}`
       const rejectedLog = {
@@ -266,10 +254,10 @@ const testInsertValidationStatusBasedS3 = (getRepository) => {
         }
       }
 
-      const result = await repository().insert(rejectedLog)
+      const result = await getRepository().insert(rejectedLog)
       expect(result.insertedId).toBeTruthy()
 
-      const found = await repository().findBySummaryLogId(summaryLogId)
+      const found = await getRepository().findBySummaryLogId(summaryLogId)
       expect(found.file.status).toBe('rejected')
       expect(found.file.s3).toBeUndefined()
     })
@@ -283,9 +271,9 @@ const testInsertValidationStatusBasedS3 = (getRepository) => {
         }
       }
 
-      await expect(repository().insert(completeLogWithoutS3)).rejects.toThrow(
-        /Invalid summary log data.*s3/
-      )
+      await expect(
+        getRepository().insert(completeLogWithoutS3)
+      ).rejects.toThrow(/Invalid summary log data.*s3/)
     })
 
     it('accepts pending file without S3 info', async () => {
@@ -299,10 +287,10 @@ const testInsertValidationStatusBasedS3 = (getRepository) => {
         }
       }
 
-      const result = await repository().insert(pendingLog)
+      const result = await getRepository().insert(pendingLog)
       expect(result.insertedId).toBeTruthy()
 
-      const found = await repository().findBySummaryLogId(summaryLogId)
+      const found = await getRepository().findBySummaryLogId(summaryLogId)
       expect(found.file.status).toBe('pending')
       expect(found.file.s3).toBeUndefined()
     })

--- a/src/repositories/summary-logs-repository.validation.js
+++ b/src/repositories/summary-logs-repository.validation.js
@@ -10,7 +10,11 @@ const summaryLogInsertSchema = Joi.object({
     s3: Joi.object({
       bucket: Joi.string().required(),
       key: Joi.string().required()
-    }).required()
+    }).when('status', {
+      is: 'complete',
+      then: Joi.required(),
+      otherwise: Joi.optional()
+    })
   }).required(),
   organisationId: Joi.string().optional(),
   registrationId: Joi.string().optional()

--- a/src/repositories/summary-logs-repository.validation.js
+++ b/src/repositories/summary-logs-repository.validation.js
@@ -6,7 +6,7 @@ const summaryLogInsertSchema = Joi.object({
   file: Joi.object({
     id: Joi.string().required(),
     name: Joi.string().required(),
-    status: Joi.string().valid('complete', 'rejected').optional(),
+    status: Joi.string().valid('complete', 'pending', 'rejected').optional(),
     s3: Joi.object({
       bucket: Joi.string().required(),
       key: Joi.string().required()

--- a/src/routes/v1/organisations/registrations/summary-logs/upload-completed.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/upload-completed.js
@@ -10,8 +10,16 @@ const uploadCompletedPayloadSchema = Joi.object({
       fileId: Joi.string().required(),
       filename: Joi.string().required(),
       fileStatus: Joi.string().valid('complete', 'rejected').required(),
-      s3Bucket: Joi.string().required(),
-      s3Key: Joi.string().required()
+      s3Bucket: Joi.string().when('fileStatus', {
+        is: 'complete',
+        then: Joi.required(),
+        otherwise: Joi.optional()
+      }),
+      s3Key: Joi.string().when('fileStatus', {
+        is: 'complete',
+        then: Joi.required(),
+        otherwise: Joi.optional()
+      })
     })
       .required()
       .unknown(true)
@@ -52,17 +60,22 @@ export const summaryLogsUploadCompleted = {
       file: { fileId, filename, fileStatus, s3Bucket, s3Key }
     } = payload.form
 
+    const fileData = {
+      id: fileId,
+      name: filename,
+      status: fileStatus
+    }
+
+    if (fileStatus === 'complete' && s3Bucket && s3Key) {
+      fileData.s3 = {
+        bucket: s3Bucket,
+        key: s3Key
+      }
+    }
+
     await summaryLogsRepository.insert({
       summaryLogId,
-      file: {
-        id: fileId,
-        name: filename,
-        status: fileStatus,
-        s3: {
-          bucket: s3Bucket,
-          key: s3Key
-        }
-      }
+      file: fileData
     })
 
     return h.response().code(StatusCodes.OK)

--- a/src/routes/v1/organisations/registrations/summary-logs/upload-completed.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/upload-completed.js
@@ -68,7 +68,7 @@ export const summaryLogsUploadCompleted = {
       status: fileStatus
     }
 
-    if (fileStatus === 'complete' && s3Bucket && s3Key) {
+    if (fileStatus === 'complete') {
       fileData.s3 = {
         bucket: s3Bucket,
         key: s3Key

--- a/src/routes/v1/organisations/registrations/summary-logs/upload-completed.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/upload-completed.js
@@ -9,7 +9,9 @@ const uploadCompletedPayloadSchema = Joi.object({
     file: Joi.object({
       fileId: Joi.string().required(),
       filename: Joi.string().required(),
-      fileStatus: Joi.string().valid('complete', 'rejected').required(),
+      fileStatus: Joi.string()
+        .valid('complete', 'pending', 'rejected')
+        .required(),
       s3Bucket: Joi.string().when('fileStatus', {
         is: 'complete',
         then: Joi.required(),

--- a/src/routes/v1/organisations/registrations/summary-logs/upload-completed.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/upload-completed.test.js
@@ -144,4 +144,30 @@ describe(`${url} route`, () => {
     const body = JSON.parse(response.payload)
     expect(body.message).toContain('s3Bucket')
   })
+
+  it('returns 200 when file is pending without S3 info', async () => {
+    const pendingPayload = {
+      uploadStatus: 'ready',
+      metadata: {
+        organisationId: 'org-123',
+        registrationId: 'reg-456'
+      },
+      form: {
+        file: {
+          fileId: 'file-pending-123',
+          filename: 'scanning.xlsx',
+          fileStatus: 'pending'
+        }
+      },
+      numberOfRejectedFiles: 0
+    }
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/v1/organisations/org-123/registrations/reg-456/summary-logs/summary-123/upload-completed',
+      payload: pendingPayload
+    })
+
+    expect(response.statusCode).toBe(200)
+  })
 })

--- a/src/routes/v1/organisations/registrations/summary-logs/upload-completed.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/upload-completed.test.js
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes'
 import { summaryLogsUploadCompletedPath } from './upload-completed.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs-repository.inmemory.js'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
@@ -57,7 +58,7 @@ describe(`${url} route`, () => {
       payload
     })
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(StatusCodes.OK)
   })
 
   it('returns 400 if payload is not an object', async () => {
@@ -67,7 +68,7 @@ describe(`${url} route`, () => {
       payload: 'not-an-object'
     })
 
-    expect(response.statusCode).toBe(400)
+    expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
     const body = JSON.parse(response.payload)
     expect(body.message).toMatch(/Invalid request payload JSON format/)
   })
@@ -79,7 +80,7 @@ describe(`${url} route`, () => {
       payload: null
     })
 
-    expect(response.statusCode).toBe(422)
+    expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
   })
 
   it('returns 422 if payload is missing form.file', async () => {
@@ -91,7 +92,7 @@ describe(`${url} route`, () => {
       }
     })
 
-    expect(response.statusCode).toBe(422)
+    expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
     const body = JSON.parse(response.payload)
     expect(body.message).toContain('"form" is required')
   })
@@ -119,7 +120,7 @@ describe(`${url} route`, () => {
       payload: rejectedPayload
     })
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(StatusCodes.OK)
   })
 
   it('returns 422 when file is complete but missing S3 info', async () => {
@@ -140,7 +141,7 @@ describe(`${url} route`, () => {
       payload: incompletePayload
     })
 
-    expect(response.statusCode).toBe(422)
+    expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
     const body = JSON.parse(response.payload)
     expect(body.message).toContain('s3Bucket')
   })
@@ -168,6 +169,6 @@ describe(`${url} route`, () => {
       payload: pendingPayload
     })
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(StatusCodes.OK)
   })
 })

--- a/src/routes/v1/organisations/registrations/summary-logs/upload-completed.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/upload-completed.test.js
@@ -95,4 +95,53 @@ describe(`${url} route`, () => {
     const body = JSON.parse(response.payload)
     expect(body.message).toContain('"form" is required')
   })
+
+  it('returns 200 when file is rejected without S3 info', async () => {
+    const rejectedPayload = {
+      uploadStatus: 'ready',
+      metadata: {
+        organisationId: 'org-123',
+        registrationId: 'reg-456'
+      },
+      form: {
+        file: {
+          fileId: 'file-rejected-123',
+          filename: 'virus.xlsx',
+          fileStatus: 'rejected'
+        }
+      },
+      numberOfRejectedFiles: 1
+    }
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/v1/organisations/org-123/registrations/reg-456/summary-logs/summary-123/upload-completed',
+      payload: rejectedPayload
+    })
+
+    expect(response.statusCode).toBe(200)
+  })
+
+  it('returns 422 when file is complete but missing S3 info', async () => {
+    const incompletePayload = {
+      uploadStatus: 'ready',
+      form: {
+        file: {
+          fileId: 'file-incomplete-123',
+          filename: 'test.xlsx',
+          fileStatus: 'complete'
+        }
+      }
+    }
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/v1/organisations/org-123/registrations/reg-456/summary-logs/summary-123/upload-completed',
+      payload: incompletePayload
+    })
+
+    expect(response.statusCode).toBe(422)
+    const body = JSON.parse(response.payload)
+    expect(body.message).toContain('s3Bucket')
+  })
 })

--- a/src/routes/v1/organisations/registrations/summary-logs/upload-completed.validation.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/upload-completed.validation.test.js
@@ -131,7 +131,7 @@ describe('POST upload-completed validation', () => {
 
     expect(response.statusCode).toBe(422)
     expect(response.result.message).toContain(
-      '"form.file.fileStatus" must be one of [complete, rejected]'
+      '"form.file.fileStatus" must be one of [complete, pending, rejected]'
     )
   })
 


### PR DESCRIPTION
Ticket: [PAE-296](https://eaflood.atlassian.net/browse/PAE-296)
## What changed

Updated validation schemas for summary log file uploads to handle different file statuses from CDP Uploader:

- Made S3 fields (`s3Bucket`, `s3Key`) conditionally required using discriminated unions
- S3 fields are **required** when `fileStatus` is `'complete'`
- S3 fields are **optional** when `fileStatus` is `'rejected'` or `'pending'`
- Added `'pending'` status for defensive handling

## Why

CDP Uploader only includes S3 bucket/key information when files are successfully scanned (`complete` status). Rejected files (virus detected, validation failures) don't have S3 info because they're never stored. The previous validation required S3 fields for all statuses, which would cause the callback endpoint to fail when receiving rejected files.

## Test plan

- [x] All existing tests pass (62 summary-logs tests)
- [x] Added tests for rejected files without S3 info
- [x] Added tests for pending files without S3 info
- [x] Added test ensuring S3 required for complete status
- [x] Replaced magic status code numbers with StatusCodes constants

[PAE-296]: https://eaflood.atlassian.net/browse/PAE-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ