### PR TITLE
PAE-1366: add eqeqeq rule and is-nil helper

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,6 +60,7 @@ export default [
   },
   {
     rules: {
+      eqeqeq: ['error', 'always'],
       'no-unused-vars': [
         'error',
         {

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -1,3 +1,4 @@
+import { isNil } from '#common/helpers/is-nil.js'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES,
@@ -514,7 +515,7 @@ const persistValidationResult = async ({
 const filterWasteBalanceRecords = (wasteRecords, processingType) =>
   wasteRecords?.filter((wr) => {
     const schema = findSchemaForProcessingType(processingType, wr.record.type)
-    return schema?.classifyForWasteBalance != null
+    return !isNil(schema?.classifyForWasteBalance)
   }) ?? []
 
 /**

--- a/src/application/summary-logs/validations/accreditation-number.js
+++ b/src/application/summary-logs/validations/accreditation-number.js
@@ -1,3 +1,4 @@
+import { isNil } from '#common/helpers/is-nil.js'
 import { createValidationIssues } from '#common/validation/validation-issues.js'
 import {
   VALIDATION_CATEGORY,
@@ -42,10 +43,9 @@ export const validateAccreditationNumber = ({
     SUMMARY_LOG_META_FIELDS.ACCREDITATION_NUMBER
   )
   const rawAccreditationValue = accreditationField?.value
-  const spreadsheetAccreditationNumber =
-    rawAccreditationValue == null
-      ? rawAccreditationValue
-      : String(rawAccreditationValue).trim()
+  const spreadsheetAccreditationNumber = isNil(rawAccreditationValue)
+    ? rawAccreditationValue
+    : String(rawAccreditationValue).trim()
 
   const location = buildMetaFieldLocation(
     accreditationField,

--- a/src/application/summary-logs/validations/registration-number.js
+++ b/src/application/summary-logs/validations/registration-number.js
@@ -1,3 +1,4 @@
+import { isNil } from '#common/helpers/is-nil.js'
 import { createValidationIssues } from '#common/validation/validation-issues.js'
 import {
   VALIDATION_CATEGORY,
@@ -33,10 +34,9 @@ export const validateRegistrationNumber = ({
     SUMMARY_LOG_META_FIELDS.REGISTRATION_NUMBER
   )
   const rawRegistrationValue = registrationField?.value
-  const spreadsheetRegistrationNumber =
-    rawRegistrationValue == null
-      ? rawRegistrationValue
-      : String(rawRegistrationValue).trim()
+  const spreadsheetRegistrationNumber = isNil(rawRegistrationValue)
+    ? rawRegistrationValue
+    : String(rawRegistrationValue).trim()
 
   const location = buildMetaFieldLocation(
     registrationField,

--- a/src/common/helpers/collections/seed-scenarios.js
+++ b/src/common/helpers/collections/seed-scenarios.js
@@ -10,6 +10,7 @@
 import crypto from 'node:crypto'
 import { ObjectId } from 'mongodb'
 
+import { isNil } from '#common/helpers/is-nil.js'
 import {
   REPROCESSING_TYPE,
   ORGANISATION_STATUS,
@@ -182,7 +183,7 @@ async function buildApprovedOrgForSeed(
   const linkedAccreditationIds = new Set(
     approvedRegistrations
       .map((r) => r.accreditationId)
-      .filter((id) => id != null)
+      .filter((id) => !isNil(id))
   )
 
   const approvedAccreditations = createApprovedAccreditations(

--- a/src/common/helpers/is-nil.js
+++ b/src/common/helpers/is-nil.js
@@ -1,0 +1,7 @@
+/**
+ * @param {unknown} value
+ * @returns {value is null | undefined}
+ */
+const isNil = (value) => value === null || value === undefined
+
+export { isNil }

--- a/src/common/helpers/is-nil.test.js
+++ b/src/common/helpers/is-nil.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { isNil } from './is-nil.js'
+
+describe('is-nil', () => {
+  it.each([
+    { value: null, label: 'null' },
+    { value: undefined, label: 'undefined' }
+  ])('should return true for $label', ({ value }) => {
+    expect(isNil(value)).toBe(true)
+  })
+
+  it.each([
+    { value: 0, label: '0' },
+    { value: '', label: 'empty string' },
+    { value: false, label: 'false' },
+    { value: NaN, label: 'NaN' },
+    { value: {}, label: 'empty object' },
+    { value: [], label: 'empty array' }
+  ])('should return false for $label', ({ value }) => {
+    expect(isNil(value)).toBe(false)
+  })
+})

--- a/src/forms-submission-data/parsing-common/form-data-mapper.js
+++ b/src/forms-submission-data/parsing-common/form-data-mapper.js
@@ -1,3 +1,4 @@
+import { isNil } from '#common/helpers/is-nil.js'
 import {
   BUSINESS_TYPE,
   GLASS_RECYCLING_PROCESS,
@@ -285,7 +286,7 @@ export function mapWastePermitType(value) {
 }
 
 export function convertToNumber(value, fieldName = 'value') {
-  if (value == null) {
+  if (isNil(value)) {
     return undefined
   }
 

--- a/src/forms-submission-data/parsing-common/parse-forms-data.js
+++ b/src/forms-submission-data/parsing-common/parse-forms-data.js
@@ -1,4 +1,5 @@
 import { mapRegulator } from './form-data-mapper.js'
+import { isNil } from '#common/helpers/is-nil.js'
 import { WASTE_PROCESSING_TYPE } from '#domain/organisations/model.js'
 
 /**
@@ -24,7 +25,7 @@ export function extractRepeaters(
   const repeaterName = repeaterPage.repeat.options.name
   const repeaterData = rawFormSubmissionObject?.data?.repeaters?.[repeaterName]
 
-  if (repeaterData == null) {
+  if (isNil(repeaterData)) {
     return []
   }
 
@@ -37,13 +38,13 @@ export function extractRepeaters(
   const componentMap = new Map(
     repeaterPage.components.flatMap((component) => {
       const outputName = fieldMapping[component.shortDescription]
-      return outputName == null ? [] : [[component.name, outputName]]
+      return isNil(outputName) ? [] : [[component.name, outputName]]
     })
   )
 
   return repeaterData.map((item) =>
     [...componentMap]
-      .filter(([componentName]) => item[componentName] != null)
+      .filter(([componentName]) => !isNil(item[componentName]))
       .reduce((result, [componentName, outputName]) => {
         result[outputName] = item[componentName]
         return result

--- a/src/overseas-sites/domain/approval.js
+++ b/src/overseas-sites/domain/approval.js
@@ -1,8 +1,10 @@
+import { isNil } from '#common/helpers/is-nil.js'
+
 /**
  * @param {Date | null | undefined} validFrom
  * @param {string} dateOfExport - ISO date string (YYYY-MM-DD)
  * @returns {boolean}
  */
 export function isOrsApprovedAtDate(validFrom, dateOfExport) {
-  return validFrom != null && validFrom <= new Date(dateOfExport)
+  return !isNil(validFrom) && validFrom <= new Date(dateOfExport)
 }

--- a/src/overseas-sites/repository/inmemory.plugin.js
+++ b/src/overseas-sites/repository/inmemory.plugin.js
@@ -1,3 +1,4 @@
+import { isNil } from '#common/helpers/is-nil.js'
 import { registerRepository } from '#plugins/register-repository.js'
 import { ObjectId } from 'mongodb'
 import { validateOverseasSiteInsert } from './validation.js'
@@ -70,7 +71,7 @@ const performRemove = (storage) => async (id) => {
  * @param {*} b
  */
 const nullishEqual = (a, b) => {
-  if (a == null && b == null) {
+  if (isNil(a) && isNil(b)) {
     return true
   }
   return a === b
@@ -81,10 +82,10 @@ const nullishEqual = (a, b) => {
  * @param {*} b
  */
 const dateEqual = (a, b) => {
-  if (a == null && b == null) {
+  if (isNil(a) && isNil(b)) {
     return true
   }
-  if (a == null || b == null) {
+  if (isNil(a) || isNil(b)) {
     return false
   }
   return new Date(a).getTime() === new Date(b).getTime()

--- a/src/overseas-sites/repository/mongodb.js
+++ b/src/overseas-sites/repository/mongodb.js
@@ -1,5 +1,6 @@
 import { ObjectId } from 'mongodb'
 
+import { isNil } from '#common/helpers/is-nil.js'
 import {
   validateOverseasSiteId,
   validateOverseasSiteInsert,
@@ -120,7 +121,7 @@ const performRemove = async (db, id) => {
 
 /** @param {unknown} value */
 const nullishFilter = (value) =>
-  value == null ? { $in: [null, undefined] } : value
+  isNil(value) ? { $in: [null, undefined] } : value
 
 /**
  * @param {Db} db

--- a/src/packaging-recycling-notes/domain/tonnage.js
+++ b/src/packaging-recycling-notes/domain/tonnage.js
@@ -1,3 +1,5 @@
+import { isNil } from '#common/helpers/is-nil.js'
+
 /**
  * @typedef {Object} AggregateTonnageParams
  * @property {Date} startDate
@@ -15,7 +17,7 @@
  * @returns {number}
  */
 export function aggregateIssuedTonnage(prns, { startDate, endDate }) {
-  const isInPeriod = (at) => at != null && at >= startDate && at <= endDate
+  const isInPeriod = (at) => !isNil(at) && at >= startDate && at <= endDate
 
   return prns
     .filter((prn) => isInPeriod(prn.status.issued?.at))

--- a/src/reports/routes/patch.js
+++ b/src/reports/routes/patch.js
@@ -2,6 +2,8 @@ import Boom from '@hapi/boom'
 import Joi from 'joi'
 import { StatusCodes } from 'http-status-codes'
 
+import { isNil } from '#common/helpers/is-nil.js'
+
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
 import { fetchCurrentReport } from '#reports/application/report-service.js'
 import { maxTwoDecimalPlaces } from '#reports/repository/schema.js'
@@ -44,8 +46,8 @@ export function buildUpdatedPrn(existingPrn, totalRevenue, freeTonnage) {
 
   if (
     updated.issuedTonnage >= 0 &&
-    updated.totalRevenue != null &&
-    updated.freeTonnage != null
+    !isNil(updated.totalRevenue) &&
+    !isNil(updated.freeTonnage)
   ) {
     const denominator = updated.issuedTonnage - updated.freeTonnage
     updated.averagePricePerTonne =


### PR DESCRIPTION
Ticket: [PAE-1366](https://eaflood.atlassian.net/browse/PAE-1366)
add strict eqeqeq eslint rule and isNil type guard helper to replace loose equality checks against null/undefined

- override neostandard's `eqeqeq: { null: 'ignore' }` to strict `['error', 'always']`
- add `isNil` helper with JSDoc type predicate for type narrowing
- replace 16 `== null` / `!= null` patterns with `isNil` across forms, overseas-sites, reports, PRNs, summary-logs

[PAE-1366]: https://eaflood.atlassian.net/browse/PAE-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ