### PR TITLE
PAE-1339: Make Registration.accreditation nullable, not optional

### DIFF
--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -242,7 +242,6 @@ const markIgnoredByDateRange = (
 
     /** @type {import('#domain/summary-logs/table-schemas/validation-pipeline.js').WasteBalanceClassificationResult | undefined} */
     const result = schema?.classifyForWasteBalance?.(wasteRecord.record.data, {
-      // @ts-expect-error meta-business validation guarantees accreditation exists for non-registered-only types
       accreditation: registration.accreditation,
       overseasSites: ORS_VALIDATION_DISABLED
     })

--- a/src/domain/organisations/registration.js
+++ b/src/domain/organisations/registration.js
@@ -32,7 +32,7 @@
 
 /**
  * @typedef {{ id: string } & {
- *  accreditation?: Accreditation;
+ *  accreditation: Accreditation | null;
  *  accreditationId?: string;
  *  approvedPersons: User[]
  *  formSubmissionTime: Date;

--- a/src/overseas-sites/routes/admin-list.js
+++ b/src/overseas-sites/routes/admin-list.js
@@ -88,7 +88,7 @@ const mapMappingToRow = (
 }
 
 /**
- * @param {Array<{orgId?: number, registrations?: Array<{material?: string, registrationNumber?: string, accreditationId?: string, accreditationNumber?: string, accreditation?: {accreditationNumber?: string}, overseasSites?: Record<string, {overseasSiteId: string}>}>, accreditations?: Array<{id?: string, accreditationNumber?: string}>}>} organisations
+ * @param {Array<import('#repositories/organisations/port.js').OrganisationsOverseasSitesAdminListItem>} organisations
  * @param {Map<string, OverseasSite>} sitesById
  */
 const buildRows = (organisations, sitesById) => {

--- a/src/repositories/organisations/contract/find-registration-by-id.contract.js
+++ b/src/repositories/organisations/contract/find-registration-by-id.contract.js
@@ -75,7 +75,7 @@ export const testFindRegistrationByIdBehaviour = (it) => {
       })
     })
 
-    it('returns registration without accreditation field when accreditationId is undefined', async () => {
+    it('returns registration with accreditation set to null when accreditationId is undefined', async () => {
       const registration = buildRegistration({
         material: 'plastic',
         wasteProcessingType: 'exporter',
@@ -93,10 +93,10 @@ export const testFindRegistrationByIdBehaviour = (it) => {
         registration.id
       )
 
-      expect(result.accreditation).toBeUndefined()
+      expect(result.accreditation).toBeNull()
     })
 
-    it('returns registration without accreditation field when accreditationId does not match any accreditation', async () => {
+    it('returns registration with accreditation set to null when accreditationId does not match any accreditation', async () => {
       const registration = buildRegistration({
         cbduNumber: 'CBDU333333',
         accreditationId: new ObjectId().toString()
@@ -113,7 +113,7 @@ export const testFindRegistrationByIdBehaviour = (it) => {
         registration.id
       )
 
-      expect(result.accreditation).toBeUndefined()
+      expect(result.accreditation).toBeNull()
     })
 
     it('throws 404 when organisation does not exist', async () => {

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -243,6 +243,7 @@ export const mapDocumentWithCurrentStatuses = (org) => {
 
   for (const item of rest.registrations) {
     item.status = getCurrentStatus(item)
+    item.accreditation = item.accreditation ?? null
   }
 
   for (const item of rest.accreditations) {

--- a/src/repositories/organisations/port.js
+++ b/src/repositories/organisations/port.js
@@ -22,7 +22,7 @@
  *   registrationNumber?: string,
  *   accreditationId?: string,
  *   accreditationNumber?: string,
- *   accreditation?: { accreditationNumber?: string },
+ *   accreditation?: { accreditationNumber?: string } | null,
  *   overseasSites?: Record<string, { overseasSiteId: string }>
  * }>} [registrations]
  * @property {Array<{ id?: string, accreditationNumber?: string }>} [accreditations]


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
## Summary

`Registration.accreditation` was typed as `accreditation?: Accreditation` (optional/undefined), but downstream consumers like `classifyForWasteBalance` accept `Accreditation | null`. The type misrepresented the runtime contract and forced an `@ts-expect-error` suppression in `summary-logs/validate.js` at a call site that genuinely receives a hydrated value.

## Changes

- **`src/domain/organisations/registration.js`** — flip the field from `accreditation?: Accreditation` to `accreditation: Accreditation | null`. Required-but-nullable is the honest contract: every reader must handle the absence case explicitly, and the absence is represented as `null`, not `undefined`.
- **`src/repositories/organisations/helpers.js`** — `mapDocumentWithCurrentStatuses` now normalises `accreditation` to `null` for every registration on every Org read. This is the single boundary that all `findById` / `findAll` / `findByIds` / `findByLinkedDefraOrgId` / `findByOrgId` paths flow through, so the contract holds across the board.
- **`src/application/summary-logs/validate.js`** — drop the now-unused `@ts-expect-error` on the `classifyForWasteBalance` call.
- **`src/repositories/organisations/contract/find-registration-by-id.contract.js`** — update two contract tests from `toBeUndefined()` to `toBeNull()` and rename them to describe the new behaviour.
- **`src/repositories/organisations/port.js`** — widen the `OrganisationsOverseasSitesAdminListItem.registrations[].accreditation` typedef to allow `| null`. This projection path bypasses `mapDocumentWithCurrentStatuses` so the field is genuinely sometimes-undefined; the typedef now matches reality.
- **`src/overseas-sites/routes/admin-list.js`** — replace the hand-rolled inline JSDoc shape on `buildRows` with the existing `OrganisationsOverseasSitesAdminListItem` typedef from `port.js` so the two stop drifting.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ