### PR TITLE
PAE-1360: Protect ORS import terminal status from duplicate SQS commands

### DIFF
--- a/src/overseas-sites/application/process-import.js
+++ b/src/overseas-sites/application/process-import.js
@@ -90,8 +90,21 @@ export const processOrsImport = async (importId, deps) => {
     const finalStatus = allFailed
       ? ORS_IMPORT_STATUS.FAILED
       : ORS_IMPORT_STATUS.COMPLETED
-    await orsImportsRepository.updateStatus(importId, finalStatus)
-    await orsImportMetrics.recordStatusTransition({ status: finalStatus })
+    const updated = await orsImportsRepository.updateStatus(
+      importId,
+      finalStatus
+    )
+    if (updated) {
+      await orsImportMetrics.recordStatusTransition({ status: finalStatus })
+    } else {
+      logger.info({
+        message: `ORS import ${importId} final status write blocked; another worker has already reached a terminal status`,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.SERVER,
+          action: LOGGING_EVENT_ACTIONS.PROCESS_SUCCESS
+        }
+      })
+    }
   })
 }
 

--- a/src/overseas-sites/application/process-import.js
+++ b/src/overseas-sites/application/process-import.js
@@ -6,7 +6,8 @@ import {
 } from '#common/enums/index.js'
 import {
   ORS_FILE_RESULT_STATUS,
-  ORS_IMPORT_STATUS
+  ORS_IMPORT_STATUS,
+  isOrsImportStatusTerminal
 } from '../domain/import-status.js'
 import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 import { processImportFile } from './process-import-file.js'
@@ -43,6 +44,17 @@ export const processOrsImport = async (importId, deps) => {
   const importDoc = await orsImportsRepository.findById(importId)
   if (!importDoc) {
     throw new PermanentError(`ORS import ${importId} not found`)
+  }
+
+  if (isOrsImportStatusTerminal(importDoc.status)) {
+    logger.info({
+      message: `ORS import ${importId} already in terminal status ${importDoc.status}; skipping duplicate command`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.PROCESS_SUCCESS
+      }
+    })
+    return
   }
 
   await orsImportMetrics.timedImport(async () => {

--- a/src/overseas-sites/application/process-import.test.js
+++ b/src/overseas-sites/application/process-import.test.js
@@ -552,6 +552,40 @@ describe('processOrsImport', () => {
     })
   })
 
+  it('bails out without processing when import is already COMPLETED', async () => {
+    const importDoc = {
+      _id: 'import-123',
+      status: ORS_IMPORT_STATUS.COMPLETED,
+      files: [{ fileId: 'f1', fileName: 'sites.xlsx', s3Uri: 's3://bucket/f1' }]
+    }
+    orsImportsRepository.findById.mockResolvedValue(importDoc)
+
+    await processOrsImport('import-123', deps())
+
+    expect(uploadsRepository.findByLocation).not.toHaveBeenCalled()
+    expect(processImportFile).not.toHaveBeenCalled()
+    expect(orsImportsRepository.updateStatus).not.toHaveBeenCalled()
+    expect(orsImportsRepository.recordFileResult).not.toHaveBeenCalled()
+    expect(orsImportMetrics.timedImport).not.toHaveBeenCalled()
+  })
+
+  it('bails out without processing when import is already FAILED', async () => {
+    const importDoc = {
+      _id: 'import-123',
+      status: ORS_IMPORT_STATUS.FAILED,
+      files: [{ fileId: 'f1', fileName: 'sites.xlsx', s3Uri: 's3://bucket/f1' }]
+    }
+    orsImportsRepository.findById.mockResolvedValue(importDoc)
+
+    await processOrsImport('import-123', deps())
+
+    expect(uploadsRepository.findByLocation).not.toHaveBeenCalled()
+    expect(processImportFile).not.toHaveBeenCalled()
+    expect(orsImportsRepository.updateStatus).not.toHaveBeenCalled()
+    expect(orsImportsRepository.recordFileResult).not.toHaveBeenCalled()
+    expect(orsImportMetrics.timedImport).not.toHaveBeenCalled()
+  })
+
   it('sets FAILED when all files in a multi-file batch fail', async () => {
     const importDoc = {
       _id: 'import-123',

--- a/src/overseas-sites/application/process-import.test.js
+++ b/src/overseas-sites/application/process-import.test.js
@@ -27,7 +27,7 @@ describe('processOrsImport', () => {
 
     orsImportsRepository = {
       findById: vi.fn(),
-      updateStatus: vi.fn(),
+      updateStatus: vi.fn().mockResolvedValue(true),
       recordFileResult: vi.fn()
     }
 
@@ -550,6 +550,40 @@ describe('processOrsImport', () => {
       logger,
       user
     })
+  })
+
+  it('does not record final status metric when terminal update was blocked by another worker', async () => {
+    const importDoc = {
+      _id: 'import-123',
+      status: ORS_IMPORT_STATUS.PREPROCESSING,
+      files: [{ fileId: 'f1', fileName: 'sites.xlsx', s3Uri: 's3://bucket/f1' }]
+    }
+    orsImportsRepository.findById.mockResolvedValue(importDoc)
+    uploadsRepository.findByLocation.mockResolvedValue(Buffer.from('data'))
+    processImportFile.mockResolvedValue({
+      status: ORS_FILE_RESULT_STATUS.SUCCESS,
+      sitesCreated: 1,
+      mappingsUpdated: 1,
+      registrationNumber: 'EPR/AB1234CD/R1',
+      errors: []
+    })
+    orsImportsRepository.updateStatus
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+
+    await processOrsImport('import-123', deps())
+
+    expect(orsImportMetrics.recordStatusTransition).toHaveBeenCalledWith({
+      status: ORS_IMPORT_STATUS.PROCESSING
+    })
+    expect(orsImportMetrics.recordStatusTransition).not.toHaveBeenCalledWith({
+      status: ORS_IMPORT_STATUS.COMPLETED
+    })
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('import-123')
+      })
+    )
   })
 
   it('bails out without processing when import is already COMPLETED', async () => {

--- a/src/overseas-sites/domain/import-status.js
+++ b/src/overseas-sites/domain/import-status.js
@@ -23,6 +23,19 @@ const STATUS_TO_TTL = {
   [ORS_IMPORT_STATUS.COMPLETED]: null
 }
 
+const VALID_ORS_IMPORT_TRANSITIONS = Object.freeze({
+  [ORS_IMPORT_STATUS.PREPROCESSING]: Object.freeze([
+    ORS_IMPORT_STATUS.PROCESSING,
+    ORS_IMPORT_STATUS.FAILED
+  ]),
+  [ORS_IMPORT_STATUS.PROCESSING]: Object.freeze([
+    ORS_IMPORT_STATUS.COMPLETED,
+    ORS_IMPORT_STATUS.FAILED
+  ]),
+  [ORS_IMPORT_STATUS.COMPLETED]: Object.freeze([]),
+  [ORS_IMPORT_STATUS.FAILED]: Object.freeze([])
+})
+
 /**
  * @param {string} status
  * @returns {Date|null}
@@ -39,3 +52,18 @@ export const calculateOrsImportExpiresAt = (status) => {
 
   return new Date(Date.now() + ttl)
 }
+
+/**
+ * A terminal status is one from which no further transitions are allowed.
+ * Writes to an import already in a terminal status are silently dropped by the
+ * repository to keep at-least-once SQS delivery idempotent.
+ *
+ * @param {string} status
+ * @returns {boolean}
+ */
+export const isOrsImportStatusTerminal = (status) =>
+  VALID_ORS_IMPORT_TRANSITIONS[status]?.length === 0
+
+export const ORS_IMPORT_TERMINAL_STATUSES = Object.freeze(
+  Object.values(ORS_IMPORT_STATUS).filter(isOrsImportStatusTerminal)
+)

--- a/src/overseas-sites/domain/import-status.js
+++ b/src/overseas-sites/domain/import-status.js
@@ -64,6 +64,10 @@ export const calculateOrsImportExpiresAt = (status) => {
 export const isOrsImportStatusTerminal = (status) =>
   VALID_ORS_IMPORT_TRANSITIONS[status]?.length === 0
 
+/**
+ * Concrete list of terminal statuses for use as a MongoDB `$nin` filter value.
+ * Kept in sync with `isOrsImportStatusTerminal` by derivation.
+ */
 export const ORS_IMPORT_TERMINAL_STATUSES = Object.freeze(
   Object.values(ORS_IMPORT_STATUS).filter(isOrsImportStatusTerminal)
 )

--- a/src/overseas-sites/domain/import-status.test.js
+++ b/src/overseas-sites/domain/import-status.test.js
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 
 import {
   ORS_IMPORT_STATUS,
-  calculateOrsImportExpiresAt
+  calculateOrsImportExpiresAt,
+  isOrsImportStatusTerminal
 } from './import-status.js'
 
 const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24
@@ -48,5 +49,25 @@ describe('calculateOrsImportExpiresAt', () => {
     expect(() => calculateOrsImportExpiresAt('banana')).toThrow(
       'Unknown ORS import status for TTL calculation: banana'
     )
+  })
+})
+
+describe('isOrsImportStatusTerminal', () => {
+  it('returns true for COMPLETED', () => {
+    expect(isOrsImportStatusTerminal(ORS_IMPORT_STATUS.COMPLETED)).toBe(true)
+  })
+
+  it('returns true for FAILED', () => {
+    expect(isOrsImportStatusTerminal(ORS_IMPORT_STATUS.FAILED)).toBe(true)
+  })
+
+  it('returns false for PREPROCESSING', () => {
+    expect(isOrsImportStatusTerminal(ORS_IMPORT_STATUS.PREPROCESSING)).toBe(
+      false
+    )
+  })
+
+  it('returns false for PROCESSING', () => {
+    expect(isOrsImportStatusTerminal(ORS_IMPORT_STATUS.PROCESSING)).toBe(false)
   })
 })

--- a/src/overseas-sites/imports/repository/inmemory.js
+++ b/src/overseas-sites/imports/repository/inmemory.js
@@ -1,5 +1,8 @@
 import { registerRepository } from '#plugins/register-repository.js'
-import { calculateOrsImportExpiresAt } from '../../domain/import-status.js'
+import {
+  calculateOrsImportExpiresAt,
+  isOrsImportStatusTerminal
+} from '../../domain/import-status.js'
 
 /** @import { OrsImport, OrsImportsRepositoryFactory } from './port.js' */
 
@@ -33,7 +36,7 @@ export function createInMemoryOrsImportsRepository() {
 
     async updateStatus(id, status) {
       const doc = storage.get(id)
-      if (doc) {
+      if (doc && !isOrsImportStatusTerminal(doc.status)) {
         doc.status = status
         doc.expiresAt = calculateOrsImportExpiresAt(status)
         doc.updatedAt = new Date().toISOString()

--- a/src/overseas-sites/imports/repository/inmemory.js
+++ b/src/overseas-sites/imports/repository/inmemory.js
@@ -36,11 +36,13 @@ export function createInMemoryOrsImportsRepository() {
 
     async updateStatus(id, status) {
       const doc = storage.get(id)
-      if (doc && !isOrsImportStatusTerminal(doc.status)) {
-        doc.status = status
-        doc.expiresAt = calculateOrsImportExpiresAt(status)
-        doc.updatedAt = new Date().toISOString()
+      if (!doc || isOrsImportStatusTerminal(doc.status)) {
+        return false
       }
+      doc.status = status
+      doc.expiresAt = calculateOrsImportExpiresAt(status)
+      doc.updatedAt = new Date().toISOString()
+      return true
     },
 
     async addFiles(id, files) {

--- a/src/overseas-sites/imports/repository/inmemory.test.js
+++ b/src/overseas-sites/imports/repository/inmemory.test.js
@@ -69,22 +69,30 @@ describe('In-memory ORS imports repository', () => {
   })
 
   describe('updateStatus', () => {
-    it('does nothing when updating status of nonexistent import', async () => {
-      await repository.updateStatus('nonexistent', ORS_IMPORT_STATUS.PROCESSING)
+    it('returns false when updating status of nonexistent import', async () => {
+      const result = await repository.updateStatus(
+        'nonexistent',
+        ORS_IMPORT_STATUS.PROCESSING
+      )
 
+      expect(result).toBe(false)
       const found = await repository.findById('nonexistent')
       expect(found).toBeNull()
     })
 
-    it('updates the status', async () => {
+    it('updates the status and returns true', async () => {
       await repository.create({
         _id: 'import-1',
         status: ORS_IMPORT_STATUS.PREPROCESSING,
         files: []
       })
 
-      await repository.updateStatus('import-1', ORS_IMPORT_STATUS.PROCESSING)
+      const result = await repository.updateStatus(
+        'import-1',
+        ORS_IMPORT_STATUS.PROCESSING
+      )
 
+      expect(result).toBe(true)
       const after = await repository.findById('import-1')
       expect(after.status).toBe(ORS_IMPORT_STATUS.PROCESSING)
       expect(after.updatedAt).toBeDefined()
@@ -103,28 +111,36 @@ describe('In-memory ORS imports repository', () => {
       expect(after.expiresAt).toBeNull()
     })
 
-    it('refuses to transition from COMPLETED to FAILED', async () => {
+    it('refuses to transition from COMPLETED to FAILED and returns false', async () => {
       await repository.create({
         _id: 'import-1',
         status: ORS_IMPORT_STATUS.COMPLETED,
         files: []
       })
 
-      await repository.updateStatus('import-1', ORS_IMPORT_STATUS.FAILED)
+      const result = await repository.updateStatus(
+        'import-1',
+        ORS_IMPORT_STATUS.FAILED
+      )
 
+      expect(result).toBe(false)
       const after = await repository.findById('import-1')
       expect(after.status).toBe(ORS_IMPORT_STATUS.COMPLETED)
     })
 
-    it('refuses to transition from FAILED to COMPLETED', async () => {
+    it('refuses to transition from FAILED to COMPLETED and returns false', async () => {
       await repository.create({
         _id: 'import-1',
         status: ORS_IMPORT_STATUS.FAILED,
         files: []
       })
 
-      await repository.updateStatus('import-1', ORS_IMPORT_STATUS.COMPLETED)
+      const result = await repository.updateStatus(
+        'import-1',
+        ORS_IMPORT_STATUS.COMPLETED
+      )
 
+      expect(result).toBe(false)
       const after = await repository.findById('import-1')
       expect(after.status).toBe(ORS_IMPORT_STATUS.FAILED)
     })

--- a/src/overseas-sites/imports/repository/inmemory.test.js
+++ b/src/overseas-sites/imports/repository/inmemory.test.js
@@ -102,6 +102,45 @@ describe('In-memory ORS imports repository', () => {
       const after = await repository.findById('import-1')
       expect(after.expiresAt).toBeNull()
     })
+
+    it('refuses to transition from COMPLETED to FAILED', async () => {
+      await repository.create({
+        _id: 'import-1',
+        status: ORS_IMPORT_STATUS.COMPLETED,
+        files: []
+      })
+
+      await repository.updateStatus('import-1', ORS_IMPORT_STATUS.FAILED)
+
+      const after = await repository.findById('import-1')
+      expect(after.status).toBe(ORS_IMPORT_STATUS.COMPLETED)
+    })
+
+    it('refuses to transition from FAILED to COMPLETED', async () => {
+      await repository.create({
+        _id: 'import-1',
+        status: ORS_IMPORT_STATUS.FAILED,
+        files: []
+      })
+
+      await repository.updateStatus('import-1', ORS_IMPORT_STATUS.COMPLETED)
+
+      const after = await repository.findById('import-1')
+      expect(after.status).toBe(ORS_IMPORT_STATUS.FAILED)
+    })
+
+    it('refuses to transition away from COMPLETED even back to PROCESSING', async () => {
+      await repository.create({
+        _id: 'import-1',
+        status: ORS_IMPORT_STATUS.COMPLETED,
+        files: []
+      })
+
+      await repository.updateStatus('import-1', ORS_IMPORT_STATUS.PROCESSING)
+
+      const after = await repository.findById('import-1')
+      expect(after.status).toBe(ORS_IMPORT_STATUS.COMPLETED)
+    })
   })
 
   describe('recordFileResult', () => {

--- a/src/overseas-sites/imports/repository/mongodb.js
+++ b/src/overseas-sites/imports/repository/mongodb.js
@@ -2,8 +2,8 @@
 /** @import { OrsImport, OrsImportsRepositoryFactory } from './port.js' */
 
 import {
-  ORS_IMPORT_TERMINAL_STATUSES,
-  calculateOrsImportExpiresAt
+  calculateOrsImportExpiresAt,
+  ORS_IMPORT_TERMINAL_STATUSES
 } from '../../domain/import-status.js'
 
 const COLLECTION_NAME = 'ors-imports'
@@ -48,7 +48,7 @@ export const createOrsImportsRepository = async (db) => {
 
     async updateStatus(id, status) {
       const expiresAt = calculateOrsImportExpiresAt(status)
-      await collection.updateOne(
+      const result = await collection.updateOne(
         { _id: id, status: { $nin: ORS_IMPORT_TERMINAL_STATUSES } },
         {
           $set: {
@@ -58,6 +58,7 @@ export const createOrsImportsRepository = async (db) => {
           }
         }
       )
+      return result.matchedCount > 0
     },
 
     async recordFileResult(id, fileIndex, result) {

--- a/src/overseas-sites/imports/repository/mongodb.js
+++ b/src/overseas-sites/imports/repository/mongodb.js
@@ -1,7 +1,10 @@
 /** @import { Db } from 'mongodb' */
 /** @import { OrsImport, OrsImportsRepositoryFactory } from './port.js' */
 
-import { calculateOrsImportExpiresAt } from '../../domain/import-status.js'
+import {
+  ORS_IMPORT_TERMINAL_STATUSES,
+  calculateOrsImportExpiresAt
+} from '../../domain/import-status.js'
 
 const COLLECTION_NAME = 'ors-imports'
 
@@ -46,7 +49,7 @@ export const createOrsImportsRepository = async (db) => {
     async updateStatus(id, status) {
       const expiresAt = calculateOrsImportExpiresAt(status)
       await collection.updateOne(
-        { _id: id },
+        { _id: id, status: { $nin: ORS_IMPORT_TERMINAL_STATUSES } },
         {
           $set: {
             status,

--- a/src/overseas-sites/imports/repository/mongodb.test.js
+++ b/src/overseas-sites/imports/repository/mongodb.test.js
@@ -49,17 +49,32 @@ describe('MongoDB ORS imports repository', () => {
     expect(found).toBeNull()
   })
 
-  it('updates the status', async ({ repository }) => {
+  it('updates the status and returns true', async ({ repository }) => {
     await repository.create({
       _id: 'import-test-2',
       status: ORS_IMPORT_STATUS.PREPROCESSING,
       files: []
     })
 
-    await repository.updateStatus('import-test-2', ORS_IMPORT_STATUS.PROCESSING)
+    const result = await repository.updateStatus(
+      'import-test-2',
+      ORS_IMPORT_STATUS.PROCESSING
+    )
 
+    expect(result).toBe(true)
     const found = await repository.findById('import-test-2')
     expect(found.status).toBe(ORS_IMPORT_STATUS.PROCESSING)
+  })
+
+  it('returns false when updating a nonexistent import', async ({
+    repository
+  }) => {
+    const result = await repository.updateStatus(
+      'nonexistent',
+      ORS_IMPORT_STATUS.PROCESSING
+    )
+
+    expect(result).toBe(false)
   })
 
   it('appends files to the import', async ({ repository }) => {
@@ -154,7 +169,7 @@ describe('MongoDB ORS imports repository', () => {
     expect(found.expiresAt).toBeNull()
   })
 
-  it('refuses to transition from COMPLETED to FAILED', async ({
+  it('refuses to transition from COMPLETED to FAILED and returns false', async ({
     repository
   }) => {
     await repository.create({
@@ -163,13 +178,17 @@ describe('MongoDB ORS imports repository', () => {
       files: []
     })
 
-    await repository.updateStatus('import-forward-1', ORS_IMPORT_STATUS.FAILED)
+    const result = await repository.updateStatus(
+      'import-forward-1',
+      ORS_IMPORT_STATUS.FAILED
+    )
 
+    expect(result).toBe(false)
     const found = await repository.findById('import-forward-1')
     expect(found.status).toBe(ORS_IMPORT_STATUS.COMPLETED)
   })
 
-  it('refuses to transition from FAILED to COMPLETED', async ({
+  it('refuses to transition from FAILED to COMPLETED and returns false', async ({
     repository
   }) => {
     await repository.create({
@@ -178,11 +197,12 @@ describe('MongoDB ORS imports repository', () => {
       files: []
     })
 
-    await repository.updateStatus(
+    const result = await repository.updateStatus(
       'import-forward-2',
       ORS_IMPORT_STATUS.COMPLETED
     )
 
+    expect(result).toBe(false)
     const found = await repository.findById('import-forward-2')
     expect(found.status).toBe(ORS_IMPORT_STATUS.FAILED)
   })

--- a/src/overseas-sites/imports/repository/mongodb.test.js
+++ b/src/overseas-sites/imports/repository/mongodb.test.js
@@ -154,6 +154,39 @@ describe('MongoDB ORS imports repository', () => {
     expect(found.expiresAt).toBeNull()
   })
 
+  it('refuses to transition from COMPLETED to FAILED', async ({
+    repository
+  }) => {
+    await repository.create({
+      _id: 'import-forward-1',
+      status: ORS_IMPORT_STATUS.COMPLETED,
+      files: []
+    })
+
+    await repository.updateStatus('import-forward-1', ORS_IMPORT_STATUS.FAILED)
+
+    const found = await repository.findById('import-forward-1')
+    expect(found.status).toBe(ORS_IMPORT_STATUS.COMPLETED)
+  })
+
+  it('refuses to transition from FAILED to COMPLETED', async ({
+    repository
+  }) => {
+    await repository.create({
+      _id: 'import-forward-2',
+      status: ORS_IMPORT_STATUS.FAILED,
+      files: []
+    })
+
+    await repository.updateStatus(
+      'import-forward-2',
+      ORS_IMPORT_STATUS.COMPLETED
+    )
+
+    const found = await repository.findById('import-forward-2')
+    expect(found.status).toBe(ORS_IMPORT_STATUS.FAILED)
+  })
+
   it('records a file result by index', async ({ repository }) => {
     await repository.create({
       _id: 'import-test-3',

--- a/src/overseas-sites/imports/repository/port.js
+++ b/src/overseas-sites/imports/repository/port.js
@@ -22,7 +22,7 @@
  * @property {(importDoc: Omit<OrsImport, 'createdAt' | 'updatedAt' | 'expiresAt'>) => Promise<OrsImport>} create
  * @property {(id: string) => Promise<OrsImport|null>} findById
  * @property {(id: string, files: OrsImportFile[]) => Promise<void>} addFiles
- * @property {(id: string, status: string) => Promise<void>} updateStatus
+ * @property {(id: string, status: string) => Promise<boolean>} updateStatus
  * @property {(id: string, fileIndex: number, result: object) => Promise<void>} recordFileResult
  */
 

--- a/src/server/queue-consumer/ors-import-commands.js
+++ b/src/server/queue-consumer/ors-import-commands.js
@@ -51,13 +51,23 @@ export const orsImportCommandHandlers = [
     },
     onFailure: async (payload, /** @type {OrsImportHandlerDeps} */ deps) => {
       try {
-        await deps.orsImportsRepository.updateStatus(
+        const updated = await deps.orsImportsRepository.updateStatus(
           payload.importId,
           ORS_IMPORT_STATUS.FAILED
         )
-        await orsImportMetrics.recordStatusTransition({
-          status: ORS_IMPORT_STATUS.FAILED
-        })
+        if (updated) {
+          await orsImportMetrics.recordStatusTransition({
+            status: ORS_IMPORT_STATUS.FAILED
+          })
+        } else {
+          deps.logger.info({
+            message: `ORS import ${payload.importId} is already in a terminal status; not marking as failed`,
+            event: {
+              category: LOGGING_EVENT_CATEGORIES.SERVER,
+              action: LOGGING_EVENT_ACTIONS.PROCESS_SUCCESS
+            }
+          })
+        }
       } catch (err) {
         deps.logger.error({
           err,

--- a/src/server/queue-consumer/ors-import-commands.test.js
+++ b/src/server/queue-consumer/ors-import-commands.test.js
@@ -82,6 +82,8 @@ describe('orsImportCommandHandlers', () => {
 
     describe('onFailure', () => {
       it('marks ORS import as failed', async () => {
+        deps.orsImportsRepository.updateStatus.mockResolvedValue(true)
+
         await handler.onFailure({ importId: 'import-123' }, deps)
 
         expect(deps.orsImportsRepository.updateStatus).toHaveBeenCalledWith(
@@ -90,12 +92,34 @@ describe('orsImportCommandHandlers', () => {
         )
       })
 
-      it('records failed status transition metric', async () => {
+      it('records failed status transition metric when update succeeded', async () => {
+        deps.orsImportsRepository.updateStatus.mockResolvedValue(true)
+
         await handler.onFailure({ importId: 'import-123' }, deps)
 
         expect(orsImportMetrics.recordStatusTransition).toHaveBeenCalledWith({
           status: 'failed'
         })
+      })
+
+      it('does not record status metric when update was blocked by terminal status', async () => {
+        deps.orsImportsRepository.updateStatus.mockResolvedValue(false)
+
+        await handler.onFailure({ importId: 'import-123' }, deps)
+
+        expect(orsImportMetrics.recordStatusTransition).not.toHaveBeenCalled()
+      })
+
+      it('logs when update was blocked by terminal status', async () => {
+        deps.orsImportsRepository.updateStatus.mockResolvedValue(false)
+
+        await handler.onFailure({ importId: 'import-123' }, deps)
+
+        expect(deps.logger.info).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining('import-123')
+          })
+        )
       })
 
       it('logs error when marking as failed throws', async () => {


### PR DESCRIPTION
Ticket: [PAE-1360](https://eaflood.atlassian.net/browse/PAE-1360)
## Summary

Fixes a race condition where multi-file ORS imports could report `failed` status despite all files having been processed successfully.

## Background

At-least-once SQS delivery can result in two `import-overseas-sites` commands being enqueued for the same `importId` — for example, when the upstream cdp-uploader callback fires twice for a single scan-complete event. The first worker processes all files, writes `COMPLETED`, and deletes the S3 objects. The second worker then finds every file missing in storage, records each as a `FAILURE`, and overwrites the `COMPLETED` status with `FAILED`.

The behaviour was exposed by replacing LocalStack 3.8.1 with Floci 1.5.3 in the journey-test compose stack (Floci's tighter S3-event/SQS timing makes the race window much more likely to fire). The same failure mode was latent under LocalStack and can fire on real AWS.

## What changed

Worker-layer defence in two places, both backed by a central state-transition map in the domain layer.

- **Bail at start on terminal status.** `processOrsImport` reads the import, and if its status is already `COMPLETED` or `FAILED`, logs an info line and returns without processing — keeping duplicate SQS commands idempotent.
- **Forward-only transitions at the persistence boundary.** `updateStatus` in both the in-memory and MongoDB repositories refuses to transition away from a terminal status. MongoDB uses a `$nin` filter on the `updateOne` predicate (atomic; no read-then-write window); the in-memory adapter uses the same guard derived from the domain helper.
- **Boolean return from `updateStatus`** so callers know when a write was dropped. `processOrsImport`'s final transition and the SQS `onFailure` handler both check the return value: they skip the status-transition metric and log an info line when the write was blocked, so the `FAILED` counter no longer increments spuriously on duplicate-delivery races.

Terminal statuses are derived from a single `VALID_ORS_IMPORT_TRANSITIONS` map in `domain/import-status.js` — modelled on the existing summary-logs `transitionStatus` pattern.

[PAE-1360]: https://eaflood.atlassian.net/browse/PAE-1360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ