### PR TITLE
PAE-1320: add date format validation to reprocessed-loads and received-loads-for-reprocessing tables

### DIFF
--- a/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { DROPDOWN_PLACEHOLDER } from '../shared/index.js'
+import { DROPDOWN_PLACEHOLDER, createDateFieldSchema } from '../shared/index.js'
 import { REPROCESSED_LOADS_FIELDS as FIELDS } from './fields.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#application/waste-records/row-transformers/create-row-transformer.js'
@@ -54,5 +54,9 @@ export const REPROCESSED_LOADS = {
    *
    * All fields are OPTIONAL - validation only applies to fields that have values.
    */
-  validationSchema: Joi.object({}).unknown(true).prefs({ abortEarly: false })
+  validationSchema: Joi.object({
+    [FIELDS.DATE_LOAD_LEFT_SITE]: createDateFieldSchema()
+  })
+    .unknown(true)
+    .prefs({ abortEarly: false })
 }

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.test.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.test.js
@@ -66,5 +66,36 @@ describe('REPROCESSED_LOADS (REPROCESSOR_INPUT)', () => {
       const { error } = validationSchema.validate({ UNKNOWN_FIELD: 'value' })
       expect(error).toBeUndefined()
     })
+
+    describe('DATE_LOAD_LEFT_SITE', () => {
+      it('accepts a valid ISO date string', () => {
+        const { error } = validationSchema.validate({
+          DATE_LOAD_LEFT_SITE: '2026-01-21'
+        })
+        expect(error).toBeUndefined()
+      })
+
+      it('accepts a Date object and coerces to YYYY-MM-DD', () => {
+        const { error, value } = validationSchema.validate({
+          DATE_LOAD_LEFT_SITE: new Date('2026-01-21')
+        })
+        expect(error).toBeUndefined()
+        expect(value.DATE_LOAD_LEFT_SITE).toBe('2026-01-21')
+      })
+
+      it('rejects a non-ISO date string (M/D/YYYY)', () => {
+        const { error } = validationSchema.validate({
+          DATE_LOAD_LEFT_SITE: '1/21/2026'
+        })
+        expect(error).toBeDefined()
+      })
+
+      it('rejects an invalid date string', () => {
+        const { error } = validationSchema.validate({
+          DATE_LOAD_LEFT_SITE: 'not-a-date'
+        })
+        expect(error).toBeDefined()
+      })
+    })
   })
 })

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { DROPDOWN_PLACEHOLDER } from '../shared/index.js'
+import { DROPDOWN_PLACEHOLDER, createDateFieldSchema } from '../shared/index.js'
 import { RECEIVED_LOADS_FIELDS as FIELDS } from './fields.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#application/waste-records/row-transformers/create-row-transformer.js'
@@ -72,5 +72,9 @@ export const RECEIVED_LOADS_FOR_REPROCESSING = {
    *
    * All fields are OPTIONAL - validation only applies to fields that have values.
    */
-  validationSchema: Joi.object({}).unknown(true).prefs({ abortEarly: false })
+  validationSchema: Joi.object({
+    [FIELDS.DATE_RECEIVED_FOR_REPROCESSING]: createDateFieldSchema()
+  })
+    .unknown(true)
+    .prefs({ abortEarly: false })
 }

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.test.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.test.js
@@ -109,5 +109,36 @@ describe('RECEIVED_LOADS_FOR_REPROCESSING (REPROCESSOR_OUTPUT)', () => {
       const { error } = validationSchema.validate({ UNKNOWN_FIELD: 'value' })
       expect(error).toBeUndefined()
     })
+
+    describe('DATE_RECEIVED_FOR_REPROCESSING', () => {
+      it('accepts a valid ISO date string', () => {
+        const { error } = validationSchema.validate({
+          DATE_RECEIVED_FOR_REPROCESSING: '2026-01-21'
+        })
+        expect(error).toBeUndefined()
+      })
+
+      it('accepts a Date object and coerces to YYYY-MM-DD', () => {
+        const { error, value } = validationSchema.validate({
+          DATE_RECEIVED_FOR_REPROCESSING: new Date('2026-01-21')
+        })
+        expect(error).toBeUndefined()
+        expect(value.DATE_RECEIVED_FOR_REPROCESSING).toBe('2026-01-21')
+      })
+
+      it('rejects a non-ISO date string (M/D/YYYY)', () => {
+        const { error } = validationSchema.validate({
+          DATE_RECEIVED_FOR_REPROCESSING: '1/21/2026'
+        })
+        expect(error).toBeDefined()
+      })
+
+      it('rejects an invalid date string', () => {
+        const { error } = validationSchema.validate({
+          DATE_RECEIVED_FOR_REPROCESSING: 'not-a-date'
+        })
+        expect(error).toBeDefined()
+      })
+    })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1320](https://eaflood.atlassian.net/browse/PAE-1320)
## Changes
- Add `createDateFieldSchema` validation for `DATE_LOAD_LEFT_SITE` in REPROCESSOR_INPUT reprocessed-loads table
- Add `createDateFieldSchema` validation for `DATE_RECEIVED_FOR_REPROCESSING` in REPROCESSOR_OUTPUT received-loads-for-reprocessing table
- Add VAL010 date validation tests covering ISO strings, Date objects, M/D/YYYY rejection, and invalid strings

[PAE-1320]: https://eaflood.atlassian.net/browse/PAE-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ