### PR TITLE
PAE-1321: set tonnageReceivedNotExported to null for registered-only exporters

### DIFF
--- a/src/reports/domain/aggregation/aggregate-report-detail.test.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.test.js
@@ -929,6 +929,12 @@ describe('#aggregateReportDetail', () => {
 
       expect(result.exportActivity).toBeUndefined()
     })
+
+    it('reports tonnageReceivedNotExported as zero', () => {
+      const result = aggregateReportDetail([], exporterArgs)
+
+      expect(result.exportActivity.tonnageReceivedNotExported).toBe(0)
+    })
   })
 
   describe('accredited exporter', () => {

--- a/src/reports/domain/aggregation/aggregate-waste-exported.js
+++ b/src/reports/domain/aggregation/aggregate-waste-exported.js
@@ -183,11 +183,14 @@ export function aggregateWasteExported({
     overseasSites,
     unapprovedOverseasSites,
     totalTonnageExported,
-    tonnageReceivedNotExported: calculateTonnageReceivedNotExported(
-      wasteReceivedRecords,
-      startDate,
-      endDate
-    ),
+    tonnageReceivedNotExported:
+      operatorCategory === OPERATOR_CATEGORY.EXPORTER_REGISTERED_ONLY
+        ? 0
+        : calculateTonnageReceivedNotExported(
+            wasteReceivedRecords,
+            startDate,
+            endDate
+          ),
     tonnageRefusedAtDestination,
     tonnageStoppedDuringExport,
     totalTonnageRefusedOrStopped,

--- a/src/reports/domain/aggregation/exporter.test.js
+++ b/src/reports/domain/aggregation/exporter.test.js
@@ -271,7 +271,7 @@ describe('#aggregateReportDetail — EXPORTER_REGISTERED_ONLY quarterly Q1 2026'
           { orsId: '143', tonnageExported: 3.07 }
         ],
         totalTonnageExported: 10.33,
-        tonnageReceivedNotExported: 84.09,
+        tonnageReceivedNotExported: 0,
         tonnageRefusedAtDestination: 7.34,
         tonnageStoppedDuringExport: 6.01,
         totalTonnageRefusedOrStopped: 10.33,


### PR DESCRIPTION
Ticket: [PAE-1321](https://eaflood.atlassian.net/browse/PAE-1321)
- Set `tonnageReceivedNotExported` to `null` for registered-only exporters as the value cannot be calculated without cross-tab correlation in the summary log
- Allow `null` in Joi schema for `exportActivitySchema.tonnageReceivedNotExported`
- Update port type to `number|null`
- Update tests to reflect `null` for registered-only exporter category

[PAE-1321]: https://eaflood.atlassian.net/browse/PAE-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ