### PR TITLE
PAE-1194: Look up dev cleanup endpoint by numeric orgId

### DIFF
--- a/src/non-prod-data-reset/mongodb.js
+++ b/src/non-prod-data-reset/mongodb.js
@@ -12,6 +12,7 @@ import { logger } from '#common/helpers/logging/logger.js'
 
 const COLLECTIONS = {
   ORGANISATIONS: 'epr-organisations',
+  ORGANISATION: 'organisation',
   PACKAGING_RECYCLING_NOTES: 'packaging-recycling-notes',
   WASTE_BALANCES: 'waste-balances',
   REPORTS: 'reports',
@@ -27,7 +28,8 @@ const EMPTY_COUNTS = Object.freeze({
   'waste-records': 0,
   'summary-logs': 0,
   'overseas-sites': 0,
-  'epr-organisations': 0
+  'epr-organisations': 0,
+  organisation: 0
 })
 
 const toObjectId = (id) => ObjectId.createFromHexString(id)
@@ -41,7 +43,7 @@ const toObjectId = (id) => ObjectId.createFromHexString(id)
  * @param {number} orgId
  */
 const findOrganisationForCleanup = async (db, orgId) =>
-  db.collection(COLLECTIONS.ORGANISATIONS).findOne({ orgId: Number(orgId) })
+  db.collection(COLLECTIONS.ORGANISATIONS).findOne({ orgId })
 
 const extractCascadeKeys = (organisation) => {
   const accreditationIds = (organisation.accreditations ?? []).map((a) => a.id)
@@ -61,10 +63,17 @@ const extractCascadeKeys = (organisation) => {
  * (each derived from keys already extracted from the organisation document)
  * so there are no ordering constraints between steps.
  *
+ * Two different id shapes drive the filters. Most collections store the
+ * epr-organisations _id hex on the document, so they join against mongoIdHex.
+ * The 'organisation' collection (written by the journey-test apply path) is
+ * keyed by the numeric orgId, so its filter joins against orgId directly.
+ *
+ * @param {number} orgId
  * @param {string} mongoIdHex
  * @param {{ accreditationIds: string[], overseasSiteIds: string[] }} keys
  */
 const buildCascadeSteps = (
+  orgId,
   mongoIdHex,
   { accreditationIds, overseasSiteIds }
 ) => [
@@ -108,6 +117,11 @@ const buildCascadeSteps = (
     label: 'epr-organisations',
     collection: COLLECTIONS.ORGANISATIONS,
     filter: { _id: toObjectId(mongoIdHex) }
+  },
+  {
+    label: 'organisation',
+    collection: COLLECTIONS.ORGANISATION,
+    filter: { orgId }
   }
 ]
 
@@ -163,6 +177,6 @@ export const createNonProdDataReset = (db, { isProduction = false } = {}) => ({
     }
     const mongoIdHex = organisation._id.toHexString()
     const keys = extractCascadeKeys(organisation)
-    return runCascade(db, buildCascadeSteps(mongoIdHex, keys))
+    return runCascade(db, buildCascadeSteps(orgId, mongoIdHex, keys))
   }
 })

--- a/src/non-prod-data-reset/mongodb.js
+++ b/src/non-prod-data-reset/mongodb.js
@@ -6,7 +6,7 @@ import { logger } from '#common/helpers/logging/logger.js'
 
 /**
  * @typedef {{
- *   deleteByOrgId: (orgId: string) => Promise<Record<string, number>>
+ *   deleteByOrgId: (orgId: number) => Promise<Record<string, number>>
  * }} NonProdDataReset
  */
 
@@ -20,27 +20,30 @@ const COLLECTIONS = {
   OVERSEAS_SITES: 'overseas-sites'
 }
 
-const isValidObjectIdHex = (id) => /^[0-9a-fA-F]{24}$/.test(id)
+const EMPTY_COUNTS = Object.freeze({
+  'packaging-recycling-notes': 0,
+  'waste-balances': 0,
+  reports: 0,
+  'waste-records': 0,
+  'summary-logs': 0,
+  'overseas-sites': 0,
+  'epr-organisations': 0
+})
 
 const toObjectId = (id) => ObjectId.createFromHexString(id)
 
 /**
+ * Looks up the organisation by its numeric orgId (the stable identifier used
+ * by journey tests and upstream systems), not the Mongo _id. Shape validation
+ * for the incoming id lives at the route layer.
+ *
  * @param {Db} db
- * @param {string} orgId
+ * @param {number} orgId
  */
-const findOrganisationForCleanup = async (db, orgId) => {
-  if (!isValidObjectIdHex(orgId)) {
-    return null
-  }
-  return db
-    .collection(COLLECTIONS.ORGANISATIONS)
-    .findOne({ _id: toObjectId(orgId) })
-}
+const findOrganisationForCleanup = async (db, orgId) =>
+  db.collection(COLLECTIONS.ORGANISATIONS).findOne({ orgId: Number(orgId) })
 
 const extractCascadeKeys = (organisation) => {
-  if (!organisation) {
-    return { accreditationIds: [], overseasSiteIds: [] }
-  }
   const accreditationIds = (organisation.accreditations ?? []).map((a) => a.id)
   const overseasSiteIds = (organisation.registrations ?? []).flatMap((reg) =>
     Object.values(reg.overseasSites ?? {}).map((entry) => entry.overseasSiteId)
@@ -58,14 +61,17 @@ const extractCascadeKeys = (organisation) => {
  * (each derived from keys already extracted from the organisation document)
  * so there are no ordering constraints between steps.
  *
- * @param {string} orgId
+ * @param {string} mongoIdHex
  * @param {{ accreditationIds: string[], overseasSiteIds: string[] }} keys
  */
-const buildCascadeSteps = (orgId, { accreditationIds, overseasSiteIds }) => [
+const buildCascadeSteps = (
+  mongoIdHex,
+  { accreditationIds, overseasSiteIds }
+) => [
   {
     label: 'packaging-recycling-notes',
     collection: COLLECTIONS.PACKAGING_RECYCLING_NOTES,
-    filter: { 'organisation.id': orgId }
+    filter: { 'organisation.id': mongoIdHex }
   },
   {
     label: 'waste-balances',
@@ -78,17 +84,17 @@ const buildCascadeSteps = (orgId, { accreditationIds, overseasSiteIds }) => [
   {
     label: 'reports',
     collection: COLLECTIONS.REPORTS,
-    filter: { organisationId: orgId }
+    filter: { organisationId: mongoIdHex }
   },
   {
     label: 'waste-records',
     collection: COLLECTIONS.WASTE_RECORDS,
-    filter: { organisationId: orgId }
+    filter: { organisationId: mongoIdHex }
   },
   {
     label: 'summary-logs',
     collection: COLLECTIONS.SUMMARY_LOGS,
-    filter: { organisationId: orgId }
+    filter: { organisationId: mongoIdHex }
   },
   {
     label: 'overseas-sites',
@@ -101,7 +107,7 @@ const buildCascadeSteps = (orgId, { accreditationIds, overseasSiteIds }) => [
   {
     label: 'epr-organisations',
     collection: COLLECTIONS.ORGANISATIONS,
-    filter: isValidObjectIdHex(orgId) ? { _id: toObjectId(orgId) } : null
+    filter: { _id: toObjectId(mongoIdHex) }
   }
 ]
 
@@ -146,13 +152,17 @@ export const createNonProdDataReset = (db, { isProduction = false } = {}) => ({
   async deleteByOrgId(orgId) {
     if (isProduction) {
       logger.error(
-        { event: { reference: orgId } },
+        { event: { reference: String(orgId) } },
         'Refusing to run non-prod cascade delete in production environment.'
       )
       throw new Error('Non-prod data reset is disabled in production.')
     }
     const organisation = await findOrganisationForCleanup(db, orgId)
+    if (!organisation) {
+      return { ...EMPTY_COUNTS }
+    }
+    const mongoIdHex = organisation._id.toHexString()
     const keys = extractCascadeKeys(organisation)
-    return runCascade(db, buildCascadeSteps(orgId, keys))
+    return runCascade(db, buildCascadeSteps(mongoIdHex, keys))
   }
 })

--- a/src/non-prod-data-reset/mongodb.test.js
+++ b/src/non-prod-data-reset/mongodb.test.js
@@ -226,7 +226,7 @@ describe('non-prod data reset (mongo)', () => {
         })
       )
 
-      const counts = await reset.deleteByOrgId(seeded.organisationId)
+      const counts = await reset.deleteByOrgId(seeded.organisation.orgId)
 
       expect(counts).toEqual({
         'packaging-recycling-notes': 2,
@@ -257,7 +257,7 @@ describe('non-prod data reset (mongo)', () => {
       const other = await seedOrganisationWithOverseasSites(repositories)
       await seedDownstreamForOrganisation(repositories, other)
 
-      await reset.deleteByOrgId(target.organisationId)
+      await reset.deleteByOrgId(target.organisation.orgId)
 
       expect(
         await database
@@ -304,15 +304,7 @@ describe('non-prod data reset (mongo)', () => {
     it('returns all-zero counts when the organisation does not exist', async ({
       reset
     }) => {
-      const counts = await reset.deleteByOrgId(new ObjectId().toHexString())
-
-      expect(counts).toEqual(EMPTY_COUNTS)
-    })
-
-    it('returns all-zero counts when the id is not a valid object id', async ({
-      reset
-    }) => {
-      const counts = await reset.deleteByOrgId('not-an-object-id')
+      const counts = await reset.deleteByOrgId(999999)
 
       expect(counts).toEqual(EMPTY_COUNTS)
     })
@@ -324,11 +316,11 @@ describe('non-prod data reset (mongo)', () => {
       const seeded = await seedOrganisationWithOverseasSites(repositories)
       await seedDownstreamForOrganisation(repositories, seeded)
 
-      const first = await reset.deleteByOrgId(seeded.organisationId)
+      const first = await reset.deleteByOrgId(seeded.organisation.orgId)
       expect(first['epr-organisations']).toBe(1)
       expect(first['packaging-recycling-notes']).toBe(1)
 
-      const second = await reset.deleteByOrgId(seeded.organisationId)
+      const second = await reset.deleteByOrgId(seeded.organisation.orgId)
       expect(second).toEqual(EMPTY_COUNTS)
     })
 
@@ -339,9 +331,10 @@ describe('non-prod data reset (mongo)', () => {
       // Raw insert: we are deliberately constructing a malformed org doc to
       // exercise the cascade's empty-accreditations branch, which bypasses
       // adapter-level validation.
-      const orgId = new ObjectId()
+      const orgId = 600001
       await database.collection('epr-organisations').insertOne({
-        _id: orgId,
+        _id: new ObjectId(),
+        orgId,
         accreditations: [],
         registrations: []
       })
@@ -351,7 +344,7 @@ describe('non-prod data reset (mongo)', () => {
         accreditationId: new ObjectId().toHexString()
       })
 
-      const counts = await reset.deleteByOrgId(orgId.toHexString())
+      const counts = await reset.deleteByOrgId(orgId)
 
       expect(counts['waste-balances']).toBe(0)
       expect(await database.collection('waste-balances').countDocuments()).toBe(
@@ -363,9 +356,10 @@ describe('non-prod data reset (mongo)', () => {
       database,
       reset
     }) => {
-      const orgId = new ObjectId()
+      const orgId = 600002
       await database.collection('epr-organisations').insertOne({
-        _id: orgId,
+        _id: new ObjectId(),
+        orgId,
         accreditations: [],
         registrations: [{ id: new ObjectId().toHexString() }]
       })
@@ -375,7 +369,7 @@ describe('non-prod data reset (mongo)', () => {
         name: 'Orphan'
       })
 
-      const counts = await reset.deleteByOrgId(orgId.toHexString())
+      const counts = await reset.deleteByOrgId(orgId)
 
       expect(counts['overseas-sites']).toBe(0)
       expect(await database.collection('overseas-sites').countDocuments()).toBe(
@@ -396,7 +390,7 @@ describe('non-prod data reset (mongo)', () => {
       nonProdDataResetPlugin.register(server, { db: database })
 
       await expect(
-        server.app.nonProdDataReset.deleteByOrgId(seeded.organisationId)
+        server.app.nonProdDataReset.deleteByOrgId(seeded.organisation.orgId)
       ).rejects.toThrow('Non-prod data reset is disabled in production.')
 
       expect(
@@ -415,14 +409,14 @@ describe('non-prod data reset (mongo)', () => {
       database,
       reset
     }) => {
-      // Raw insert of a skeletal org doc with only _id, to cover the
-      // `?? []` fallbacks in extractCascadeKeys for both accreditations
-      // and registrations. The unique index on `orgId` allows at most one
-      // such null-orgId document at a time, which is fine for this branch.
-      const orgId = new ObjectId()
-      await database.collection('epr-organisations').insertOne({ _id: orgId })
+      // Raw insert of a skeletal org doc missing accreditations and
+      // registrations, to cover the `?? []` fallbacks in extractCascadeKeys.
+      const orgId = 600003
+      await database
+        .collection('epr-organisations')
+        .insertOne({ _id: new ObjectId(), orgId })
 
-      const counts = await reset.deleteByOrgId(orgId.toHexString())
+      const counts = await reset.deleteByOrgId(orgId)
 
       expect(counts['epr-organisations']).toBe(1)
       expect(counts['waste-balances']).toBe(0)

--- a/src/non-prod-data-reset/mongodb.test.js
+++ b/src/non-prod-data-reset/mongodb.test.js
@@ -40,6 +40,7 @@ const DATABASE_NAME = 'epr-backend'
 
 const COLLECTIONS = [
   'epr-organisations',
+  'organisation',
   'packaging-recycling-notes',
   'waste-balances',
   'reports',
@@ -196,6 +197,18 @@ const seedDownstreamForOrganisation = async (
   )
 }
 
+// The 'organisation' collection is written by the journey-test apply path and
+// keyed by the numeric orgId, so the cascade step filters by orgId directly.
+// No real adapter exists in this repo, so we raw-insert here.
+const seedOrganisationCollection = async (database, orgId) => {
+  await database.collection('organisation').insertOne({
+    _id: new ObjectId(),
+    orgId,
+    orgName: 'Target',
+    email: 'test@example.com'
+  })
+}
+
 const EMPTY_COUNTS = {
   'packaging-recycling-notes': 0,
   'waste-balances': 0,
@@ -203,7 +216,8 @@ const EMPTY_COUNTS = {
   'waste-records': 0,
   'summary-logs': 0,
   'overseas-sites': 0,
-  'epr-organisations': 0
+  'epr-organisations': 0,
+  organisation: 0
 }
 
 describe('non-prod data reset (mongo)', () => {
@@ -215,6 +229,7 @@ describe('non-prod data reset (mongo)', () => {
     }) => {
       const seeded = await seedOrganisationWithOverseasSites(repositories)
       await seedDownstreamForOrganisation(repositories, seeded)
+      await seedOrganisationCollection(database, seeded.organisation.orgId)
       // A second PRN so the deleteMany semantics get exercised.
       await repositories.prns.create(
         buildDraftPrn({
@@ -235,7 +250,8 @@ describe('non-prod data reset (mongo)', () => {
         'waste-records': 1,
         'summary-logs': 1,
         'overseas-sites': 2,
-        'epr-organisations': 1
+        'epr-organisations': 1,
+        organisation: 1
       })
 
       for (const name of COLLECTIONS) {
@@ -253,9 +269,11 @@ describe('non-prod data reset (mongo)', () => {
     }) => {
       const target = await seedOrganisationWithOverseasSites(repositories)
       await seedDownstreamForOrganisation(repositories, target)
+      await seedOrganisationCollection(database, target.organisation.orgId)
 
       const other = await seedOrganisationWithOverseasSites(repositories)
       await seedDownstreamForOrganisation(repositories, other)
+      await seedOrganisationCollection(database, other.organisation.orgId)
 
       await reset.deleteByOrgId(target.organisation.orgId)
 
@@ -299,6 +317,16 @@ describe('non-prod data reset (mongo)', () => {
           _id: ObjectId.createFromHexString(other.organisationId)
         })
       ).toBe(1)
+      expect(
+        await database
+          .collection('organisation')
+          .countDocuments({ orgId: other.organisation.orgId })
+      ).toBe(1)
+      expect(
+        await database
+          .collection('organisation')
+          .countDocuments({ orgId: target.organisation.orgId })
+      ).toBe(0)
     })
 
     it('returns all-zero counts when the organisation does not exist', async ({

--- a/src/routes/v1/dev/organisations/delete-by-id.js
+++ b/src/routes/v1/dev/organisations/delete-by-id.js
@@ -7,18 +7,19 @@ import Joi from 'joi'
 /**
  * @typedef {HapiRequest & {
  *   nonProdDataReset: NonProdDataReset
- *   params: { id: string }
+ *   params: { id: number }
  * }} DeleteByIdRequest
  */
 
 export const devOrganisationsDeleteByIdPath = '/v1/dev/organisations/{id}'
 
 const params = Joi.object({
-  id: Joi.string().trim().min(1).required()
+  id: Joi.number().integer().positive().required()
 }).messages({
   'any.required': '{#label} is required',
-  'string.empty': '{#label} cannot be empty',
-  'string.min': '{#label} cannot be empty'
+  'number.base': '{#label} must be a positive integer',
+  'number.integer': '{#label} must be a positive integer',
+  'number.positive': '{#label} must be a positive integer'
 })
 
 export const devOrganisationsDeleteById = {

--- a/src/routes/v1/dev/organisations/delete-by-id.js
+++ b/src/routes/v1/dev/organisations/delete-by-id.js
@@ -13,13 +13,15 @@ import Joi from 'joi'
 
 export const devOrganisationsDeleteByIdPath = '/v1/dev/organisations/{id}'
 
+const POSITIVE_INTEGER_MESSAGE = '{#label} must be a positive integer'
+
 const params = Joi.object({
   id: Joi.number().integer().positive().required()
 }).messages({
   'any.required': '{#label} is required',
-  'number.base': '{#label} must be a positive integer',
-  'number.integer': '{#label} must be a positive integer',
-  'number.positive': '{#label} must be a positive integer'
+  'number.base': POSITIVE_INTEGER_MESSAGE,
+  'number.integer': POSITIVE_INTEGER_MESSAGE,
+  'number.positive': POSITIVE_INTEGER_MESSAGE
 })
 
 export const devOrganisationsDeleteById = {

--- a/src/routes/v1/dev/organisations/delete-by-id.test.js
+++ b/src/routes/v1/dev/organisations/delete-by-id.test.js
@@ -2,7 +2,6 @@ import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemor
 import { createTestServer } from '#test/create-test-server.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 import { StatusCodes } from 'http-status-codes'
-import { ObjectId } from 'mongodb'
 import { describe, it, expect, beforeEach } from 'vitest'
 
 describe('DELETE /v1/dev/organisations/{id}', () => {
@@ -17,7 +16,7 @@ describe('DELETE /v1/dev/organisations/{id}', () => {
 
       const response = await server.inject({
         method: 'DELETE',
-        url: `/v1/dev/organisations/${new ObjectId().toString()}`
+        url: '/v1/dev/organisations/506544'
       })
 
       expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
@@ -49,28 +48,44 @@ describe('DELETE /v1/dev/organisations/{id}', () => {
       })
     })
 
-    it('returns 422 when id is whitespace-only', async () => {
+    it('returns 422 when id is non-numeric', async () => {
       const response = await server.inject({
         method: 'DELETE',
-        url: '/v1/dev/organisations/%20%20%20'
+        url: '/v1/dev/organisations/not-a-number'
       })
 
       expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
-      const body = JSON.parse(response.payload)
-      expect(body.message).toBe('"id" cannot be empty')
+    })
+
+    it('returns 422 when id is a Mongo ObjectId hex string', async () => {
+      const response = await server.inject({
+        method: 'DELETE',
+        url: '/v1/dev/organisations/507f1f77bcf86cd799439011'
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+    })
+
+    it('returns 422 when id is zero or negative', async () => {
+      const response = await server.inject({
+        method: 'DELETE',
+        url: '/v1/dev/organisations/0'
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
     })
 
     it('does not require authentication', async () => {
       const response = await server.inject({
         method: 'DELETE',
-        url: `/v1/dev/organisations/${new ObjectId().toString()}`
+        url: '/v1/dev/organisations/506544'
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
     })
 
     it('returns 200 with the counts surfaced by the reset module', async () => {
-      const orgId = new ObjectId().toString()
+      const orgId = 506544
 
       const response = await server.inject({
         method: 'DELETE',
@@ -84,8 +99,8 @@ describe('DELETE /v1/dev/organisations/{id}', () => {
       })
     })
 
-    it('passes the path id through to the reset module', async () => {
-      const orgId = new ObjectId().toString()
+    it('passes the numeric path id through to the reset module', async () => {
+      const orgId = 506544
       const received = []
       const nonProdDataReset = {
         deleteByOrgId: async (id) => {


### PR DESCRIPTION
## Summary

Two related fixes landing together. Both target the dev-only DELETE /v1/dev/organisations/{id} cleanup endpoint and the 6051 orphan orgs accumulating in TEST.

### 1. Look up the cleanup endpoint by numeric orgId

The endpoint validated \`{id}\` as any non-empty string and silently no-opped whenever it was not a 24-char hex ObjectId: \`findOrganisationForCleanup\` returned null, the cascade ran with empty keys, and the handler responded 200 with zero counts. Journey tests track the numeric counter orgId (e.g. 506544), so every cleanup call has been silently dropping data for the lifetime of the suite.

Joi now validates the path id as a positive integer (422 otherwise). The module looks up by \`{ orgId }\` and uses the doc's \`_id.toHexString()\` for downstream joins, so the existing filters stay unchanged. Not-found returns all-zero counts directly.

### 2. Extend the cascade to the 'organisation' collection

The cascade covered 7 collections but skipped \`organisation\`, which is the production apply-path collection (POST /v1/apply/organisation) written for every real submission as well as every journey-test run. Journey-test rows were never cleaned up and have accumulated indefinitely: TEST currently holds 6051 rows sharing a single email with no discriminator between humans and tests.

Add an \`organisation\` step filtering by numeric orgId directly (the apply path stores orgId on each doc, so no \`_id\` join is needed). Broadening the cascade is safe because the endpoint is non-prod-only (triple-gated: route gate, plugin registration, \`cdpEnvironment\`-prod refusal) and is always driven by a specific orgId the caller owns; it cannot sweep across orgs it doesn't name.