### PR TITLE
PAE-1321: derive tonnageReceivedNotExported from row-based filter rather than arithmetic subtraction

### DIFF
--- a/src/common/helpers/decimal-utils.js
+++ b/src/common/helpers/decimal-utils.js
@@ -153,13 +153,3 @@ export function greaterThan(a, b) {
 export function isZero(value) {
   return toDecimal(value).isZero()
 }
-
-/**
- * Check if a value is negative.
- *
- * @param {DecimalValue} value - Value to check
- * @returns {boolean} True if value is less than zero
- */
-export function isNegative(value) {
-  return toDecimal(value).isNegative()
-}

--- a/src/common/helpers/decimal-utils.test.js
+++ b/src/common/helpers/decimal-utils.test.js
@@ -1,17 +1,16 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import Decimal from 'decimal.js'
 import { Decimal128 } from 'mongodb'
 import {
-  toDecimal,
-  toNumber,
-  roundToTwoDecimalPlaces,
-  add,
-  subtract,
-  equals,
   abs,
+  add,
+  equals,
   greaterThan,
   isZero,
-  isNegative
+  roundToTwoDecimalPlaces,
+  subtract,
+  toDecimal,
+  toNumber
 } from '#common/helpers/decimal-utils.js'
 
 describe('decimal-utils', () => {
@@ -368,28 +367,6 @@ describe('decimal-utils', () => {
     it('should handle result of addition to zero', () => {
       const result = add(5, -5)
       expect(isZero(result)).toBe(true)
-    })
-  })
-
-  describe('isNegative', () => {
-    it('should return true for a negative number', () => {
-      expect(isNegative(-1)).toBe(true)
-    })
-
-    it('should return true for a negative string', () => {
-      expect(isNegative('-0.01')).toBe(true)
-    })
-
-    it('should return true for a negative Decimal', () => {
-      expect(isNegative(new Decimal(-42.5))).toBe(true)
-    })
-
-    it('should return false for zero', () => {
-      expect(isNegative(0)).toBe(false)
-    })
-
-    it('should return false for a positive number', () => {
-      expect(isNegative(1)).toBe(false)
     })
   })
 

--- a/src/reports/domain/aggregation/aggregate-report-detail.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.js
@@ -136,12 +136,14 @@ export function aggregateReportDetail(
     source: { summaryLogId, lastUploadedAt },
     recyclingActivity,
     ...(wasteExportedDateField && {
-      exportActivity: aggregateWasteExported(
+      exportActivity: aggregateWasteExported({
         wasteExportedRecords,
-        wasteRepatriatedRecords,
-        recyclingActivity.totalTonnageReceived,
+        repatriatedRecords: wasteRepatriatedRecords,
+        wasteReceivedRecords,
+        startDate,
+        endDate,
         orsDetailsMap
-      )
+      })
     }),
     wasteSent: aggregateWasteSentOn(wasteSentOnRecords)
   }

--- a/src/reports/domain/aggregation/aggregate-report-detail.test.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.test.js
@@ -982,6 +982,74 @@ describe('#aggregateReportDetail', () => {
         }
       ])
     })
+
+    describe('tonnageReceivedNotExported', () => {
+      it('excludes records whose DATE_OF_EXPORT falls within the same period', () => {
+        const records = [
+          buildAccreditedExportedRecord({
+            DATE_RECEIVED_FOR_EXPORT: '2026-02-05',
+            DATE_OF_EXPORT: '2026-02-20',
+            TONNAGE_RECEIVED_FOR_EXPORT: 50
+          })
+        ]
+
+        const result = aggregateReportDetail(records, accreditedExporterArgs)
+
+        expect(result.exportActivity.tonnageReceivedNotExported).toBe(0)
+      })
+
+      it('includes records whose DATE_OF_EXPORT is after the period', () => {
+        const records = [
+          buildAccreditedExportedRecord({
+            DATE_RECEIVED_FOR_EXPORT: '2026-02-05',
+            DATE_OF_EXPORT: '2026-03-10',
+            TONNAGE_RECEIVED_FOR_EXPORT: 37.5
+          })
+        ]
+
+        const result = aggregateReportDetail(records, accreditedExporterArgs)
+
+        expect(result.exportActivity.tonnageReceivedNotExported).toBe(37.5)
+      })
+
+      it('includes records with no DATE_OF_EXPORT', () => {
+        const records = [
+          buildAccreditedExportedRecord({
+            DATE_RECEIVED_FOR_EXPORT: '2026-02-05',
+            DATE_OF_EXPORT: null,
+            TONNAGE_RECEIVED_FOR_EXPORT: 25
+          })
+        ]
+
+        const result = aggregateReportDetail(records, accreditedExporterArgs)
+
+        expect(result.exportActivity.tonnageReceivedNotExported).toBe(25)
+      })
+
+      it('sums only records not exported within the period', () => {
+        const records = [
+          buildAccreditedExportedRecord({
+            DATE_RECEIVED_FOR_EXPORT: '2026-02-05',
+            DATE_OF_EXPORT: '2026-02-20',
+            TONNAGE_RECEIVED_FOR_EXPORT: 30
+          }),
+          buildAccreditedExportedRecord({
+            DATE_RECEIVED_FOR_EXPORT: '2026-02-10',
+            DATE_OF_EXPORT: '2026-03-05',
+            TONNAGE_RECEIVED_FOR_EXPORT: 20
+          }),
+          buildAccreditedExportedRecord({
+            DATE_RECEIVED_FOR_EXPORT: '2026-02-15',
+            DATE_OF_EXPORT: null,
+            TONNAGE_RECEIVED_FOR_EXPORT: 10
+          })
+        ]
+
+        const result = aggregateReportDetail(records, accreditedExporterArgs)
+
+        expect(result.exportActivity.tonnageReceivedNotExported).toBe(30)
+      })
+    })
   })
 
   describe('unvalidated data (registered-only validation is placeholder)', () => {

--- a/src/reports/domain/aggregation/aggregate-waste-exported.js
+++ b/src/reports/domain/aggregation/aggregate-waste-exported.js
@@ -1,13 +1,12 @@
 import {
   add,
-  subtract,
   toDecimal,
   roundToTwoDecimalPlaces,
-  toNumber,
-  isNegative
+  toNumber
 } from '#common/helpers/decimal-utils.js'
 import { groupAndSum, isYes } from './helpers.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { isDateInRange } from './filter-records-by-date.js'
 
 const ORS_ID_DIGITS = 3
 const ZERO = '0'
@@ -74,31 +73,40 @@ function getTonnageRepatriated(repatriatedRecords) {
   )
 }
 
-function calculateTonnageNotExported(
-  totalTonnageReceived,
-  totalTonnageExportedDecimal
+function calculateTonnageReceivedNotExported(
+  wasteReceivedRecords,
+  startDate,
+  endDate
 ) {
-  const receivedMinusExported = subtract(
-    toDecimal(totalTonnageReceived),
-    totalTonnageExportedDecimal
-  )
   return roundToTwoDecimalPlaces(
-    isNegative(receivedMinusExported) ? toDecimal(0) : receivedMinusExported
+    wasteReceivedRecords
+      .filter(
+        ({ data }) => !isDateInRange(data.DATE_OF_EXPORT, startDate, endDate)
+      )
+      .reduce(
+        (sum, { data }) => add(sum, toNumber(data.TONNAGE_RECEIVED_FOR_EXPORT)),
+        toDecimal(0)
+      )
   )
 }
 
 /**
- * @param {import('#domain/waste-records/model.js').WasteRecord[]} wasteExportedRecords
- * @param {import('#domain/waste-records/model.js').WasteRecord[]} repatriatedRecords
- * @param {number} totalTonnageReceived
- * @param {Map<string, { siteName: string|null, country: string|null }>} [orsDetailsMap]
+ * @param {object} params
+ * @param {import('#domain/waste-records/model.js').WasteRecord[]} params.wasteExportedRecords
+ * @param {import('#domain/waste-records/model.js').WasteRecord[]} params.repatriatedRecords
+ * @param {import('#domain/waste-records/model.js').WasteRecord[]} params.wasteReceivedRecords
+ * @param {string} params.startDate - ISO date string (YYYY-MM-DD)
+ * @param {string} params.endDate - ISO date string (YYYY-MM-DD)
+ * @param {Map<string, { siteName: string|null, country: string|null }>} [params.orsDetailsMap]
  */
-export function aggregateWasteExported(
+export function aggregateWasteExported({
   wasteExportedRecords,
   repatriatedRecords,
-  totalTonnageReceived,
+  wasteReceivedRecords,
+  startDate,
+  endDate,
   orsDetailsMap = new Map()
-) {
+}) {
   const exportedRecords = wasteExportedRecords.filter(
     ({ type }) => type === WASTE_RECORD_TYPE.EXPORTED
   )
@@ -150,9 +158,10 @@ export function aggregateWasteExported(
     overseasSites,
     unapprovedOverseasSites,
     totalTonnageExported,
-    tonnageReceivedNotExported: calculateTonnageNotExported(
-      totalTonnageReceived,
-      totalTonnageExportedDecimal
+    tonnageReceivedNotExported: calculateTonnageReceivedNotExported(
+      wasteReceivedRecords,
+      startDate,
+      endDate
     ),
     tonnageRefusedAtDestination,
     tonnageStoppedDuringExport,

--- a/src/reports/domain/aggregation/exporter.test.js
+++ b/src/reports/domain/aggregation/exporter.test.js
@@ -1,19 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import { aggregateReportDetail } from '#root/reports/domain/aggregation/aggregate-report-detail.js'
-import { aggregateWasteExported } from '#root/reports/domain/aggregation/aggregate-waste-exported.js'
-import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import wasteRecordsAccredited from './test-data/exporter-accredited.json'
 import wasteRecordsRegisteredOnly from './test-data/exporter-reg-only.json'
-
-const buildExportedRecord = (tonnage) => ({
-  type: WASTE_RECORD_TYPE.EXPORTED,
-  data: {
-    TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: tonnage,
-    WAS_THE_WASTE_REFUSED: 'No',
-    WAS_THE_WASTE_STOPPED: 'No'
-  }
-})
 
 describe('#aggregateReportDetail — EXPORTER accredited monthly January 2026', () => {
   it('aggregates in-period records into the full report detail', () => {
@@ -73,7 +62,7 @@ describe('#aggregateReportDetail — EXPORTER accredited monthly January 2026', 
           { orsId: 124, tonnageExported: 65.62 }
         ],
         totalTonnageExported: 89.03,
-        tonnageReceivedNotExported: 57.67,
+        tonnageReceivedNotExported: 0,
         tonnageRefusedAtDestination: 50,
         tonnageStoppedDuringExport: 50,
         totalTonnageRefusedOrStopped: 50,
@@ -210,7 +199,7 @@ describe('#aggregateReportDetail — EXPORTER_REGISTERED_ONLY quarterly Q1 2026'
           { orsId: 143, tonnageExported: 3.07 }
         ],
         totalTonnageExported: 10.33,
-        tonnageReceivedNotExported: 73.76,
+        tonnageReceivedNotExported: 84.09,
         tonnageRefusedAtDestination: 7.34,
         tonnageStoppedDuringExport: 6.01,
         totalTonnageRefusedOrStopped: 10.33,
@@ -248,25 +237,5 @@ describe('#aggregateReportDetail — EXPORTER_REGISTERED_ONLY quarterly Q1 2026'
         ]
       }
     })
-  })
-})
-
-describe('#aggregateWasteExported — tonnageReceivedNotExported', () => {
-  it('returns zero when exported tonnage exceeds received tonnage', () => {
-    const result = aggregateWasteExported([buildExportedRecord(80)], [], 50)
-
-    expect(result.tonnageReceivedNotExported).toBe(0)
-  })
-
-  it('returns zero when exported tonnage equals received tonnage', () => {
-    const result = aggregateWasteExported([buildExportedRecord(50)], [], 50)
-
-    expect(result.tonnageReceivedNotExported).toBe(0)
-  })
-
-  it('returns the difference when received tonnage exceeds exported tonnage', () => {
-    const result = aggregateWasteExported([buildExportedRecord(30)], [], 50)
-
-    expect(result.tonnageReceivedNotExported).toBe(20)
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1321](https://eaflood.atlassian.net/browse/PAE-1321)
## Changes

Replace the arithmetic subtraction approach for `tonnageReceivedNotExported` with a row-based filter: sum `TONNAGE_RECEIVED_FOR_EXPORT` for records received within the reporting period whose `DATE_OF_EXPORT` is blank or falls in a later period.

This correctly captures waste received but not yet exported, rather than the net difference between two independent totals.

[PAE-1321]: https://eaflood.atlassian.net/browse/PAE-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ