### PR TITLE
PAE-1312: Split unapproved overseas sites in report aggregation

### DIFF
--- a/src/reports/domain/aggregation/aggregate-report-detail.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.js
@@ -19,7 +19,8 @@ import { aggregateWasteSentOn } from './aggregate-waste-sent-on.js'
 
 /**
  * @typedef {Object} AggregatedExportActivity
- * @property {Array<{orsId: string, siteName: string|null, country: string|null}>} overseasSites
+ * @property {Array<{orsId: string, siteName: string, country: string|null, tonnageExported: number}>} overseasSites
+ * @property {Array<{orsId: string, tonnageExported: number}>} unapprovedOverseasSites
  * @property {number} totalTonnageExported
  * @property {number} tonnageReceivedNotExported
  * @property {number} tonnageRefusedAtDestination

--- a/src/reports/domain/aggregation/aggregate-report-detail.test.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.test.js
@@ -453,7 +453,7 @@ describe('#aggregateReportDetail', () => {
       expect(result.exportActivity.totalTonnageExported).toBe(11.47)
     })
 
-    it('extracts overseas sites from exported records', () => {
+    it('routes unresolved ORS IDs to unapprovedOverseasSites and keeps overseasSites empty', () => {
       const records = [
         buildExportedRecord({
           OSR_NAME: 'EuroPlast Recycling GmbH',
@@ -468,10 +468,113 @@ describe('#aggregateReportDetail', () => {
 
       const result = aggregateReportDetail(records, exporterArgs)
 
-      expect(result.exportActivity.overseasSites).toStrictEqual([
-        { orsId: '001', siteName: null, country: null, tonnageExported: 5 },
-        { orsId: '096', siteName: null, country: null, tonnageExported: 5 }
+      expect(result.exportActivity.overseasSites).toStrictEqual([])
+      expect(result.exportActivity.unapprovedOverseasSites).toStrictEqual([
+        { orsId: '001', tonnageExported: 5 },
+        { orsId: '096', tonnageExported: 5 }
       ])
+    })
+
+    it('splits approved and unapproved ORS entries by whether a siteName is resolved', () => {
+      const records = [
+        buildExportedRecord({
+          OSR_ID: '001',
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 5
+        }),
+        buildExportedRecord({
+          DATE_OF_EXPORT: '2026-02-10',
+          OSR_ID: '096',
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 3
+        }),
+        buildExportedRecord({
+          DATE_OF_EXPORT: '2026-03-01',
+          OSR_ID: '200',
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 7
+        })
+      ]
+      const orsDetailsMap = new Map([
+        ['001', { siteName: 'EuroPlast GmbH', country: 'Germany' }],
+        ['096', { siteName: null, country: null }]
+      ])
+
+      const result = aggregateReportDetail(records, {
+        ...exporterArgs,
+        orsDetailsMap
+      })
+
+      expect(result.exportActivity.overseasSites).toStrictEqual([
+        {
+          orsId: '001',
+          siteName: 'EuroPlast GmbH',
+          country: 'Germany',
+          tonnageExported: 5
+        }
+      ])
+      expect(result.exportActivity.unapprovedOverseasSites).toStrictEqual([
+        { orsId: '096', tonnageExported: 3 },
+        { orsId: '200', tonnageExported: 7 }
+      ])
+    })
+
+    it('sums tonnage for duplicate unapproved ORS IDs', () => {
+      const records = [
+        buildExportedRecord({
+          OSR_ID: '500',
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 4
+        }),
+        buildExportedRecord({
+          DATE_OF_EXPORT: '2026-02-10',
+          OSR_ID: '500',
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 2.5
+        }),
+        buildExportedRecord({
+          DATE_OF_EXPORT: '2026-03-05',
+          OSR_ID: '500',
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 1.25
+        })
+      ]
+
+      const result = aggregateReportDetail(records, exporterArgs)
+
+      expect(result.exportActivity.unapprovedOverseasSites).toStrictEqual([
+        { orsId: '500', tonnageExported: 7.75 }
+      ])
+    })
+
+    it('has overseasSites and unapprovedOverseasSites tonnages that together equal totalTonnageExported', () => {
+      const records = [
+        buildExportedRecord({
+          OSR_ID: '001',
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 10
+        }),
+        buildExportedRecord({
+          DATE_OF_EXPORT: '2026-02-10',
+          OSR_ID: '999',
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 15
+        })
+      ]
+      const orsDetailsMap = new Map([
+        ['001', { siteName: 'EuroPlast GmbH', country: 'Germany' }]
+      ])
+
+      const result = aggregateReportDetail(records, {
+        ...exporterArgs,
+        orsDetailsMap
+      })
+
+      const approvedTotal = result.exportActivity.overseasSites.reduce(
+        (sum, s) => sum + s.tonnageExported,
+        0
+      )
+      const unapprovedTotal =
+        result.exportActivity.unapprovedOverseasSites.reduce(
+          (sum, s) => sum + s.tonnageExported,
+          0
+        )
+
+      expect(approvedTotal + unapprovedTotal).toBe(
+        result.exportActivity.totalTonnageExported
+      )
     })
 
     it('populates siteName and country from orsDetailsMap', () => {
@@ -567,10 +670,18 @@ describe('#aggregateReportDetail', () => {
           OSR_ID: '096'
         })
       ]
+      const orsDetailsMap = new Map([
+        ['001', { siteName: 'EuroPlast Recycling GmbH', country: 'Germany' }],
+        ['096', { siteName: 'RecyclePlast SA', country: 'France' }]
+      ])
 
-      const result = aggregateReportDetail(records, exporterArgs)
+      const result = aggregateReportDetail(records, {
+        ...exporterArgs,
+        orsDetailsMap
+      })
 
       expect(result.exportActivity.overseasSites).toHaveLength(2)
+      expect(result.exportActivity.unapprovedOverseasSites).toHaveLength(0)
     })
 
     it('returns empty wasteExported when no exported records match', () => {
@@ -578,6 +689,7 @@ describe('#aggregateReportDetail', () => {
 
       expect(result.exportActivity.totalTonnageExported).toBe(0)
       expect(result.exportActivity.overseasSites).toStrictEqual([])
+      expect(result.exportActivity.unapprovedOverseasSites).toStrictEqual([])
       expect(result.exportActivity.tonnageRefusedAtDestination).toBe(0)
       expect(result.exportActivity.tonnageStoppedDuringExport).toBe(0)
       expect(result.exportActivity.totalTonnageRefusedOrStopped).toBe(0)
@@ -813,7 +925,7 @@ describe('#aggregateReportDetail', () => {
       expect(february.exportActivity.totalTonnageExported).toBe(40)
     })
 
-    it('returns overseas sites with orsId only when OSR_NAME is absent', () => {
+    it('routes unresolved ORS IDs to unapprovedOverseasSites for accredited exporter', () => {
       const records = [
         buildAccreditedExportedRecord({ OSR_ID: '001' }),
         buildAccreditedExportedRecord({
@@ -824,9 +936,10 @@ describe('#aggregateReportDetail', () => {
 
       const result = aggregateReportDetail(records, accreditedExporterArgs)
 
-      expect(result.exportActivity.overseasSites).toStrictEqual([
-        { orsId: '001', siteName: null, country: null, tonnageExported: 48 },
-        { orsId: '096', siteName: null, country: null, tonnageExported: 48 }
+      expect(result.exportActivity.overseasSites).toStrictEqual([])
+      expect(result.exportActivity.unapprovedOverseasSites).toStrictEqual([
+        { orsId: '001', tonnageExported: 48 },
+        { orsId: '096', tonnageExported: 48 }
       ])
     })
 

--- a/src/reports/domain/aggregation/aggregate-report-detail.test.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.test.js
@@ -545,16 +545,27 @@ describe('#aggregateReportDetail', () => {
       const records = [
         buildExportedRecord({
           OSR_ID: '001',
-          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 10
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 1.01
+        }),
+        buildExportedRecord({
+          DATE_OF_EXPORT: '2026-02-01',
+          OSR_ID: '002',
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 2.02
         }),
         buildExportedRecord({
           DATE_OF_EXPORT: '2026-02-10',
+          OSR_ID: '998',
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 3.03
+        }),
+        buildExportedRecord({
+          DATE_OF_EXPORT: '2026-03-01',
           OSR_ID: '999',
-          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 15
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 4.04
         })
       ]
       const orsDetailsMap = new Map([
-        ['001', { siteName: 'EuroPlast GmbH', country: 'Germany' }]
+        ['001', { siteName: 'EuroPlast GmbH', country: 'Germany' }],
+        ['002', { siteName: 'RecyclePlast SA', country: 'France' }]
       ])
 
       const result = aggregateReportDetail(records, {
@@ -572,9 +583,12 @@ describe('#aggregateReportDetail', () => {
           0
         )
 
-      expect(approvedTotal + unapprovedTotal).toBe(
-        result.exportActivity.totalTonnageExported
+      expect(approvedTotal + unapprovedTotal).toBeCloseTo(
+        result.exportActivity.totalTonnageExported,
+        2
       )
+      expect(result.exportActivity.overseasSites).toHaveLength(2)
+      expect(result.exportActivity.unapprovedOverseasSites).toHaveLength(2)
     })
 
     it('populates siteName and country from orsDetailsMap', () => {

--- a/src/reports/domain/aggregation/aggregate-waste-exported.js
+++ b/src/reports/domain/aggregation/aggregate-waste-exported.js
@@ -14,24 +14,52 @@ const ZERO = '0'
 
 const zeroPadOrsId = (orsId) => String(orsId).padStart(ORS_ID_DIGITS, ZERO)
 
-const generateOverseasSiteSummary = (wasteExportedRecords, orsDetailsMap) => {
-  // OSR_ID is wrongly named, it should be ORS_ID but its a significant amount of work to correct that.
-  return groupAndSum(
-    wasteExportedRecords.filter(({ data }) => data.OSR_ID),
-    ({ data }) => data.OSR_ID,
-    ({ data }) => {
-      const details = orsDetailsMap.get(zeroPadOrsId(data.OSR_ID))
-      return {
-        orsId: data.OSR_ID,
-        siteName: details?.siteName ?? null,
-        country: details?.country ?? null
-      }
-    },
-    ({ data }) => toNumber(data.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED)
-  ).map(({ tonnageDecimal, ...rest }) => ({
+const summariseTonnage = (grouped) =>
+  grouped.map(({ tonnageDecimal, ...rest }) => ({
     ...rest,
     tonnageExported: roundToTwoDecimalPlaces(tonnageDecimal)
   }))
+
+const generateOverseasSiteSummaries = (wasteExportedRecords, orsDetailsMap) => {
+  // OSR_ID is wrongly named, it should be ORS_ID but its a significant amount of work to correct that.
+  const recordsWithOrsId = wasteExportedRecords.filter(
+    ({ data }) => data.OSR_ID
+  )
+
+  const hasApprovedSite = ({ data }) => {
+    const details = orsDetailsMap.get(zeroPadOrsId(data.OSR_ID))
+    return Boolean(details?.siteName)
+  }
+
+  const getTonnage = ({ data }) =>
+    toNumber(data.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED)
+
+  const overseasSites = summariseTonnage(
+    groupAndSum(
+      recordsWithOrsId.filter(hasApprovedSite),
+      ({ data }) => data.OSR_ID,
+      ({ data }) => {
+        const details = orsDetailsMap.get(zeroPadOrsId(data.OSR_ID))
+        return {
+          orsId: data.OSR_ID,
+          siteName: details.siteName,
+          country: details.country
+        }
+      },
+      getTonnage
+    )
+  )
+
+  const unapprovedOverseasSites = summariseTonnage(
+    groupAndSum(
+      recordsWithOrsId.filter((record) => !hasApprovedSite(record)),
+      ({ data }) => data.OSR_ID,
+      ({ data }) => ({ orsId: data.OSR_ID }),
+      getTonnage
+    )
+  )
+
+  return { overseasSites, unapprovedOverseasSites }
 }
 
 function getTonnageRepatriated(repatriatedRecords) {
@@ -115,8 +143,12 @@ export function aggregateWasteExported(
     refusedOrStoppedDecimal
   )
 
+  const { overseasSites, unapprovedOverseasSites } =
+    generateOverseasSiteSummaries(exportedRecords, orsDetailsMap)
+
   return {
-    overseasSites: generateOverseasSiteSummary(exportedRecords, orsDetailsMap),
+    overseasSites,
+    unapprovedOverseasSites,
     totalTonnageExported,
     tonnageReceivedNotExported: calculateTonnageNotExported(
       totalTonnageReceived,

--- a/src/reports/domain/aggregation/exporter.test.js
+++ b/src/reports/domain/aggregation/exporter.test.js
@@ -67,9 +67,10 @@ describe('#aggregateReportDetail — EXPORTER accredited monthly January 2026', 
         tonnageNotRecycled: null
       },
       exportActivity: {
-        overseasSites: [
-          { orsId: 512, siteName: null, country: null, tonnageExported: 23.41 },
-          { orsId: 124, siteName: null, country: null, tonnageExported: 65.62 }
+        overseasSites: [],
+        unapprovedOverseasSites: [
+          { orsId: 512, tonnageExported: 23.41 },
+          { orsId: 124, tonnageExported: 65.62 }
         ],
         totalTonnageExported: 89.03,
         tonnageReceivedNotExported: 57.67,
@@ -123,6 +124,7 @@ describe('#aggregateReportDetail — EXPORTER accredited monthly February 2026',
       },
       exportActivity: {
         overseasSites: [],
+        unapprovedOverseasSites: [],
         totalTonnageExported: 0,
         tonnageReceivedNotExported: 0,
         tonnageRefusedAtDestination: 0,
@@ -200,11 +202,12 @@ describe('#aggregateReportDetail — EXPORTER_REGISTERED_ONLY quarterly Q1 2026'
         tonnageNotRecycled: null
       },
       exportActivity: {
-        overseasSites: [
-          { orsId: 565, siteName: null, country: null, tonnageExported: 2.99 },
-          { orsId: 297, siteName: null, country: null, tonnageExported: 3.02 },
-          { orsId: 893, siteName: null, country: null, tonnageExported: 1.26 },
-          { orsId: 143, siteName: null, country: null, tonnageExported: 3.07 }
+        overseasSites: [],
+        unapprovedOverseasSites: [
+          { orsId: 565, tonnageExported: 2.99 },
+          { orsId: 297, tonnageExported: 3.02 },
+          { orsId: 893, tonnageExported: 1.26 },
+          { orsId: 143, tonnageExported: 3.07 }
         ],
         totalTonnageExported: 10.33,
         tonnageReceivedNotExported: 73.76,

--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -57,7 +57,8 @@
 
 /**
  * @typedef {Object} ExportActivity
- * @property {Array<{orsId: string, siteName: string|null, country: string|null, tonnageExported?: number}>} overseasSites
+ * @property {Array<{orsId: string, siteName: string, country: string|null, tonnageExported?: number}>} overseasSites
+ * @property {Array<{orsId: string, tonnageExported: number}>} unapprovedOverseasSites
  * @property {number} totalTonnageExported
  * @property {number} tonnageReceivedNotExported
  * @property {number|null} tonnageRefusedAtDestination

--- a/src/reports/routes/get-detail.test.js
+++ b/src/reports/routes/get-detail.test.js
@@ -513,7 +513,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
         )
       })
 
-      it('aggregates waste exported with overseas site details', async () => {
+      it('routes exported records to unapprovedOverseasSites when overseas-sites repo is unavailable', async () => {
         const { server, organisationId, registrationId } = await createServer(
           {
             wasteProcessingType: 'exporter',
@@ -714,7 +714,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
         ])
       })
 
-      it('aggregates waste exported with overseas site details', async () => {
+      it('routes exported records to unapprovedOverseasSites when overseas-sites repo is unavailable', async () => {
         const { server, organisationId, registrationId } = await createServer(
           {
             wasteProcessingType: 'exporter',

--- a/src/reports/routes/get-detail.test.js
+++ b/src/reports/routes/get-detail.test.js
@@ -558,20 +558,10 @@ describe(`GET ${reportsGetDetailPath}`, () => {
         const payload = JSON.parse(response.payload)
 
         expect(payload.exportActivity.totalTonnageExported).toBe(11.47)
-        expect(payload.exportActivity.overseasSites).toHaveLength(2)
-        expect(payload.exportActivity.overseasSites).toStrictEqual([
-          {
-            country: null,
-            orsId: '001',
-            siteName: null,
-            tonnageExported: 8.47
-          },
-          {
-            country: null,
-            orsId: '096',
-            siteName: null,
-            tonnageExported: 3
-          }
+        expect(payload.exportActivity.overseasSites).toStrictEqual([])
+        expect(payload.exportActivity.unapprovedOverseasSites).toStrictEqual([
+          { orsId: '001', tonnageExported: 8.47 },
+          { orsId: '096', tonnageExported: 3 }
         ])
       })
 
@@ -635,6 +625,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
         expect(payload.recyclingActivity.suppliers).toStrictEqual([])
         expect(payload.exportActivity.totalTonnageExported).toBe(0)
         expect(payload.exportActivity.overseasSites).toStrictEqual([])
+        expect(payload.exportActivity.unapprovedOverseasSites).toStrictEqual([])
         expect(
           payload.wasteSent.tonnageSentToReprocessor +
             payload.wasteSent.tonnageSentToExporter +
@@ -764,9 +755,11 @@ describe(`GET ${reportsGetDetailPath}`, () => {
         const payload = JSON.parse(response.payload)
 
         expect(payload.exportActivity.totalTonnageExported).toBe(11.5)
-        expect(payload.exportActivity.overseasSites).toHaveLength(2)
-        expect(payload.exportActivity.overseasSites[0].orsId).toBe('001')
-        expect(payload.exportActivity.overseasSites[0].siteName).toBeNull()
+        expect(payload.exportActivity.overseasSites).toStrictEqual([])
+        expect(payload.exportActivity.unapprovedOverseasSites).toStrictEqual([
+          { orsId: '001', tonnageExported: 5 },
+          { orsId: '096', tonnageExported: 6.5 }
+        ])
       })
 
       it('filters waste received and exported by different date fields', async () => {
@@ -837,6 +830,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
         expect(payload.recyclingActivity.suppliers).toStrictEqual([])
         expect(payload.exportActivity.totalTonnageExported).toBe(0)
         expect(payload.exportActivity.overseasSites).toStrictEqual([])
+        expect(payload.exportActivity.unapprovedOverseasSites).toStrictEqual([])
         expect(
           payload.wasteSent.tonnageSentToReprocessor +
             payload.wasteSent.tonnageSentToExporter +


### PR DESCRIPTION
Ticket: [PAE-1312](https://eaflood.atlassian.net/browse/PAE-1312)
## Summary

Fixes PAE-1312. When a summary log references an overseas reprocessor (ORS) ID that doesn't resolve to a site record in our database, report aggregation was producing a row in `exportActivity.overseasSites` with `siteName: null, country: null` — which the frontend renders as a blank row under the column header "Approved overseas reprocessor ID".

Those unresolved entries are now routed into a new parallel field, `exportActivity.unapprovedOverseasSites`. The existing `overseasSites` array contains only rows whose ORS ID resolves to a real site name, so no more blank rows.

## Design (per PAE-1312 Jira comment, approved)

The two arrays partition the exported tonnage — nothing is silently dropped:

- `overseasSites: Array<{orsId, siteName, country, tonnageExported}>` — only entries with a resolved site name
- `unapprovedOverseasSites: Array<{orsId, tonnageExported}>` — ORS IDs the exporter referenced that we couldn't resolve

The split rule is `Boolean(orsDetailsMap.get(zeroPadOrsId(id))?.siteName)`, which collapses the three "unapproved" cases (ID absent from the map, map entry with null `siteName`, no `siteName` at all) into one consistent check.

Frontend rendering of the new unapproved section will follow in a separate PR against `epr-frontend`.

## Changes

- `src/reports/domain/aggregation/aggregate-waste-exported.js` — replaces `generateOverseasSiteSummary` with `generateOverseasSiteSummaries`, which returns both arrays from a single pass over the records. Adds a small `summariseTonnage` helper and a `hasApprovedSite` predicate.
- `src/reports/domain/aggregation/aggregate-report-detail.js` — `AggregatedExportActivity` typedef updated: `overseasSites` now guarantees a non-null `siteName`, `unapprovedOverseasSites` added.
- `src/reports/repository/port.js` — matching update to the persisted `ExportActivity` typedef so the repository contract agrees with the aggregator.
- Tests updated across `aggregate-report-detail.test.js`, `exporter.test.js`, and `routes/get-detail.test.js` to assert the new partitioned shape, including an explicit partition test that proves both arrays together account for `totalTonnageExported`.


[PAE-1312]: https://eaflood.atlassian.net/browse/PAE-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ