### PR TITLE
PAE-1230: Immediate redrive on transient errors and fix log levels

### DIFF
--- a/src/common/helpers/sqs/sqs-client.js
+++ b/src/common/helpers/sqs/sqs-client.js
@@ -1,7 +1,8 @@
 import {
   SQSClient,
   GetQueueUrlCommand,
-  GetQueueAttributesCommand
+  GetQueueAttributesCommand,
+  ChangeMessageVisibilityCommand
 } from '@aws-sdk/client-sqs'
 
 /** @typedef {import('@aws-sdk/client-sqs').SQSClient} SQSClientType */
@@ -55,4 +56,27 @@ export async function getMaxReceiveCount(sqsClient, queueUrl) {
 
   const parsed = JSON.parse(redrivePolicy)
   return Number(parsed.maxReceiveCount)
+}
+
+/**
+ * Resets the visibility timeout of a message so it becomes immediately
+ * available for redelivery.
+ * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html#terminating-message-visibility-timeout
+ * @param {SQSClientType} sqsClient
+ * @param {string} queueUrl
+ * @param {string} receiptHandle
+ * @returns {Promise<void>}
+ */
+export async function resetVisibilityTimeout(
+  sqsClient,
+  queueUrl,
+  receiptHandle
+) {
+  await sqsClient.send(
+    new ChangeMessageVisibilityCommand({
+      QueueUrl: queueUrl,
+      ReceiptHandle: receiptHandle,
+      VisibilityTimeout: 0
+    })
+  )
 }

--- a/src/common/helpers/sqs/sqs-client.js
+++ b/src/common/helpers/sqs/sqs-client.js
@@ -59,8 +59,8 @@ export async function getMaxReceiveCount(sqsClient, queueUrl) {
 }
 
 /**
- * Resets the visibility timeout of a message so it becomes immediately
- * available for redelivery.
+ * Reduces the visibility timeout of a message so it becomes quickly
+ * available for redelivery (1 s delay to allow transient issues to clear).
  * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html#terminating-message-visibility-timeout
  * @param {SQSClientType} sqsClient
  * @param {string} queueUrl
@@ -76,7 +76,7 @@ export async function resetVisibilityTimeout(
     new ChangeMessageVisibilityCommand({
       QueueUrl: queueUrl,
       ReceiptHandle: receiptHandle,
-      VisibilityTimeout: 0
+      VisibilityTimeout: 1
     })
   )
 }

--- a/src/common/helpers/sqs/sqs-client.js
+++ b/src/common/helpers/sqs/sqs-client.js
@@ -1,8 +1,7 @@
 import {
   SQSClient,
   GetQueueUrlCommand,
-  GetQueueAttributesCommand,
-  ChangeMessageVisibilityCommand
+  GetQueueAttributesCommand
 } from '@aws-sdk/client-sqs'
 
 /** @typedef {import('@aws-sdk/client-sqs').SQSClient} SQSClientType */
@@ -56,27 +55,4 @@ export async function getMaxReceiveCount(sqsClient, queueUrl) {
 
   const parsed = JSON.parse(redrivePolicy)
   return Number(parsed.maxReceiveCount)
-}
-
-/**
- * Reduces the visibility timeout of a message so it becomes quickly
- * available for redelivery (1 s delay to allow transient issues to clear).
- * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html#terminating-message-visibility-timeout
- * @param {SQSClientType} sqsClient
- * @param {string} queueUrl
- * @param {string} receiptHandle
- * @returns {Promise<void>}
- */
-export async function resetVisibilityTimeout(
-  sqsClient,
-  queueUrl,
-  receiptHandle
-) {
-  await sqsClient.send(
-    new ChangeMessageVisibilityCommand({
-      QueueUrl: queueUrl,
-      ReceiptHandle: receiptHandle,
-      VisibilityTimeout: 1
-    })
-  )
 }

--- a/src/server/queue-consumer/consumer.integration.test.js
+++ b/src/server/queue-consumer/consumer.integration.test.js
@@ -562,7 +562,7 @@ describe('SQS command queue consumer integration', () => {
         })
 
         // Create a queue with a long visibility timeout (30s) so the only
-        // way the retry arrives within 10s is via resetVisibilityTimeout.
+        // way the retry arrives within 10s is via terminateVisibilityTimeout.
         const longTimeoutQueueName = `epr_backend_commands_vis_${Date.now()}`
         const longTimeoutDlqName = `${longTimeoutQueueName}_dlq`
 

--- a/src/server/queue-consumer/consumer.integration.test.js
+++ b/src/server/queue-consumer/consumer.integration.test.js
@@ -626,7 +626,7 @@ describe('SQS command queue consumer integration', () => {
         const startTime = Date.now()
 
         // Wait for the second attempt — proves the visibility timeout was
-        // reset to 0, because otherwise SQS would hold the message for 30s.
+        // reset to 1s, because otherwise SQS would hold the message for 30s.
         await vi.waitFor(
           () => {
             expect(mockValidator.mock.calls.length).toBeGreaterThanOrEqual(2)

--- a/src/server/queue-consumer/consumer.integration.test.js
+++ b/src/server/queue-consumer/consumer.integration.test.js
@@ -2,6 +2,8 @@ import { describe, expect, vi, beforeEach } from 'vitest'
 import {
   SendMessageCommand,
   GetQueueUrlCommand,
+  GetQueueAttributesCommand,
+  CreateQueueCommand,
   ReceiveMessageCommand
 } from '@aws-sdk/client-sqs'
 import { it } from '#vite/fixtures/sqs.js'
@@ -538,6 +540,102 @@ describe('SQS command queue consumer integration', () => {
           },
           { timeout: 15000, interval: 500 }
         )
+
+        await stopConsumerAndWait(consumer)
+      }
+    )
+  })
+
+  describe('visibility timeout reset', () => {
+    it(
+      'retries a transient error faster than the queue visibility timeout',
+      { timeout: TEST_TIMEOUT },
+      async ({ sqsClient }) => {
+        const mockValidator = vi
+          .fn()
+          .mockRejectedValue(new Error('Database timeout'))
+        vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
+
+        summaryLogsRepository.findById.mockResolvedValue({
+          version: 1,
+          summaryLog: { status: SUMMARY_LOG_STATUS.VALIDATING }
+        })
+
+        // Create a queue with a long visibility timeout (30s) so the only
+        // way the retry arrives within 10s is via resetVisibilityTimeout.
+        const longTimeoutQueueName = `epr_backend_commands_vis_${Date.now()}`
+        const longTimeoutDlqName = `${longTimeoutQueueName}_dlq`
+
+        const dlqResult = await sqsClient.send(
+          new CreateQueueCommand({ QueueName: longTimeoutDlqName })
+        )
+
+        const dlqAttributes = await sqsClient.send(
+          new GetQueueAttributesCommand({
+            QueueUrl: dlqResult.QueueUrl,
+            AttributeNames: ['QueueArn']
+          })
+        )
+        const dlqArn = dlqAttributes.Attributes.QueueArn
+
+        await sqsClient.send(
+          new CreateQueueCommand({
+            QueueName: longTimeoutQueueName,
+            Attributes: {
+              VisibilityTimeout: '30',
+              RedrivePolicy: JSON.stringify({
+                deadLetterTargetArn: dlqArn,
+                maxReceiveCount: '3'
+              })
+            }
+          })
+        )
+
+        const { QueueUrl: queueUrl } = await sqsClient.send(
+          new GetQueueUrlCommand({ QueueName: longTimeoutQueueName })
+        )
+
+        // Send a validate command directly (not via the executor, since the
+        // executor resolves the queue name from sqsClient.queueName)
+        await sqsClient.send(
+          new SendMessageCommand({
+            QueueUrl: queueUrl,
+            MessageBody: JSON.stringify({
+              command: 'validate',
+              summaryLogId: `vis-test-${Date.now()}`,
+              context: { traceId: 'trace-vis-test' }
+            })
+          })
+        )
+
+        const consumer = await createCommandQueueConsumer(
+          {
+            sqsClient,
+            queueName: longTimeoutQueueName,
+            logger,
+            summaryLogsRepository,
+            organisationsRepository,
+            wasteRecordsRepository,
+            wasteBalancesRepository,
+            summaryLogExtractor
+          },
+          summaryLogCommandHandlers
+        )
+
+        consumer.start()
+        const startTime = Date.now()
+
+        // Wait for the second attempt — proves the visibility timeout was
+        // reset to 0, because otherwise SQS would hold the message for 30s.
+        await vi.waitFor(
+          () => {
+            expect(mockValidator.mock.calls.length).toBeGreaterThanOrEqual(2)
+          },
+          { timeout: 10000 }
+        )
+
+        const elapsed = Date.now() - startTime
+        expect(elapsed).toBeLessThan(10000)
 
         await stopConsumerAndWait(consumer)
       }

--- a/src/server/queue-consumer/consumer.js
+++ b/src/server/queue-consumer/consumer.js
@@ -175,7 +175,10 @@ const handleCommandError = async ({
     return
   }
 
-  if (!isFinalTransientAttempt) {
+  // ReceiptHandle is always present on messages from ReceiveMessage in
+  // practice, but the SDK types it as optional. Guard rather than assert,
+  // so we fall back to normal SQS retry timing if it's ever absent.
+  if (!isFinalTransientAttempt && message.ReceiptHandle) {
     try {
       await resetVisibilityTimeout(sqsClient, queueUrl, message.ReceiptHandle)
     } catch (resetErr) {

--- a/src/server/queue-consumer/consumer.js
+++ b/src/server/queue-consumer/consumer.js
@@ -175,7 +175,7 @@ const handleCommandError = async ({
     return
   }
 
-  if (!isFinalTransientAttempt && message.ReceiptHandle) {
+  if (!isFinalTransientAttempt) {
     try {
       await resetVisibilityTimeout(sqsClient, queueUrl, message.ReceiptHandle)
     } catch (resetErr) {

--- a/src/server/queue-consumer/consumer.js
+++ b/src/server/queue-consumer/consumer.js
@@ -3,7 +3,8 @@ import { Consumer } from 'sqs-consumer'
 
 import {
   resolveQueueUrl,
-  getMaxReceiveCount
+  getMaxReceiveCount,
+  resetVisibilityTimeout
 } from '#common/helpers/sqs/sqs-client.js'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -137,6 +138,7 @@ const getFailureLabel = (isPermanent, isFinalTransientAttempt) => {
  * @param {object} params.payload
  * @param {import('@aws-sdk/client-sqs').Message} params.message
  * @param {number|null} params.maxReceiveCount
+ * @param {string} params.queueUrl
  * @param {ConsumerDependencies} params.deps
  */
 const handleCommandError = async ({
@@ -145,16 +147,18 @@ const handleCommandError = async ({
   payload,
   message,
   maxReceiveCount,
+  queueUrl,
   deps
 }) => {
-  const { logger } = deps
+  const { logger, sqsClient } = deps
   const isPermanent = err instanceof PermanentError
   const receiveCount = Number(message.Attributes?.ApproximateReceiveCount ?? 0)
   const isFinalTransientAttempt =
     !isPermanent && maxReceiveCount !== null && receiveCount >= maxReceiveCount
   const isTerminal = isPermanent || isFinalTransientAttempt
+  const logLevel = isTerminal ? 'error' : 'warn'
 
-  logger.error({
+  logger[logLevel]({
     err,
     message: `Command failed (${getFailureLabel(isPermanent, isFinalTransientAttempt)}): ${handler.command} for ${handler.describe(payload)} messageId=${message.MessageId}`,
     event: {
@@ -170,6 +174,18 @@ const handleCommandError = async ({
   if (isPermanent) {
     return
   }
+
+  if (!isFinalTransientAttempt && message.ReceiptHandle) {
+    try {
+      await resetVisibilityTimeout(sqsClient, queueUrl, message.ReceiptHandle)
+    } catch (resetErr) {
+      logger.warn({
+        err: resetErr,
+        message: `Failed to reset visibility timeout for messageId=${message.MessageId}`
+      })
+    }
+  }
+
   throw err
 }
 
@@ -177,12 +193,14 @@ const handleCommandError = async ({
  * Creates the message handler for the SQS consumer.
  * @param {ConsumerDependencies} deps
  * @param {number|null} maxReceiveCount
+ * @param {string} queueUrl
  * @param {import('joi').ObjectSchema} envelopeSchema
  * @param {Map<string, CommandHandler>} handlerMap
  * @returns {(message: import('@aws-sdk/client-sqs').Message) => Promise<import('@aws-sdk/client-sqs').Message | void>}
  */
 const createMessageHandler =
-  (deps, maxReceiveCount, envelopeSchema, handlerMap) => async (message) => {
+  (deps, maxReceiveCount, queueUrl, envelopeSchema, handlerMap) =>
+  async (message) => {
     const { logger } = deps
 
     const result = parseCommandMessage(
@@ -236,6 +254,7 @@ const createMessageHandler =
         payload,
         message,
         maxReceiveCount,
+        queueUrl,
         deps: commandDeps
       })
 
@@ -273,7 +292,7 @@ const attachEventHandlers = (
   })
 
   consumer.on('processing_error', (err) => {
-    logger.error({
+    logger.warn({
       err,
       message: 'SQS message processing error',
       event: {
@@ -360,7 +379,13 @@ export const createCommandQueueConsumer = async (deps, handlers) => {
     queueUrl,
     sqs: sqsClient,
     handleMessage: /** @type {*} */ (
-      createMessageHandler(deps, maxReceiveCount, envelopeSchema, handlerMap)
+      createMessageHandler(
+        deps,
+        maxReceiveCount,
+        queueUrl,
+        envelopeSchema,
+        handlerMap
+      )
     ),
     handleMessageTimeout: COMMAND_TIMEOUT_MS,
     attributeNames: /** @type {*} */ (['ApproximateReceiveCount'])

--- a/src/server/queue-consumer/consumer.js
+++ b/src/server/queue-consumer/consumer.js
@@ -294,6 +294,9 @@ const attachEventHandlers = (
     })
   })
 
+  // Most errors are already logged with full context in handleCommandError.
+  // This handler catches errors that bypass it (e.g. unparseable messages)
+  // and provides a fallback log for those cases.
   consumer.on('processing_error', (err) => {
     logger.warn({
       err,

--- a/src/server/queue-consumer/consumer.js
+++ b/src/server/queue-consumer/consumer.js
@@ -3,8 +3,7 @@ import { Consumer } from 'sqs-consumer'
 
 import {
   resolveQueueUrl,
-  getMaxReceiveCount,
-  resetVisibilityTimeout
+  getMaxReceiveCount
 } from '#common/helpers/sqs/sqs-client.js'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -138,7 +137,6 @@ const getFailureLabel = (isPermanent, isFinalTransientAttempt) => {
  * @param {object} params.payload
  * @param {import('@aws-sdk/client-sqs').Message} params.message
  * @param {number|null} params.maxReceiveCount
- * @param {string} params.queueUrl
  * @param {ConsumerDependencies} params.deps
  */
 const handleCommandError = async ({
@@ -147,10 +145,9 @@ const handleCommandError = async ({
   payload,
   message,
   maxReceiveCount,
-  queueUrl,
   deps
 }) => {
-  const { logger, sqsClient } = deps
+  const { logger } = deps
   const isPermanent = err instanceof PermanentError
   const receiveCount = Number(message.Attributes?.ApproximateReceiveCount ?? 0)
   const isFinalTransientAttempt =
@@ -175,20 +172,8 @@ const handleCommandError = async ({
     return
   }
 
-  // ReceiptHandle is always present on messages from ReceiveMessage in
-  // practice, but the SDK types it as optional. Guard rather than assert,
-  // so we fall back to normal SQS retry timing if it's ever absent.
-  if (!isFinalTransientAttempt && message.ReceiptHandle) {
-    try {
-      await resetVisibilityTimeout(sqsClient, queueUrl, message.ReceiptHandle)
-    } catch (resetErr) {
-      logger.warn({
-        err: resetErr,
-        message: `Failed to reset visibility timeout for messageId=${message.MessageId}`
-      })
-    }
-  }
-
+  // Visibility reset is handled by sqs-consumer's terminateVisibilityTimeout
+  // option, which applies to all handler errors (including unparseable messages)
   throw err
 }
 
@@ -196,14 +181,12 @@ const handleCommandError = async ({
  * Creates the message handler for the SQS consumer.
  * @param {ConsumerDependencies} deps
  * @param {number|null} maxReceiveCount
- * @param {string} queueUrl
  * @param {import('joi').ObjectSchema} envelopeSchema
  * @param {Map<string, CommandHandler>} handlerMap
  * @returns {(message: import('@aws-sdk/client-sqs').Message) => Promise<import('@aws-sdk/client-sqs').Message | void>}
  */
 const createMessageHandler =
-  (deps, maxReceiveCount, queueUrl, envelopeSchema, handlerMap) =>
-  async (message) => {
+  (deps, maxReceiveCount, envelopeSchema, handlerMap) => async (message) => {
     const { logger } = deps
 
     const result = parseCommandMessage(
@@ -257,7 +240,6 @@ const createMessageHandler =
         payload,
         message,
         maxReceiveCount,
-        queueUrl,
         deps: commandDeps
       })
 
@@ -385,15 +367,10 @@ export const createCommandQueueConsumer = async (deps, handlers) => {
     queueUrl,
     sqs: sqsClient,
     handleMessage: /** @type {*} */ (
-      createMessageHandler(
-        deps,
-        maxReceiveCount,
-        queueUrl,
-        envelopeSchema,
-        handlerMap
-      )
+      createMessageHandler(deps, maxReceiveCount, envelopeSchema, handlerMap)
     ),
     handleMessageTimeout: COMMAND_TIMEOUT_MS,
+    terminateVisibilityTimeout: 1,
     attributeNames: /** @type {*} */ (['ApproximateReceiveCount'])
   })
 

--- a/src/server/queue-consumer/consumer.test.js
+++ b/src/server/queue-consumer/consumer.test.js
@@ -1,7 +1,8 @@
 import { Consumer } from 'sqs-consumer'
 import {
   GetQueueUrlCommand,
-  GetQueueAttributesCommand
+  GetQueueAttributesCommand,
+  ChangeMessageVisibilityCommand
 } from '@aws-sdk/client-sqs'
 
 import { createCommandQueueConsumer } from './consumer.js'
@@ -16,7 +17,8 @@ import {
 vi.mock('sqs-consumer')
 vi.mock('@aws-sdk/client-sqs', () => ({
   GetQueueUrlCommand: vi.fn(),
-  GetQueueAttributesCommand: vi.fn()
+  GetQueueAttributesCommand: vi.fn(),
+  ChangeMessageVisibilityCommand: vi.fn()
 }))
 vi.mock('#application/summary-logs/validate.js')
 vi.mock('#application/waste-records/sync-from-summary-log.js')
@@ -93,6 +95,13 @@ describe('createCommandQueueConsumer', () => {
       this.QueueName = params.QueueName
     })
     vi.mocked(GetQueueAttributesCommand).mockImplementation(function () {})
+    vi.mocked(ChangeMessageVisibilityCommand).mockImplementation(
+      function (params) {
+        this.QueueUrl = params.QueueUrl
+        this.ReceiptHandle = params.ReceiptHandle
+        this.VisibilityTimeout = params.VisibilityTimeout
+      }
+    )
     vi.mocked(createSummaryLogsValidator).mockReturnValue(vi.fn())
     vi.mocked(syncFromSummaryLog).mockReturnValue(
       vi.fn().mockResolvedValue({ created: 0, updated: 0 })
@@ -258,13 +267,13 @@ describe('createCommandQueueConsumer', () => {
       })
     })
 
-    it('logs error on processing_error event', async () => {
+    it('logs warning on processing_error event', async () => {
       await createConsumer()
       const error = new Error('Processing failed')
 
       eventHandlers.processing_error(error)
 
-      expect(logger.error).toHaveBeenCalledWith({
+      expect(logger.warn).toHaveBeenCalledWith({
         err: error,
         message: 'SQS message processing error',
         event: {
@@ -706,6 +715,7 @@ describe('createCommandQueueConsumer', () => {
 
         const message = {
           MessageId: 'msg-123',
+          ReceiptHandle: 'receipt-123',
           Attributes: { ApproximateReceiveCount: '1' },
           Body: JSON.stringify({
             command: 'validate',
@@ -716,13 +726,13 @@ describe('createCommandQueueConsumer', () => {
 
         await expect(handleMessage(message)).rejects.toThrow('Database timeout')
 
-        expect(childLogger.error).toHaveBeenCalledWith(
+        expect(childLogger.warn).toHaveBeenCalledWith(
           expect.objectContaining({
             message: expect.stringContaining('Command failed')
           })
         )
         // Global logger should NOT get the command error
-        expect(logger.error).not.toHaveBeenCalledWith(
+        expect(logger.warn).not.toHaveBeenCalledWith(
           expect.objectContaining({
             message: expect.stringContaining('Command failed')
           })
@@ -877,6 +887,7 @@ describe('createCommandQueueConsumer', () => {
 
           const message = {
             MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
             Attributes: { ApproximateReceiveCount: '1' },
             Body: JSON.stringify({
               command: 'validate',
@@ -897,6 +908,7 @@ describe('createCommandQueueConsumer', () => {
 
           const message = {
             MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
             Attributes: { ApproximateReceiveCount: '1' },
             Body: JSON.stringify({
               command: 'validate',
@@ -917,6 +929,7 @@ describe('createCommandQueueConsumer', () => {
 
           const message = {
             MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
             Body: JSON.stringify({
               command: 'validate',
               summaryLogId: 'log-123'
@@ -941,6 +954,7 @@ describe('createCommandQueueConsumer', () => {
 
           const message = {
             MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
             Attributes: { ApproximateReceiveCount: '2' },
             Body: JSON.stringify({
               command: 'validate',
@@ -957,6 +971,163 @@ describe('createCommandQueueConsumer', () => {
             1,
             expect.objectContaining({
               status: SUMMARY_LOG_STATUS.VALIDATION_FAILED
+            })
+          )
+        })
+
+        it('logs non-final transient errors as warnings', async () => {
+          const transientError = new Error('Database timeout')
+          const mockValidator = vi.fn().mockRejectedValue(transientError)
+          vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
+
+          const message = {
+            MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
+            Attributes: { ApproximateReceiveCount: '1' },
+            Body: JSON.stringify({
+              command: 'validate',
+              summaryLogId: 'log-123'
+            })
+          }
+
+          await handleMessage(message).catch(() => {})
+
+          expect(logger.warn).toHaveBeenCalledWith(
+            expect.objectContaining({
+              err: transientError,
+              message: expect.stringContaining(
+                'Command failed (transient, will retry)'
+              )
+            })
+          )
+        })
+
+        it('resets visibility timeout on non-final transient error for immediate retry', async () => {
+          const mockValidator = vi
+            .fn()
+            .mockRejectedValue(new Error('Database timeout'))
+          vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
+
+          const message = {
+            MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
+            Attributes: { ApproximateReceiveCount: '1' },
+            Body: JSON.stringify({
+              command: 'validate',
+              summaryLogId: 'log-123'
+            })
+          }
+
+          await handleMessage(message).catch(() => {})
+
+          expect(sqsClient.send).toHaveBeenCalledWith(
+            expect.objectContaining({
+              QueueUrl: 'http://localhost:4566/000000000000/test-queue',
+              ReceiptHandle: 'receipt-123',
+              VisibilityTimeout: 0
+            })
+          )
+        })
+
+        it('logs warning when visibility timeout reset fails', async () => {
+          const mockValidator = vi
+            .fn()
+            .mockRejectedValue(new Error('Database timeout'))
+          vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
+
+          const resetError = new Error('SQS reset failed')
+          sqsClient.send.mockImplementation((command) => {
+            if (command instanceof GetQueueAttributesCommand) {
+              return Promise.resolve({
+                Attributes: {
+                  RedrivePolicy: JSON.stringify({ maxReceiveCount: '2' })
+                }
+              })
+            }
+            if (command instanceof ChangeMessageVisibilityCommand) {
+              return Promise.reject(resetError)
+            }
+            return Promise.resolve({
+              QueueUrl: 'http://localhost:4566/000000000000/test-queue'
+            })
+          })
+
+          const message = {
+            MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
+            Attributes: { ApproximateReceiveCount: '1' },
+            Body: JSON.stringify({
+              command: 'validate',
+              summaryLogId: 'log-123'
+            })
+          }
+
+          await handleMessage(message).catch(() => {})
+
+          expect(logger.warn).toHaveBeenCalledWith({
+            err: resetError,
+            message: 'Failed to reset visibility timeout for messageId=msg-123'
+          })
+        })
+
+        it('logs final transient attempt as error', async () => {
+          const transientError = new Error('Database timeout')
+          const mockValidator = vi.fn().mockRejectedValue(transientError)
+          vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
+
+          summaryLogsRepository.findById.mockResolvedValue({
+            version: 1,
+            summaryLog: { status: SUMMARY_LOG_STATUS.VALIDATING }
+          })
+
+          const message = {
+            MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
+            Attributes: { ApproximateReceiveCount: '2' },
+            Body: JSON.stringify({
+              command: 'validate',
+              summaryLogId: 'log-123'
+            })
+          }
+
+          await handleMessage(message).catch(() => {})
+
+          expect(logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({
+              err: transientError,
+              message: expect.stringContaining(
+                'Command failed (transient, final attempt)'
+              )
+            })
+          )
+        })
+
+        it('does not reset visibility timeout on final attempt', async () => {
+          const mockValidator = vi
+            .fn()
+            .mockRejectedValue(new Error('Database timeout'))
+          vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
+
+          summaryLogsRepository.findById.mockResolvedValue({
+            version: 1,
+            summaryLog: { status: SUMMARY_LOG_STATUS.VALIDATING }
+          })
+
+          const message = {
+            MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
+            Attributes: { ApproximateReceiveCount: '2' },
+            Body: JSON.stringify({
+              command: 'validate',
+              summaryLogId: 'log-123'
+            })
+          }
+
+          await handleMessage(message).catch(() => {})
+
+          expect(sqsClient.send).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+              VisibilityTimeout: 0
             })
           )
         })
@@ -1104,6 +1275,7 @@ describe('createCommandQueueConsumer', () => {
 
           const message = {
             MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
             Attributes: { ApproximateReceiveCount: '1' },
             Body: JSON.stringify({
               command: 'submit',
@@ -1131,6 +1303,7 @@ describe('createCommandQueueConsumer', () => {
 
           const message = {
             MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
             Attributes: { ApproximateReceiveCount: '1' },
             Body: JSON.stringify({
               command: 'submit',
@@ -1161,6 +1334,7 @@ describe('createCommandQueueConsumer', () => {
 
           const message = {
             MessageId: 'msg-123',
+            ReceiptHandle: 'receipt-123',
             Attributes: { ApproximateReceiveCount: '2' },
             Body: JSON.stringify({
               command: 'submit',

--- a/src/server/queue-consumer/consumer.test.js
+++ b/src/server/queue-consumer/consumer.test.js
@@ -1,8 +1,7 @@
 import { Consumer } from 'sqs-consumer'
 import {
   GetQueueUrlCommand,
-  GetQueueAttributesCommand,
-  ChangeMessageVisibilityCommand
+  GetQueueAttributesCommand
 } from '@aws-sdk/client-sqs'
 
 import { createCommandQueueConsumer } from './consumer.js'
@@ -17,8 +16,7 @@ import {
 vi.mock('sqs-consumer')
 vi.mock('@aws-sdk/client-sqs', () => ({
   GetQueueUrlCommand: vi.fn(),
-  GetQueueAttributesCommand: vi.fn(),
-  ChangeMessageVisibilityCommand: vi.fn()
+  GetQueueAttributesCommand: vi.fn()
 }))
 vi.mock('#application/summary-logs/validate.js')
 vi.mock('#application/waste-records/sync-from-summary-log.js')
@@ -95,13 +93,6 @@ describe('createCommandQueueConsumer', () => {
       this.QueueName = params.QueueName
     })
     vi.mocked(GetQueueAttributesCommand).mockImplementation(function () {})
-    vi.mocked(ChangeMessageVisibilityCommand).mockImplementation(
-      function (params) {
-        this.QueueUrl = params.QueueUrl
-        this.ReceiptHandle = params.ReceiptHandle
-        this.VisibilityTimeout = params.VisibilityTimeout
-      }
-    )
     vi.mocked(createSummaryLogsValidator).mockReturnValue(vi.fn())
     vi.mocked(syncFromSummaryLog).mockReturnValue(
       vi.fn().mockResolvedValue({ created: 0, updated: 0 })
@@ -212,6 +203,7 @@ describe('createCommandQueueConsumer', () => {
         sqs: sqsClient,
         handleMessage: expect.any(Function),
         handleMessageTimeout: 300000,
+        terminateVisibilityTimeout: 1,
         attributeNames: ['ApproximateReceiveCount']
       })
     })
@@ -1002,74 +994,6 @@ describe('createCommandQueueConsumer', () => {
           )
         })
 
-        it('resets visibility timeout on non-final transient error for immediate retry', async () => {
-          const mockValidator = vi
-            .fn()
-            .mockRejectedValue(new Error('Database timeout'))
-          vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
-
-          const message = {
-            MessageId: 'msg-123',
-            ReceiptHandle: 'receipt-123',
-            Attributes: { ApproximateReceiveCount: '1' },
-            Body: JSON.stringify({
-              command: 'validate',
-              summaryLogId: 'log-123'
-            })
-          }
-
-          await handleMessage(message).catch(() => {})
-
-          expect(sqsClient.send).toHaveBeenCalledWith(
-            expect.objectContaining({
-              QueueUrl: 'http://localhost:4566/000000000000/test-queue',
-              ReceiptHandle: 'receipt-123',
-              VisibilityTimeout: 1
-            })
-          )
-        })
-
-        it('logs warning when visibility timeout reset fails', async () => {
-          const mockValidator = vi
-            .fn()
-            .mockRejectedValue(new Error('Database timeout'))
-          vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
-
-          const resetError = new Error('SQS reset failed')
-          sqsClient.send.mockImplementation((command) => {
-            if (command instanceof GetQueueAttributesCommand) {
-              return Promise.resolve({
-                Attributes: {
-                  RedrivePolicy: JSON.stringify({ maxReceiveCount: '2' })
-                }
-              })
-            }
-            if (command instanceof ChangeMessageVisibilityCommand) {
-              return Promise.reject(resetError)
-            }
-            return Promise.resolve({
-              QueueUrl: 'http://localhost:4566/000000000000/test-queue'
-            })
-          })
-
-          const message = {
-            MessageId: 'msg-123',
-            ReceiptHandle: 'receipt-123',
-            Attributes: { ApproximateReceiveCount: '1' },
-            Body: JSON.stringify({
-              command: 'validate',
-              summaryLogId: 'log-123'
-            })
-          }
-
-          await handleMessage(message).catch(() => {})
-
-          expect(logger.warn).toHaveBeenCalledWith({
-            err: resetError,
-            message: 'Failed to reset visibility timeout for messageId=msg-123'
-          })
-        })
-
         it('logs final transient attempt as error', async () => {
           const transientError = new Error('Database timeout')
           const mockValidator = vi.fn().mockRejectedValue(transientError)
@@ -1098,36 +1022,6 @@ describe('createCommandQueueConsumer', () => {
               message: expect.stringContaining(
                 'Command failed (transient, final attempt)'
               )
-            })
-          )
-        })
-
-        it('does not reset visibility timeout on final attempt', async () => {
-          const mockValidator = vi
-            .fn()
-            .mockRejectedValue(new Error('Database timeout'))
-          vi.mocked(createSummaryLogsValidator).mockReturnValue(mockValidator)
-
-          summaryLogsRepository.findById.mockResolvedValue({
-            version: 1,
-            summaryLog: { status: SUMMARY_LOG_STATUS.VALIDATING }
-          })
-
-          const message = {
-            MessageId: 'msg-123',
-            ReceiptHandle: 'receipt-123',
-            Attributes: { ApproximateReceiveCount: '2' },
-            Body: JSON.stringify({
-              command: 'validate',
-              summaryLogId: 'log-123'
-            })
-          }
-
-          await handleMessage(message).catch(() => {})
-
-          expect(sqsClient.send).not.toHaveBeenCalledWith(
-            expect.objectContaining({
-              VisibilityTimeout: 1
             })
           )
         })

--- a/src/server/queue-consumer/consumer.test.js
+++ b/src/server/queue-consumer/consumer.test.js
@@ -1024,7 +1024,7 @@ describe('createCommandQueueConsumer', () => {
             expect.objectContaining({
               QueueUrl: 'http://localhost:4566/000000000000/test-queue',
               ReceiptHandle: 'receipt-123',
-              VisibilityTimeout: 0
+              VisibilityTimeout: 1
             })
           )
         })
@@ -1127,7 +1127,7 @@ describe('createCommandQueueConsumer', () => {
 
           expect(sqsClient.send).not.toHaveBeenCalledWith(
             expect.objectContaining({
-              VisibilityTimeout: 0
+              VisibilityTimeout: 1
             })
           )
         })


### PR DESCRIPTION
Ticket: [PAE-1230](https://eaflood.atlassian.net/browse/PAE-1230)
## Summary

When an SQS message fails processing (transient error, invalid JSON, unknown command), the consumer now resets the message's visibility timeout to 1s so it is immediately available for retry, rather than waiting for the full queue visibility timeout (30s default).

This uses sqs-consumer's built-in `terminateVisibilityTimeout` option on `Consumer.create`, which handles the `ChangeMessageVisibility` call for all handler errors in one place. Earlier iterations did this manually inside `handleCommandError`, which missed unparseable messages (they throw before reaching that code path). The library option covers both paths.

Other changes:
- Use `warn` log level for non-terminal transient failures, reserving `error` for permanent failures and final transient attempts
- Demote `processing_error` event handler to `warn` (most errors are already logged with full context in `handleCommandError`; this handler catches the remainder)

### Background

The original PR (#951) was reverted (#971) because the ECS task role in CDP lacked `sqs:ChangeMessageVisibility`; that has since been granted. This PR also replaces the manual `resetVisibilityTimeout` helper with the library's built-in support, removing the `ChangeMessageVisibilityCommand` import from our code entirely.

## Test plan

- [x] Unit tests: warn log levels, final attempt error logging, `terminateVisibilityTimeout: 1` passed to `Consumer.create`
- [x] Integration test: creates a queue with 30s visibility timeout, verifies retry completes in under 10s (proving the reset works)
- [x] Manual test: sent malformed messages (invalid JSON, unknown command) to LocalStack queue, confirmed ~2s retries and DLQ delivery after 3 attempts
- [x] All existing tests passing, 100% coverage

[PAE-1230]: https://eaflood.atlassian.net/browse/PAE-1230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ