### PR TITLE
PAE-1329: preserve fatal issues in capIssuesForStorage

### DIFF
--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -2,7 +2,8 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES,
   VALIDATION_CATEGORY,
-  VALIDATION_CODE
+  VALIDATION_CODE,
+  VALIDATION_SEVERITY
 } from '#common/enums/index.js'
 import { logger } from '#common/helpers/logging/logger.js'
 import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
@@ -653,14 +654,40 @@ export const createSummaryLogsValidator = ({
  * the summary log document exceeding MongoDB's 16 MiB BSON limit.
  * @see https://eaflood.atlassian.net/browse/PAE-1244
  *
+ * Fatal issues are always preserved — they determine the summary log status
+ * and are required by the frontend to render specific error messages.
+ * Non-fatal issues fill the remaining capacity.
+ *
  * @param {ValidationIssue[]} allIssues - All validation issues
  * @returns {{ cappedIssues: ValidationIssue[], totalIssuesCount: number }}
  */
 const capIssuesForStorage = (allIssues) => {
-  const shouldTruncate = allIssues.length > MAX_VALIDATION_ISSUES
-  const issues = shouldTruncate
-    ? allIssues.slice(0, MAX_VALIDATION_ISSUES)
-    : allIssues
+  if (allIssues.length <= MAX_VALIDATION_ISSUES) {
+    for (const issue of allIssues) {
+      if (
+        typeof issue.context?.actual === 'string' &&
+        issue.context.actual.length > MAX_ACTUAL_LENGTH
+      ) {
+        issue.context.actual =
+          issue.context.actual.slice(0, MAX_ACTUAL_LENGTH) + '…'
+      }
+    }
+
+    return {
+      cappedIssues: allIssues,
+      totalIssuesCount: allIssues.length
+    }
+  }
+
+  const fatal = allIssues.filter(
+    (issue) => issue.severity === VALIDATION_SEVERITY.FATAL
+  )
+  const nonFatal = allIssues.filter(
+    (issue) => issue.severity !== VALIDATION_SEVERITY.FATAL
+  )
+  const cappedFatal = fatal.slice(0, MAX_VALIDATION_ISSUES)
+  const nonFatalSlots = Math.max(0, MAX_VALIDATION_ISSUES - cappedFatal.length)
+  const issues = [...cappedFatal, ...nonFatal.slice(0, nonFatalSlots)]
 
   for (const issue of issues) {
     if (

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -1963,5 +1963,74 @@ describe('SummaryLogsValidator', () => {
         updateCall.validation.issues.length
       )
     })
+
+    it('preserves fatal issues when truncating past MAX_VALIDATION_ISSUES', async () => {
+      // Create 10 rows with only ROW_ID filled — each produces ~13
+      // error-level FIELD_REQUIRED issues (one per missing waste balance
+      // field), for a total well over MAX_VALIDATION_ISSUES.
+      const excludedRows = Array.from({ length: 10 }, (_, i) => ({
+        ROW_ID: 10000 + i,
+        DATE_RECEIVED_FOR_REPROCESSING: null,
+        EWC_CODE: null,
+        DESCRIPTION_WASTE: null,
+        WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: null,
+        GROSS_WEIGHT: null,
+        TARE_WEIGHT: null,
+        PALLET_WEIGHT: null,
+        NET_WEIGHT: null,
+        BAILING_WIRE_PROTOCOL: null,
+        HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: null,
+        WEIGHT_OF_NON_TARGET_MATERIALS: null,
+        RECYCLABLE_PROPORTION_PERCENTAGE: null,
+        TONNAGE_RECEIVED_FOR_RECYCLING: null,
+        SUPPLIER_NAME: null,
+        SUPPLIER_ADDRESS: null,
+        SUPPLIER_POSTCODE: null,
+        SUPPLIER_EMAIL: null,
+        SUPPLIER_PHONE_NUMBER: null,
+        ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: null,
+        YOUR_REFERENCE: null,
+        WEIGHBRIDGE_TICKET: null,
+        CARRIER_NAME: null,
+        CBD_REG_NUMBER: null,
+        CARRIER_VEHICLE_REGISTRATION_NUMBER: null
+      }))
+
+      summaryLogExtractor.extract.mockResolvedValue(
+        buildExtractedData({
+          data: {
+            RECEIVED_LOADS_FOR_REPROCESSING: buildReceivedLoadsTable({
+              rows: excludedRows
+            })
+          }
+        })
+      )
+
+      // An existing waste record whose ROW_ID is NOT in the current upload
+      // triggers a fatal SEQUENTIAL_ROW_REMOVED error during data-business
+      // validation — appended AFTER the 130+ non-fatal data-syntax issues.
+      wasteRecordsRepository.findByRegistration.mockResolvedValue([
+        buildExistingWasteRecord(buildReceivedLoadRow({ ROW_ID: 99999 }))
+      ])
+
+      await validateSummaryLog(summaryLogId)
+
+      const updateCall = summaryLogsRepository.update.mock.calls[0][2]
+      const { issues, totalIssuesCount } = updateCall.validation
+
+      // The fatal issue must survive truncation
+      const fatalIssues = issues.filter((i) => i.severity === 'fatal')
+      expect(fatalIssues).toHaveLength(1)
+      expect(fatalIssues[0].code).toBe('SEQUENTIAL_ROW_REMOVED')
+
+      // Total stored issues are capped
+      expect(issues.length).toBeLessThanOrEqual(MAX_VALIDATION_ISSUES)
+
+      // totalIssuesCount reflects the real pre-cap count
+      expect(totalIssuesCount).toBeGreaterThan(MAX_VALIDATION_ISSUES)
+
+      // Status should be invalid (the fatal was detected pre-cap)
+      expect(updateCall.status).toBe(SUMMARY_LOG_STATUS.INVALID)
+    })
   })
 })


### PR DESCRIPTION
## Summary

`capIssuesForStorage` used a naive `allIssues.slice(0, 100)` that could silently discard fatal issues when preceded by >100 non-fatal errors.

The status was set correctly (determined pre-cap via `issues.isFatal()`), but the stored `validation.issues` array lost the fatal. The frontend then sees `status=invalid` with zero fatals in the issues list, falls through to a generic "Sorry, there is a problem with the service" error page instead of showing a meaningful validation message.

## Fix

Partition issues by severity before capping: retain all fatals first (up to the cap), then fill remaining slots with non-fatals.

## Reproduction conditions

- A spreadsheet with many partially-filled rows producing >100 non-fatal `FIELD_REQUIRED` errors at the data-syntax level
- Plus any condition that produces a fatal issue at a later validation stage (e.g. `SEQUENTIAL_ROW_REMOVED` in data-business, or `VALIDATION_SYSTEM_ERROR` from an unhandled exception in `markIgnoredByDateRange`)

## Testing

- New test: `preserves fatal issues when truncating past MAX_VALIDATION_ISSUES` — creates >100 non-fatal data-syntax errors followed by a fatal `SEQUENTIAL_ROW_REMOVED`, verifies the fatal survives capping
- All 5,408 existing tests pass