### PR TITLE
PAE-1328: User-entered tonnageNotExported for registered-only exporters

### DIFF
--- a/src/reports/domain/aggregation/aggregate-report-detail.test.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.test.js
@@ -930,10 +930,10 @@ describe('#aggregateReportDetail', () => {
       expect(result.exportActivity).toBeUndefined()
     })
 
-    it('reports tonnageReceivedNotExported as zero', () => {
+    it('reports tonnageReceivedNotExported as null', () => {
       const result = aggregateReportDetail([], exporterArgs)
 
-      expect(result.exportActivity.tonnageReceivedNotExported).toBe(0)
+      expect(result.exportActivity.tonnageReceivedNotExported).toBeNull()
     })
   })
 

--- a/src/reports/domain/aggregation/aggregate-waste-exported.js
+++ b/src/reports/domain/aggregation/aggregate-waste-exported.js
@@ -185,7 +185,7 @@ export function aggregateWasteExported({
     totalTonnageExported,
     tonnageReceivedNotExported:
       operatorCategory === OPERATOR_CATEGORY.EXPORTER_REGISTERED_ONLY
-        ? 0
+        ? null
         : calculateTonnageReceivedNotExported(
             wasteReceivedRecords,
             startDate,

--- a/src/reports/domain/aggregation/exporter.test.js
+++ b/src/reports/domain/aggregation/exporter.test.js
@@ -271,7 +271,7 @@ describe('#aggregateReportDetail — EXPORTER_REGISTERED_ONLY quarterly Q1 2026'
           { orsId: '143', tonnageExported: 3.07 }
         ],
         totalTonnageExported: 10.33,
-        tonnageReceivedNotExported: 0,
+        tonnageReceivedNotExported: null,
         tonnageRefusedAtDestination: 7.34,
         tonnageStoppedDuringExport: 6.01,
         totalTonnageRefusedOrStopped: 10.33,

--- a/src/reports/repository/contract/updateReport.contract.js
+++ b/src/reports/repository/contract/updateReport.contract.js
@@ -121,7 +121,12 @@ export const testUpdateReportBehaviour = (it) => {
         reportId,
         version: 1,
         fields: {
-          recyclingActivity: { tonnageRecycled: 100.5, tonnageNotRecycled: 20 }
+          recyclingActivity: {
+            suppliers: [],
+            totalTonnageReceived: 0,
+            tonnageRecycled: 100.5,
+            tonnageNotRecycled: 20
+          }
         }
       })
 

--- a/src/reports/repository/contract/updateReport.contract.js
+++ b/src/reports/repository/contract/updateReport.contract.js
@@ -132,6 +132,34 @@ export const testUpdateReportBehaviour = (it) => {
       })
     })
 
+    it('updates exportActivity fields', async () => {
+      const { id: reportId } = await repository.createReport(
+        buildCreateReportParams({
+          exportActivity: {
+            overseasSites: [],
+            unapprovedOverseasSites: [],
+            totalTonnageExported: 0,
+            tonnageReceivedNotExported: null,
+            tonnageRefusedAtDestination: 0,
+            tonnageStoppedDuringExport: 0,
+            totalTonnageRefusedOrStopped: 0,
+            tonnageRepatriated: 0
+          }
+        })
+      )
+
+      await repository.updateReport({
+        reportId,
+        version: 1,
+        fields: {
+          exportActivity: { tonnageReceivedNotExported: 15.5 }
+        }
+      })
+
+      const result = await repository.findReportById(reportId)
+      expect(result.exportActivity.tonnageReceivedNotExported).toBe(15.5)
+    })
+
     it('throws notFound for unknown reportId', async () => {
       await expect(
         repository.updateReport({

--- a/src/reports/repository/inmemory.js
+++ b/src/reports/repository/inmemory.js
@@ -106,11 +106,14 @@ const updateReport = async (reports, params) => {
     )
   }
 
-  reports.set(reportId, {
-    ...existing,
-    ...fields,
-    version: existing.version + 1
-  })
+  const updated = { ...existing, ...fields, version: existing.version + 1 }
+  if (fields.exportActivity !== undefined) {
+    updated.exportActivity = {
+      ...existing.exportActivity,
+      ...fields.exportActivity
+    }
+  }
+  reports.set(reportId, updated)
 }
 
 /**

--- a/src/reports/repository/mongodb.js
+++ b/src/reports/repository/mongodb.js
@@ -105,6 +105,10 @@ const performUpdateReport = async (db, params) => {
     setFields.recyclingActivity = fields.recyclingActivity
   }
 
+  if (fields.exportActivity !== undefined) {
+    setFields.exportActivity = fields.exportActivity
+  }
+
   const { matchedCount } = await db
     .collection(REPORTS_COLLECTION)
     .updateOne(

--- a/src/reports/repository/mongodb.js
+++ b/src/reports/repository/mongodb.js
@@ -106,7 +106,9 @@ const performUpdateReport = async (db, params) => {
   }
 
   if (fields.exportActivity !== undefined) {
-    setFields.exportActivity = fields.exportActivity
+    for (const [key, value] of Object.entries(fields.exportActivity)) {
+      setFields[`exportActivity.${key}`] = value
+    }
   }
 
   const { matchedCount } = await db

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -161,7 +161,7 @@ const updatableFieldsSchema = Joi.object({
       .min(0)
       .allow(null)
       .custom(maxTwoDecimalPlaces)
-  }).unknown(true)
+  })
 })
   .min(1)
   .required()

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -146,6 +146,12 @@ export const createReportSchema = Joi.object({
 const updatableFieldsSchema = Joi.object({
   supportingInformation: Joi.string().allow(''),
   prn: prnSchema.fork('issuedTonnage', (s) => s.optional()),
+  exportActivity: Joi.object({
+    tonnageReceivedNotExported: Joi.number()
+      .min(0)
+      .allow(null)
+      .custom(maxTwoDecimalPlaces)
+  }),
   recyclingActivity: Joi.object({
     tonnageRecycled: Joi.number()
       .min(0)
@@ -155,13 +161,7 @@ const updatableFieldsSchema = Joi.object({
       .min(0)
       .allow(null)
       .custom(maxTwoDecimalPlaces)
-  }).unknown(true),
-  exportActivity: Joi.object({
-    tonnageReceivedNotExported: Joi.number()
-      .min(0)
-      .allow(null)
-      .custom(maxTwoDecimalPlaces)
-  })
+  }).unknown(true)
 })
   .min(1)
   .required()

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -89,7 +89,7 @@ const exportActivitySchema = Joi.object({
     .items(unapprovedOverseasSiteSchema)
     .required(),
   totalTonnageExported: Joi.number().min(0).required(),
-  tonnageReceivedNotExported: Joi.number().min(0).required(),
+  tonnageReceivedNotExported: Joi.number().min(0).allow(null),
   tonnageRefusedAtDestination: Joi.number().min(0).required(),
   tonnageStoppedDuringExport: Joi.number().min(0).required(),
   totalTonnageRefusedOrStopped: Joi.number().min(0).required(),
@@ -152,6 +152,12 @@ const updatableFieldsSchema = Joi.object({
       .allow(null)
       .custom(maxTwoDecimalPlaces),
     tonnageNotRecycled: Joi.number()
+      .min(0)
+      .allow(null)
+      .custom(maxTwoDecimalPlaces)
+  }).unknown(true),
+  exportActivity: Joi.object({
+    tonnageReceivedNotExported: Joi.number()
       .min(0)
       .allow(null)
       .custom(maxTwoDecimalPlaces)

--- a/src/reports/routes/patch.js
+++ b/src/reports/routes/patch.js
@@ -5,6 +5,7 @@ import { StatusCodes } from 'http-status-codes'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
 import { fetchCurrentReport } from '#reports/application/report-service.js'
 import { maxTwoDecimalPlaces } from '#reports/repository/schema.js'
+import { WASTE_PROCESSING_TYPE } from '#domain/organisations/model.js'
 import {
   periodParamsSchema,
   standardUserAuth,
@@ -60,8 +61,9 @@ export function buildUpdatedPrn(existingPrn, totalRevenue, freeTonnage) {
  * Guards against updates to report data fields when the report is not in progress.
  * @param {object} payload
  * @param {import('#reports/repository/port.js').Report} report
+ * @param {object} registration
  */
-function guardReportDataFields(payload, report) {
+function guardReportDataFields(payload, report, registration) {
   const hasPrnFields = 'prnRevenue' in payload || 'freeTonnage' in payload
 
   if (hasPrnFields && !report.prn) {
@@ -78,6 +80,17 @@ function guardReportDataFields(payload, report) {
     throw Boom.badRequest(
       `freeTonnage (${payload.freeTonnage}) must not exceed total issued tonnage (${report.prn.issuedTonnage})`
     )
+  }
+
+  if ('tonnageNotExported' in payload) {
+    const isRegisteredOnlyExporter =
+      registration.wasteProcessingType === WASTE_PROCESSING_TYPE.EXPORTER &&
+      !registration.accreditationId
+    if (!isRegisteredOnlyExporter) {
+      throw Boom.badRequest(
+        'tonnageNotExported can only be set for registered-only exporters'
+      )
+    }
   }
 }
 
@@ -134,19 +147,25 @@ export const reportsPatch = {
    * @param {HapiResponseToolkit} h
    */
   handler: async (request, h) => {
-    const { reportsRepository, params } = request
+    const { organisationsRepository, reportsRepository, params } = request
     const { organisationId, registrationId, cadence } = params
     const year = Number(params.year)
     const period = Number(params.period)
 
-    const report = await fetchCurrentReport(
-      reportsRepository,
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period
-    )
+    const [registration, report] = await Promise.all([
+      organisationsRepository.findRegistrationById(
+        organisationId,
+        registrationId
+      ),
+      fetchCurrentReport(
+        reportsRepository,
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period
+      )
+    ])
 
     if (!report) {
       throw Boom.notFound(
@@ -169,7 +188,7 @@ export const reportsPatch = {
       )
     }
 
-    guardReportDataFields(request.payload, report)
+    guardReportDataFields(request.payload, report, registration)
 
     const fields = buildUpdateFields(request.payload, report)
 

--- a/src/reports/routes/patch.js
+++ b/src/reports/routes/patch.js
@@ -112,10 +112,7 @@ function buildUpdateFields(payload, report) {
   }
 
   if (tonnageNotExported !== undefined) {
-    fields.exportActivity = {
-      ...report.exportActivity,
-      tonnageReceivedNotExported: tonnageNotExported
-    }
+    fields.exportActivity = { tonnageReceivedNotExported: tonnageNotExported }
   }
 
   return fields

--- a/src/reports/routes/patch.js
+++ b/src/reports/routes/patch.js
@@ -21,7 +21,8 @@ const payloadSchema = Joi.object({
   prnRevenue: Joi.number().min(0).custom(maxTwoDecimalPlaces),
   freeTonnage: Joi.number().integer().min(0),
   tonnageRecycled: Joi.number().min(0).custom(maxTwoDecimalPlaces),
-  tonnageNotRecycled: Joi.number().min(0).custom(maxTwoDecimalPlaces)
+  tonnageNotRecycled: Joi.number().min(0).custom(maxTwoDecimalPlaces),
+  tonnageNotExported: Joi.number().min(0).custom(maxTwoDecimalPlaces)
 }).min(1)
 
 /**
@@ -92,6 +93,7 @@ function buildUpdateFields(payload, report) {
     freeTonnage,
     tonnageRecycled,
     tonnageNotRecycled,
+    tonnageNotExported,
     ...otherFields
   } = payload
 
@@ -106,6 +108,13 @@ function buildUpdateFields(payload, report) {
       ...report.recyclingActivity,
       ...(tonnageRecycled !== undefined && { tonnageRecycled }),
       ...(tonnageNotRecycled !== undefined && { tonnageNotRecycled })
+    }
+  }
+
+  if (tonnageNotExported !== undefined) {
+    fields.exportActivity = {
+      ...report.exportActivity,
+      tonnageReceivedNotExported: tonnageNotExported
     }
   }
 

--- a/src/reports/routes/patch.test.js
+++ b/src/reports/routes/patch.test.js
@@ -672,6 +672,43 @@ describe(`PATCH ${reportsPatchPath}`, () => {
         expect(payload.exportActivity.totalTonnageExported).toBe(20)
       })
 
+      it('returns 400 when patching tonnageNotExported for an accredited exporter', async () => {
+        const { server, organisationId, registrationId } =
+          await createServerWithReport(
+            {
+              wasteProcessingType: 'exporter',
+              accreditationId: new ObjectId().toString()
+            },
+            { prn: { issuedTonnage: 100 } }
+          )
+
+        const response = await patchReport(
+          server,
+          organisationId,
+          registrationId,
+          { tonnageNotExported: 10 }
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+      })
+
+      it('returns 400 when patching tonnageNotExported for a reprocessor', async () => {
+        const { server, organisationId, registrationId } =
+          await createServerWithReport({
+            wasteProcessingType: 'reprocessor',
+            accreditationId: undefined
+          })
+
+        const response = await patchReport(
+          server,
+          organisationId,
+          registrationId,
+          { tonnageNotExported: 10 }
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+      })
+
       it('returns 422 when tonnageNotExported is negative', async () => {
         const { server, organisationId, registrationId } =
           await createServerWithReport({

--- a/src/reports/routes/patch.test.js
+++ b/src/reports/routes/patch.test.js
@@ -604,6 +604,112 @@ describe(`PATCH ${reportsPatchPath}`, () => {
       })
     })
 
+    describe('updating export activity fields', () => {
+      it('returns 200 when patching tonnageNotExported', async () => {
+        const { server, organisationId, registrationId } =
+          await createServerWithReport(
+            {
+              wasteProcessingType: 'exporter',
+              accreditationId: undefined
+            },
+            {
+              exportActivity: {
+                overseasSites: [],
+                unapprovedOverseasSites: [],
+                totalTonnageExported: 0,
+                tonnageReceivedNotExported: null,
+                tonnageRefusedAtDestination: 0,
+                tonnageStoppedDuringExport: 0,
+                totalTonnageRefusedOrStopped: 0,
+                tonnageRepatriated: 0
+              }
+            }
+          )
+
+        const response = await patchReport(
+          server,
+          organisationId,
+          registrationId,
+          { tonnageNotExported: 15.5 }
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const payload = JSON.parse(response.payload)
+        expect(payload.exportActivity.tonnageReceivedNotExported).toBe(15.5)
+      })
+
+      it('preserves existing exportActivity fields when patching tonnageNotExported', async () => {
+        const { server, organisationId, registrationId } =
+          await createServerWithReport(
+            {
+              wasteProcessingType: 'exporter',
+              accreditationId: undefined
+            },
+            {
+              exportActivity: {
+                overseasSites: [],
+                unapprovedOverseasSites: [],
+                totalTonnageExported: 20,
+                tonnageReceivedNotExported: null,
+                tonnageRefusedAtDestination: 0,
+                tonnageStoppedDuringExport: 0,
+                totalTonnageRefusedOrStopped: 0,
+                tonnageRepatriated: 0
+              }
+            }
+          )
+
+        const response = await patchReport(
+          server,
+          organisationId,
+          registrationId,
+          { tonnageNotExported: 10 }
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const payload = JSON.parse(response.payload)
+        expect(payload.exportActivity.tonnageReceivedNotExported).toBe(10)
+        expect(payload.exportActivity.totalTonnageExported).toBe(20)
+      })
+
+      it('returns 422 when tonnageNotExported is negative', async () => {
+        const { server, organisationId, registrationId } =
+          await createServerWithReport({
+            wasteProcessingType: 'exporter',
+            accreditationId: undefined
+          })
+
+        const response = await patchReport(
+          server,
+          organisationId,
+          registrationId,
+          { tonnageNotExported: -1 }
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      })
+
+      it.each([10.123, 0.001, 5.999])(
+        'returns 422 when tonnageNotExported is %s (more than 2 decimal places)',
+        async (tonnageNotExported) => {
+          const { server, organisationId, registrationId } =
+            await createServerWithReport({
+              wasteProcessingType: 'exporter',
+              accreditationId: undefined
+            })
+
+          const response = await patchReport(
+            server,
+            organisationId,
+            registrationId,
+            { tonnageNotExported }
+          )
+
+          expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+        }
+      )
+    })
+
     describe('PRN data status guard', () => {
       it('returns 400 when patching PRN fields on a report with no PRN record', async () => {
         const { server, organisationId, registrationId } =


### PR DESCRIPTION
Ticket: [PAE-1328](https://eaflood.atlassian.net/browse/PAE-1328)
## Summary

- Return `null` from aggregation for `EXPORTER_REGISTERED_ONLY` instead of calculating `tonnageReceivedNotExported` from waste records
- Accept `tonnageNotExported` in PATCH payload and map to `exportActivity.tonnageReceivedNotExported`
- Add `exportActivity` to MongoDB `performUpdateReport` so the user-entered value is persisted
- Relax `exportActivitySchema` to allow `null` on `tonnageReceivedNotExported`



[PAE-1328]: https://eaflood.atlassian.net/browse/PAE-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ