### PR TITLE
PAE-1322: tighten reporting schema for recyclingActivity, exportActivity and wasteSent

### DIFF
--- a/src/packaging-recycling-notes/application/get-issued-tonnage.js
+++ b/src/packaging-recycling-notes/application/get-issued-tonnage.js
@@ -14,12 +14,12 @@ import { aggregateIssuedTonnage } from '#packaging-recycling-notes/domain/tonnag
  *
  * @param {import('../repository/port.js').PackagingRecyclingNotesRepository} prnRepository
  * @param {GetIssuedTonnageParams} params
- * @returns {Promise<{ issuedTonnage: number } | undefined>}
+ * @returns {Promise<{ issuedTonnage: number } | null>}
  */
 export async function getIssuedTonnage(prnRepository, params) {
   const { accreditationId, startDate, endDate } = params
   if (!accreditationId) {
-    return undefined
+    return null
   }
   const start = new Date(startDate + 'T00:00:00.000Z')
   const end = new Date(endDate + 'T23:59:59.999Z')

--- a/src/packaging-recycling-notes/application/get-issued-tonnage.test.js
+++ b/src/packaging-recycling-notes/application/get-issued-tonnage.test.js
@@ -70,22 +70,22 @@ async function acceptPrn(repo, id, { acceptedAt = IN_PERIOD } = {}) {
 }
 
 describe('getIssuedTonnage', () => {
-  it('returns undefined when accreditationId is absent', async () => {
+  it('returns null when accreditationId is absent', async () => {
     const result = await getIssuedTonnage(createRepo(), {
       ...defaultParams,
       accreditationId: undefined
     })
 
-    expect(result).toBeUndefined()
+    expect(result).toBeNull()
   })
 
-  it('returns undefined when accreditationId is null', async () => {
+  it('returns null when accreditationId is null', async () => {
     const result = await getIssuedTonnage(createRepo(), {
       ...defaultParams,
       accreditationId: null
     })
 
-    expect(result).toBeUndefined()
+    expect(result).toBeNull()
   })
 
   it('returns issuedTonnage for qualifying PRNs', async () => {

--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -206,7 +206,7 @@ export async function fetchOrGenerateReportForPeriod({
  * @param {number} params.year
  * @param {string} params.cadence
  * @param {number} params.period
- * @returns {Promise<import('#reports/domain/aggregation/aggregate-report-detail.js').AggregatedReportDetail & { prn: { issuedTonnage: number } | undefined }>}
+ * @returns {Promise<import('#reports/domain/aggregation/aggregate-report-detail.js').AggregatedReportDetail & { prn: { issuedTonnage: number } | null }>}
  */
 async function getAggregatedReportDetail({
   packagingRecyclingNotesRepository,

--- a/src/reports/application/report-service.test.js
+++ b/src/reports/application/report-service.test.js
@@ -113,6 +113,19 @@ describe('report-service', () => {
         source: {
           summaryLogId: 'sl-1',
           lastUploadedAt: '2026-04-01T21:22:28.351Z'
+        },
+        prn: null,
+        recyclingActivity: {
+          suppliers: [],
+          totalTonnageReceived: 0,
+          tonnageRecycled: null,
+          tonnageNotRecycled: null
+        },
+        wasteSent: {
+          tonnageSentToReprocessor: 0,
+          tonnageSentToExporter: 0,
+          tonnageSentToAnotherSite: 0,
+          finalDestinations: []
         }
       })
 
@@ -290,7 +303,7 @@ describe('report-service', () => {
           }
         })
 
-      it('is undefined for non-accredited operator', async () => {
+      it('is null for non-accredited operator', async () => {
         const reportsRepository = createInMemoryReportsRepository()()
         const params = defaultParams()
         params.registration = buildRegistration({ accreditationId: undefined })
@@ -305,7 +318,7 @@ describe('report-service', () => {
           changedBy
         })
 
-        expect(report.prn).toBeUndefined()
+        expect(report.prn).toBeNull()
       })
 
       it('persists prn with issuedTonnage 0 when accredited and no PRNs exist', async () => {

--- a/src/reports/domain/aggregation/aggregate-report-detail.test.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.test.js
@@ -653,13 +653,13 @@ describe('#aggregateReportDetail', () => {
 
       expect(result.exportActivity.overseasSites).toStrictEqual([
         {
-          orsId: 124,
+          orsId: '124',
           siteName: 'EuroPlast GmbH',
           country: 'Germany',
           tonnageExported: 5
         },
         {
-          orsId: 99,
+          orsId: '099',
           siteName: 'RecyclePlast SA',
           country: 'France',
           tonnageExported: 3

--- a/src/reports/domain/aggregation/aggregate-waste-exported.js
+++ b/src/reports/domain/aggregation/aggregate-waste-exported.js
@@ -36,11 +36,12 @@ const generateOverseasSiteSummaries = (wasteExportedRecords, orsDetailsMap) => {
   const overseasSites = summariseTonnage(
     groupAndSum(
       recordsWithOrsId.filter(hasApprovedSite),
-      ({ data }) => data.OSR_ID,
+      ({ data }) => zeroPadOrsId(data.OSR_ID),
       ({ data }) => {
-        const details = orsDetailsMap.get(zeroPadOrsId(data.OSR_ID))
+        const orsId = zeroPadOrsId(data.OSR_ID)
+        const details = orsDetailsMap.get(orsId)
         return {
-          orsId: data.OSR_ID,
+          orsId,
           siteName: details.siteName,
           country: details.country
         }
@@ -52,8 +53,8 @@ const generateOverseasSiteSummaries = (wasteExportedRecords, orsDetailsMap) => {
   const unapprovedOverseasSites = summariseTonnage(
     groupAndSum(
       recordsWithOrsId.filter((record) => !hasApprovedSite(record)),
-      ({ data }) => data.OSR_ID,
-      ({ data }) => ({ orsId: data.OSR_ID }),
+      ({ data }) => zeroPadOrsId(data.OSR_ID),
+      ({ data }) => ({ orsId: zeroPadOrsId(data.OSR_ID) }),
       getTonnage
     )
   )

--- a/src/reports/domain/aggregation/exporter.test.js
+++ b/src/reports/domain/aggregation/exporter.test.js
@@ -58,8 +58,8 @@ describe('#aggregateReportDetail — EXPORTER accredited monthly January 2026', 
       exportActivity: {
         overseasSites: [],
         unapprovedOverseasSites: [
-          { orsId: 512, tonnageExported: 23.41 },
-          { orsId: 124, tonnageExported: 65.62 }
+          { orsId: '512', tonnageExported: 23.41 },
+          { orsId: '124', tonnageExported: 65.62 }
         ],
         totalTonnageExported: 89.03,
         tonnageReceivedNotExported: 0,
@@ -193,10 +193,10 @@ describe('#aggregateReportDetail — EXPORTER_REGISTERED_ONLY quarterly Q1 2026'
       exportActivity: {
         overseasSites: [],
         unapprovedOverseasSites: [
-          { orsId: 565, tonnageExported: 2.99 },
-          { orsId: 297, tonnageExported: 3.02 },
-          { orsId: 893, tonnageExported: 1.26 },
-          { orsId: 143, tonnageExported: 3.07 }
+          { orsId: '565', tonnageExported: 2.99 },
+          { orsId: '297', tonnageExported: 3.02 },
+          { orsId: '893', tonnageExported: 1.26 },
+          { orsId: '143', tonnageExported: 3.07 }
         ],
         totalTonnageExported: 10.33,
         tonnageReceivedNotExported: 84.09,

--- a/src/reports/repository/contract/createReport.contract.js
+++ b/src/reports/repository/contract/createReport.contract.js
@@ -48,6 +48,19 @@ export const testCreateReportBehaviour = (it) => {
           lastUploadedAt: expect.any(String),
           summaryLogId: expect.any(String)
         },
+        prn: null,
+        recyclingActivity: {
+          suppliers: [],
+          totalTonnageReceived: 0,
+          tonnageRecycled: null,
+          tonnageNotRecycled: null
+        },
+        wasteSent: {
+          tonnageSentToReprocessor: 0,
+          tonnageSentToExporter: 0,
+          tonnageSentToAnotherSite: 0,
+          finalDestinations: []
+        },
         material: 'plastic',
         wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
         siteAddress: '1 Recycling Lane',

--- a/src/reports/repository/contract/findReportById.contract.js
+++ b/src/reports/repository/contract/findReportById.contract.js
@@ -43,6 +43,19 @@ export const testFindReportByIdBehaviour = (it) => {
           lastUploadedAt: expect.any(String),
           summaryLogId: expect.any(String)
         },
+        prn: null,
+        recyclingActivity: {
+          suppliers: [],
+          totalTonnageReceived: 0,
+          tonnageRecycled: null,
+          tonnageNotRecycled: null
+        },
+        wasteSent: {
+          tonnageSentToReprocessor: 0,
+          tonnageSentToExporter: 0,
+          tonnageSentToAnotherSite: 0,
+          finalDestinations: []
+        },
         startDate: DEFAULT_REPORT_START_DATE,
         endDate: DEFAULT_REPORT_END_DATE,
         dueDate: DEFAULT_REPORT_DUE_DATE,

--- a/src/reports/repository/contract/test-data.js
+++ b/src/reports/repository/contract/test-data.js
@@ -66,5 +66,18 @@ export const buildCreateReportParams = (overrides = {}) => ({
   wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
   changedBy: buildUserSummary(),
   source: { summaryLogId: 'sl-1', lastUploadedAt: '2026-04-01T21:22:28.351Z' },
+  prn: null,
+  recyclingActivity: {
+    suppliers: [],
+    totalTonnageReceived: 0,
+    tonnageRecycled: null,
+    tonnageNotRecycled: null
+  },
+  wasteSent: {
+    tonnageSentToReprocessor: 0,
+    tonnageSentToExporter: 0,
+    tonnageSentToAnotherSite: 0,
+    finalDestinations: []
+  },
   ...overrides
 })

--- a/src/reports/repository/helpers.js
+++ b/src/reports/repository/helpers.js
@@ -85,7 +85,9 @@ export const prepareCreateReportParams = (validatedParams) => {
   const { changedBy, ...reportCreateParams } = validatedParams
 
   const providedReportParams = Object.fromEntries(
-    Object.entries(reportCreateParams).filter(([_, value]) => value != null)
+    Object.entries(reportCreateParams).filter(
+      ([_, value]) => value !== undefined
+    )
   )
   const now = new Date().toISOString()
   const reportId = randomUUID()

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -51,15 +51,73 @@ export const prnSchema = Joi.object({
   averagePricePerTonne: Joi.number().min(0).allow(null)
 }).optional()
 
+const supplierSchema = Joi.object({
+  supplierName: Joi.string().allow(null).optional(),
+  facilityType: Joi.string().allow(null).optional(),
+  supplierAddress: Joi.string().allow(null).optional(),
+  supplierPhone: Joi.string().allow(null).optional(),
+  supplierEmail: Joi.string().allow(null).optional(),
+  tonnageReceived: Joi.number().min(0).required()
+})
+
+const recyclingActivitySchema = Joi.object({
+  suppliers: Joi.array().items(supplierSchema).required(),
+  totalTonnageReceived: Joi.number().min(0).required(),
+  tonnageRecycled: Joi.number().min(0).allow(null).custom(maxTwoDecimalPlaces),
+  tonnageNotRecycled: Joi.number()
+    .min(0)
+    .allow(null)
+    .custom(maxTwoDecimalPlaces)
+}).required()
+
+const overseasSiteSchema = Joi.object({
+  orsId: Joi.string().required(),
+  siteName: Joi.string().allow(null).required(),
+  country: Joi.string().allow(null).required(),
+  tonnageExported: Joi.number().min(0).required()
+})
+
+const unapprovedOverseasSiteSchema = Joi.object({
+  orsId: Joi.string().required(),
+  tonnageExported: Joi.number().min(0).required()
+})
+
+const exportActivitySchema = Joi.object({
+  overseasSites: Joi.array().items(overseasSiteSchema).required(),
+  unapprovedOverseasSites: Joi.array()
+    .items(unapprovedOverseasSiteSchema)
+    .required(),
+  totalTonnageExported: Joi.number().min(0).required(),
+  tonnageReceivedNotExported: Joi.number().min(0).required(),
+  tonnageRefusedAtDestination: Joi.number().min(0).required(),
+  tonnageStoppedDuringExport: Joi.number().min(0).required(),
+  totalTonnageRefusedOrStopped: Joi.number().min(0).required(),
+  tonnageRepatriated: Joi.number().min(0).required()
+}).optional()
+
+const finalDestinationSchema = Joi.object({
+  recipientName: Joi.string().allow(null).optional(),
+  facilityType: Joi.string().allow(null).optional(),
+  address: Joi.string().allow(null).optional(),
+  tonnageSentOn: Joi.number().min(0).required()
+})
+
+const wasteSentSchema = Joi.object({
+  tonnageSentToReprocessor: Joi.number().min(0).required(),
+  tonnageSentToExporter: Joi.number().min(0).required(),
+  tonnageSentToAnotherSite: Joi.number().min(0).required(),
+  finalDestinations: Joi.array().items(finalDestinationSchema).required()
+}).required()
+
 const reportDataFieldsSchema = {
   source: Joi.object({
     summaryLogId: Joi.string().allow(null),
     lastUploadedAt: Joi.string().isoDate().allow(null)
   }).required(),
-  recyclingActivity: Joi.object().optional(),
-  exportActivity: Joi.object().optional(),
-  wasteSent: Joi.object().optional(),
-  prn: prnSchema,
+  recyclingActivity: recyclingActivitySchema,
+  exportActivity: exportActivitySchema,
+  wasteSent: wasteSentSchema,
+  prn: prnSchema.allow(null).required(),
   supportingInformation: Joi.string().optional()
 }
 

--- a/src/reports/routes/get-detail.test.js
+++ b/src/reports/routes/get-detail.test.js
@@ -919,6 +919,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
               }
             ]
           },
+          prn: null,
           source: {
             summaryLogId: 'sl-1',
             lastUploadedAt: '2026-04-01T21:22:28.351Z'

--- a/src/reports/routes/get.test.js
+++ b/src/reports/routes/get.test.js
@@ -249,6 +249,19 @@ describe(`GET ${reportsGetPath}`, () => {
           source: {
             summaryLogId: 'sl-1',
             lastUploadedAt: '2024-01-15T00:00:00.000Z'
+          },
+          prn: null,
+          recyclingActivity: {
+            suppliers: [],
+            totalTonnageReceived: 0,
+            tonnageRecycled: null,
+            tonnageNotRecycled: null
+          },
+          wasteSent: {
+            tonnageSentToReprocessor: 0,
+            tonnageSentToExporter: 0,
+            tonnageSentToAnotherSite: 0,
+            finalDestinations: []
           }
         })
 
@@ -292,6 +305,19 @@ describe(`GET ${reportsGetPath}`, () => {
           source: {
             summaryLogId: 'sl-1',
             lastUploadedAt: '2024-01-15T00:00:00.000Z'
+          },
+          prn: null,
+          recyclingActivity: {
+            suppliers: [],
+            totalTonnageReceived: 0,
+            tonnageRecycled: null,
+            tonnageNotRecycled: null
+          },
+          wasteSent: {
+            tonnageSentToReprocessor: 0,
+            tonnageSentToExporter: 0,
+            tonnageSentToAnotherSite: 0,
+            finalDestinations: []
           }
         })
 
@@ -341,6 +367,19 @@ describe(`GET ${reportsGetPath}`, () => {
           source: {
             summaryLogId: 'sl-1',
             lastUploadedAt: '2024-01-15T00:00:00.000Z'
+          },
+          prn: null,
+          recyclingActivity: {
+            suppliers: [],
+            totalTonnageReceived: 0,
+            tonnageRecycled: null,
+            tonnageNotRecycled: null
+          },
+          wasteSent: {
+            tonnageSentToReprocessor: 0,
+            tonnageSentToExporter: 0,
+            tonnageSentToAnotherSite: 0,
+            finalDestinations: []
           }
         })
 
@@ -384,6 +423,19 @@ describe(`GET ${reportsGetPath}`, () => {
           source: {
             summaryLogId: 'sl-1',
             lastUploadedAt: '2024-01-15T00:00:00.000Z'
+          },
+          prn: null,
+          recyclingActivity: {
+            suppliers: [],
+            totalTonnageReceived: 0,
+            tonnageRecycled: null,
+            tonnageNotRecycled: null
+          },
+          wasteSent: {
+            tonnageSentToReprocessor: 0,
+            tonnageSentToExporter: 0,
+            tonnageSentToAnotherSite: 0,
+            finalDestinations: []
           }
         })
 

--- a/src/reports/routes/patch.js
+++ b/src/reports/routes/patch.js
@@ -103,7 +103,7 @@ function buildUpdateFields(payload, report) {
 
   if (tonnageRecycled !== undefined || tonnageNotRecycled !== undefined) {
     fields.recyclingActivity = {
-      ...(report.recyclingActivity || {}),
+      ...report.recyclingActivity,
       ...(tonnageRecycled !== undefined && { tonnageRecycled }),
       ...(tonnageNotRecycled !== undefined && { tonnageNotRecycled })
     }


### PR DESCRIPTION
Ticket: [PAE-1322](https://eaflood.atlassian.net/browse/PAE-1322)
## PAE-1322: tighten reporting schema for recyclingActivity, exportActivity and wasteSent

<!-- Describe your changes -->

- Make reporting schema stricter for aggregated fields

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1322]: https://eaflood.atlassian.net/browse/PAE-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ