### PR TITLE
PAE-1340: Add context.traceId to SQS command message envelope

### DIFF
--- a/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
@@ -1,7 +1,13 @@
 import { describe, expect, vi, beforeEach } from 'vitest'
 import { GetQueueUrlCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs'
+import { getTraceId } from '@defra/hapi-tracing'
 import { it } from '#vite/fixtures/sqs.js'
 import { createSqsCommandExecutor } from './sqs-command-executor.js'
+
+vi.mock(import('@defra/hapi-tracing'), () => ({
+  getTraceId: vi.fn(() => null),
+  tracing: { plugin: {} }
+}))
 
 const TEST_TIMEOUT = 30000
 
@@ -303,6 +309,84 @@ describe('SQS command executor integration', () => {
             logger
           })
         ).rejects.toThrow()
+      }
+    )
+  })
+
+  describe('trace context propagation', () => {
+    it(
+      'includes context.traceId in message when trace ID is available',
+      { timeout: TEST_TIMEOUT },
+      async ({ sqsClient }) => {
+        getTraceId.mockReturnValue('trace-abc-123')
+
+        const executor = await createSqsCommandExecutor({
+          sqsClient,
+          queueName: sqsClient.queueName,
+          logger
+        })
+
+        const summaryLogId = `trace-test-${Date.now()}`
+        await executor.summaryLogsWorker.validate(summaryLogId)
+
+        const { QueueUrl: queueUrl } = await sqsClient.send(
+          new GetQueueUrlCommand({ QueueName: sqsClient.queueName })
+        )
+
+        const response = await sqsClient.send(
+          new ReceiveMessageCommand({
+            QueueUrl: queueUrl,
+            WaitTimeSeconds: 5
+          })
+        )
+
+        expect(response.Messages).toHaveLength(1)
+
+        const message = JSON.parse(response.Messages[0].Body)
+        expect(message).toEqual({
+          command: 'validate',
+          summaryLogId,
+          context: { traceId: 'trace-abc-123' }
+        })
+
+        getTraceId.mockReturnValue(null)
+      }
+    )
+
+    it(
+      'omits context when no trace ID is available',
+      { timeout: TEST_TIMEOUT },
+      async ({ sqsClient }) => {
+        getTraceId.mockReturnValue(null)
+
+        const executor = await createSqsCommandExecutor({
+          sqsClient,
+          queueName: sqsClient.queueName,
+          logger
+        })
+
+        const summaryLogId = `no-trace-test-${Date.now()}`
+        await executor.summaryLogsWorker.validate(summaryLogId)
+
+        const { QueueUrl: queueUrl } = await sqsClient.send(
+          new GetQueueUrlCommand({ QueueName: sqsClient.queueName })
+        )
+
+        const response = await sqsClient.send(
+          new ReceiveMessageCommand({
+            QueueUrl: queueUrl,
+            WaitTimeSeconds: 5
+          })
+        )
+
+        expect(response.Messages).toHaveLength(1)
+
+        const message = JSON.parse(response.Messages[0].Body)
+        expect(message).toEqual({
+          command: 'validate',
+          summaryLogId
+        })
+        expect(message).not.toHaveProperty('context')
       }
     )
   })

--- a/src/adapters/sqs-command-executor/sqs-command-executor.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.js
@@ -1,4 +1,5 @@
 import { SendMessageCommand } from '@aws-sdk/client-sqs'
+import { getTraceId } from '@defra/hapi-tracing'
 
 import {
   LOGGING_EVENT_ACTIONS,
@@ -38,6 +39,19 @@ const extractUser = (request) => {
 }
 
 /**
+ * Builds the message context object containing observability data.
+ * Separated from domain payload so consumers can strip it before dispatch.
+ * @returns {{ traceId: string } | undefined}
+ */
+const buildContext = () => {
+  const traceId = getTraceId()
+  if (!traceId) {
+    return undefined
+  }
+  return { traceId }
+}
+
+/**
  * Sends a command message to the SQS queue.
  * @param {string} queueUrl
  * @param {SQSClient} sqsClient
@@ -54,7 +68,8 @@ const sendCommandMessage = async (
   payload,
   description
 ) => {
-  const messageBody = { command, ...payload }
+  const context = buildContext()
+  const messageBody = { command, ...payload, ...(context && { context }) }
 
   await sqsClient.send(
     new SendMessageCommand({


### PR DESCRIPTION
## What

Adds the originating HTTP request's trace ID (`x-cdp-request-id`) to SQS command messages via an optional `context` envelope field, separating observability data from domain payload.

## Why

When the queue consumer processes validate/submit commands, it runs outside the HTTP request's `AsyncLocalStorage` context, so `getTraceId()` returns `null`. This means the entire validation and submission flow produces logs that cannot be correlated back to the originating request. This change captures the trace ID at send time so a follow-up change in the consumer can restore it.

## How

- `sendCommandMessage()` in `sqs-command-executor.js` now calls `getTraceId()` from `@defra/hapi-tracing` and includes it in an optional `context` object on the message body
- When no trace ID is available (e.g. local dev without the header, or non-HTTP producers), the `context` field is omitted — backward compatible with existing consumers

### Message format

**Before:**
```json
{"command": "validate", "summaryLogId": "abc-123"}
```

**After (with trace):**
```json
{"command": "validate", "summaryLogId": "abc-123", "context": {"traceId": "d4f8e2a1-..."}}
```

**After (without trace):**
```json
{"command": "validate", "summaryLogId": "abc-123"}
```

## Testing

- Integration tests added for both scenarios (trace present / absent)
- 100% coverage maintained on touched file
- All existing tests pass (18/18 in SQS executor suite)

## Follow-up

Consumer-side trace restoration will be done in a separate PR.