### PR TITLE
PAE-1339: Fix type errors and add lint:types to CI

### DIFF
--- a/.github/actions/test-and-scan/action.yml
+++ b/.github/actions/test-and-scan/action.yml
@@ -34,6 +34,10 @@ runs:
       shell: bash
       run: npm run lint
 
+    - name: Lint types
+      shell: bash
+      run: npm run lint:types
+
     - name: Run tests
       shell: bash
       run: npm test

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "postinstall": "npm run setup:husky",
     "lint": "eslint --cache --cache-strategy content \"**/*.js\"",
     "lint:fix": "npm run lint -- --fix",
+    "lint:types": "tsc -p jsconfig.typecheck.json",
     "postversion": "git add package.json package-lock.json && git commit -m $npm_package_version",
     "benchmark:file": "node benchmarks/parse-file.js",
     "test": "TZ=UTC vitest run --coverage",

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -241,6 +241,7 @@ const markIgnoredByDateRange = (
 
     /** @type {import('#domain/summary-logs/table-schemas/validation-pipeline.js').WasteBalanceClassificationResult | undefined} */
     const result = schema?.classifyForWasteBalance?.(wasteRecord.record.data, {
+      // @ts-expect-error meta-business validation guarantees accreditation exists for non-registered-only types
       accreditation: registration.accreditation,
       overseasSites: ORS_VALIDATION_DISABLED
     })
@@ -643,6 +644,19 @@ export const createSummaryLogsValidator = ({
   }
 }
 
+/** @param {ValidationIssue[]} issues */
+const truncateActualValues = (issues) => {
+  for (const issue of issues) {
+    if (
+      typeof issue.context?.actual === 'string' &&
+      issue.context.actual.length > MAX_ACTUAL_LENGTH
+    ) {
+      issue.context.actual =
+        issue.context.actual.slice(0, MAX_ACTUAL_LENGTH) + '…'
+    }
+  }
+}
+
 /**
  * Caps the issues array and truncates long actual values for MongoDB storage.
  *
@@ -657,18 +671,6 @@ export const createSummaryLogsValidator = ({
  * @param {ValidationIssue[]} allIssues - All validation issues
  * @returns {{ cappedIssues: ValidationIssue[], totalIssuesCount: number }}
  */
-const truncateActualValues = (issues) => {
-  for (const issue of issues) {
-    if (
-      typeof issue.context?.actual === 'string' &&
-      issue.context.actual.length > MAX_ACTUAL_LENGTH
-    ) {
-      issue.context.actual =
-        issue.context.actual.slice(0, MAX_ACTUAL_LENGTH) + '…'
-    }
-  }
-}
-
 const capIssuesForStorage = (allIssues) => {
   let cappedIssues
 

--- a/src/non-prod-data-reset/mongodb.js
+++ b/src/non-prod-data-reset/mongodb.js
@@ -146,7 +146,7 @@ export const createNonProdDataReset = (db, { isProduction = false } = {}) => ({
   async deleteByOrgId(orgId) {
     if (isProduction) {
       logger.error(
-        { orgId },
+        { event: { reference: orgId } },
         'Refusing to run non-prod cascade delete in production environment.'
       )
       throw new Error('Non-prod data reset is disabled in production.')

--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -177,7 +177,7 @@
  * @typedef {Object} UpdateReportParams
  * @property {string} reportId
  * @property {number} version - current version for optimistic locking
- * @property {{ status?: ReportStatus, supportingInformation?: string, prn?: Partial<PrnData>, recyclingActivity?: Partial<RecyclingActivity> }} fields
+ * @property {{ status?: ReportStatus, supportingInformation?: string, prn?: Partial<PrnData>, recyclingActivity?: Partial<RecyclingActivity>, exportActivity?: Partial<ExportActivity> }} fields
  * @property {UserSummary} [changedBy]
  */
 


### PR DESCRIPTION
## Summary

- Fix 5 type errors so `tsc` passes cleanly:
  - Add `@ts-expect-error` for accreditation type mismatch in `validate.js` — meta-business validation guarantees accreditation exists for non-registered-only types
  - Move `truncateActualValues` above the `capIssuesForStorage` JSDoc block so tsc associates the `@param`/`@returns` annotations with the correct function
  - Add `exportActivity` to `UpdateReportParams.fields` typedef (missing since PAE-1328 added export activity patching)
  - Use `event.reference` for `orgId` in non-prod cascade delete logger call (PAE-1194 passed a bare field not in `IndexedLogProperties`)
- Add `lint:types` npm script (`tsc -p jsconfig.typecheck.json`)
- Add "Lint types" CI step to the test-and-scan GitHub Action, between linting and tests