### PR TITLE
PAE-1194: Add registration and accreditation to DELETE cascade

### DIFF
--- a/src/non-prod-data-reset/mongodb.js
+++ b/src/non-prod-data-reset/mongodb.js
@@ -13,6 +13,8 @@ import { logger } from '#common/helpers/logging/logger.js'
 const COLLECTIONS = {
   ORGANISATIONS: 'epr-organisations',
   ORGANISATION: 'organisation',
+  REGISTRATION: 'registration',
+  ACCREDITATION: 'accreditation',
   PACKAGING_RECYCLING_NOTES: 'packaging-recycling-notes',
   WASTE_BALANCES: 'waste-balances',
   REPORTS: 'reports',
@@ -28,6 +30,8 @@ const EMPTY_COUNTS = Object.freeze({
   'waste-records': 0,
   'summary-logs': 0,
   'overseas-sites': 0,
+  registration: 0,
+  accreditation: 0,
   'epr-organisations': 0,
   organisation: 0
 })
@@ -112,6 +116,16 @@ const buildCascadeSteps = (
       overseasSiteIds.length === 0
         ? null
         : { _id: { $in: overseasSiteIds.map(toObjectId) } }
+  },
+  {
+    label: 'registration',
+    collection: COLLECTIONS.REGISTRATION,
+    filter: { orgId }
+  },
+  {
+    label: 'accreditation',
+    collection: COLLECTIONS.ACCREDITATION,
+    filter: { orgId }
   },
   {
     label: 'epr-organisations',

--- a/src/non-prod-data-reset/mongodb.test.js
+++ b/src/non-prod-data-reset/mongodb.test.js
@@ -41,6 +41,8 @@ const DATABASE_NAME = 'epr-backend'
 const COLLECTIONS = [
   'epr-organisations',
   'organisation',
+  'registration',
+  'accreditation',
   'packaging-recycling-notes',
   'waste-balances',
   'reports',
@@ -209,6 +211,22 @@ const seedOrganisationCollection = async (database, orgId) => {
   })
 }
 
+// The 'registration' and 'accreditation' staging collections are written by
+// the forms-submission-data migration path and keyed by orgId. No real adapter
+// exists in the cascade module, so we raw-insert here.
+const seedStagingCollections = async (database, orgId) => {
+  await database.collection('registration').insertOne({
+    _id: new ObjectId(),
+    orgId,
+    referenceNumber: `REG-${orgId}`
+  })
+  await database.collection('accreditation').insertOne({
+    _id: new ObjectId(),
+    orgId,
+    referenceNumber: `ACC-${orgId}`
+  })
+}
+
 const EMPTY_COUNTS = {
   'packaging-recycling-notes': 0,
   'waste-balances': 0,
@@ -216,6 +234,8 @@ const EMPTY_COUNTS = {
   'waste-records': 0,
   'summary-logs': 0,
   'overseas-sites': 0,
+  registration: 0,
+  accreditation: 0,
   'epr-organisations': 0,
   organisation: 0
 }
@@ -230,6 +250,7 @@ describe('non-prod data reset (mongo)', () => {
       const seeded = await seedOrganisationWithOverseasSites(repositories)
       await seedDownstreamForOrganisation(repositories, seeded)
       await seedOrganisationCollection(database, seeded.organisation.orgId)
+      await seedStagingCollections(database, seeded.organisation.orgId)
       // A second PRN so the deleteMany semantics get exercised.
       await repositories.prns.create(
         buildDraftPrn({
@@ -250,6 +271,8 @@ describe('non-prod data reset (mongo)', () => {
         'waste-records': 1,
         'summary-logs': 1,
         'overseas-sites': 2,
+        registration: 1,
+        accreditation: 1,
         'epr-organisations': 1,
         organisation: 1
       })
@@ -270,10 +293,12 @@ describe('non-prod data reset (mongo)', () => {
       const target = await seedOrganisationWithOverseasSites(repositories)
       await seedDownstreamForOrganisation(repositories, target)
       await seedOrganisationCollection(database, target.organisation.orgId)
+      await seedStagingCollections(database, target.organisation.orgId)
 
       const other = await seedOrganisationWithOverseasSites(repositories)
       await seedDownstreamForOrganisation(repositories, other)
       await seedOrganisationCollection(database, other.organisation.orgId)
+      await seedStagingCollections(database, other.organisation.orgId)
 
       await reset.deleteByOrgId(target.organisation.orgId)
 
@@ -316,6 +341,16 @@ describe('non-prod data reset (mongo)', () => {
         await database.collection('epr-organisations').countDocuments({
           _id: ObjectId.createFromHexString(other.organisationId)
         })
+      ).toBe(1)
+      expect(
+        await database
+          .collection('registration')
+          .countDocuments({ orgId: other.organisation.orgId })
+      ).toBe(1)
+      expect(
+        await database
+          .collection('accreditation')
+          .countDocuments({ orgId: other.organisation.orgId })
       ).toBe(1)
       expect(
         await database


### PR DESCRIPTION
Ticket: [PAE-1194](https://eaflood.atlassian.net/browse/PAE-1194)
## Summary

- Adds the `registration` and `accreditation` staging collections to the non-prod DELETE cascade at `/v1/dev/organisations/{id}`
- Both collections are filtered by `orgId`, matching the existing `organisation` collection pattern
- Without this, orphaned staging docs cause the delta calculator to attempt re-migration on server restart

## Test plan

- [x] Existing cascade integration test extended to seed and assert deletion of staging docs
- [x] "Leaves unrelated" test extended to verify other orgs' staging docs survive
- [x] EMPTY_COUNTS updated so idempotency and not-found tests pass with new shape
- [x] Full suite green, 100% coverage, type checks clean

[PAE-1194]: https://eaflood.atlassian.net/browse/PAE-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ