### PR TITLE
PAE-1323: Per-row ORS approval status in report aggregation

### DIFF
--- a/src/domain/summary-logs/table-schemas/exporter/received-loads-for-export.js
+++ b/src/domain/summary-logs/table-schemas/exporter/received-loads-for-export.js
@@ -38,6 +38,7 @@ import {
 import { ORS_VALIDATION_DISABLED } from '../shared/classification-reason.js'
 import { isAccreditedAtDates } from '#common/helpers/dates/accreditation.js'
 import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
+import { isOrsApprovedAtDate } from '#overseas-sites/domain/approval.js'
 
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 /** @import {OverseasSitesContext} from '../validation-pipeline.js' */
@@ -220,10 +221,7 @@ export const RECEIVED_LOADS_FOR_EXPORT = {
 
     if (overseasSites !== ORS_VALIDATION_DISABLED) {
       const ors = overseasSites[toThreeDigitId(data[FIELDS.OSR_ID])]
-      if (
-        !ors?.validFrom ||
-        new Date(ors.validFrom) > new Date(data[FIELDS.DATE_OF_EXPORT])
-      ) {
+      if (!isOrsApprovedAtDate(ors?.validFrom, data[FIELDS.DATE_OF_EXPORT])) {
         return {
           outcome: ROW_OUTCOME.EXCLUDED,
           reasons: [{ code: CLASSIFICATION_REASON.ORS_NOT_APPROVED }]

--- a/src/overseas-sites/application/get-ors-details-map.js
+++ b/src/overseas-sites/application/get-ors-details-map.js
@@ -6,7 +6,7 @@
  *
  * @param {OverseasSitesRepository} overseasSitesRepository
  * @param {Record<string, { overseasSiteId: string }> | undefined} overseasSites
- * @returns {Promise<Map<string, { siteName: string|null, country: string|null }>>}
+ * @returns {Promise<Map<string, { siteName: string|null, country: string|null, validFrom: string|null }>>}
  */
 export async function getOrsDetailsMap(overseasSitesRepository, overseasSites) {
   if (!overseasSitesRepository) {
@@ -27,7 +27,11 @@ export async function getOrsDetailsMap(overseasSitesRepository, overseasSites) {
       const site = sitesById.get(overseasSiteId)
       return [
         orsKey,
-        { siteName: site?.name ?? null, country: site?.country ?? null }
+        {
+          siteName: site?.name ?? null,
+          country: site?.country ?? null,
+          validFrom: site?.validFrom ?? null
+        }
       ]
     })
   )

--- a/src/overseas-sites/application/get-ors-details-map.js
+++ b/src/overseas-sites/application/get-ors-details-map.js
@@ -6,7 +6,7 @@
  *
  * @param {OverseasSitesRepository} overseasSitesRepository
  * @param {Record<string, { overseasSiteId: string }> | undefined} overseasSites
- * @returns {Promise<Map<string, { siteName: string|null, country: string|null, validFrom: string|null }>>}
+ * @returns {Promise<Map<string, { siteName: string|null, country: string|null, validFrom: Date|null }>>}
  */
 export async function getOrsDetailsMap(overseasSitesRepository, overseasSites) {
   if (!overseasSitesRepository) {

--- a/src/overseas-sites/application/get-ors-details-map.js
+++ b/src/overseas-sites/application/get-ors-details-map.js
@@ -1,8 +1,8 @@
 /** @import {OverseasSitesRepository} from '#overseas-sites/repository/port.js' */
 
 /**
- * Builds a map from ORS key (e.g. "120") to site name and country,
- * looked up from the overseas-sites repository.
+ * Builds a map from ORS key (e.g. "120") to site name, country, and
+ * valid-from date, looked up from the overseas-sites repository.
  *
  * @param {OverseasSitesRepository} overseasSitesRepository
  * @param {Record<string, { overseasSiteId: string }> | undefined} overseasSites

--- a/src/overseas-sites/application/get-ors-details-map.test.js
+++ b/src/overseas-sites/application/get-ors-details-map.test.js
@@ -5,8 +5,18 @@ describe('getOrsDetailsMap', () => {
   it('returns a map keyed by ORS key with siteName and country', async () => {
     const overseasSitesRepository = {
       findByIds: vi.fn().mockResolvedValue([
-        { id: 'site-aaa', name: 'EuroPlast GmbH', country: 'Germany' },
-        { id: 'site-bbb', name: 'RecyclePlast SA', country: 'France' }
+        {
+          id: 'site-aaa',
+          name: 'EuroPlast GmbH',
+          country: 'Germany',
+          validFrom: '2025-01-15'
+        },
+        {
+          id: 'site-bbb',
+          name: 'RecyclePlast SA',
+          country: 'France',
+          validFrom: '2024-06-01'
+        }
       ])
     }
     const overseasSites = {
@@ -22,11 +32,13 @@ describe('getOrsDetailsMap', () => {
     expect(result).toBeInstanceOf(Map)
     expect(result.get('ORS_1')).toStrictEqual({
       siteName: 'EuroPlast GmbH',
-      country: 'Germany'
+      country: 'Germany',
+      validFrom: '2025-01-15'
     })
     expect(result.get('ORS_2')).toStrictEqual({
       siteName: 'RecyclePlast SA',
-      country: 'France'
+      country: 'France',
+      validFrom: '2024-06-01'
     })
     expect(overseasSitesRepository.findByIds).toHaveBeenCalledWith([
       'site-aaa',
@@ -86,7 +98,11 @@ describe('getOrsDetailsMap', () => {
       overseasSites
     )
 
-    expect(result.get('ORS_1')).toStrictEqual({ siteName: null, country: null })
+    expect(result.get('ORS_1')).toStrictEqual({
+      siteName: null,
+      country: null,
+      validFrom: null
+    })
   })
 
   it('sets siteName and country to null when site fields are absent', async () => {
@@ -102,6 +118,10 @@ describe('getOrsDetailsMap', () => {
       overseasSites
     )
 
-    expect(result.get('ORS_1')).toStrictEqual({ siteName: null, country: null })
+    expect(result.get('ORS_1')).toStrictEqual({
+      siteName: null,
+      country: null,
+      validFrom: null
+    })
   })
 })

--- a/src/overseas-sites/application/get-ors-details-map.test.js
+++ b/src/overseas-sites/application/get-ors-details-map.test.js
@@ -9,13 +9,13 @@ describe('getOrsDetailsMap', () => {
           id: 'site-aaa',
           name: 'EuroPlast GmbH',
           country: 'Germany',
-          validFrom: '2025-01-15'
+          validFrom: new Date('2025-01-15')
         },
         {
           id: 'site-bbb',
           name: 'RecyclePlast SA',
           country: 'France',
-          validFrom: '2024-06-01'
+          validFrom: new Date('2024-06-01')
         }
       ])
     }
@@ -33,12 +33,12 @@ describe('getOrsDetailsMap', () => {
     expect(result.get('ORS_1')).toStrictEqual({
       siteName: 'EuroPlast GmbH',
       country: 'Germany',
-      validFrom: '2025-01-15'
+      validFrom: new Date('2025-01-15')
     })
     expect(result.get('ORS_2')).toStrictEqual({
       siteName: 'RecyclePlast SA',
       country: 'France',
-      validFrom: '2024-06-01'
+      validFrom: new Date('2024-06-01')
     })
     expect(overseasSitesRepository.findByIds).toHaveBeenCalledWith([
       'site-aaa',

--- a/src/overseas-sites/application/get-ors-details-map.test.js
+++ b/src/overseas-sites/application/get-ors-details-map.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { getOrsDetailsMap } from './get-ors-details-map.js'
 
 describe('getOrsDetailsMap', () => {
-  it('returns a map keyed by ORS key with siteName and country', async () => {
+  it('returns a map keyed by ORS key with siteName, country, and validFrom', async () => {
     const overseasSitesRepository = {
       findByIds: vi.fn().mockResolvedValue([
         {
@@ -85,7 +85,7 @@ describe('getOrsDetailsMap', () => {
     expect(overseasSitesRepository.findByIds).not.toHaveBeenCalled()
   })
 
-  it('sets siteName and country to null when site is not found', async () => {
+  it('sets siteName, country, and validFrom to null when site is not found', async () => {
     const overseasSitesRepository = {
       findByIds: vi.fn().mockResolvedValue([])
     }
@@ -105,7 +105,7 @@ describe('getOrsDetailsMap', () => {
     })
   })
 
-  it('sets siteName and country to null when site fields are absent', async () => {
+  it('sets siteName, country, and validFrom to null when site fields are absent', async () => {
     const overseasSitesRepository = {
       findByIds: vi.fn().mockResolvedValue([{ id: 'site-aaa' }])
     }

--- a/src/overseas-sites/domain/approval.js
+++ b/src/overseas-sites/domain/approval.js
@@ -1,0 +1,8 @@
+/**
+ * @param {Date | null | undefined} validFrom
+ * @param {string} dateOfExport - ISO date string (YYYY-MM-DD)
+ * @returns {boolean}
+ */
+export function isOrsApprovedAtDate(validFrom, dateOfExport) {
+  return validFrom != null && validFrom <= new Date(dateOfExport)
+}

--- a/src/overseas-sites/domain/approval.test.js
+++ b/src/overseas-sites/domain/approval.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { isOrsApprovedAtDate } from './approval.js'
+
+describe('#isOrsApprovedAtDate', () => {
+  it('returns true when validFrom is on the date of export', () => {
+    const validFrom = new Date('2026-01-20')
+    expect(isOrsApprovedAtDate(validFrom, '2026-01-20')).toBe(true)
+  })
+
+  it('returns true when validFrom is before the date of export', () => {
+    const validFrom = new Date('2025-06-01')
+    expect(isOrsApprovedAtDate(validFrom, '2026-01-20')).toBe(true)
+  })
+
+  it('returns false when validFrom is after the date of export', () => {
+    const validFrom = new Date('2026-02-01')
+    expect(isOrsApprovedAtDate(validFrom, '2026-01-20')).toBe(false)
+  })
+
+  it('returns false when validFrom is null', () => {
+    expect(isOrsApprovedAtDate(null, '2026-01-20')).toBe(false)
+  })
+
+  it('returns false when validFrom is undefined', () => {
+    expect(isOrsApprovedAtDate(undefined, '2026-01-20')).toBe(false)
+  })
+})

--- a/src/reports/domain/aggregation/aggregate-report-detail.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.js
@@ -62,7 +62,7 @@ import { aggregateWasteSentOn } from './aggregate-waste-sent-on.js'
  * @param {string} options.cadence - Cadence key ('monthly' or 'quarterly')
  * @param {number} options.year
  * @param {number} options.period
- * @param {Map<string, {siteName: string|null, country: string|null, validFrom: string|null}>} [options.orsDetailsMap]
+ * @param {Map<string, {siteName: string|null, country: string|null, validFrom: Date|null}>} [options.orsDetailsMap]
  * @returns {AggregatedReportDetail}
  */
 export function aggregateReportDetail(

--- a/src/reports/domain/aggregation/aggregate-report-detail.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.js
@@ -19,7 +19,7 @@ import { aggregateWasteSentOn } from './aggregate-waste-sent-on.js'
 
 /**
  * @typedef {Object} AggregatedExportActivity
- * @property {Array<{orsId: string, siteName: string, country: string|null, tonnageExported: number}>} overseasSites
+ * @property {Array<{orsId: string, siteName: string, country: string|null, tonnageExported: number, approved: boolean}>} overseasSites
  * @property {Array<{orsId: string, tonnageExported: number}>} unapprovedOverseasSites
  * @property {number} totalTonnageExported
  * @property {number} tonnageReceivedNotExported
@@ -142,7 +142,8 @@ export function aggregateReportDetail(
         wasteReceivedRecords,
         startDate,
         endDate,
-        orsDetailsMap
+        orsDetailsMap,
+        operatorCategory
       })
     }),
     wasteSent: aggregateWasteSentOn(wasteSentOnRecords)

--- a/src/reports/domain/aggregation/aggregate-report-detail.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.js
@@ -62,7 +62,7 @@ import { aggregateWasteSentOn } from './aggregate-waste-sent-on.js'
  * @param {string} options.cadence - Cadence key ('monthly' or 'quarterly')
  * @param {number} options.year
  * @param {number} options.period
- * @param {Map<string, {siteName: string|null, country: string|null}>} [options.orsDetailsMap]
+ * @param {Map<string, {siteName: string|null, country: string|null, validFrom: string|null}>} [options.orsDetailsMap]
  * @returns {AggregatedReportDetail}
  */
 export function aggregateReportDetail(

--- a/src/reports/domain/aggregation/aggregate-report-detail.test.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.test.js
@@ -475,7 +475,7 @@ describe('#aggregateReportDetail', () => {
       ])
     })
 
-    it('splits approved and unapproved ORS entries by whether a siteName is resolved', () => {
+    it('splits resolved and unresolved ORS entries by whether a siteName is resolved', () => {
       const records = [
         buildExportedRecord({
           OSR_ID: '001',
@@ -493,8 +493,15 @@ describe('#aggregateReportDetail', () => {
         })
       ]
       const orsDetailsMap = new Map([
-        ['001', { siteName: 'EuroPlast GmbH', country: 'Germany' }],
-        ['096', { siteName: null, country: null }]
+        [
+          '001',
+          {
+            siteName: 'EuroPlast GmbH',
+            country: 'Germany',
+            validFrom: new Date('2025-01-01')
+          }
+        ],
+        ['096', { siteName: null, country: null, validFrom: null }]
       ])
 
       const result = aggregateReportDetail(records, {
@@ -507,7 +514,8 @@ describe('#aggregateReportDetail', () => {
           orsId: '001',
           siteName: 'EuroPlast GmbH',
           country: 'Germany',
-          tonnageExported: 5
+          tonnageExported: 5,
+          approved: false
         }
       ])
       expect(result.exportActivity.unapprovedOverseasSites).toStrictEqual([
@@ -564,8 +572,22 @@ describe('#aggregateReportDetail', () => {
         })
       ]
       const orsDetailsMap = new Map([
-        ['001', { siteName: 'EuroPlast GmbH', country: 'Germany' }],
-        ['002', { siteName: 'RecyclePlast SA', country: 'France' }]
+        [
+          '001',
+          {
+            siteName: 'EuroPlast GmbH',
+            country: 'Germany',
+            validFrom: new Date('2025-01-01')
+          }
+        ],
+        [
+          '002',
+          {
+            siteName: 'RecyclePlast SA',
+            country: 'France',
+            validFrom: new Date('2025-01-01')
+          }
+        ]
       ])
 
       const result = aggregateReportDetail(records, {
@@ -604,8 +626,22 @@ describe('#aggregateReportDetail', () => {
         })
       ]
       const orsDetailsMap = new Map([
-        ['001', { siteName: 'EuroPlast GmbH', country: 'Germany' }],
-        ['096', { siteName: 'RecyclePlast SA', country: 'France' }]
+        [
+          '001',
+          {
+            siteName: 'EuroPlast GmbH',
+            country: 'Germany',
+            validFrom: new Date('2025-01-01')
+          }
+        ],
+        [
+          '096',
+          {
+            siteName: 'RecyclePlast SA',
+            country: 'France',
+            validFrom: new Date('2025-01-01')
+          }
+        ]
       ])
 
       const result = aggregateReportDetail(records, {
@@ -618,13 +654,15 @@ describe('#aggregateReportDetail', () => {
           orsId: '001',
           siteName: 'EuroPlast GmbH',
           country: 'Germany',
-          tonnageExported: 5
+          tonnageExported: 5,
+          approved: false
         },
         {
           orsId: '096',
           siteName: 'RecyclePlast SA',
           country: 'France',
-          tonnageExported: 3
+          tonnageExported: 3,
+          approved: false
         }
       ])
     })
@@ -642,8 +680,22 @@ describe('#aggregateReportDetail', () => {
         })
       ]
       const orsDetailsMap = new Map([
-        ['124', { siteName: 'EuroPlast GmbH', country: 'Germany' }],
-        ['099', { siteName: 'RecyclePlast SA', country: 'France' }]
+        [
+          '124',
+          {
+            siteName: 'EuroPlast GmbH',
+            country: 'Germany',
+            validFrom: new Date('2025-01-01')
+          }
+        ],
+        [
+          '099',
+          {
+            siteName: 'RecyclePlast SA',
+            country: 'France',
+            validFrom: new Date('2025-01-01')
+          }
+        ]
       ])
 
       const result = aggregateReportDetail(records, {
@@ -656,18 +708,20 @@ describe('#aggregateReportDetail', () => {
           orsId: '124',
           siteName: 'EuroPlast GmbH',
           country: 'Germany',
-          tonnageExported: 5
+          tonnageExported: 5,
+          approved: false
         },
         {
           orsId: '099',
           siteName: 'RecyclePlast SA',
           country: 'France',
-          tonnageExported: 3
+          tonnageExported: 3,
+          approved: false
         }
       ])
     })
 
-    it('deduplicates overseas sites by OSR_ID', () => {
+    it('deduplicates overseas sites by OSR_ID and approval status', () => {
       const records = [
         buildExportedRecord({
           OSR_NAME: 'EuroPlast Recycling GmbH',
@@ -685,8 +739,22 @@ describe('#aggregateReportDetail', () => {
         })
       ]
       const orsDetailsMap = new Map([
-        ['001', { siteName: 'EuroPlast Recycling GmbH', country: 'Germany' }],
-        ['096', { siteName: 'RecyclePlast SA', country: 'France' }]
+        [
+          '001',
+          {
+            siteName: 'EuroPlast Recycling GmbH',
+            country: 'Germany',
+            validFrom: new Date('2025-01-01')
+          }
+        ],
+        [
+          '096',
+          {
+            siteName: 'RecyclePlast SA',
+            country: 'France',
+            validFrom: new Date('2025-01-01')
+          }
+        ]
       ])
 
       const result = aggregateReportDetail(records, {
@@ -965,7 +1033,14 @@ describe('#aggregateReportDetail', () => {
         })
       ]
       const orsDetailsMap = new Map([
-        ['001', { siteName: 'EuroPlast GmbH', country: 'Germany' }]
+        [
+          '001',
+          {
+            siteName: 'EuroPlast GmbH',
+            country: 'Germany',
+            validFrom: new Date('2025-01-01')
+          }
+        ]
       ])
 
       const result = aggregateReportDetail(records, {
@@ -978,7 +1053,8 @@ describe('#aggregateReportDetail', () => {
           orsId: '001',
           siteName: 'EuroPlast GmbH',
           country: 'Germany',
-          tonnageExported: 48
+          tonnageExported: 48,
+          approved: true
         }
       ])
     })

--- a/src/reports/domain/aggregation/aggregate-waste-exported.js
+++ b/src/reports/domain/aggregation/aggregate-waste-exported.js
@@ -98,7 +98,7 @@ function calculateTonnageReceivedNotExported(
  * @param {import('#domain/waste-records/model.js').WasteRecord[]} params.wasteReceivedRecords
  * @param {string} params.startDate - ISO date string (YYYY-MM-DD)
  * @param {string} params.endDate - ISO date string (YYYY-MM-DD)
- * @param {Map<string, { siteName: string|null, country: string|null, validFrom: string|null }>} [params.orsDetailsMap]
+ * @param {Map<string, { siteName: string|null, country: string|null, validFrom: Date|null }>} [params.orsDetailsMap]
  */
 export function aggregateWasteExported({
   wasteExportedRecords,

--- a/src/reports/domain/aggregation/aggregate-waste-exported.js
+++ b/src/reports/domain/aggregation/aggregate-waste-exported.js
@@ -7,6 +7,7 @@ import {
 import { groupAndSum, isYes } from './helpers.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { isDateInRange } from './filter-records-by-date.js'
+import { isOrsApprovedAtDate } from '#overseas-sites/domain/approval.js'
 
 const ORS_ID_DIGITS = 3
 const ZERO = '0'
@@ -19,15 +20,29 @@ const summariseTonnage = (grouped) =>
     tonnageExported: roundToTwoDecimalPlaces(tonnageDecimal)
   }))
 
-const generateOverseasSiteSummaries = (wasteExportedRecords, orsDetailsMap) => {
+const REGISTERED_ONLY = 'EXPORTER_REGISTERED_ONLY'
+
+const generateOverseasSiteSummaries = (
+  wasteExportedRecords,
+  orsDetailsMap,
+  operatorCategory
+) => {
   // OSR_ID is wrongly named, it should be ORS_ID but its a significant amount of work to correct that.
   const recordsWithOrsId = wasteExportedRecords.filter(
     ({ data }) => data.OSR_ID
   )
 
-  const hasApprovedSite = ({ data }) => {
+  const isResolvedSite = ({ data }) => {
     const details = orsDetailsMap.get(zeroPadOrsId(data.OSR_ID))
     return Boolean(details?.siteName)
+  }
+
+  const isApproved = ({ data }) => {
+    if (operatorCategory === REGISTERED_ONLY) {
+      return false
+    }
+    const details = orsDetailsMap.get(zeroPadOrsId(data.OSR_ID))
+    return isOrsApprovedAtDate(details?.validFrom, data.DATE_OF_EXPORT)
   }
 
   const getTonnage = ({ data }) =>
@@ -35,15 +50,19 @@ const generateOverseasSiteSummaries = (wasteExportedRecords, orsDetailsMap) => {
 
   const overseasSites = summariseTonnage(
     groupAndSum(
-      recordsWithOrsId.filter(hasApprovedSite),
-      ({ data }) => zeroPadOrsId(data.OSR_ID),
+      recordsWithOrsId.filter(isResolvedSite),
+      ({ data }) => {
+        const approved = isApproved({ data })
+        return `${zeroPadOrsId(data.OSR_ID)}:${approved}`
+      },
       ({ data }) => {
         const orsId = zeroPadOrsId(data.OSR_ID)
         const details = orsDetailsMap.get(orsId)
         return {
           orsId,
           siteName: details.siteName,
-          country: details.country
+          country: details.country,
+          approved: isApproved({ data })
         }
       },
       getTonnage
@@ -52,7 +71,7 @@ const generateOverseasSiteSummaries = (wasteExportedRecords, orsDetailsMap) => {
 
   const unapprovedOverseasSites = summariseTonnage(
     groupAndSum(
-      recordsWithOrsId.filter((record) => !hasApprovedSite(record)),
+      recordsWithOrsId.filter((record) => !isResolvedSite(record)),
       ({ data }) => zeroPadOrsId(data.OSR_ID),
       ({ data }) => ({ orsId: zeroPadOrsId(data.OSR_ID) }),
       getTonnage
@@ -99,6 +118,7 @@ function calculateTonnageReceivedNotExported(
  * @param {string} params.startDate - ISO date string (YYYY-MM-DD)
  * @param {string} params.endDate - ISO date string (YYYY-MM-DD)
  * @param {Map<string, { siteName: string|null, country: string|null, validFrom: Date|null }>} [params.orsDetailsMap]
+ * @param {string} params.operatorCategory
  */
 export function aggregateWasteExported({
   wasteExportedRecords,
@@ -106,7 +126,8 @@ export function aggregateWasteExported({
   wasteReceivedRecords,
   startDate,
   endDate,
-  orsDetailsMap = new Map()
+  orsDetailsMap = new Map(),
+  operatorCategory
 }) {
   const exportedRecords = wasteExportedRecords.filter(
     ({ type }) => type === WASTE_RECORD_TYPE.EXPORTED
@@ -153,7 +174,11 @@ export function aggregateWasteExported({
   )
 
   const { overseasSites, unapprovedOverseasSites } =
-    generateOverseasSiteSummaries(exportedRecords, orsDetailsMap)
+    generateOverseasSiteSummaries(
+      exportedRecords,
+      orsDetailsMap,
+      operatorCategory
+    )
 
   return {
     overseasSites,

--- a/src/reports/domain/aggregation/aggregate-waste-exported.js
+++ b/src/reports/domain/aggregation/aggregate-waste-exported.js
@@ -8,6 +8,7 @@ import { groupAndSum, isYes } from './helpers.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { isDateInRange } from './filter-records-by-date.js'
 import { isOrsApprovedAtDate } from '#overseas-sites/domain/approval.js'
+import { OPERATOR_CATEGORY } from '../operator-category.js'
 
 const ORS_ID_DIGITS = 3
 const ZERO = '0'
@@ -19,8 +20,6 @@ const summariseTonnage = (grouped) =>
     ...rest,
     tonnageExported: roundToTwoDecimalPlaces(tonnageDecimal)
   }))
-
-const REGISTERED_ONLY = 'EXPORTER_REGISTERED_ONLY'
 
 const generateOverseasSiteSummaries = (
   wasteExportedRecords,
@@ -38,7 +37,7 @@ const generateOverseasSiteSummaries = (
   }
 
   const isApproved = ({ data }) => {
-    if (operatorCategory === REGISTERED_ONLY) {
+    if (operatorCategory === OPERATOR_CATEGORY.EXPORTER_REGISTERED_ONLY) {
       return false
     }
     const details = orsDetailsMap.get(zeroPadOrsId(data.OSR_ID))

--- a/src/reports/domain/aggregation/aggregate-waste-exported.js
+++ b/src/reports/domain/aggregation/aggregate-waste-exported.js
@@ -98,7 +98,7 @@ function calculateTonnageReceivedNotExported(
  * @param {import('#domain/waste-records/model.js').WasteRecord[]} params.wasteReceivedRecords
  * @param {string} params.startDate - ISO date string (YYYY-MM-DD)
  * @param {string} params.endDate - ISO date string (YYYY-MM-DD)
- * @param {Map<string, { siteName: string|null, country: string|null }>} [params.orsDetailsMap]
+ * @param {Map<string, { siteName: string|null, country: string|null, validFrom: string|null }>} [params.orsDetailsMap]
  */
 export function aggregateWasteExported({
   wasteExportedRecords,

--- a/src/reports/domain/aggregation/exporter.test.js
+++ b/src/reports/domain/aggregation/exporter.test.js
@@ -5,12 +5,32 @@ import wasteRecordsAccredited from './test-data/exporter-accredited.json'
 import wasteRecordsRegisteredOnly from './test-data/exporter-reg-only.json'
 
 describe('#aggregateReportDetail — EXPORTER accredited monthly January 2026', () => {
-  it('aggregates in-period records into the full report detail', () => {
+  const orsDetailsMap = new Map([
+    [
+      '512',
+      {
+        siteName: 'EuroPaper GmbH',
+        country: 'DE',
+        validFrom: new Date('2026-01-15')
+      }
+    ],
+    [
+      '124',
+      {
+        siteName: 'RecycleFrance SA',
+        country: 'FR',
+        validFrom: new Date('2026-01-25')
+      }
+    ]
+  ])
+
+  it('aggregates in-period records with per-row approval status', () => {
     const result = aggregateReportDetail(wasteRecordsAccredited, {
       operatorCategory: 'EXPORTER',
       cadence: 'monthly',
       year: 2026,
-      period: 1
+      period: 1,
+      orsDetailsMap
     })
 
     expect(result).toEqual({
@@ -56,11 +76,30 @@ describe('#aggregateReportDetail — EXPORTER accredited monthly January 2026', 
         tonnageNotRecycled: null
       },
       exportActivity: {
-        overseasSites: [],
-        unapprovedOverseasSites: [
-          { orsId: '512', tonnageExported: 23.41 },
-          { orsId: '124', tonnageExported: 65.62 }
+        overseasSites: [
+          {
+            orsId: '512',
+            siteName: 'EuroPaper GmbH',
+            country: 'DE',
+            tonnageExported: 23.41,
+            approved: true
+          },
+          {
+            orsId: '124',
+            siteName: 'RecycleFrance SA',
+            country: 'FR',
+            tonnageExported: 15.62,
+            approved: false
+          },
+          {
+            orsId: '124',
+            siteName: 'RecycleFrance SA',
+            country: 'FR',
+            tonnageExported: 50,
+            approved: true
+          }
         ],
+        unapprovedOverseasSites: [],
         totalTonnageExported: 89.03,
         tonnageReceivedNotExported: 0,
         tonnageRefusedAtDestination: 50,
@@ -132,12 +171,32 @@ describe('#aggregateReportDetail — EXPORTER accredited monthly February 2026',
 })
 
 describe('#aggregateReportDetail — EXPORTER_REGISTERED_ONLY quarterly Q1 2026', () => {
-  it('aggregates in-period records into the full report detail', () => {
+  const orsDetailsMap = new Map([
+    [
+      '565',
+      {
+        siteName: 'RegSite Alpha',
+        country: 'NL',
+        validFrom: new Date('2025-01-01')
+      }
+    ],
+    [
+      '297',
+      {
+        siteName: 'RegSite Beta',
+        country: 'BE',
+        validFrom: new Date('2025-06-01')
+      }
+    ]
+  ])
+
+  it('aggregates in-period records with approved always false for registered-only', () => {
     const result = aggregateReportDetail(wasteRecordsRegisteredOnly, {
       operatorCategory: 'EXPORTER_REGISTERED_ONLY',
       cadence: 'quarterly',
       year: 2026,
-      period: 1
+      period: 1,
+      orsDetailsMap
     })
 
     expect(result).toEqual({
@@ -191,10 +250,23 @@ describe('#aggregateReportDetail — EXPORTER_REGISTERED_ONLY quarterly Q1 2026'
         tonnageNotRecycled: null
       },
       exportActivity: {
-        overseasSites: [],
+        overseasSites: [
+          {
+            orsId: '565',
+            siteName: 'RegSite Alpha',
+            country: 'NL',
+            tonnageExported: 2.99,
+            approved: false
+          },
+          {
+            orsId: '297',
+            siteName: 'RegSite Beta',
+            country: 'BE',
+            tonnageExported: 3.02,
+            approved: false
+          }
+        ],
         unapprovedOverseasSites: [
-          { orsId: '565', tonnageExported: 2.99 },
-          { orsId: '297', tonnageExported: 3.02 },
           { orsId: '893', tonnageExported: 1.26 },
           { orsId: '143', tonnageExported: 3.07 }
         ],

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -74,7 +74,8 @@ const overseasSiteSchema = Joi.object({
   orsId: Joi.string().required(),
   siteName: Joi.string().allow(null).required(),
   country: Joi.string().allow(null).required(),
-  tonnageExported: Joi.number().min(0).required()
+  tonnageExported: Joi.number().min(0).required(),
+  approved: Joi.boolean().required()
 })
 
 const unapprovedOverseasSiteSchema = Joi.object({


### PR DESCRIPTION
Ticket: [PAE-1323](https://eaflood.atlassian.net/browse/PAE-1323)

## Summary

Adds per-row overseas site approval status to the report aggregation layer, so the frontend can conditionally show an Approved column for accredited exporters.

### Expose validFrom in ORS details map

- `getOrsDetailsMap` now includes `validFrom: site?.validFrom ?? null` alongside the existing `siteName` and `country` fields
- JSDoc type annotations updated to reflect the new `validFrom: Date|null` field

### Per-row approval status in aggregation

- Extract shared `isOrsApprovedAtDate(validFrom, dateOfExport)` predicate to `src/overseas-sites/domain/approval.js` — single source of truth for the validFrom business rule, used by both waste balance classification and report aggregation
- `aggregateWasteExported` now accepts `operatorCategory` (plumbed from `aggregateReportDetail`)
- Rename `hasApprovedSite` → `isResolvedSite` (checks DB presence via siteName, not approval)
- Resolved overseas sites now carry a per-row `approved` boolean:
  - Accredited exporters: `validFrom <= DATE_OF_EXPORT`
  - Registered-only exporters: always `false`
- Sites group by `(orsId, approved)` — a single ORS ID can produce two rows when records straddle the validFrom boundary
- Unresolved sites (Table 2 / `unapprovedOverseasSites`) unchanged
- Joi schema updated with `approved: Joi.boolean().required()`
- `received-loads-for-export.js` refactored to use the shared predicate

## Breaking change

`overseasSites` entries now include `approved: boolean`. Reports persisted in MongoDB before this change won't have the field — **test environment report data needs wiping** after deploy.

[PAE-1323]: https://eaflood.atlassian.net/browse/PAE-1323