### PR TITLE
PAE-1341: Add structured logging to summary log routes

### DIFF
--- a/src/routes/v1/organisations/registrations/summary-logs/file/get.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/file/get.js
@@ -42,7 +42,8 @@ export const summaryLogFile = {
       message: `Summary log file downloaded for summaryLogId: ${summaryLogId}, organisationId: ${organisationId}, registrationId: ${registrationId}`,
       event: {
         category: LOGGING_EVENT_CATEGORIES.SERVER,
-        action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
+        action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS,
+        reference: summaryLogId
       }
     })
 

--- a/src/routes/v1/organisations/registrations/summary-logs/file/get.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/file/get.js
@@ -1,4 +1,8 @@
 import { ROLES } from '#common/helpers/auth/constants.js'
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/index.js'
 import { auditSummaryLogDownload } from '#root/auditing/summary-logs.js'
 
 /** @typedef {import('#repositories/summary-logs/port.js').SummaryLogsRepository} SummaryLogsRepository */
@@ -23,7 +27,7 @@ export const summaryLogFile = {
    * @param {Object} h - Hapi response toolkit
    */
   handler: async (request, h) => {
-    const { summaryLogsRepository } = request
+    const { summaryLogsRepository, logger } = request
     const { organisationId, registrationId, summaryLogId } = request.params
 
     const { url } = await summaryLogsRepository.getDownloadUrl(summaryLogId)
@@ -32,6 +36,14 @@ export const summaryLogFile = {
       summaryLogId,
       organisationId,
       registrationId
+    })
+
+    logger.info({
+      message: `Summary log file downloaded for summaryLogId: ${summaryLogId}, organisationId: ${organisationId}, registrationId: ${registrationId}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
+      }
     })
 
     return h.redirect(url).temporary()

--- a/src/routes/v1/organisations/registrations/summary-logs/file/get.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/file/get.test.js
@@ -115,7 +115,8 @@ describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/
           message: `Summary log file downloaded for summaryLogId: ${summaryLogId}, organisationId: ${organisationId}, registrationId: ${registrationId}`,
           event: {
             category: LOGGING_EVENT_CATEGORIES.SERVER,
-            action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
+            action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS,
+            reference: summaryLogId
           }
         })
       )

--- a/src/routes/v1/organisations/registrations/summary-logs/file/get.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/file/get.test.js
@@ -1,6 +1,10 @@
 import { StatusCodes } from 'http-status-codes'
 import { ObjectId } from 'mongodb'
 
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/index.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
 import { createTestServer } from '#test/create-test-server.js'
@@ -90,6 +94,30 @@ describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/
           organisationId,
           registrationId
         }
+      )
+    })
+
+    it('logs the download with structured event data', async () => {
+      const { server, summaryLogsRepository } = await createServer()
+      await summaryLogsRepository.insert(
+        summaryLogId,
+        summaryLogFactory.submitted({
+          organisationId,
+          registrationId,
+          file: { uri: 's3://re-ex-summary-logs/uploads/test-file.xlsx' }
+        })
+      )
+
+      await makeRequest(server)
+
+      expect(server.loggerMocks.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: `Summary log file downloaded for summaryLogId: ${summaryLogId}, organisationId: ${organisationId}, registrationId: ${registrationId}`,
+          event: {
+            category: LOGGING_EVENT_CATEGORIES.SERVER,
+            action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS
+          }
+        })
       )
     })
   })

--- a/src/routes/v1/organisations/registrations/summary-logs/get.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.js
@@ -1,5 +1,9 @@
 import { StatusCodes } from 'http-status-codes'
 
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/index.js'
 import { getDefaultStatus } from '#domain/summary-logs/status.js'
 import { extractResponseMetaFields } from '#domain/summary-logs/extract-response-meta-fields.js'
 import { transformValidationResponse } from './transform-validation-response.js'
@@ -27,7 +31,7 @@ export const summaryLogsGet = {
    * @param {Object} h - Hapi response toolkit
    */
   handler: async (request, h) => {
-    const { summaryLogsRepository, params } = request
+    const { summaryLogsRepository, params, logger } = request
     const { summaryLogId } = params
 
     const result = await summaryLogsRepository.findById(summaryLogId)
@@ -47,6 +51,15 @@ export const summaryLogsGet = {
       }),
       ...extractResponseMetaFields(summaryLog.meta)
     }
+
+    logger.info({
+      message: `Summary log status retrieved: summaryLogId=${summaryLogId}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS,
+        reference: summaryLogId
+      }
+    })
 
     return h.response(response).code(StatusCodes.OK)
   }

--- a/src/routes/v1/organisations/registrations/summary-logs/get.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.test.js
@@ -1,5 +1,9 @@
 import { StatusCodes } from 'http-status-codes'
 import { ObjectId } from 'mongodb'
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/index.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
@@ -51,6 +55,29 @@ describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/
       expect(response.statusCode).toBe(StatusCodes.OK)
       const payload = JSON.parse(response.payload)
       expect(payload.status).toBe(SUMMARY_LOG_STATUS.PREPROCESSING)
+    })
+  })
+
+  describe('logging', () => {
+    it('logs a structured info event when a summary log is found', async () => {
+      const { server, summaryLogsRepository } = await createServer()
+      await summaryLogsRepository.insert(
+        summaryLogId,
+        summaryLogFactory.validated({ organisationId, registrationId })
+      )
+
+      await makeRequest(server)
+
+      expect(server.loggerMocks.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: `Summary log status retrieved: summaryLogId=${summaryLogId}`,
+          event: {
+            category: LOGGING_EVENT_CATEGORIES.SERVER,
+            action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS,
+            reference: summaryLogId
+          }
+        })
+      )
     })
   })
 


### PR DESCRIPTION
Ticket: [PAE-1340](https://eaflood.atlassian.net/browse/PAE-1341)

## What

Adds `logger.info()` calls to two summary log route handlers that previously had no application-level logging:

1. **`GET .../summary-logs/{summaryLogId}/file`** — the file download redirect
2. **`GET .../summary-logs/{summaryLogId}`** — the status polling endpoint

## Why

Both handlers returned responses without emitting any application-level log. If you search logs for download or status-check activity, there is nothing to find — making it harder to trace user journeys and diagnose issues.

Every other summary log route handler (POST create, upload-completed, submit) already logs a structured info event on success. These two were the gap.

## How

- Added `logger.info()` with the standard event pattern (`category: SERVER`, `action: REQUEST_SUCCESS`, `reference: summaryLogId`)
- File download route: logs after the audit write, before the redirect
- Status route: logs after building the response, before returning

## Testing

- New tests in both `get.test.js` and `file/get.test.js` assert structured log is emitted with correct message and event data
- All existing tests continue to pass
- 100% coverage maintained
- Lint, format, and typecheck all pass

[PAE-1340]: https://eaflood.atlassian.net/browse/PAE-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ