### PR TITLE
PAE-1330: Remove FEATURE_FLAG_REGISTERED_ONLY from epr-backend

### DIFF
--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -82,7 +82,6 @@ describe('SummaryLogsValidator integration', () => {
    *  reprocessingType?: 'input' | 'output';
    *  metadata?: Record<string, MetadataEntry>;
    *  summaryLogExtractor?: SummaryLogExtractor;
-   *  featureFlags?: import('#feature-flags/feature-flags.port.js').FeatureFlags;
    * }} RunValidationParams
    * @param {RunValidationParams} params
    */
@@ -93,8 +92,7 @@ describe('SummaryLogsValidator integration', () => {
     reprocessingType = 'input',
     metadata,
     data,
-    summaryLogExtractor = null,
-    featureFlags
+    summaryLogExtractor = null
   }) => {
     const testOrg = createTestOrg(
       registrationType,
@@ -117,8 +115,7 @@ describe('SummaryLogsValidator integration', () => {
       summaryLogsRepository,
       organisationsRepository,
       wasteRecordsRepository,
-      summaryLogExtractor: extractor,
-      featureFlags
+      summaryLogExtractor: extractor
     })
 
     await summaryLogsRepository.insert(summaryLogId, summaryLog)
@@ -136,6 +133,7 @@ describe('SummaryLogsValidator integration', () => {
   }
 
   it('should update status as expected when validation succeeds', async () => {
+    const accreditationNumber = 'ACC-001'
     const metadata = {
       REGISTRATION_NUMBER: {
         value: 'REG-123',
@@ -152,12 +150,17 @@ describe('SummaryLogsValidator integration', () => {
       TEMPLATE_VERSION: {
         value: 5,
         location: { sheet: 'Cover', row: 4, column: 'B' }
+      },
+      ACCREDITATION_NUMBER: {
+        value: accreditationNumber,
+        location: { sheet: 'Cover', row: 5, column: 'B' }
       }
     }
 
     const { updated } = await runValidation({
       registrationType: 'reprocessor',
       registrationWRN: 'REG-123',
+      accreditationNumber,
       metadata
     })
 
@@ -190,16 +193,23 @@ describe('SummaryLogsValidator integration', () => {
       {
         registrationType: 'reprocessor',
         registrationWRN: 'REG-123',
+        accreditationNumber: 'ACC-001',
         spreadsheetType: 'REPROCESSOR_INPUT'
       },
       {
         registrationType: 'exporter',
         registrationWRN: 'REG-456',
+        accreditationNumber: 'ACC-002',
         spreadsheetType: 'EXPORTER'
       }
     ])(
       'when $spreadsheetType type matches $registrationType registration',
-      ({ registrationType, registrationWRN, spreadsheetType }) => {
+      ({
+        registrationType,
+        registrationWRN,
+        accreditationNumber,
+        spreadsheetType
+      }) => {
         it('should validate successfully', async () => {
           const metadata = {
             REGISTRATION_NUMBER: {
@@ -217,12 +227,17 @@ describe('SummaryLogsValidator integration', () => {
             TEMPLATE_VERSION: {
               value: 5,
               location: { sheet: 'Cover', row: 4, column: 'B' }
+            },
+            ACCREDITATION_NUMBER: {
+              value: accreditationNumber,
+              location: { sheet: 'Cover', row: 5, column: 'B' }
             }
           }
 
           const { updated } = await runValidation({
             registrationType,
             registrationWRN,
+            accreditationNumber,
             metadata
           })
 
@@ -465,7 +480,7 @@ describe('SummaryLogsValidator integration', () => {
         registrationWRN: 'REG-456',
         metadata: {
           TEMPLATE_VERSION: {
-            value: '5.0',
+            value: '2.1',
             location: { sheet: 'Cover', row: 1, column: 'B' }
           },
           REGISTRATION_NUMBER: {
@@ -473,7 +488,7 @@ describe('SummaryLogsValidator integration', () => {
             location: { sheet: 'Cover', row: 2, column: 'B' }
           },
           PROCESSING_TYPE: {
-            value: 'EXPORTER',
+            value: 'EXPORTER_REGISTERED_ONLY',
             location: { sheet: 'Cover', row: 3, column: 'B' }
           },
           MATERIAL: {
@@ -487,7 +502,7 @@ describe('SummaryLogsValidator integration', () => {
       expect(updated.summaryLog.validation.issues).toEqual([])
     })
 
-    it('should fail validation when registration has no accreditation but spreadsheet provides number', async () => {
+    it('should fail validation when registered-only org uploads accredited template', async () => {
       const { updated } = await runValidation({
         registrationType: 'exporter',
         registrationWRN: 'REG-456',
@@ -507,10 +522,6 @@ describe('SummaryLogsValidator integration', () => {
           MATERIAL: {
             value: 'Paper_and_board',
             location: { sheet: 'Cover', row: 4, column: 'B' }
-          },
-          ACCREDITATION_NUMBER: {
-            value: '12345678',
-            location: { sheet: 'Cover', row: 5, column: 'B' }
           }
         }
       })
@@ -519,7 +530,7 @@ describe('SummaryLogsValidator integration', () => {
       expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.INVALID)
       expect(updated.summaryLog.validation.issues).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ code: 'ACCREDITATION_UNEXPECTED' })
+          expect.objectContaining({ code: 'PROCESSING_TYPE_MISMATCH' })
         ])
       )
     })
@@ -545,34 +556,11 @@ describe('SummaryLogsValidator integration', () => {
       }
     }
 
-    // START: registered-only feature flag — delete this block when flag is removed
-    const registeredOnlyFeatureFlags = {
-      isRegisteredOnlyEnabled: () => true
-    }
-
-    it('should reject with feature flag disabled', async () => {
-      const { updated } = await runValidation({
-        registrationType: 'reprocessor',
-        registrationWRN: 'REG-789',
-        metadata: registeredOnlyMetadata,
-        featureFlags: { isRegisteredOnlyEnabled: () => false }
-      })
-
-      expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.INVALID)
-      expect(updated.summaryLog.validation.issues).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ code: 'PROCESSING_TYPE_INVALID' })
-        ])
-      )
-    })
-    // END: registered-only feature flag
-
     it('should validate successfully', async () => {
       const { updated } = await runValidation({
         registrationType: 'reprocessor',
         registrationWRN: 'REG-789',
-        metadata: registeredOnlyMetadata,
-        featureFlags: registeredOnlyFeatureFlags
+        metadata: registeredOnlyMetadata
       })
 
       expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.VALIDATED)
@@ -647,8 +635,7 @@ describe('SummaryLogsValidator integration', () => {
               }
             ]
           }
-        },
-        featureFlags: registeredOnlyFeatureFlags
+        }
       })
 
       expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.VALIDATED)
@@ -682,34 +669,11 @@ describe('SummaryLogsValidator integration', () => {
       }
     }
 
-    // START: registered-only feature flag — delete this block when flag is removed
-    const registeredOnlyFeatureFlags = {
-      isRegisteredOnlyEnabled: () => true
-    }
-
-    it('should reject with feature flag disabled', async () => {
-      const { updated } = await runValidation({
-        registrationType: 'exporter',
-        registrationWRN: 'REG-EXP-789',
-        metadata: registeredOnlyMetadata,
-        featureFlags: { isRegisteredOnlyEnabled: () => false }
-      })
-
-      expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.INVALID)
-      expect(updated.summaryLog.validation.issues).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ code: 'PROCESSING_TYPE_INVALID' })
-        ])
-      )
-    })
-    // END: registered-only feature flag
-
     it('should validate successfully', async () => {
       const { updated } = await runValidation({
         registrationType: 'exporter',
         registrationWRN: 'REG-EXP-789',
-        metadata: registeredOnlyMetadata,
-        featureFlags: registeredOnlyFeatureFlags
+        metadata: registeredOnlyMetadata
       })
 
       expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.VALIDATED)

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -241,7 +241,7 @@ const markIgnoredByDateRange = (
 
     /** @type {import('#domain/summary-logs/table-schemas/validation-pipeline.js').WasteBalanceClassificationResult | undefined} */
     const result = schema?.classifyForWasteBalance?.(wasteRecord.record.data, {
-      accreditation: registration.accreditation ?? null,
+      accreditation: registration.accreditation,
       overseasSites: ORS_VALIDATION_DISABLED
     })
 
@@ -258,8 +258,7 @@ const performValidationChecks = async ({
   summaryLogExtractor,
   organisationsRepository,
   wasteRecordsRepository,
-  validateDataSyntax,
-  featureFlags
+  validateDataSyntax
 }) => {
   const issues = createValidationIssues()
   let wasteRecords = null
@@ -274,7 +273,7 @@ const performValidationChecks = async ({
 
     meta = extractMetaValues(parsed.meta)
 
-    issues.merge(validateMetaSyntax({ parsed, featureFlags }))
+    issues.merge(validateMetaSyntax({ parsed }))
 
     if (issues.isFatal()) {
       return { issues, wasteRecords, meta }
@@ -291,8 +290,7 @@ const performValidationChecks = async ({
       validateMetaBusiness({
         parsed,
         registration,
-        loggingContext,
-        featureFlags
+        loggingContext
       })
     )
 
@@ -561,8 +559,7 @@ export const createSummaryLogsValidator = ({
   summaryLogsRepository,
   organisationsRepository,
   wasteRecordsRepository,
-  summaryLogExtractor,
-  featureFlags
+  summaryLogExtractor
 }) => {
   const validateDataSyntax = createDataSyntaxValidator(PROCESSING_TYPE_TABLES)
 
@@ -593,8 +590,7 @@ export const createSummaryLogsValidator = ({
       summaryLogExtractor,
       organisationsRepository,
       wasteRecordsRepository,
-      validateDataSyntax,
-      featureFlags
+      validateDataSyntax
     })
     const validationDurationMs = Date.now() - validationStart
 

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -54,6 +54,7 @@ const buildMeta = (overrides = {}) => ({
   PROCESSING_TYPE: { value: 'REPROCESSOR_INPUT' },
   TEMPLATE_VERSION: { value: 5 },
   MATERIAL: { value: 'Aluminium' },
+  ACCREDITATION_NUMBER: { value: 'ACC12345' },
   ...overrides
 })
 
@@ -176,20 +177,7 @@ describe('SummaryLogsValidator', () => {
   beforeEach(async () => {
     summaryLogExtractor = {
       extract: vi.fn().mockResolvedValue({
-        meta: {
-          REGISTRATION_NUMBER: {
-            value: 'REG12345'
-          },
-          PROCESSING_TYPE: {
-            value: 'REPROCESSOR_INPUT'
-          },
-          TEMPLATE_VERSION: {
-            value: 5
-          },
-          MATERIAL: {
-            value: 'Aluminium'
-          }
-        },
+        meta: buildMeta(),
         data: {}
       })
     }
@@ -204,6 +192,7 @@ describe('SummaryLogsValidator', () => {
         validFrom: '2025-01-01T00:00:00.000Z',
         validTo: '2025-12-31T23:59:59.999Z',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01T00:00:00.000Z',
           validTo: '2025-12-31T23:59:59.999Z',
           statusHistory: [
@@ -358,7 +347,8 @@ describe('SummaryLogsValidator', () => {
           REGISTRATION_NUMBER: 'REG12345',
           PROCESSING_TYPE: 'REPROCESSOR_INPUT',
           TEMPLATE_VERSION: 5,
-          MATERIAL: 'Aluminium'
+          MATERIAL: 'Aluminium',
+          ACCREDITATION_NUMBER: 'ACC12345'
         }
       })
     )
@@ -423,7 +413,8 @@ describe('SummaryLogsValidator', () => {
           REGISTRATION_NUMBER: 'REG99999',
           PROCESSING_TYPE: 'REPROCESSOR_INPUT',
           TEMPLATE_VERSION: 5,
-          MATERIAL: 'Aluminium'
+          MATERIAL: 'Aluminium',
+          ACCREDITATION_NUMBER: 'ACC12345'
         }
       })
     )
@@ -933,6 +924,7 @@ describe('SummaryLogsValidator', () => {
         reprocessingType: 'input',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -986,6 +978,7 @@ describe('SummaryLogsValidator', () => {
         reprocessingType: 'input',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -1051,6 +1044,7 @@ describe('SummaryLogsValidator', () => {
         reprocessingType: 'input',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -1143,6 +1137,7 @@ describe('SummaryLogsValidator', () => {
         wasteProcessingType: 'exporter',
         material: 'paper',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -1251,6 +1246,7 @@ describe('SummaryLogsValidator', () => {
         wasteProcessingType: 'exporter',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -1331,6 +1327,7 @@ describe('SummaryLogsValidator', () => {
         reprocessingType: 'output',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -1381,6 +1378,7 @@ describe('SummaryLogsValidator', () => {
         reprocessingType: 'output',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -1439,6 +1437,7 @@ describe('SummaryLogsValidator', () => {
         reprocessingType: 'output',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -1529,6 +1528,7 @@ describe('SummaryLogsValidator', () => {
         reprocessingType: 'input',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -1602,6 +1602,7 @@ describe('SummaryLogsValidator', () => {
         reprocessingType: 'input',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -1667,6 +1668,7 @@ describe('SummaryLogsValidator', () => {
         reprocessingType: 'output',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -1705,6 +1707,7 @@ describe('SummaryLogsValidator', () => {
         wasteProcessingType: 'exporter',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [
@@ -1811,6 +1814,7 @@ describe('SummaryLogsValidator', () => {
         reprocessingType: 'input',
         material: 'aluminium',
         accreditation: {
+          accreditationNumber: 'ACC12345',
           validFrom: '2025-01-01',
           validTo: '2025-12-31',
           statusHistory: [

--- a/src/application/summary-logs/validations/accreditation-number.js
+++ b/src/application/summary-logs/validations/accreditation-number.js
@@ -20,24 +20,20 @@ import {
  * @param {Object} params.parsed - The parsed summary log structure from the parser
  * @param {Object} params.registration - The registration object from the organisations repository
  * @param {string} params.loggingContext - Logging context message
- * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [params.featureFlags]
  * @returns {Object} validation issues with any issues found
  */
 export const validateAccreditationNumber = ({
   parsed,
   registration,
-  loggingContext,
-  featureFlags
+  loggingContext
 }) => {
   const issues = createValidationIssues()
 
   // Registered-only templates have no accreditation field — nothing to validate
-  if (featureFlags?.isRegisteredOnlyEnabled()) {
-    const processingType =
-      parsed.meta[SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]?.value
-    if (REGISTERED_ONLY_PROCESSING_TYPES.has(processingType)) {
-      return issues
-    }
+  const processingType =
+    parsed.meta[SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]?.value
+  if (REGISTERED_ONLY_PROCESSING_TYPES.has(processingType)) {
+    return issues
   }
 
   const accreditationNumber = registration.accreditation?.accreditationNumber

--- a/src/application/summary-logs/validations/accreditation-number.test.js
+++ b/src/application/summary-logs/validations/accreditation-number.test.js
@@ -310,7 +310,7 @@ describe('validateAccreditationNumber', () => {
   })
 
   it.each(['REPROCESSOR_REGISTERED_ONLY', 'EXPORTER_REGISTERED_ONLY'])(
-    'skips validation when template is %s and feature flag is enabled',
+    'skips validation when template is %s',
     (processingType) => {
       const registration = {
         id: 'reg-123'
@@ -324,8 +324,7 @@ describe('validateAccreditationNumber', () => {
       const issues = validateAccreditationNumber({
         parsed,
         registration,
-        loggingContext: 'test-msg',
-        featureFlags: { isRegisteredOnlyEnabled: () => true }
+        loggingContext: 'test-msg'
       })
 
       expect(issues.isFatal()).toBe(false)
@@ -353,8 +352,7 @@ describe('validateAccreditationNumber', () => {
       const issues = validateAccreditationNumber({
         parsed,
         registration,
-        loggingContext: 'test-msg',
-        featureFlags: { isRegisteredOnlyEnabled: () => true }
+        loggingContext: 'test-msg'
       })
 
       expect(issues.isFatal()).toBe(false)
@@ -363,7 +361,7 @@ describe('validateAccreditationNumber', () => {
     }
   )
 
-  it('does not skip validation for accredited template when feature flag is enabled', () => {
+  it('does not skip validation for accredited template', () => {
     const registration = {
       id: 'reg-123',
       accreditation: {
@@ -381,41 +379,12 @@ describe('validateAccreditationNumber', () => {
     const issues = validateAccreditationNumber({
       parsed,
       registration,
-      loggingContext: 'test-msg',
-      featureFlags: { isRegisteredOnlyEnabled: () => true }
+      loggingContext: 'test-msg'
     })
 
     expect(issues.isFatal()).toBe(false)
     expect(issues.getAllIssues()).toHaveLength(0)
     expect(mockLoggerInfo).toHaveBeenCalled()
-  })
-
-  it('does not skip validation for registered-only template when feature flag is disabled', () => {
-    const registration = {
-      id: 'reg-123',
-      accreditation: {
-        id: 'acc-123',
-        accreditationNumber: '12345678'
-      }
-    }
-    const parsed = {
-      meta: {
-        PROCESSING_TYPE: { value: 'REPROCESSOR_REGISTERED_ONLY' },
-        ACCREDITATION_NUMBER: { value: undefined }
-      }
-    }
-
-    const issues = validateAccreditationNumber({
-      parsed,
-      registration,
-      loggingContext: 'test-msg',
-      featureFlags: { isRegisteredOnlyEnabled: () => false }
-    })
-
-    expect(issues.isFatal()).toBe(true)
-    expect(issues.getAllIssues()[0]).toMatchObject({
-      message: 'Invalid summary log: missing accreditation number'
-    })
   })
 
   it('coerces numeric spreadsheet value to string before comparing', () => {

--- a/src/application/summary-logs/validations/meta-business.js
+++ b/src/application/summary-logs/validations/meta-business.js
@@ -17,14 +17,12 @@ import { validateMaterialType } from './material-type.js'
  * @param {Object} params.parsed - The parsed summary log data
  * @param {Object} params.registration - The registration from the database
  * @param {string} params.loggingContext - Context string for logging
- * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [params.featureFlags]
  * @returns {Object} Validation issues object
  */
 export const validateMetaBusiness = ({
   parsed,
   registration,
-  loggingContext,
-  featureFlags
+  loggingContext
 }) => {
   const issues = createValidationIssues()
 
@@ -34,9 +32,7 @@ export const validateMetaBusiness = ({
     validateAccreditationNumber,
     validateMaterialType
   ]) {
-    issues.merge(
-      validate({ parsed, registration, loggingContext, featureFlags })
-    )
+    issues.merge(validate({ parsed, registration, loggingContext }))
   }
 
   return issues

--- a/src/application/summary-logs/validations/meta-syntax.js
+++ b/src/application/summary-logs/validations/meta-syntax.js
@@ -44,12 +44,11 @@ const mapJoiErrorToCode = (fieldName, joiType) => {
  *
  * @param {Object} params
  * @param {Object} params.parsed - The parsed summary log structure from the parser
- * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [params.featureFlags] - Feature flags for controlling accepted processing types
  * @param {Object} [params.registration] - Unused, for signature compatibility
  * @param {string} [params.loggingContext] - Unused, for signature compatibility
  * @returns {Object} validation issues with any issues found
  */
-export const validateMetaSyntax = ({ parsed, featureFlags }) => {
+export const validateMetaSyntax = ({ parsed }) => {
   const issues = createValidationIssues()
 
   const metaValues = {}
@@ -61,7 +60,6 @@ export const validateMetaSyntax = ({ parsed, featureFlags }) => {
   }
 
   const schema = createMetaSchema({
-    registeredOnlyEnabled: featureFlags?.isRegisteredOnlyEnabled(),
     minTemplateVersions: MIN_TEMPLATE_VERSIONS
   })
 

--- a/src/application/summary-logs/validations/meta-syntax.schema.js
+++ b/src/application/summary-logs/validations/meta-syntax.schema.js
@@ -2,13 +2,10 @@ import Joi from 'joi'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { customJoi } from '#common/validation/custom-joi.js'
 
-const ALWAYS_VALID_PROCESSING_TYPES = [
+const VALID_PROCESSING_TYPES = [
   PROCESSING_TYPES.REPROCESSOR_INPUT,
   PROCESSING_TYPES.REPROCESSOR_OUTPUT,
-  PROCESSING_TYPES.EXPORTER
-]
-
-const REGISTERED_ONLY_PROCESSING_TYPES = [
+  PROCESSING_TYPES.EXPORTER,
   PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY,
   PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY
 ]
@@ -17,28 +14,19 @@ const IS_REQUIRED = 'is required'
 
 /**
  * Creates a Joi schema for meta section fields
- * Valid processing types vary based on feature flags
  *
  * @param {Object} [options]
- * @param {boolean} [options.registeredOnlyEnabled] - Whether registered-only processing types are accepted
  * @param {Record<string, number>} [options.minTemplateVersions] - Minimum template version per processing type
  * @returns {Joi.ObjectSchema}
  */
-export const createMetaSchema = ({
-  registeredOnlyEnabled,
-  minTemplateVersions = {}
-} = {}) => {
-  const validTypes = registeredOnlyEnabled
-    ? [...ALWAYS_VALID_PROCESSING_TYPES, ...REGISTERED_ONLY_PROCESSING_TYPES]
-    : ALWAYS_VALID_PROCESSING_TYPES
-
+export const createMetaSchema = ({ minTemplateVersions = {} } = {}) => {
   return Joi.object({
     PROCESSING_TYPE: customJoi
       .coercedString()
-      .valid(...validTypes)
+      .valid(...VALID_PROCESSING_TYPES)
       .required()
       .messages({
-        'any.only': `must be one of: ${validTypes.join(', ')}`,
+        'any.only': `must be one of: ${VALID_PROCESSING_TYPES.join(', ')}`,
         'any.required': IS_REQUIRED
       }),
     TEMPLATE_VERSION: Joi.number()

--- a/src/application/summary-logs/validations/meta-syntax.test.js
+++ b/src/application/summary-logs/validations/meta-syntax.test.js
@@ -320,82 +320,6 @@ describe('validateMetaSyntax', () => {
   })
 
   describe('registered-only processing types', () => {
-    // START: registered-only feature flag — delete this block when flag is removed
-    const registeredOnlyFeatureFlags = {
-      isRegisteredOnlyEnabled: () => true
-    }
-
-    it('rejects REPROCESSOR_REGISTERED_ONLY when feature flag is disabled', () => {
-      const parsed = {
-        meta: {
-          ...createValidMeta(),
-          PROCESSING_TYPE: { value: 'REPROCESSOR_REGISTERED_ONLY' }
-        }
-      }
-
-      const result = validateMetaSyntax({
-        parsed,
-        featureFlags: { isRegisteredOnlyEnabled: () => false }
-      })
-
-      expect(result.isValid()).toBe(false)
-
-      const fatals = result.getIssuesBySeverity(VALIDATION_SEVERITY.FATAL)
-      expect(fatals).toHaveLength(1)
-      expect(fatals[0].message).toContain('PROCESSING_TYPE')
-      expect(fatals[0].message).toContain('must be one of')
-      expect(fatals[0].message).not.toContain('REPROCESSOR_REGISTERED_ONLY')
-    })
-
-    it('rejects REPROCESSOR_REGISTERED_ONLY when no feature flags provided', () => {
-      const parsed = {
-        meta: {
-          ...createValidMeta(),
-          PROCESSING_TYPE: { value: 'REPROCESSOR_REGISTERED_ONLY' }
-        }
-      }
-
-      const result = validateMetaSyntax({ parsed })
-
-      expect(result.isValid()).toBe(false)
-    })
-
-    it('rejects EXPORTER_REGISTERED_ONLY when feature flag is disabled', () => {
-      const parsed = {
-        meta: {
-          ...createValidMeta(),
-          PROCESSING_TYPE: { value: 'EXPORTER_REGISTERED_ONLY' }
-        }
-      }
-
-      const result = validateMetaSyntax({
-        parsed,
-        featureFlags: { isRegisteredOnlyEnabled: () => false }
-      })
-
-      expect(result.isValid()).toBe(false)
-
-      const fatals = result.getIssuesBySeverity(VALIDATION_SEVERITY.FATAL)
-      expect(fatals).toHaveLength(1)
-      expect(fatals[0].message).toContain('PROCESSING_TYPE')
-      expect(fatals[0].message).toContain('must be one of')
-      expect(fatals[0].message).not.toContain('EXPORTER_REGISTERED_ONLY')
-    })
-
-    it('rejects EXPORTER_REGISTERED_ONLY when no feature flags provided', () => {
-      const parsed = {
-        meta: {
-          ...createValidMeta(),
-          PROCESSING_TYPE: { value: 'EXPORTER_REGISTERED_ONLY' }
-        }
-      }
-
-      const result = validateMetaSyntax({ parsed })
-
-      expect(result.isValid()).toBe(false)
-    })
-    // END: registered-only feature flag
-
     it('accepts REPROCESSOR_REGISTERED_ONLY', () => {
       const parsed = {
         meta: {
@@ -405,10 +329,7 @@ describe('validateMetaSyntax', () => {
         }
       }
 
-      const result = validateMetaSyntax({
-        parsed,
-        featureFlags: registeredOnlyFeatureFlags
-      })
+      const result = validateMetaSyntax({ parsed })
 
       expect(result.isValid()).toBe(true)
     })
@@ -422,10 +343,7 @@ describe('validateMetaSyntax', () => {
         }
       }
 
-      const result = validateMetaSyntax({
-        parsed,
-        featureFlags: registeredOnlyFeatureFlags
-      })
+      const result = validateMetaSyntax({ parsed })
 
       expect(result.isValid()).toBe(true)
     })
@@ -439,10 +357,7 @@ describe('validateMetaSyntax', () => {
         }
       }
 
-      const result = validateMetaSyntax({
-        parsed,
-        featureFlags: registeredOnlyFeatureFlags
-      })
+      const result = validateMetaSyntax({ parsed })
 
       expect(result.isValid()).toBe(false)
       expect(result.isFatal()).toBe(true)
@@ -462,10 +377,7 @@ describe('validateMetaSyntax', () => {
         }
       }
 
-      const result = validateMetaSyntax({
-        parsed,
-        featureFlags: registeredOnlyFeatureFlags
-      })
+      const result = validateMetaSyntax({ parsed })
 
       expect(result.isValid()).toBe(true)
     })
@@ -479,10 +391,7 @@ describe('validateMetaSyntax', () => {
         }
       }
 
-      const result = validateMetaSyntax({
-        parsed,
-        featureFlags: registeredOnlyFeatureFlags
-      })
+      const result = validateMetaSyntax({ parsed })
 
       expect(result.isValid()).toBe(true)
     })
@@ -496,10 +405,7 @@ describe('validateMetaSyntax', () => {
         }
       }
 
-      const result = validateMetaSyntax({
-        parsed,
-        featureFlags: registeredOnlyFeatureFlags
-      })
+      const result = validateMetaSyntax({ parsed })
 
       expect(result.isValid()).toBe(false)
       expect(result.isFatal()).toBe(true)

--- a/src/application/summary-logs/validations/processing-type.js
+++ b/src/application/summary-logs/validations/processing-type.js
@@ -19,29 +19,10 @@ const VALID_WASTE_PROCESSING_TYPES = [
   ...new Set(Object.values(PROCESSING_TYPE_TO_WASTE_PROCESSING_TYPE))
 ]
 
-/**
- * Waste processing types that have a registered-only template counterpart
- * e.g. 'reprocessor' has REPROCESSOR_REGISTERED_ONLY
- */
-const WASTE_TYPES_WITH_REGISTERED_ONLY = new Set(
-  [...REGISTERED_ONLY_PROCESSING_TYPES].map(
-    (pt) => PROCESSING_TYPE_TO_WASTE_PROCESSING_TYPE[pt]
-  )
-)
-
 const isRegisteredOnlyMismatch = ({
-  featureFlags,
-  wasteProcessingType,
   spreadsheetProcessingType,
   registration
 }) => {
-  if (
-    !featureFlags?.isRegisteredOnlyEnabled() ||
-    !WASTE_TYPES_WITH_REGISTERED_ONLY.has(wasteProcessingType)
-  ) {
-    return false
-  }
-
   const isRegisteredOnlyTemplate = REGISTERED_ONLY_PROCESSING_TYPES.has(
     spreadsheetProcessingType
   )
@@ -67,8 +48,7 @@ const isReprocessingTypeMismatch = (
 export const validateProcessingType = ({
   parsed,
   registration,
-  loggingContext,
-  featureFlags
+  loggingContext
 }) => {
   const issues = createValidationIssues()
 
@@ -114,8 +94,6 @@ export const validateProcessingType = ({
 
   if (
     isRegisteredOnlyMismatch({
-      featureFlags,
-      wasteProcessingType,
       spreadsheetProcessingType,
       registration
     })

--- a/src/application/summary-logs/validations/processing-type.test.js
+++ b/src/application/summary-logs/validations/processing-type.test.js
@@ -12,9 +12,6 @@ vi.mock('#common/helpers/logging/logger.js', () => ({
   }
 }))
 
-const registeredOnlyEnabled = { isRegisteredOnlyEnabled: () => true }
-const registeredOnlyDisabled = { isRegisteredOnlyEnabled: () => false }
-
 describe('validateProcessingType', () => {
   afterEach(() => {
     vi.resetAllMocks()
@@ -122,8 +119,7 @@ describe('validateProcessingType', () => {
       const result = validateProcessingType({
         parsed,
         registration,
-        loggingContext: 'test',
-        featureFlags: registeredOnlyEnabled
+        loggingContext: 'test'
       })
 
       expect(result.isValid()).toBe(true)
@@ -157,8 +153,7 @@ describe('validateProcessingType', () => {
       const result = validateProcessingType({
         parsed,
         registration,
-        loggingContext: 'test',
-        featureFlags: registeredOnlyEnabled
+        loggingContext: 'test'
       })
 
       expect(result.isValid()).toBe(false)
@@ -197,8 +192,7 @@ describe('validateProcessingType', () => {
       const result = validateProcessingType({
         parsed,
         registration,
-        loggingContext: 'test',
-        featureFlags: registeredOnlyEnabled
+        loggingContext: 'test'
       })
 
       expect(result.isValid()).toBe(false)
@@ -235,8 +229,7 @@ describe('validateProcessingType', () => {
       const result = validateProcessingType({
         parsed,
         registration,
-        loggingContext: 'test',
-        featureFlags: registeredOnlyEnabled
+        loggingContext: 'test'
       })
 
       expect(result.isValid()).toBe(false)
@@ -248,47 +241,6 @@ describe('validateProcessingType', () => {
       expect(fatals[0].category).toBe(VALIDATION_CATEGORY.BUSINESS)
     }
   )
-
-  it('skips accredited-vs-registered-only check when feature flag is disabled', () => {
-    const parsed = {
-      meta: {
-        PROCESSING_TYPE: { value: 'EXPORTER' }
-      }
-    }
-    const registration = {
-      wasteProcessingType: 'exporter'
-      // No accreditation — registered-only
-    }
-
-    const result = validateProcessingType({
-      parsed,
-      registration,
-      loggingContext: 'test',
-      featureFlags: registeredOnlyDisabled
-    })
-
-    expect(result.isValid()).toBe(true)
-  })
-
-  it('skips accredited-vs-registered-only check when featureFlags is not provided', () => {
-    const parsed = {
-      meta: {
-        PROCESSING_TYPE: { value: 'EXPORTER' }
-      }
-    }
-    const registration = {
-      wasteProcessingType: 'exporter'
-      // No accreditation — registered-only
-    }
-
-    const result = validateProcessingType({
-      parsed,
-      registration,
-      loggingContext: 'test'
-    })
-
-    expect(result.isValid()).toBe(true)
-  })
 
   it('categorizes type mismatch as fatal business error', () => {
     const parsed = {

--- a/src/config.js
+++ b/src/config.js
@@ -360,12 +360,6 @@ const baseConfig = {
       default: false,
       env: 'FEATURE_FLAG_REPORTS'
     },
-    registeredOnly: {
-      doc: 'Feature Flag: Enable registered only summary log uploads',
-      format: Boolean,
-      default: false,
-      env: 'FEATURE_FLAG_REGISTERED_ONLY'
-    },
     orsWasteBalanceValidation: {
       doc: 'Feature Flag: Validate ORS approval status during exporter waste balance classification',
       format: Boolean,

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -17,9 +17,6 @@ export const createConfigFeatureFlags = (config) => ({
   isReportsEnabled() {
     return config.get('featureFlags.reports')
   },
-  isRegisteredOnlyEnabled() {
-    return config.get('featureFlags.registeredOnly')
-  },
   isOrsWasteBalanceValidationEnabled() {
     return config.get('featureFlags.orsWasteBalanceValidation')
   }

--- a/src/feature-flags/feature-flags.config.test.js
+++ b/src/feature-flags/feature-flags.config.test.js
@@ -58,19 +58,6 @@ describe('createConfigFeatureFlags', () => {
     expect(config.get).toHaveBeenCalledWith('featureFlags.reports')
   })
 
-  it('should return true when registeredOnly flag is enabled', () => {
-    const config = { get: vi.fn().mockReturnValue(true) }
-    const flags = createConfigFeatureFlags(config)
-    expect(flags.isRegisteredOnlyEnabled()).toBe(true)
-    expect(config.get).toHaveBeenCalledWith('featureFlags.registeredOnly')
-  })
-
-  it('should return false when registeredOnly flag is disabled', () => {
-    const config = { get: vi.fn().mockReturnValue(false) }
-    const flags = createConfigFeatureFlags(config)
-    expect(flags.isRegisteredOnlyEnabled()).toBe(false)
-  })
-
   it('returns true when orsWasteBalanceValidation flag is enabled', () => {
     const config = { get: vi.fn().mockReturnValue(true) }
     const flags = createConfigFeatureFlags(config)

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -17,9 +17,6 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   isReportsEnabled() {
     return flags.reports ?? false
   },
-  isRegisteredOnlyEnabled() {
-    return flags.registeredOnly ?? false
-  },
   isOrsWasteBalanceValidationEnabled() {
     return flags.orsWasteBalanceValidation ?? false
   }

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -85,21 +85,6 @@ describe('createInMemoryFeatureFlags', () => {
     expect(flags.isReportsEnabled()).toBe(false)
   })
 
-  it('returns true when registeredOnly flag is enabled', () => {
-    const flags = createInMemoryFeatureFlags({ registeredOnly: true })
-    expect(flags.isRegisteredOnlyEnabled()).toBe(true)
-  })
-
-  it('returns false when registeredOnly flag is disabled', () => {
-    const flags = createInMemoryFeatureFlags({ registeredOnly: false })
-    expect(flags.isRegisteredOnlyEnabled()).toBe(false)
-  })
-
-  it('returns false when registeredOnly flag is not provided', () => {
-    const flags = createInMemoryFeatureFlags({})
-    expect(flags.isRegisteredOnlyEnabled()).toBe(false)
-  })
-
   it('returns true when orsWasteBalanceValidation flag is enabled', () => {
     const flags = createInMemoryFeatureFlags({
       orsWasteBalanceValidation: true

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -5,7 +5,6 @@
  * @property {() => boolean} isCopyFormFilesToS3Enabled
  * @property {() => boolean} isOverseasSitesEnabled
  * @property {() => boolean} isReportsEnabled
- * @property {() => boolean} isRegisteredOnlyEnabled
  * @property {() => boolean} isOrsWasteBalanceValidationEnabled
  */
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -584,6 +584,9 @@ describe('Submission and placeholder tests', () => {
       worksheet.getCell('A4').value = '__EPR_META_TEMPLATE_VERSION'
       worksheet.getCell('B4').value = 5
 
+      worksheet.getCell('A5').value = '__EPR_META_ACCREDITATION_NUMBER'
+      worksheet.getCell('B5').value = 'ACC-PLACEHOLDER-001'
+
       worksheet.getCell('A6').value =
         '__EPR_DATA_RECEIVED_LOADS_FOR_REPROCESSING'
       // Waste balance fields (Section 1)
@@ -741,11 +744,24 @@ describe('Submission and placeholder tests', () => {
       uploadsRepository = createInMemoryUploadsRepository()
       testSummaryLogsRepository = summaryLogsRepositoryFactory(mockLogger)
 
+      const accreditationId = 'acc-placeholder-test'
       const testOrg = buildOrganisation({
         registrations: [
           {
             id: registrationId,
             registrationNumber: 'REG-123',
+            material: 'paper',
+            wasteProcessingType: 'reprocessor',
+            reprocessingType: 'input',
+            formSubmissionTime: new Date(),
+            submittedToRegulator: 'ea',
+            accreditationId
+          }
+        ],
+        accreditations: [
+          {
+            id: accreditationId,
+            accreditationNumber: 'ACC-PLACEHOLDER-001',
             material: 'paper',
             wasteProcessingType: 'reprocessor',
             reprocessingType: 'input',

--- a/src/server/queue-consumer/summary-log-commands.js
+++ b/src/server/queue-consumer/summary-log-commands.js
@@ -58,16 +58,14 @@ export const summaryLogCommandHandlers = [
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
-        summaryLogExtractor,
-        featureFlags
+        summaryLogExtractor
       } = deps
 
       const validateSummaryLog = createSummaryLogsValidator({
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
-        summaryLogExtractor,
-        featureFlags
+        summaryLogExtractor
       })
 
       await validateSummaryLog(payload.summaryLogId)


### PR DESCRIPTION
Ticket: [PAE-1330](https://eaflood.atlassian.net/browse/PAE-1330)
## Summary

- Remove the `registeredOnly` feature flag from config, port, config implementation, and in-memory implementation
- Make registered-only processing type validation unconditional — the meta-syntax schema always accepts registered-only types, and the processing-type/accreditation-number validators enforce template-to-registration consistency without a flag check
- Remove the `featureFlags` parameter threading through the validation pipeline (no longer needed by any validator)
- Remove dead code: `WASTE_TYPES_WITH_REGISTERED_ONLY` guard was unreachable after the valid-type check
- Fix test data that was using accredited templates against unaccredited registrations (masked by the feature flag being off)

Jira: PAE-1330

[PAE-1330]: https://eaflood.atlassian.net/browse/PAE-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ