### PR TITLE
PAE-1335: Prevent expected 409s from logging at error severity

### DIFF
--- a/src/reports/routes/post.js
+++ b/src/reports/routes/post.js
@@ -93,6 +93,10 @@ export const reportsPost = {
         .response(withRegistrationDetails(createdReport, registration))
         .code(StatusCodes.CREATED)
     } catch (error) {
+      if (error.isBoom) {
+        throw error
+      }
+
       logger.error({
         err: error,
         message: `Failure on ${reportsPostPath}`,
@@ -107,7 +111,7 @@ export const reportsPost = {
         }
       })
 
-      throw error
+      throw Boom.badImplementation(`Failure on ${reportsPostPath}`)
     }
   }
 }

--- a/src/reports/routes/post.js
+++ b/src/reports/routes/post.js
@@ -9,14 +9,30 @@ import { createReportForPeriod } from '#reports/application/report-service.js'
 import { auditReportCreate } from '#reports/application/audit.js'
 import { CADENCE } from '#reports/domain/cadence.js'
 import {
+  extractChangedBy,
   periodParamsSchema,
   standardUserAuth,
-  withRegistrationDetails,
-  extractChangedBy
+  withRegistrationDetails
 } from './shared.js'
 
 export const reportsPostPath =
   '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}'
+
+const logUnexpectedError = (logger, error) => {
+  logger.error({
+    err: error,
+    message: `Failure on ${reportsPostPath}`,
+    event: {
+      category: LOGGING_EVENT_CATEGORIES.SERVER,
+      action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+    },
+    http: {
+      response: {
+        status_code: StatusCodes.INTERNAL_SERVER_ERROR
+      }
+    }
+  })
+}
 
 export const reportsPost = {
   method: 'POST',
@@ -97,19 +113,7 @@ export const reportsPost = {
         throw error
       }
 
-      logger.error({
-        err: error,
-        message: `Failure on ${reportsPostPath}`,
-        event: {
-          category: LOGGING_EVENT_CATEGORIES.SERVER,
-          action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
-        },
-        http: {
-          response: {
-            status_code: StatusCodes.INTERNAL_SERVER_ERROR
-          }
-        }
-      })
+      logUnexpectedError(logger, error)
 
       throw Boom.badImplementation(`Failure on ${reportsPostPath}`)
     }

--- a/src/reports/routes/post.test.js
+++ b/src/reports/routes/post.test.js
@@ -289,6 +289,24 @@ describe(`POST ${reportsPostPath}`, () => {
           })
         )
       })
+
+      it('does not log when an expected Boom error is thrown', async () => {
+        const { server, organisationId, registrationId } = await createServer({
+          wasteProcessingType: 'reprocessor',
+          accreditationId: undefined
+        })
+
+        await makeRequest(server, organisationId, registrationId)
+        const response = await makeRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+        expect(server.loggerMocks.error).not.toHaveBeenCalled()
+        expect(server.loggerMocks.warn).not.toHaveBeenCalled()
+      })
     })
 
     describe('auditing', () => {


### PR DESCRIPTION
Ticket: [PAE-1335](https://eaflood.atlassian.net/browse/PAE-1335)
## Summary
The reports create POST handler was logging every caught error at error severity, including expected business conflicts like "report already exists" (409). This triggered production alerts for normal user behaviour. This fix aligns the handler with the convention used by roughly a dozen other route handlers in this codebase: expected Boom errors bypass the error logger entirely, and only unexpected errors are logged and normalised to a 500 response.

## What Changed
- Expected Boom errors thrown from inside the reports create handler now bypass the catch-block logger rather than being logged at error severity.
- Unexpected (non-Boom) errors are wrapped as a bad-implementation response, matching the pattern used by other route handlers.
- Added a test asserting 409 responses no longer trigger catch-block logging.

## Why
Production alerts were firing for expected user behaviour (clicking "Use this data" twice via the browser back button) because every caught error was being logged at error severity. Bringing this handler into line with the existing convention removes the noise without inventing a new pattern.

[PAE-1335]: https://eaflood.atlassian.net/browse/PAE-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ