### PR TITLE
PAE-1322: coerce supplierPhone to string and add structured logging to reports POST

### DIFF
--- a/src/reports/domain/aggregation/aggregate-report-detail.test.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.test.js
@@ -208,6 +208,31 @@ describe('#aggregateReportDetail', () => {
       ])
     })
 
+    it('coerces a numeric SUPPLIER_PHONE_NUMBER to a string', () => {
+      const records = [
+        buildReceivedRecord({
+          SUPPLIER_PHONE_NUMBER: 1234567890,
+          TONNAGE_RECEIVED_FOR_RECYCLING: 10
+        })
+      ]
+
+      const result = aggregateReportDetail(records, defaultArgs)
+
+      expect(result.recyclingActivity.suppliers[0].supplierPhone).toBe(
+        '1234567890'
+      )
+    })
+
+    it('sets supplierPhone to null when SUPPLIER_PHONE_NUMBER is absent', () => {
+      const records = [
+        buildReceivedRecord({ TONNAGE_RECEIVED_FOR_RECYCLING: 10 })
+      ]
+
+      const result = aggregateReportDetail(records, defaultArgs)
+
+      expect(result.recyclingActivity.suppliers[0].supplierPhone).toBeNull()
+    })
+
     it('only includes received records in waste received totals', () => {
       const records = [
         buildReceivedRecord({ TONNAGE_RECEIVED_FOR_RECYCLING: 50 }),

--- a/src/reports/domain/aggregation/aggregate-waste-received.js
+++ b/src/reports/domain/aggregation/aggregate-waste-received.js
@@ -50,7 +50,7 @@ export function aggregateWasteReceived(wasteReceivedRecords, tonnageField) {
         data.SUPPLIER_ADDRESS,
         data.SUPPLIER_POSTCODE
       ),
-      supplierPhone: data.SUPPLIER_PHONE_NUMBER ?? null,
+      supplierPhone: data.SUPPLIER_PHONE_NUMBER?.toString() ?? null,
       supplierEmail: data.SUPPLIER_EMAIL ?? null
     }),
     ({ data }) => data[tonnageField]

--- a/src/reports/routes/post.js
+++ b/src/reports/routes/post.js
@@ -1,6 +1,10 @@
 import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
 
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/index.js'
 import { createReportForPeriod } from '#reports/application/report-service.js'
 import { auditReportCreate } from '#reports/application/audit.js'
 import { CADENCE } from '#reports/domain/cadence.js'
@@ -31,52 +35,79 @@ export const reportsPost = {
       packagingRecyclingNotesRepository,
       reportsRepository,
       overseasSitesRepository,
-      params
+      params,
+      logger
     } = request
     const { organisationId, registrationId, year, cadence, period } = params
 
-    const registration = await organisationsRepository.findRegistrationById(
-      organisationId,
-      registrationId
-    )
-
-    const expectedCadence = registration.accreditationId
-      ? CADENCE.monthly
-      : CADENCE.quarterly
-
-    if (cadence !== expectedCadence) {
-      throw Boom.badRequest(
-        `Cadence '${cadence}' does not match registration type — expected '${expectedCadence}'`
+    try {
+      const registration = await organisationsRepository.findRegistrationById(
+        organisationId,
+        registrationId
       )
+
+      const expectedCadence = registration.accreditationId
+        ? CADENCE.monthly
+        : CADENCE.quarterly
+
+      if (cadence !== expectedCadence) {
+        throw Boom.badRequest(
+          `Cadence '${cadence}' does not match registration type — expected '${expectedCadence}'`
+        )
+      }
+
+      const createdReport = await createReportForPeriod({
+        reportsRepository,
+        wasteRecordsRepository,
+        packagingRecyclingNotesRepository,
+        overseasSitesRepository,
+        organisationId,
+        registrationId,
+        registration,
+        year,
+        cadence,
+        period,
+        changedBy: extractChangedBy(request.auth.credentials)
+      })
+
+      await auditReportCreate(request, {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber: createdReport.submissionNumber,
+        reportId: createdReport.id,
+        createdAt: createdReport.status.created.at
+      })
+
+      logger.info({
+        message: `Report created: id=${createdReport.id}`,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.SERVER,
+          action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
+        }
+      })
+
+      return h
+        .response(withRegistrationDetails(createdReport, registration))
+        .code(StatusCodes.CREATED)
+    } catch (error) {
+      logger.error({
+        err: error,
+        message: `Failure on ${reportsPostPath}`,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.SERVER,
+          action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+        },
+        http: {
+          response: {
+            status_code: StatusCodes.INTERNAL_SERVER_ERROR
+          }
+        }
+      })
+
+      throw error
     }
-
-    const createdReport = await createReportForPeriod({
-      reportsRepository,
-      wasteRecordsRepository,
-      packagingRecyclingNotesRepository,
-      overseasSitesRepository,
-      organisationId,
-      registrationId,
-      registration,
-      year,
-      cadence,
-      period,
-      changedBy: extractChangedBy(request.auth.credentials)
-    })
-
-    await auditReportCreate(request, {
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      submissionNumber: createdReport.submissionNumber,
-      reportId: createdReport.id,
-      createdAt: createdReport.status.created.at
-    })
-
-    return h
-      .response(withRegistrationDetails(createdReport, registration))
-      .code(StatusCodes.CREATED)
   }
 }

--- a/src/reports/routes/post.test.js
+++ b/src/reports/routes/post.test.js
@@ -13,6 +13,10 @@ import {
   buildOrganisation,
   buildRegistration
 } from '#repositories/organisations/contract/test-data.js'
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/index.js'
 import { reportsPostPath } from './post.js'
 import * as reportAudit from '#reports/application/audit.js'
 
@@ -248,6 +252,43 @@ describe(`POST ${reportsPostPath}`, () => {
       })
 
       expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+    })
+
+    describe('error handling', () => {
+      beforeEach(() => vi.clearAllMocks())
+
+      it('logs error details when an unexpected error occurs', async () => {
+        const { server, organisationId, registrationId } = await createServer({
+          wasteProcessingType: 'reprocessor',
+          accreditationId: undefined
+        })
+
+        const unexpectedError = new Error('unexpected failure')
+        reportAudit.auditReportCreate.mockRejectedValueOnce(unexpectedError)
+
+        const response = await makeRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+        expect(server.loggerMocks.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            err: unexpectedError,
+            message: `Failure on ${reportsPostPath}`,
+            event: {
+              category: LOGGING_EVENT_CATEGORIES.SERVER,
+              action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+            },
+            http: {
+              response: {
+                status_code: StatusCodes.INTERNAL_SERVER_ERROR
+              }
+            }
+          })
+        )
+      })
     })
 
     describe('auditing', () => {


### PR DESCRIPTION
Ticket: [PAE-1322](https://eaflood.atlassian.net/browse/PAE-1322)
## Summary
- Coerce `SUPPLIER_PHONE_NUMBER` to string in `aggregateWasteReceived` so numeric values serialise correctly as `supplierPhone`
- Wrap the reports POST handler in try/catch with structured `logger.info` on success and `logger.error` on unexpected failure
- Add tests for phone number coercion (numeric and absent) and for the catch block logging shape


[PAE-1322]: https://eaflood.atlassian.net/browse/PAE-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ