### PR TITLE
PAE-1194: Gate non-prod data reset on cdpEnvironment

### DIFF
--- a/src/non-prod-data-reset/mongodb.plugin.js
+++ b/src/non-prod-data-reset/mongodb.plugin.js
@@ -2,13 +2,21 @@ import { config } from '#root/config.js'
 import { registerRepository } from '#plugins/register-repository.js'
 import { createNonProdDataReset } from './mongodb.js'
 
+const isProduction = () => config.get('cdpEnvironment') === 'prod'
+
 /**
  * Registers request.nonProdDataReset only when FEATURE_FLAG_DEV_ENDPOINTS is
  * enabled. When the flag is off, this plugin is not added to the server at
  * all, so the capability literally does not exist on the request object.
  * This is defence in depth beyond the router-level route gate in
  * plugins/router.js. As a final safety net, the adapter itself refuses to
- * run cascade deletes when isProduction is true.
+ * run cascade deletes when the CDP environment is prod.
+ *
+ * Note: we gate on cdpEnvironment rather than config.isProduction because
+ * the latter is derived from NODE_ENV, which CDP sets to 'production' in
+ * every environment (dev/test/prod). Using it here would disable the dev
+ * cleanup endpoint in non-prod CDP envs, which is exactly where the
+ * frontend journey tests need it.
  */
 export const nonProdDataResetPlugin = {
   name: 'nonProdDataReset',
@@ -20,7 +28,7 @@ export const nonProdDataResetPlugin = {
   ) => {
     const db = options?.db ?? server.db
     const reset = createNonProdDataReset(db, {
-      isProduction: config.get('isProduction')
+      isProduction: isProduction()
     })
     registerRepository(server, 'nonProdDataReset', () => reset)
   }

--- a/src/non-prod-data-reset/mongodb.test.js
+++ b/src/non-prod-data-reset/mongodb.test.js
@@ -28,7 +28,9 @@ import {
 } from '#repositories/waste-records/contract/test-data.js'
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
 
+import { config } from '#root/config.js'
 import { createNonProdDataReset } from './mongodb.js'
+import { nonProdDataResetPlugin } from './mongodb.plugin.js'
 
 vi.mock('@aws-sdk/s3-request-presigner', () => ({
   getSignedUrl: vi.fn().mockResolvedValue('https://signed.example')
@@ -371,31 +373,71 @@ describe('non-prod data reset (mongo)', () => {
       )
     })
 
-    it('refuses to run in production and leaves data untouched', async ({
+    it('cascades deletes via the plugin in a non-prod CDP environment even when NODE_ENV is production', async ({
       database,
       repositories
     }) => {
       const seeded = await seedOrganisationWithOverseasSites(repositories)
       await seedDownstreamForOrganisation(repositories, seeded)
 
-      const productionReset = createNonProdDataReset(database, {
-        isProduction: true
-      })
+      // Simulates CDP: NODE_ENV=production is set on every CDP environment
+      // including test, so config.isProduction is true. The plugin must not
+      // use that as its safety gate; it must check cdpEnvironment instead.
+      const previousIsProduction = config.get('isProduction')
+      const previousCdpEnvironment = config.get('cdpEnvironment')
+      config.set('isProduction', true)
+      config.set('cdpEnvironment', 'test')
 
-      await expect(
-        productionReset.deleteByOrgId(seeded.organisationId)
-      ).rejects.toThrow('Non-prod data reset is disabled in production.')
+      const server = { app: {}, logger: mockLogger, ext: () => {} }
+      try {
+        nonProdDataResetPlugin.register(server, { db: database })
+        const counts = await server.app.nonProdDataReset.deleteByOrgId(
+          seeded.organisationId
+        )
 
-      expect(
-        await database.collection('epr-organisations').countDocuments({
-          _id: ObjectId.createFromHexString(seeded.organisationId)
-        })
-      ).toBe(1)
-      expect(
-        await database
-          .collection('packaging-recycling-notes')
-          .countDocuments({ 'organisation.id': seeded.organisationId })
-      ).toBe(1)
+        expect(counts['epr-organisations']).toBe(1)
+        expect(
+          await database.collection('epr-organisations').countDocuments({
+            _id: ObjectId.createFromHexString(seeded.organisationId)
+          })
+        ).toBe(0)
+      } finally {
+        config.set('isProduction', previousIsProduction)
+        config.set('cdpEnvironment', previousCdpEnvironment)
+      }
+    })
+
+    it('refuses via the plugin when the CDP environment is prod', async ({
+      database,
+      repositories
+    }) => {
+      const seeded = await seedOrganisationWithOverseasSites(repositories)
+      await seedDownstreamForOrganisation(repositories, seeded)
+
+      const previousCdpEnvironment = config.get('cdpEnvironment')
+      config.set('cdpEnvironment', 'prod')
+
+      const server = { app: {}, logger: mockLogger, ext: () => {} }
+      try {
+        nonProdDataResetPlugin.register(server, { db: database })
+
+        await expect(
+          server.app.nonProdDataReset.deleteByOrgId(seeded.organisationId)
+        ).rejects.toThrow('Non-prod data reset is disabled in production.')
+
+        expect(
+          await database.collection('epr-organisations').countDocuments({
+            _id: ObjectId.createFromHexString(seeded.organisationId)
+          })
+        ).toBe(1)
+        expect(
+          await database
+            .collection('packaging-recycling-notes')
+            .countDocuments({ 'organisation.id': seeded.organisationId })
+        ).toBe(1)
+      } finally {
+        config.set('cdpEnvironment', previousCdpEnvironment)
+      }
     })
 
     it('handles an organisation document missing accreditations and registrations entirely', async ({

--- a/src/non-prod-data-reset/mongodb.test.js
+++ b/src/non-prod-data-reset/mongodb.test.js
@@ -100,6 +100,16 @@ const it = mongoIt.extend({
 
   reset: async ({ database }, use) => {
     await use(createNonProdDataReset(database))
+  },
+
+  // Snapshot config.cdpEnvironment for the duration of a test and expose a
+  // setter. Restores the previous value on teardown so the `config` singleton
+  // doesn't leak state between tests.
+  // eslint-disable-next-line no-empty-pattern
+  setCdpEnvironment: async ({}, use) => {
+    const previous = config.get('cdpEnvironment')
+    await use((value) => config.set('cdpEnvironment', value))
+    config.set('cdpEnvironment', previous)
   }
 })
 
@@ -373,71 +383,32 @@ describe('non-prod data reset (mongo)', () => {
       )
     })
 
-    it('cascades deletes via the plugin in a non-prod CDP environment even when NODE_ENV is production', async ({
-      database,
-      repositories
-    }) => {
-      const seeded = await seedOrganisationWithOverseasSites(repositories)
-      await seedDownstreamForOrganisation(repositories, seeded)
-
-      // Simulates CDP: NODE_ENV=production is set on every CDP environment
-      // including test, so config.isProduction is true. The plugin must not
-      // use that as its safety gate; it must check cdpEnvironment instead.
-      const previousIsProduction = config.get('isProduction')
-      const previousCdpEnvironment = config.get('cdpEnvironment')
-      config.set('isProduction', true)
-      config.set('cdpEnvironment', 'test')
-
-      const server = { app: {}, logger: mockLogger, ext: () => {} }
-      try {
-        nonProdDataResetPlugin.register(server, { db: database })
-        const counts = await server.app.nonProdDataReset.deleteByOrgId(
-          seeded.organisationId
-        )
-
-        expect(counts['epr-organisations']).toBe(1)
-        expect(
-          await database.collection('epr-organisations').countDocuments({
-            _id: ObjectId.createFromHexString(seeded.organisationId)
-          })
-        ).toBe(0)
-      } finally {
-        config.set('isProduction', previousIsProduction)
-        config.set('cdpEnvironment', previousCdpEnvironment)
-      }
-    })
-
     it('refuses via the plugin when the CDP environment is prod', async ({
       database,
-      repositories
+      repositories,
+      setCdpEnvironment
     }) => {
       const seeded = await seedOrganisationWithOverseasSites(repositories)
       await seedDownstreamForOrganisation(repositories, seeded)
-
-      const previousCdpEnvironment = config.get('cdpEnvironment')
-      config.set('cdpEnvironment', 'prod')
+      setCdpEnvironment('prod')
 
       const server = { app: {}, logger: mockLogger, ext: () => {} }
-      try {
-        nonProdDataResetPlugin.register(server, { db: database })
+      nonProdDataResetPlugin.register(server, { db: database })
 
-        await expect(
-          server.app.nonProdDataReset.deleteByOrgId(seeded.organisationId)
-        ).rejects.toThrow('Non-prod data reset is disabled in production.')
+      await expect(
+        server.app.nonProdDataReset.deleteByOrgId(seeded.organisationId)
+      ).rejects.toThrow('Non-prod data reset is disabled in production.')
 
-        expect(
-          await database.collection('epr-organisations').countDocuments({
-            _id: ObjectId.createFromHexString(seeded.organisationId)
-          })
-        ).toBe(1)
-        expect(
-          await database
-            .collection('packaging-recycling-notes')
-            .countDocuments({ 'organisation.id': seeded.organisationId })
-        ).toBe(1)
-      } finally {
-        config.set('cdpEnvironment', previousCdpEnvironment)
-      }
+      expect(
+        await database.collection('epr-organisations').countDocuments({
+          _id: ObjectId.createFromHexString(seeded.organisationId)
+        })
+      ).toBe(1)
+      expect(
+        await database
+          .collection('packaging-recycling-notes')
+          .countDocuments({ 'organisation.id': seeded.organisationId })
+      ).toBe(1)
     })
 
     it('handles an organisation document missing accreditations and registrations entirely', async ({


### PR DESCRIPTION
Ticket: [PAE-1194](https://eaflood.atlassian.net/browse/PAE-1194)

## Summary

The `nonProdDataReset` plugin previously gated its cascade-delete safety check on `config.isProduction`, which is derived from `NODE_ENV`. CDP sets `NODE_ENV=production` on every environment (dev, test, perf-test, ext-test, prod), so the gate fired in every CDP environment and disabled the `/dev/organisations` cleanup endpoint in exactly the places the frontend journey tests need it.

This PR switches the plugin to check `cdpEnvironment === 'prod'` instead, which is the only CDP-provided signal that actually distinguishes production from the other environments. The adapter in `non-prod-data-reset/mongodb.js` is unchanged: it still refuses to run when its `isProduction` flag is true. The plugin is just responsible for deriving that flag from the correct source.

The pre-existing test that drove `createNonProdDataReset` directly with `isProduction: true` has been replaced with a test that drives the plugin with `cdpEnvironment` set to `'prod'`. This is the test that actually pins the fix: under the old plugin, `cdpEnvironment=prod` had no effect (because vitest runs with `NODE_ENV=test`, so `config.isProduction` was already false), and the cascade would have run instead of throwing. A small `setCdpEnvironment` fixture was added to snapshot and restore the config value so the singleton does not leak state between tests.

[PAE-1194]: https://eaflood.atlassian.net/browse/PAE-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ