### PR TITLE
PAE-1327: Report creation should fail when summary log is never uploaded

### DIFF
--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -305,6 +305,12 @@ export async function createReportForPeriod({
     period
   })
 
+  if (aggregatedReportData.source.summaryLogId === null) {
+    throw Boom.badData(
+      'Cannot create report: no summary log has been uploaded for this registration'
+    )
+  }
+
   return reportsRepository.createReport({
     organisationId,
     registrationId,

--- a/src/reports/application/report-service.test.js
+++ b/src/reports/application/report-service.test.js
@@ -239,6 +239,25 @@ describe('report-service', () => {
       ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 400 } })
     })
 
+    it('throws badData when no summary log has been uploaded for the registration', async () => {
+      const reportsRepository = createInMemoryReportsRepository()()
+      const wasteRecordsRepository = createInMemoryWasteRecordsRepository([])()
+      const packagingRecyclingNotesRepository =
+        createInMemoryPackagingRecyclingNotesRepository()()
+      const params = defaultParams()
+      const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
+
+      await expect(
+        createReportForPeriod({
+          reportsRepository,
+          wasteRecordsRepository,
+          packagingRecyclingNotesRepository,
+          ...params,
+          changedBy
+        })
+      ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 422 } })
+    })
+
     it('resolves glass material to glass recycling process', async () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const params = defaultParams()

--- a/src/reports/repository/contract/createReport.contract.js
+++ b/src/reports/repository/contract/createReport.contract.js
@@ -143,5 +143,15 @@ export const testCreateReportBehaviour = (it) => {
         repository.createReport({ organisationId: DEFAULT_ORG_ID })
       ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 400 } })
     })
+
+    it('throws badRequest when source.summaryLogId is null', async () => {
+      await expect(
+        repository.createReport(
+          buildCreateReportParams({
+            source: { summaryLogId: null, lastUploadedAt: null }
+          })
+        )
+      ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 400 } })
+    })
   })
 }

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -112,8 +112,8 @@ const wasteSentSchema = Joi.object({
 
 const reportDataFieldsSchema = {
   source: Joi.object({
-    summaryLogId: Joi.string().allow(null),
-    lastUploadedAt: Joi.string().isoDate().allow(null)
+    summaryLogId: Joi.string(),
+    lastUploadedAt: Joi.string().isoDate()
   }).required(),
   recyclingActivity: recyclingActivitySchema,
   exportActivity: exportActivitySchema,

--- a/src/reports/routes/status.js
+++ b/src/reports/routes/status.js
@@ -2,6 +2,10 @@ import Boom from '@hapi/boom'
 import Joi from 'joi'
 import { StatusCodes } from 'http-status-codes'
 
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/index.js'
 import { auditReportStatusTransition } from '#reports/application/audit.js'
 import { fetchCurrentReport } from '#reports/application/report-service.js'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
@@ -42,7 +46,7 @@ export const reportsStatus = {
    * @param {HapiResponseToolkit} h
    */
   handler: async (request, h) => {
-    const { reportsRepository, params } = request
+    const { reportsRepository, params, logger } = request
     const { organisationId, registrationId, cadence } = params
     const year = Number(params.year)
     const period = Number(params.period)
@@ -90,6 +94,14 @@ export const reportsStatus = {
       reportId: report.id,
       previous,
       next: updated
+    })
+
+    logger.info({
+      message: `Report ${report.id} status changed: ${previous.status.currentStatus} → ${status}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
+      }
     })
 
     return h


### PR DESCRIPTION
Ticket: [PAE-1327](https://eaflood.atlassian.net/browse/PAE-1327)
## [PAE-1327: Report creation should fail when summary log is never uploaded](https://github.com/DEFRA/epr-backend/commit/b8c0038c5cc1e29d246e18134da333e9e06d82d8)

<!-- Describe your changes -->
At least for now block anyone creating report without SL submission. Then can implement how to show this in UI

<img width="1395" height="1459" alt="image" src="https://github.com/user-attachments/assets/8f49b246-2ee7-4eb9-988c-77b1a5d1646e" />

<img width="1076" height="291" alt="image" src="https://github.com/user-attachments/assets/5f83e4e8-3c37-41cb-adb9-a689496d023a" />


Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1327]: https://eaflood.atlassian.net/browse/PAE-1327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ