### PR TITLE
PAE-1340: Restore trace context from SQS message in queue consumer

### DIFF
--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -112,6 +112,7 @@ describe('SummaryLogsValidator integration', () => {
     const wasteRecordsRepository = createInMemoryWasteRecordsRepository()()
 
     const validateSummaryLog = createSummaryLogsValidator({
+      logger,
       summaryLogsRepository,
       organisationsRepository,
       wasteRecordsRepository,

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -5,7 +5,6 @@ import {
   VALIDATION_CODE,
   VALIDATION_SEVERITY
 } from '#common/enums/index.js'
-import { logger } from '#common/helpers/logging/logger.js'
 import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
 import {
   SUMMARY_LOG_STATUS,
@@ -53,7 +52,8 @@ export const MAX_ACTUAL_LENGTH = 200
 const extractSummaryLog = async ({
   summaryLogExtractor,
   summaryLog,
-  loggingContext
+  loggingContext,
+  logger
 }) => {
   const parsed = await summaryLogExtractor.extract(summaryLog)
 
@@ -115,7 +115,8 @@ const fetchRegistration = async ({
   organisationsRepository,
   organisationId,
   registrationId,
-  loggingContext
+  loggingContext,
+  logger
 }) => {
   const registration = await organisationsRepository.findRegistrationById(
     organisationId,
@@ -200,7 +201,7 @@ const extractMetaValues = (parsedMeta) => {
   )
 }
 
-const handleValidationFailure = (error, issues, loggingContext) => {
+const handleValidationFailure = (error, issues, loggingContext, logger) => {
   if (error instanceof SpreadsheetValidationError) {
     logger.warn({
       err: error,
@@ -256,6 +257,7 @@ const performValidationChecks = async ({
   summaryLogId,
   summaryLog,
   loggingContext,
+  logger,
   summaryLogExtractor,
   organisationsRepository,
   wasteRecordsRepository,
@@ -269,7 +271,8 @@ const performValidationChecks = async ({
     const parsed = await extractSummaryLog({
       summaryLogExtractor,
       summaryLog,
-      loggingContext
+      loggingContext,
+      logger
     })
 
     meta = extractMetaValues(parsed.meta)
@@ -284,7 +287,8 @@ const performValidationChecks = async ({
       organisationsRepository,
       organisationId: summaryLog.organisationId,
       registrationId: summaryLog.registrationId,
-      loggingContext
+      loggingContext,
+      logger
     })
 
     issues.merge(
@@ -321,7 +325,7 @@ const performValidationChecks = async ({
 
     issues.merge(dataResult.issues)
   } catch (error) {
-    handleValidationFailure(error, issues, loggingContext)
+    handleValidationFailure(error, issues, loggingContext, logger)
   }
 
   return { issues, wasteRecords, meta }
@@ -557,6 +561,7 @@ const classifyLoads = ({
 }
 
 export const createSummaryLogsValidator = ({
+  logger,
   summaryLogsRepository,
   organisationsRepository,
   wasteRecordsRepository,
@@ -588,6 +593,7 @@ export const createSummaryLogsValidator = ({
       summaryLogId,
       summaryLog,
       loggingContext,
+      logger,
       summaryLogExtractor,
       organisationsRepository,
       wasteRecordsRepository,

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -142,13 +142,11 @@ const mockLoggerInfo = vi.fn()
 const mockLoggerWarn = vi.fn()
 const mockLoggerError = vi.fn()
 
-vi.mock('#common/helpers/logging/logger.js', () => ({
-  logger: {
-    info: (...args) => mockLoggerInfo(...args),
-    warn: (...args) => mockLoggerWarn(...args),
-    error: (...args) => mockLoggerError(...args)
-  }
-}))
+const logger = {
+  info: (...args) => mockLoggerInfo(...args),
+  warn: (...args) => mockLoggerWarn(...args),
+  error: (...args) => mockLoggerError(...args)
+}
 
 const mockRecordStatusTransition = vi.fn()
 const mockRecordValidationDuration = vi.fn()
@@ -234,6 +232,7 @@ describe('SummaryLogsValidator', () => {
     }
 
     validateSummaryLog = createSummaryLogsValidator({
+      logger,
       summaryLogsRepository: /** @type {any} */ (summaryLogsRepository),
       organisationsRepository: /** @type {any} */ (organisationsRepository),
       wasteRecordsRepository: /** @type {any} */ (wasteRecordsRepository),
@@ -656,6 +655,7 @@ describe('SummaryLogsValidator', () => {
     }
 
     const brokenValidate = createSummaryLogsValidator({
+      logger,
       summaryLogsRepository: brokenRepository,
       organisationsRepository: /** @type {any} */ (organisationsRepository),
       wasteRecordsRepository: /** @type {any} */ (wasteRecordsRepository),

--- a/src/common/helpers/logging/logger.js
+++ b/src/common/helpers/logging/logger.js
@@ -30,6 +30,7 @@ import { loggerOptions } from './logger-options.js'
  * @property {(obj: IndexedLogProperties, msg?: string, ...args: any[]) => void} debug
  * @property {(obj: IndexedLogProperties, msg?: string, ...args: any[]) => void} trace
  * @property {(obj: IndexedLogProperties, msg?: string, ...args: any[]) => void} fatal
+ * @property {(bindings: Record<string, unknown>) => TypedLogger} child
  */
 
 /**

--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -462,7 +462,8 @@ export const createTestInfrastructure = async (
     summaryLogsRepository,
     organisationsRepository,
     wasteRecordsRepository,
-    summaryLogExtractor
+    summaryLogExtractor,
+    logger: mockLogger
   })
 
   const featureFlags = createInMemoryFeatureFlags({ summaryLogs: true })
@@ -541,7 +542,8 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
     summaryLogsRepository,
     organisationsRepository,
     wasteRecordsRepository,
-    summaryLogExtractor: dynamicExtractor
+    summaryLogExtractor: dynamicExtractor,
+    logger: mockLogger
   })
 
   const featureFlags = createInMemoryFeatureFlags({

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
@@ -242,7 +242,8 @@ describe('Repeated uploads of identical data', () => {
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
-        summaryLogExtractor
+        summaryLogExtractor,
+        logger: mockLogger
       })
 
       const syncWasteRecords = syncFromSummaryLog({

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -353,7 +353,8 @@ describe('Submission and placeholder tests', () => {
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
-        summaryLogExtractor: validationExtractor
+        summaryLogExtractor: validationExtractor,
+        logger: mockLogger
       })
 
       const syncWasteRecords = syncFromSummaryLog({
@@ -803,7 +804,8 @@ describe('Submission and placeholder tests', () => {
         summaryLogsRepository: testSummaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
-        summaryLogExtractor
+        summaryLogExtractor,
+        logger: mockLogger
       })
       const featureFlags = createInMemoryFeatureFlags()
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
@@ -381,7 +381,8 @@ describe('Advanced validation scenarios', () => {
         summaryLogsRepository: testSummaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
-        summaryLogExtractor
+        summaryLogExtractor,
+        logger: mockLogger
       })
       const featureFlags = createInMemoryFeatureFlags()
 
@@ -559,7 +560,8 @@ describe('Advanced validation scenarios', () => {
         summaryLogsRepository: testSummaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
-        summaryLogExtractor
+        summaryLogExtractor,
+        logger: mockLogger
       })
       const featureFlags = createInMemoryFeatureFlags()
 

--- a/src/server/queue-consumer/consumer.integration.test.js
+++ b/src/server/queue-consumer/consumer.integration.test.js
@@ -7,6 +7,7 @@ import {
 import { it } from '#vite/fixtures/sqs.js'
 import { createCommandQueueConsumer } from './consumer.js'
 import { summaryLogCommandHandlers } from './summary-log-commands.js'
+import { createSqsCommandExecutor } from '#adapters/sqs-command-executor/sqs-command-executor.js'
 import { createSummaryLogsValidator } from '#application/summary-logs/validate.js'
 import { submitSummaryLog } from '#application/summary-logs/submit.js'
 import { PermanentError } from '#server/queue-consumer/permanent-error.js'
@@ -14,6 +15,14 @@ import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 
 vi.mock('#application/summary-logs/validate.js')
 vi.mock('#application/summary-logs/submit.js')
+
+// Force the producer to emit envelope context so these tests exercise the
+// real message shape consumers see in production. Without this, getTraceId()
+// returns undefined outside a Hapi request and the producer omits context,
+// which is how the PAE-1340 envelope regression slipped past CI.
+vi.mock('@defra/hapi-tracing', () => ({
+  getTraceId: vi.fn(() => 'trace-integration-test')
+}))
 
 const TEST_TIMEOUT = 60000
 
@@ -60,8 +69,13 @@ describe('SQS command queue consumer integration', () => {
     logger = {
       info: vi.fn(),
       error: vi.fn(),
-      warn: vi.fn()
+      warn: vi.fn(),
+      child: vi.fn()
     }
+    // The consumer wraps the logger in a trace-bound child when the envelope
+    // carries a traceId (PAE-1340). Returning `this` keeps every assertion
+    // looking at a single logger object.
+    logger.child.mockReturnValue(logger)
 
     summaryLogsRepository = {
       findById: vi.fn().mockResolvedValue(null),
@@ -95,6 +109,17 @@ describe('SQS command queue consumer integration', () => {
       },
       summaryLogCommandHandlers
     )
+
+  // Build the real producer so tests exercise the same envelope shape the
+  // consumer receives in production. Hand-crafting JSON.stringify payloads
+  // lets the producer and consumer drift silently, which is exactly what
+  // happened with PAE-1340.
+  const createExecutor = (sqsClient) =>
+    createSqsCommandExecutor({
+      sqsClient,
+      queueName: sqsClient.queueName,
+      logger
+    })
 
   describe('queue connection', () => {
     it(
@@ -143,21 +168,12 @@ describe('SQS command queue consumer integration', () => {
         const mockValidator = vi.fn().mockResolvedValue(undefined)
         vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
 
-        const { QueueUrl: queueUrl } = await sqsClient.send(
-          new GetQueueUrlCommand({ QueueName: sqsClient.queueName })
-        )
+        const executor = await createExecutor(sqsClient)
 
-        // Send a validate command
+        // Send a validate command through the real producer so the envelope
+        // (command + payload + context) matches the production message shape.
         const summaryLogId = `validate-test-${Date.now()}`
-        await sqsClient.send(
-          new SendMessageCommand({
-            QueueUrl: queueUrl,
-            MessageBody: JSON.stringify({
-              command: 'validate',
-              summaryLogId
-            })
-          })
-        )
+        await executor.summaryLogsWorker.validate(summaryLogId)
 
         const consumer = await createConsumer(sqsClient)
 
@@ -179,27 +195,18 @@ describe('SQS command queue consumer integration', () => {
       'calls submitSummaryLog when submit command received',
       { timeout: TEST_TIMEOUT },
       async ({ sqsClient }) => {
-        const { QueueUrl: queueUrl } = await sqsClient.send(
-          new GetQueueUrlCommand({ QueueName: sqsClient.queueName })
-        )
+        const executor = await createExecutor(sqsClient)
 
-        // Send a submit command with user context
+        // Send a submit command through the real producer with a stubbed
+        // Hapi request so extractUser projects the user onto the payload.
         const summaryLogId = `submit-test-${Date.now()}`
         const user = {
           id: 'user-123',
           email: 'test@example.com',
           scope: ['operator']
         }
-        await sqsClient.send(
-          new SendMessageCommand({
-            QueueUrl: queueUrl,
-            MessageBody: JSON.stringify({
-              command: 'submit',
-              summaryLogId,
-              user
-            })
-          })
-        )
+        const request = { auth: { credentials: user } }
+        await executor.summaryLogsWorker.submit(summaryLogId, request)
 
         const consumer = await createConsumer(sqsClient)
 
@@ -242,16 +249,10 @@ describe('SQS command queue consumer integration', () => {
           new GetQueueUrlCommand({ QueueName: sqsClient.dlqName })
         )
 
+        const executor = await createExecutor(sqsClient)
+
         const summaryLogId = `delete-on-success-${Date.now()}`
-        await sqsClient.send(
-          new SendMessageCommand({
-            QueueUrl: queueUrl,
-            MessageBody: JSON.stringify({
-              command: 'validate',
-              summaryLogId
-            })
-          })
-        )
+        await executor.summaryLogsWorker.validate(summaryLogId)
 
         const consumer = await createConsumer(sqsClient)
 
@@ -431,16 +432,10 @@ describe('SQS command queue consumer integration', () => {
           new GetQueueUrlCommand({ QueueName: sqsClient.dlqName })
         )
 
+        const executor = await createExecutor(sqsClient)
+
         const summaryLogId = `permanent-test-${Date.now()}`
-        await sqsClient.send(
-          new SendMessageCommand({
-            QueueUrl: queueUrl,
-            MessageBody: JSON.stringify({
-              command: 'validate',
-              summaryLogId
-            })
-          })
-        )
+        await executor.summaryLogsWorker.validate(summaryLogId)
 
         const consumer = await createConsumer(sqsClient)
 
@@ -494,23 +489,14 @@ describe('SQS command queue consumer integration', () => {
           summaryLog: { status: SUMMARY_LOG_STATUS.VALIDATING }
         })
 
-        const { QueueUrl: queueUrl } = await sqsClient.send(
-          new GetQueueUrlCommand({ QueueName: sqsClient.queueName })
-        )
         const { QueueUrl: dlqUrl } = await sqsClient.send(
           new GetQueueUrlCommand({ QueueName: sqsClient.dlqName })
         )
 
+        const executor = await createExecutor(sqsClient)
+
         const summaryLogId = `transient-test-${Date.now()}`
-        await sqsClient.send(
-          new SendMessageCommand({
-            QueueUrl: queueUrl,
-            MessageBody: JSON.stringify({
-              command: 'validate',
-              summaryLogId
-            })
-          })
-        )
+        await executor.summaryLogsWorker.validate(summaryLogId)
 
         const consumer = await createConsumer(sqsClient)
 

--- a/src/server/queue-consumer/consumer.js
+++ b/src/server/queue-consumer/consumer.js
@@ -138,7 +138,6 @@ const getFailureLabel = (isPermanent, isFinalTransientAttempt) => {
  * @param {import('@aws-sdk/client-sqs').Message} params.message
  * @param {number|null} params.maxReceiveCount
  * @param {ConsumerDependencies} params.deps
- * @param {TypedLogger} params.logger
  */
 const handleCommandError = async ({
   err,
@@ -146,9 +145,9 @@ const handleCommandError = async ({
   payload,
   message,
   maxReceiveCount,
-  deps,
-  logger
+  deps
 }) => {
+  const { logger } = deps
   const isPermanent = err instanceof PermanentError
   const receiveCount = Number(message.Attributes?.ApproximateReceiveCount ?? 0)
   const isFinalTransientAttempt =
@@ -237,8 +236,7 @@ const createMessageHandler =
         payload,
         message,
         maxReceiveCount,
-        deps: commandDeps,
-        logger: commandLogger
+        deps: commandDeps
       })
 
       // handleCommandError returns (rather than throwing) for permanent errors,

--- a/src/server/queue-consumer/consumer.js
+++ b/src/server/queue-consumer/consumer.js
@@ -57,7 +57,7 @@ const buildSchemas = (handlers) => {
  * @param {TypedLogger} logger
  * @param {import('joi').ObjectSchema} envelopeSchema
  * @param {Map<string, CommandHandler>} handlerMap
- * @returns {{ handler: CommandHandler, payload: object } | null}
+ * @returns {{ handler: CommandHandler, payload: object, context?: { traceId: string } } | null}
  */
 const parseCommandMessage = (message, logger, envelopeSchema, handlerMap) => {
   let parsed
@@ -91,7 +91,7 @@ const parseCommandMessage = (message, logger, envelopeSchema, handlerMap) => {
     return null
   }
 
-  const { command, ...rest } = parsed
+  const { command, context, ...rest } = parsed
   const handler = /** @type {CommandHandler} */ (handlerMap.get(command))
 
   // Pass 2: validate payload against handler's schema
@@ -109,7 +109,7 @@ const parseCommandMessage = (message, logger, envelopeSchema, handlerMap) => {
     return null
   }
 
-  return { handler, payload }
+  return { handler, payload, context }
 }
 
 /**
@@ -198,9 +198,19 @@ const createMessageHandler =
       )
     }
 
-    const { handler, payload } = result
+    const { handler, payload, context } = result
 
-    logger.info({
+    const commandLogger = context?.traceId
+      ? /** @type {TypedLogger} */ (
+          logger.child({ trace: { id: context.traceId } })
+        )
+      : logger
+
+    const commandDeps = context?.traceId
+      ? { ...deps, logger: commandLogger }
+      : deps
+
+    commandLogger.info({
       message: `Processing command: ${handler.command} for ${handler.describe(payload)} messageId=${message.MessageId}`,
       event: {
         category: LOGGING_EVENT_CATEGORIES.SERVER,
@@ -209,9 +219,9 @@ const createMessageHandler =
     })
 
     try {
-      await handler.execute(payload, deps)
+      await handler.execute(payload, commandDeps)
 
-      logger.info({
+      commandLogger.info({
         message: `Command completed: ${handler.command} for ${handler.describe(payload)} messageId=${message.MessageId}`,
         event: {
           category: LOGGING_EVENT_CATEGORIES.SERVER,
@@ -227,8 +237,8 @@ const createMessageHandler =
         payload,
         message,
         maxReceiveCount,
-        deps,
-        logger
+        deps: commandDeps,
+        logger: commandLogger
       })
 
       // handleCommandError returns (rather than throwing) for permanent errors,
@@ -316,7 +326,13 @@ export const createCommandQueueConsumer = async (deps, handlers) => {
       handlerMap
     )
 
-    logger.error({
+    const timeoutLogger = result?.context?.traceId
+      ? /** @type {TypedLogger} */ (
+          logger.child({ trace: { id: result.context.traceId } })
+        )
+      : logger
+
+    timeoutLogger.error({
       err,
       message: result
         ? `Command timed out: ${result.handler.command} for ${result.handler.describe(result.payload)} messageId=${message.MessageId}`
@@ -328,7 +344,10 @@ export const createCommandQueueConsumer = async (deps, handlers) => {
     })
 
     if (result) {
-      await result.handler.onFailure(result.payload, deps)
+      const timeoutDeps = result.context?.traceId
+        ? { ...deps, logger: timeoutLogger }
+        : deps
+      await result.handler.onFailure(result.payload, timeoutDeps)
     }
   })
 

--- a/src/server/queue-consumer/consumer.js
+++ b/src/server/queue-consumer/consumer.js
@@ -248,54 +248,21 @@ const createMessageHandler =
   }
 
 /**
- * Creates the SQS command queue consumer.
- *
- * `deps` must include the consumer's own dependencies (sqsClient, queueName,
- * logger) **plus** whatever the registered handlers require. The consumer
- * passes the entire bag through to handler.execute() and handler.onFailure().
- *
+ * Attaches error, processing_error, and timeout_error listeners to the consumer.
  * @template {ConsumerDependencies} D
+ * @param {Consumer} consumer
  * @param {D} deps
- * @param {CommandHandler[]} handlers - Registered command handlers
- * @returns {Promise<Consumer>}
+ * @param {TypedLogger} logger
+ * @param {import('joi').ObjectSchema} envelopeSchema
+ * @param {Map<string, CommandHandler>} handlerMap
  */
-export const createCommandQueueConsumer = async (deps, handlers) => {
-  if (!handlers.length) {
-    throw new Error('At least one command handler must be registered')
-  }
-
-  const { sqsClient, queueName, logger } = deps
-
-  const queueUrl = await resolveQueueUrl(sqsClient, queueName)
-
-  logger.info({
-    message: `Resolved queue URL: ${queueUrl} for queueName=${queueName}`
-  })
-
-  const maxReceiveCount = await getMaxReceiveCount(sqsClient, queueUrl)
-
-  if (maxReceiveCount === null) {
-    logger.warn({
-      message: `No redrive policy configured for queueName=${queueName}; transient errors on final retry will not be marked as failed`
-    })
-  } else {
-    logger.info({
-      message: `Queue redrive policy: maxReceiveCount=${maxReceiveCount} for queueName=${queueName}`
-    })
-  }
-
-  const { envelopeSchema, handlerMap } = buildSchemas(handlers)
-
-  const consumer = Consumer.create({
-    queueUrl,
-    sqs: sqsClient,
-    handleMessage: /** @type {*} */ (
-      createMessageHandler(deps, maxReceiveCount, envelopeSchema, handlerMap)
-    ),
-    handleMessageTimeout: COMMAND_TIMEOUT_MS,
-    attributeNames: /** @type {*} */ (['ApproximateReceiveCount'])
-  })
-
+const attachEventHandlers = (
+  consumer,
+  deps,
+  logger,
+  envelopeSchema,
+  handlerMap
+) => {
   consumer.on('error', (err) => {
     logger.error({
       err,
@@ -350,6 +317,58 @@ export const createCommandQueueConsumer = async (deps, handlers) => {
       await result.handler.onFailure(result.payload, timeoutDeps)
     }
   })
+}
+
+/**
+ * Creates the SQS command queue consumer.
+ *
+ * `deps` must include the consumer's own dependencies (sqsClient, queueName,
+ * logger) **plus** whatever the registered handlers require. The consumer
+ * passes the entire bag through to handler.execute() and handler.onFailure().
+ *
+ * @template {ConsumerDependencies} D
+ * @param {D} deps
+ * @param {CommandHandler[]} handlers - Registered command handlers
+ * @returns {Promise<Consumer>}
+ */
+export const createCommandQueueConsumer = async (deps, handlers) => {
+  if (!handlers.length) {
+    throw new Error('At least one command handler must be registered')
+  }
+
+  const { sqsClient, queueName, logger } = deps
+
+  const queueUrl = await resolveQueueUrl(sqsClient, queueName)
+
+  logger.info({
+    message: `Resolved queue URL: ${queueUrl} for queueName=${queueName}`
+  })
+
+  const maxReceiveCount = await getMaxReceiveCount(sqsClient, queueUrl)
+
+  if (maxReceiveCount === null) {
+    logger.warn({
+      message: `No redrive policy configured for queueName=${queueName}; transient errors on final retry will not be marked as failed`
+    })
+  } else {
+    logger.info({
+      message: `Queue redrive policy: maxReceiveCount=${maxReceiveCount} for queueName=${queueName}`
+    })
+  }
+
+  const { envelopeSchema, handlerMap } = buildSchemas(handlers)
+
+  const consumer = Consumer.create({
+    queueUrl,
+    sqs: sqsClient,
+    handleMessage: /** @type {*} */ (
+      createMessageHandler(deps, maxReceiveCount, envelopeSchema, handlerMap)
+    ),
+    handleMessageTimeout: COMMAND_TIMEOUT_MS,
+    attributeNames: /** @type {*} */ (['ApproximateReceiveCount'])
+  })
+
+  attachEventHandlers(consumer, deps, logger, envelopeSchema, handlerMap)
 
   return consumer
 }

--- a/src/server/queue-consumer/consumer.test.js
+++ b/src/server/queue-consumer/consumer.test.js
@@ -61,7 +61,13 @@ describe('createCommandQueueConsumer', () => {
     logger = {
       info: vi.fn(),
       error: vi.fn(),
-      warn: vi.fn()
+      warn: vi.fn(),
+      child: vi.fn(() => ({
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        child: vi.fn()
+      }))
     }
 
     summaryLogsRepository = {
@@ -362,6 +368,69 @@ describe('createCommandQueueConsumer', () => {
         })
       )
     })
+
+    it('creates child logger for timeout_error when context.traceId is present', async () => {
+      const childLogger = {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        child: vi.fn()
+      }
+      logger.child.mockReturnValue(childLogger)
+
+      summaryLogsRepository.findById.mockResolvedValue({
+        version: 1,
+        summaryLog: { status: SUMMARY_LOG_STATUS.VALIDATING }
+      })
+
+      await createConsumer()
+      const error = new Error('Timeout')
+      const message = {
+        MessageId: 'msg-123',
+        Body: JSON.stringify({
+          command: 'validate',
+          summaryLogId: 'summary-123',
+          context: { traceId: 'trace-abc-123' }
+        })
+      }
+
+      await eventHandlers.timeout_error(error, message)
+
+      expect(logger.child).toHaveBeenCalledWith({
+        trace: { id: 'trace-abc-123' }
+      })
+      expect(childLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('Command timed out: validate')
+        })
+      )
+    })
+
+    it('uses global logger for timeout_error when context is absent', async () => {
+      summaryLogsRepository.findById.mockResolvedValue({
+        version: 1,
+        summaryLog: { status: SUMMARY_LOG_STATUS.VALIDATING }
+      })
+
+      await createConsumer()
+      const error = new Error('Timeout')
+      const message = {
+        MessageId: 'msg-123',
+        Body: JSON.stringify({
+          command: 'validate',
+          summaryLogId: 'summary-123'
+        })
+      }
+
+      await eventHandlers.timeout_error(error, message)
+
+      expect(logger.child).not.toHaveBeenCalled()
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('Command timed out: validate')
+        })
+      )
+    })
   })
 
   describe('message handling', () => {
@@ -473,6 +542,188 @@ describe('createCommandQueueConsumer', () => {
           expect.objectContaining({
             message:
               'Invalid command message for messageId=msg-123: "command" must be one of [validate, submit]'
+          })
+        )
+      })
+    })
+
+    describe('trace context', () => {
+      it('creates child logger with trace ID when context.traceId is present', async () => {
+        const childLogger = {
+          info: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          child: vi.fn()
+        }
+        logger.child.mockReturnValue(childLogger)
+
+        const mockValidator = vi.fn()
+        vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
+
+        const message = {
+          MessageId: 'msg-123',
+          Body: JSON.stringify({
+            command: 'validate',
+            summaryLogId: 'log-123',
+            context: { traceId: 'trace-abc-123' }
+          })
+        }
+
+        await handleMessage(message)
+
+        expect(logger.child).toHaveBeenCalledWith({
+          trace: { id: 'trace-abc-123' }
+        })
+        expect(childLogger.info).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining('Processing command: validate')
+          })
+        )
+        expect(childLogger.info).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining('Command completed: validate')
+          })
+        )
+      })
+
+      it('uses global logger when context is absent', async () => {
+        const mockValidator = vi.fn()
+        vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
+
+        const message = {
+          MessageId: 'msg-123',
+          Body: JSON.stringify({
+            command: 'validate',
+            summaryLogId: 'log-123'
+          })
+        }
+
+        await handleMessage(message)
+
+        expect(logger.child).not.toHaveBeenCalled()
+        expect(logger.info).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining('Processing command: validate')
+          })
+        )
+      })
+
+      it('uses global logger when context.traceId is absent', async () => {
+        const mockValidator = vi.fn()
+        vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
+
+        const message = {
+          MessageId: 'msg-123',
+          Body: JSON.stringify({
+            command: 'validate',
+            summaryLogId: 'log-123',
+            context: {}
+          })
+        }
+
+        await handleMessage(message)
+
+        expect(logger.child).not.toHaveBeenCalled()
+      })
+
+      it('strips context from payload before passing to handler', async () => {
+        const childLogger = {
+          info: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          child: vi.fn()
+        }
+        logger.child.mockReturnValue(childLogger)
+
+        const mockValidator = vi.fn()
+        vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
+
+        const message = {
+          MessageId: 'msg-123',
+          Body: JSON.stringify({
+            command: 'validate',
+            summaryLogId: 'log-123',
+            context: { traceId: 'trace-abc-123' }
+          })
+        }
+
+        await handleMessage(message)
+
+        expect(mockValidator).toHaveBeenCalledWith('log-123')
+      })
+
+      it('passes child logger through deps to handler.execute', async () => {
+        const childLogger = {
+          info: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          child: vi.fn()
+        }
+        logger.child.mockReturnValue(childLogger)
+
+        summaryLogsRepository.findById.mockResolvedValue({
+          version: 1,
+          summaryLog: {
+            status: SUMMARY_LOG_STATUS.SUBMITTING,
+            meta: {}
+          }
+        })
+        summaryLogsRepository.update.mockResolvedValue(undefined)
+
+        const message = {
+          MessageId: 'msg-123',
+          Body: JSON.stringify({
+            command: 'submit',
+            summaryLogId: 'log-123',
+            context: { traceId: 'trace-abc-123' }
+          })
+        }
+
+        await handleMessage(message)
+
+        // Submit handler calls summaryLogsRepository.update which uses logger from deps.
+        // The child logger should be in the deps passed through.
+        expect(childLogger.info).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining('Command completed: submit')
+          })
+        )
+      })
+
+      it('passes child logger through deps to handleCommandError on failure', async () => {
+        const childLogger = {
+          info: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          child: vi.fn()
+        }
+        logger.child.mockReturnValue(childLogger)
+
+        const transientError = new Error('Database timeout')
+        const mockValidator = vi.fn().mockRejectedValue(transientError)
+        vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
+
+        const message = {
+          MessageId: 'msg-123',
+          Attributes: { ApproximateReceiveCount: '1' },
+          Body: JSON.stringify({
+            command: 'validate',
+            summaryLogId: 'log-123',
+            context: { traceId: 'trace-abc-123' }
+          })
+        }
+
+        await expect(handleMessage(message)).rejects.toThrow('Database timeout')
+
+        expect(childLogger.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining('Command failed')
+          })
+        )
+        // Global logger should NOT get the command error
+        expect(logger.error).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining('Command failed')
           })
         )
       })

--- a/src/server/queue-consumer/summary-log-commands.js
+++ b/src/server/queue-consumer/summary-log-commands.js
@@ -55,6 +55,7 @@ export const summaryLogCommandHandlers = [
     }),
     execute: async (payload, /** @type {SummaryLogHandlerDeps} */ deps) => {
       const {
+        logger,
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
@@ -62,6 +63,7 @@ export const summaryLogCommandHandlers = [
       } = deps
 
       const validateSummaryLog = createSummaryLogsValidator({
+        logger,
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,

--- a/src/server/queue-consumer/summary-log-commands.test.js
+++ b/src/server/queue-consumer/summary-log-commands.test.js
@@ -76,6 +76,7 @@ describe('summaryLogCommandHandlers', () => {
         await handler.execute({ summaryLogId: 'log-123' }, deps)
 
         expect(createSummaryLogsValidator).toHaveBeenCalledWith({
+          logger: deps.logger,
           summaryLogsRepository: deps.summaryLogsRepository,
           organisationsRepository: deps.organisationsRepository,
           wasteRecordsRepository: deps.wasteRecordsRepository,


### PR DESCRIPTION
Ticket: [PAE-1340](https://eaflood.atlassian.net/browse/PAE-1340)

This pull request enhances the SQS command queue consumer to support trace context propagation and structured logging using child loggers. When a `traceId` is present in the command message context, a child logger is created and passed through all message handling, error, and timeout flows. This ensures log entries related to a specific command are correlated by trace ID, improving observability and debugging. The changes also refactor event handler attachment for better maintainability and add comprehensive tests for trace context handling.

**Trace context propagation and logging improvements:**

* The command message parser now extracts an optional `context` (with `traceId`) from each message and returns it alongside the handler and payload. [[1]](diffhunk://#diff-8287f7debcefea52330f82bc6911008e6f9aacbb644a5034eabc2ea683b27e41L60-R60) [[2]](diffhunk://#diff-8287f7debcefea52330f82bc6911008e6f9aacbb644a5034eabc2ea683b27e41L94-R94) [[3]](diffhunk://#diff-8287f7debcefea52330f82bc6911008e6f9aacbb644a5034eabc2ea683b27e41L112-R112)
* When a `traceId` is present, a child logger is created via `logger.child({ trace: { id: traceId } })` and passed through all dependencies and logging calls during message processing, error handling, and timeouts. Otherwise, the global logger is used. [[1]](diffhunk://#diff-8287f7debcefea52330f82bc6911008e6f9aacbb644a5034eabc2ea683b27e41L201-R213) [[2]](diffhunk://#diff-8287f7debcefea52330f82bc6911008e6f9aacbb644a5034eabc2ea683b27e41L212-R224) [[3]](diffhunk://#diff-8287f7debcefea52330f82bc6911008e6f9aacbb644a5034eabc2ea683b27e41L230-R241) [[4]](diffhunk://#diff-31ae3fb622af49e662b5044f9122b2e70a796fb34a3ee7274d0f0cac93dfc731L64-R70) [[5]](diffhunk://#diff-7f70027f39ea755610345f04dcb22990401f43c9e80e7ce1f5096ce25a73d169R33)

**Event handler refactoring:**

* The logic for attaching `error`, `processing_error`, and `timeout_error` event handlers is extracted into a new `attachEventHandlers` function, reducing duplication and improving maintainability. Timeout errors now also use the child logger when a trace ID is available. [[1]](diffhunk://#diff-8287f7debcefea52330f82bc6911008e6f9aacbb644a5034eabc2ea683b27e41R250-R321) [[2]](diffhunk://#diff-8287f7debcefea52330f82bc6911008e6f9aacbb644a5034eabc2ea683b27e41L289-R371)

**Testing enhancements:**

* New and updated tests verify that the child logger is correctly created and used when a trace ID is present, and that the global logger is used otherwise. Tests also ensure the child logger is passed through dependencies and used in all relevant logging and error flows. [[1]](diffhunk://#diff-31ae3fb622af49e662b5044f9122b2e70a796fb34a3ee7274d0f0cac93dfc731R371-R433) [[2]](diffhunk://#diff-31ae3fb622af49e662b5044f9122b2e70a796fb34a3ee7274d0f0cac93dfc731R550-R731)

These changes make the queue consumer more robust and observability-friendly by tying logs to individual command executions and improving test coverage.

[PAE-1340]: https://eaflood.atlassian.net/browse/PAE-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ