### PR TITLE
PAE-1340: Add structured start/completion logging to summary log submit

### DIFF
--- a/src/application/summary-logs/submit.js
+++ b/src/application/summary-logs/submit.js
@@ -58,11 +58,17 @@ export const submitSummaryLog = async (summaryLogId, deps) => {
     )
   }
 
+  const {
+    file: { id: fileId, name: filename }
+  } = summaryLog
+
+  const loggingContext = `summaryLogId=${summaryLogId}, fileId=${fileId}, filename=${filename}`
+
   const processingType =
     summaryLog.meta?.[SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]
 
   logger.info({
-    message: `Summary log submission started: summaryLogId=${summaryLogId}`,
+    message: `Summary log submission started: ${loggingContext}`,
     event: {
       category: LOGGING_EVENT_CATEGORIES.SERVER,
       action: LOGGING_EVENT_ACTIONS.START_SUCCESS
@@ -98,7 +104,7 @@ export const submitSummaryLog = async (summaryLogId, deps) => {
   })
 
   logger.info({
-    message: `Summary log submitted: summaryLogId=${summaryLogId}, created=${created}, updated=${updated}`,
+    message: `Summary log submitted: ${loggingContext}, created=${created}, updated=${updated}`,
     event: {
       category: LOGGING_EVENT_CATEGORIES.SERVER,
       action: LOGGING_EVENT_ACTIONS.PROCESS_SUCCESS

--- a/src/application/summary-logs/submit.js
+++ b/src/application/summary-logs/submit.js
@@ -1,4 +1,8 @@
 import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/index.js'
+import {
   SUMMARY_LOG_STATUS,
   transitionStatus
 } from '#domain/summary-logs/status.js'
@@ -57,6 +61,14 @@ export const submitSummaryLog = async (summaryLogId, deps) => {
   const processingType =
     summaryLog.meta?.[SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]
 
+  logger.info({
+    message: `Summary log submission started: summaryLogId=${summaryLogId}`,
+    event: {
+      category: LOGGING_EVENT_CATEGORIES.SERVER,
+      action: LOGGING_EVENT_ACTIONS.START_SUCCESS
+    }
+  })
+
   const sync = syncFromSummaryLog({
     extractor: summaryLogExtractor,
     wasteRecordRepository: wasteRecordsRepository,
@@ -86,6 +98,10 @@ export const submitSummaryLog = async (summaryLogId, deps) => {
   })
 
   logger.info({
-    message: `Summary log submitted: summaryLogId=${summaryLogId}`
+    message: `Summary log submitted: summaryLogId=${summaryLogId}, created=${created}, updated=${updated}`,
+    event: {
+      category: LOGGING_EVENT_CATEGORIES.SERVER,
+      action: LOGGING_EVENT_ACTIONS.PROCESS_SUCCESS
+    }
   })
 }

--- a/src/server/queue-consumer/consumer.test.js
+++ b/src/server/queue-consumer/consumer.test.js
@@ -740,7 +740,21 @@ describe('createCommandQueueConsumer', () => {
         )
         expect(logger.info).toHaveBeenCalledWith(
           expect.objectContaining({
-            message: 'Summary log submitted: summaryLogId=log-123'
+            message: 'Summary log submission started: summaryLogId=log-123',
+            event: expect.objectContaining({
+              category: 'server',
+              action: 'start_success'
+            })
+          })
+        )
+        expect(logger.info).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message:
+              'Summary log submitted: summaryLogId=log-123, created=0, updated=0',
+            event: expect.objectContaining({
+              category: 'server',
+              action: 'process_success'
+            })
           })
         )
       })

--- a/src/server/queue-consumer/consumer.test.js
+++ b/src/server/queue-consumer/consumer.test.js
@@ -665,7 +665,8 @@ describe('createCommandQueueConsumer', () => {
           version: 1,
           summaryLog: {
             status: SUMMARY_LOG_STATUS.SUBMITTING,
-            meta: {}
+            meta: {},
+            file: { id: 'file-456', name: 'test-file.xlsx' }
           }
         })
         summaryLogsRepository.update.mockResolvedValue(undefined)
@@ -968,7 +969,8 @@ describe('createCommandQueueConsumer', () => {
           version: 1,
           summaryLog: {
             status: SUMMARY_LOG_STATUS.SUBMITTING,
-            meta: {}
+            meta: {},
+            file: { id: 'file-456', name: 'test-file.xlsx' }
           }
         })
         summaryLogsRepository.update.mockResolvedValue(undefined)
@@ -991,7 +993,8 @@ describe('createCommandQueueConsumer', () => {
         )
         expect(logger.info).toHaveBeenCalledWith(
           expect.objectContaining({
-            message: 'Summary log submission started: summaryLogId=log-123',
+            message:
+              'Summary log submission started: summaryLogId=log-123, fileId=file-456, filename=test-file.xlsx',
             event: expect.objectContaining({
               category: 'server',
               action: 'start_success'
@@ -1001,7 +1004,7 @@ describe('createCommandQueueConsumer', () => {
         expect(logger.info).toHaveBeenCalledWith(
           expect.objectContaining({
             message:
-              'Summary log submitted: summaryLogId=log-123, created=0, updated=0',
+              'Summary log submitted: summaryLogId=log-123, fileId=file-456, filename=test-file.xlsx, created=0, updated=0',
             event: expect.objectContaining({
               category: 'server',
               action: 'process_success'
@@ -1092,7 +1095,11 @@ describe('createCommandQueueConsumer', () => {
 
           summaryLogsRepository.findById.mockResolvedValue({
             version: 1,
-            summaryLog: { status: SUMMARY_LOG_STATUS.SUBMITTING, meta: {} }
+            summaryLog: {
+              status: SUMMARY_LOG_STATUS.SUBMITTING,
+              meta: {},
+              file: { id: 'file-456', name: 'test-file.xlsx' }
+            }
           })
 
           const message = {
@@ -1115,7 +1122,11 @@ describe('createCommandQueueConsumer', () => {
 
           summaryLogsRepository.findById.mockResolvedValue({
             version: 1,
-            summaryLog: { status: SUMMARY_LOG_STATUS.SUBMITTING, meta: {} }
+            summaryLog: {
+              status: SUMMARY_LOG_STATUS.SUBMITTING,
+              meta: {},
+              file: { id: 'file-456', name: 'test-file.xlsx' }
+            }
           })
 
           const message = {
@@ -1141,7 +1152,11 @@ describe('createCommandQueueConsumer', () => {
 
           summaryLogsRepository.findById.mockResolvedValue({
             version: 1,
-            summaryLog: { status: SUMMARY_LOG_STATUS.SUBMITTING, meta: {} }
+            summaryLog: {
+              status: SUMMARY_LOG_STATUS.SUBMITTING,
+              meta: {},
+              file: { id: 'file-456', name: 'test-file.xlsx' }
+            }
           })
 
           const message = {


### PR DESCRIPTION
Ticket: [PAE-1340](https://eaflood.atlassian.net/browse/PAE-1340)
## What

Adds structured start and completion logging to `submitSummaryLog()` in the application layer, consistent with the existing pattern in `validate.js`.

## Why

`submit.js` only logged a single unstructured message at the end: `Summary log submitted: summaryLogId=...`. This made it inconsistent with `validate.js`, which logs structured events at start and completion with `event.category`, `event.action`, and `event.reference`. Structured logging enables better observability filtering and dashboarding.

## How

- **Start log** added before processing begins: `Summary log submission started: summaryLogId=...` with `event.category=server`, `event.action=start_success`
- **Completion log** updated to include created/updated waste record counts and structured event fields: `Summary log submitted: summaryLogId=..., created=N, updated=N` with `event.category=server`, `event.action=process_success`
- Both use `LOGGING_EVENT_CATEGORIES.SERVER` and appropriate `LOGGING_EVENT_ACTIONS` from the shared enums

## Testing

- Updated consumer.test.js assertions to verify both structured log events
- All 5402 tests pass
- 100% coverage maintained on touched file
- Lint, format, and type-check clean

[PAE-1340]: https://eaflood.atlassian.net/browse/PAE-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ