### PR TITLE
PAE-1321: fix JSDoc type errors flagged by tsc

### DIFF
--- a/src/reports/application/audit.js
+++ b/src/reports/application/audit.js
@@ -17,7 +17,7 @@ const AUDIT_SUB_CATEGORY = 'reports'
  * @param {number} params.year
  * @param {string} params.cadence
  * @param {number} params.period
- * @param {string} params.submissionNumber
+ * @param {number} params.submissionNumber
  * @param {string} params.reportId
  * @param {object} params.previous
  * @param {object} params.next
@@ -88,7 +88,7 @@ export async function auditReportStatusTransition(request, params) {
  * @param {number} params.year
  * @param {string} params.cadence
  * @param {number} params.period
- * @param {string} params.submissionNumber
+ * @param {number} params.submissionNumber
  * @param {string} params.reportId
  * @param {object} params.previous
  */
@@ -154,7 +154,7 @@ export async function auditReportDelete(request, params) {
  * @param {number} params.year
  * @param {string} params.cadence
  * @param {number} params.period
- * @param {string} params.submissionNumber
+ * @param {number} params.submissionNumber
  * @param {string} params.reportId
  * @param {string} params.createdAt
  */

--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -116,7 +116,7 @@ function getValidatedPeriodInfo(cadence, year, period) {
 
 /**
  * Extracts the report-specific fields from aggregated data and registration.
- * @param {import('#reports/domain/aggregation/aggregate-report-detail.js').AggregatedReportDetail & { prn?: { issuedTonnage: number } }} aggregated
+ * @param {import('#reports/domain/aggregation/aggregate-report-detail.js').AggregatedReportDetail & { prn?: { issuedTonnage: number } | null }} aggregated
  * @param {object} registration
  * @returns {object}
  */

--- a/src/reports/repository/contract/updateReport.contract.js
+++ b/src/reports/repository/contract/updateReport.contract.js
@@ -141,5 +141,55 @@ export const testUpdateReportBehaviour = (it) => {
         })
       ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 404 } })
     })
+
+    describe('rejects values with more than two decimal places', () => {
+      it('throws for prn.totalRevenue', async () => {
+        const { id: reportId } = await repository.createReport(
+          buildCreateReportParams({ prn: { issuedTonnage: 100 } })
+        )
+
+        for (const totalRevenue of [100.123, 0.001, 99.999]) {
+          await expect(
+            repository.updateReport({
+              reportId,
+              version: 1,
+              fields: { prn: { totalRevenue } }
+            })
+          ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 400 } })
+        }
+      })
+
+      it('throws for recyclingActivity.tonnageRecycled', async () => {
+        const { id: reportId } = await repository.createReport(
+          buildCreateReportParams()
+        )
+
+        for (const tonnageRecycled of [100.123, 0.001, 99.999]) {
+          await expect(
+            repository.updateReport({
+              reportId,
+              version: 1,
+              fields: { recyclingActivity: { tonnageRecycled } }
+            })
+          ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 400 } })
+        }
+      })
+
+      it('throws for recyclingActivity.tonnageNotRecycled', async () => {
+        const { id: reportId } = await repository.createReport(
+          buildCreateReportParams()
+        )
+
+        for (const tonnageNotRecycled of [100.123, 0.001, 99.999]) {
+          await expect(
+            repository.updateReport({
+              reportId,
+              version: 1,
+              fields: { recyclingActivity: { tonnageNotRecycled } }
+            })
+          ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 400 } })
+        }
+      })
+    })
   })
 }

--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -51,8 +51,8 @@
  * @typedef {Object} RecyclingActivity
  * @property {Supplier[]} suppliers
  * @property {number} totalTonnageReceived
- * @property {number} tonnageRecycled
- * @property {number} tonnageNotRecycled
+ * @property {number | null} tonnageRecycled
+ * @property {number | null} tonnageNotRecycled
  */
 
 /**
@@ -168,7 +168,7 @@
  * @property {RecyclingActivity} [recyclingActivity]
  * @property {ExportActivity} [exportActivity]
  * @property {WasteSent} [wasteSent]
- * @property {PrnData} [prn]
+ * @property {PrnData | null} [prn]
  * @property {string} [supportingInformation]
  * @property {{ summaryLogId: string, lastUploadedAt: string | null }} source
  */

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -1,5 +1,5 @@
-import Decimal from 'decimal.js'
 import Joi from 'joi'
+import { toDecimal } from '#common/helpers/decimal-utils.js'
 import { CADENCE } from '#reports/domain/cadence.js'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
 import {
@@ -38,7 +38,7 @@ export const userSummarySchema = Joi.object({
 const TWO_DECIMAL_PLACES = 2
 
 export const maxTwoDecimalPlaces = (value, helpers) => {
-  if (new Decimal(value).decimalPlaces() > TWO_DECIMAL_PLACES) {
+  if (toDecimal(value).decimalPlaces() > TWO_DECIMAL_PLACES) {
     return helpers.error('number.maxDecimalPlaces')
   }
   return value


### PR DESCRIPTION
Ticket: [PAE-1321](https://eaflood.atlassian.net/browse/PAE-1321)
- Correct \`submissionNumber\` JSDoc type from \`string\` to \`number\` in all three audit functions
- Allow \`null\` for \`RecyclingActivity.tonnageRecycled/tonnageNotRecycled\` and \`CreateReportParams.prn\` to match Joi schema and runtime values
- Replace direct \`new Decimal()\` in schema validator with \`toDecimal()\` from decimal-utils to resolve tsc construct-signature error
- Add contract tests covering decimal-precision rejection for \`prn.totalRevenue\`, \`recyclingActivity.tonnageRecycled\`, and \`recyclingActivity.tonnageNotRecycled\`

[PAE-1321]: https://eaflood.atlassian.net/browse/PAE-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ