### PR TITLE
PAE-1324: Fix isDateInRange dropping first-month records for YYYY-MM dates

### DIFF
--- a/src/common/helpers/dates/year-month.js
+++ b/src/common/helpers/dates/year-month.js
@@ -5,6 +5,6 @@
  * @param {string} isoDate - An ISO date string (YYYY-MM-DD or longer)
  * @returns {string} Year-month in YYYY-MM format
  */
-const YEAR_MONTH_LENGTH = 7
+export const YEAR_MONTH_LENGTH = 7
 
 export const toYearMonth = (isoDate) => isoDate.slice(0, YEAR_MONTH_LENGTH)

--- a/src/reports/domain/aggregation/aggregate-report-detail.test.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.test.js
@@ -7,7 +7,7 @@ import { aggregateReportDetail } from './aggregate-report-detail.js'
 const buildReceivedRecord = (overrides = {}) => ({
   type: WASTE_RECORD_TYPE.RECEIVED,
   data: {
-    MONTH_RECEIVED_FOR_REPROCESSING: '2026-01-01',
+    MONTH_RECEIVED_FOR_REPROCESSING: '2026-01',
     TONNAGE_RECEIVED_FOR_RECYCLING: 50,
     SUPPLIER_NAME: 'Grantham Waste',
     ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Baler',
@@ -92,7 +92,7 @@ describe('#aggregateReportDetail', () => {
         buildReceivedRecord(),
         {
           ...buildReceivedRecord({
-            MONTH_RECEIVED_FOR_REPROCESSING: '2026-02-01',
+            MONTH_RECEIVED_FOR_REPROCESSING: '2026-02',
             TONNAGE_RECEIVED_FOR_RECYCLING: 30
           }),
           versions: [
@@ -145,7 +145,7 @@ describe('#aggregateReportDetail', () => {
           TONNAGE_RECEIVED_FOR_RECYCLING: 42.21
         }),
         buildReceivedRecord({
-          MONTH_RECEIVED_FOR_REPROCESSING: '2026-03-01',
+          MONTH_RECEIVED_FOR_REPROCESSING: '2026-03',
           TONNAGE_RECEIVED_FOR_RECYCLING: 38.04
         })
       ]
@@ -161,7 +161,7 @@ describe('#aggregateReportDetail', () => {
           TONNAGE_RECEIVED_FOR_RECYCLING: 50
         }),
         buildReceivedRecord({
-          MONTH_RECEIVED_FOR_REPROCESSING: '2026-04-01',
+          MONTH_RECEIVED_FOR_REPROCESSING: '2026-04',
           TONNAGE_RECEIVED_FOR_RECYCLING: 100
         })
       ]
@@ -179,7 +179,7 @@ describe('#aggregateReportDetail', () => {
           TONNAGE_RECEIVED_FOR_RECYCLING: 42.21
         }),
         buildReceivedRecord({
-          MONTH_RECEIVED_FOR_REPROCESSING: '2026-02-01',
+          MONTH_RECEIVED_FOR_REPROCESSING: '2026-02',
           SUPPLIER_NAME: 'SUEZ recycling',
           ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Sorter',
           TONNAGE_RECEIVED_FOR_RECYCLING: 38.04
@@ -387,7 +387,7 @@ describe('#aggregateReportDetail', () => {
     const buildExporterReceivedRecord = (overrides = {}) => ({
       type: WASTE_RECORD_TYPE.RECEIVED,
       data: {
-        MONTH_RECEIVED_FOR_EXPORT: '2026-01-01',
+        MONTH_RECEIVED_FOR_EXPORT: '2026-01',
         TONNAGE_RECEIVED_FOR_EXPORT: 50,
         SUPPLIER_NAME: 'Grantham Waste',
         ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Baler',
@@ -422,7 +422,7 @@ describe('#aggregateReportDetail', () => {
       const records = [
         buildExporterReceivedRecord({ TONNAGE_RECEIVED_FOR_EXPORT: 42.21 }),
         buildExporterReceivedRecord({
-          MONTH_RECEIVED_FOR_EXPORT: '2026-02-01',
+          MONTH_RECEIVED_FOR_EXPORT: '2026-02',
           TONNAGE_RECEIVED_FOR_EXPORT: 38.04
         })
       ]
@@ -1059,7 +1059,7 @@ describe('#aggregateReportDetail', () => {
           TONNAGE_RECEIVED_FOR_RECYCLING: 'not a number'
         }),
         buildReceivedRecord({
-          MONTH_RECEIVED_FOR_REPROCESSING: '2026-02-01',
+          MONTH_RECEIVED_FOR_REPROCESSING: '2026-02',
           TONNAGE_RECEIVED_FOR_RECYCLING: 50
         })
       ]

--- a/src/reports/domain/aggregation/filter-records-by-date.js
+++ b/src/reports/domain/aggregation/filter-records-by-date.js
@@ -17,7 +17,11 @@ export function isDateInRange(value, startDate, endDate) {
     return false
   }
 
-  return date.localeCompare(startDate) >= 0 && date.localeCompare(endDate) <= 0
+  const normalised = date.length === 7 ? `${date}-01` : date
+  return (
+    normalised.localeCompare(startDate) >= 0 &&
+    normalised.localeCompare(endDate) <= 0
+  )
 }
 
 /**

--- a/src/reports/domain/aggregation/filter-records-by-date.js
+++ b/src/reports/domain/aggregation/filter-records-by-date.js
@@ -1,3 +1,5 @@
+import { YEAR_MONTH_LENGTH } from '#common/helpers/dates/year-month.js'
+
 /**
  * Returns true when value is a string containing a valid ISO date that falls
  * within [startDate, endDate] (both inclusive, compared lexicographically).
@@ -17,7 +19,7 @@ export function isDateInRange(value, startDate, endDate) {
     return false
   }
 
-  const normalised = date.length === 7 ? `${date}-01` : date
+  const normalised = date.length === YEAR_MONTH_LENGTH ? `${date}-01` : date
   return (
     normalised.localeCompare(startDate) >= 0 &&
     normalised.localeCompare(endDate) <= 0

--- a/src/reports/domain/aggregation/filter-records-by-date.test.js
+++ b/src/reports/domain/aggregation/filter-records-by-date.test.js
@@ -42,4 +42,37 @@ describe('#isDateInRange', () => {
       expect(isDateInRange('2026-01-01', start, end)).toBe(false)
     })
   })
+
+  describe('month-format dates (YYYY-MM)', () => {
+    it('returns true for first month of range', () => {
+      expect(isDateInRange('2025-01', start, end)).toBe(true)
+    })
+
+    it('returns true for middle month of range', () => {
+      expect(isDateInRange('2025-06', start, end)).toBe(true)
+    })
+
+    it('returns true for last month of range', () => {
+      expect(isDateInRange('2025-12', start, end)).toBe(true)
+    })
+
+    it('returns false for month before range', () => {
+      expect(isDateInRange('2024-12', start, end)).toBe(false)
+    })
+
+    it('returns false for month after range', () => {
+      expect(isDateInRange('2026-01', start, end)).toBe(false)
+    })
+
+    it('handles quarterly boundaries correctly', () => {
+      const q1Start = '2026-01-01'
+      const q1End = '2026-03-31'
+
+      expect(isDateInRange('2026-01', q1Start, q1End)).toBe(true)
+      expect(isDateInRange('2026-02', q1Start, q1End)).toBe(true)
+      expect(isDateInRange('2026-03', q1Start, q1End)).toBe(true)
+      expect(isDateInRange('2025-12', q1Start, q1End)).toBe(false)
+      expect(isDateInRange('2026-04', q1Start, q1End)).toBe(false)
+    })
+  })
 })

--- a/src/reports/routes/get-detail.test.js
+++ b/src/reports/routes/get-detail.test.js
@@ -143,7 +143,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
             {
               type: WASTE_RECORD_TYPE.RECEIVED,
               data: {
-                MONTH_RECEIVED_FOR_REPROCESSING: '2026-01-01',
+                MONTH_RECEIVED_FOR_REPROCESSING: '2026-01',
                 TONNAGE_RECEIVED_FOR_RECYCLING: 42.21,
                 SUPPLIER_NAME: 'Grantham Waste',
                 ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Baler'
@@ -152,7 +152,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
             {
               type: WASTE_RECORD_TYPE.RECEIVED,
               data: {
-                MONTH_RECEIVED_FOR_REPROCESSING: '2026-02-01',
+                MONTH_RECEIVED_FOR_REPROCESSING: '2026-02',
                 TONNAGE_RECEIVED_FOR_RECYCLING: 38.04,
                 SUPPLIER_NAME: 'SUEZ recycling',
                 ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Sorter'
@@ -231,7 +231,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
             {
               type: WASTE_RECORD_TYPE.RECEIVED,
               data: {
-                MONTH_RECEIVED_FOR_REPROCESSING: '2026-01-01',
+                MONTH_RECEIVED_FOR_REPROCESSING: '2026-01',
                 TONNAGE_RECEIVED_FOR_RECYCLING: 50,
                 SUPPLIER_NAME: 'In period',
                 ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Baler'
@@ -240,7 +240,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
             {
               type: WASTE_RECORD_TYPE.RECEIVED,
               data: {
-                MONTH_RECEIVED_FOR_REPROCESSING: '2026-04-01',
+                MONTH_RECEIVED_FOR_REPROCESSING: '2026-04',
                 TONNAGE_RECEIVED_FOR_RECYCLING: 100,
                 SUPPLIER_NAME: 'Out of period',
                 ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Sorter'
@@ -273,7 +273,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
             {
               type: WASTE_RECORD_TYPE.RECEIVED,
               data: {
-                MONTH_RECEIVED_FOR_REPROCESSING: '2026-01-01',
+                MONTH_RECEIVED_FOR_REPROCESSING: '2026-01',
                 TONNAGE_RECEIVED_FOR_RECYCLING: 50,
                 SUPPLIER_NAME: 'Test',
                 ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Baler'
@@ -481,7 +481,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
             {
               type: WASTE_RECORD_TYPE.RECEIVED,
               data: {
-                MONTH_RECEIVED_FOR_EXPORT: '2026-01-01',
+                MONTH_RECEIVED_FOR_EXPORT: '2026-01',
                 TONNAGE_RECEIVED_FOR_EXPORT: 50.25,
                 SUPPLIER_NAME: 'Grantham Waste',
                 ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Baler'
@@ -490,7 +490,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
             {
               type: WASTE_RECORD_TYPE.RECEIVED,
               data: {
-                MONTH_RECEIVED_FOR_EXPORT: '2026-02-01',
+                MONTH_RECEIVED_FOR_EXPORT: '2026-02',
                 TONNAGE_RECEIVED_FOR_EXPORT: 30,
                 SUPPLIER_NAME: 'SUEZ recycling',
                 ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Sorter'
@@ -575,7 +575,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
             {
               type: WASTE_RECORD_TYPE.RECEIVED,
               data: {
-                MONTH_RECEIVED_FOR_EXPORT: '2026-01-01',
+                MONTH_RECEIVED_FOR_EXPORT: '2026-01',
                 TONNAGE_RECEIVED_FOR_EXPORT: 50,
                 SUPPLIER_NAME: 'In period',
                 ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Baler'
@@ -584,7 +584,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
             {
               type: WASTE_RECORD_TYPE.RECEIVED,
               data: {
-                MONTH_RECEIVED_FOR_EXPORT: '2026-04-01',
+                MONTH_RECEIVED_FOR_EXPORT: '2026-04',
                 TONNAGE_RECEIVED_FOR_EXPORT: 100,
                 SUPPLIER_NAME: 'Out of period',
                 ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Sorter'


### PR DESCRIPTION
Ticket: [PAE-1324](https://eaflood.atlassian.net/browse/PAE-1324)
## Summary

- Fix `isDateInRange` to normalise `YYYY-MM` month-format dates to `YYYY-MM-01` before lexicographic comparison against `YYYY-MM-DD` period boundaries
- Correct test data across aggregation and route tests to use the real persisted `YYYY-MM` format instead of `YYYY-MM-DD`, which was masking the bug

## Why

Registered-only operators (exporter and reprocessor) store month-granularity dates via the `toYearMonth` transformer (e.g. `'2026-01'`). The `isDateInRange` function compared these directly against full ISO date boundaries (e.g. `'2026-01-01'`). Because `'2026-01' < '2026-01-01'` lexicographically, waste records from the first month of any reporting period were silently excluded from report aggregation. Months 2 and 3 passed by coincidence (e.g. `'2026-02' > '2026-01-01'`).

This affected `MONTH_RECEIVED_FOR_EXPORT` (exporter registered-only) and `MONTH_RECEIVED_FOR_REPROCESSING` (reprocessor registered-only) operator categories.

[PAE-1324]: https://eaflood.atlassian.net/browse/PAE-1324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ