### PR TITLE
PAE-1373: Speed up admin overseas sites list query

### DIFF
--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -372,7 +372,7 @@ const buildOrsAdminListBasePipeline = ({ registrationNumber }) => [
         {
           $match: {
             $expr: {
-              $eq: [{ $toString: '$_id' }, '$$overseasSiteId']
+              $eq: ['$_id', { $toObjectId: '$$overseasSiteId' }]
             }
           }
         }

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -372,7 +372,17 @@ const buildOrsAdminListBasePipeline = ({ registrationNumber }) => [
         {
           $match: {
             $expr: {
-              $eq: ['$_id', { $toObjectId: '$$overseasSiteId' }]
+              $eq: [
+                '$_id',
+                {
+                  $convert: {
+                    input: '$$overseasSiteId',
+                    to: 'objectId',
+                    onError: null,
+                    onNull: null
+                  }
+                }
+              ]
             }
           }
         }

--- a/src/repositories/organisations/mongodb.test.js
+++ b/src/repositories/organisations/mongodb.test.js
@@ -375,5 +375,55 @@ describe('MongoDB organisations repository', () => {
       expect(page.rows).toStrictEqual([])
       expect(page.totalItems).toBe(0)
     })
+
+    it('drops mappings whose overseasSiteId is not a valid ObjectId string', async ({
+      organisationsRepository,
+      mongoClient
+    }) => {
+      const repository = organisationsRepository()
+      const siteCollection = mongoClient
+        .db(DATABASE_NAME)
+        .collection('overseas-sites')
+
+      const alphaSiteId = new ObjectId()
+
+      await siteCollection.insertOne({
+        _id: alphaSiteId,
+        name: 'Alpha Reprocessor',
+        country: 'France',
+        address: {
+          line1: '1 Rue de Test',
+          townOrCity: 'Paris'
+        },
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z')
+      })
+
+      await repository.insert(
+        buildOrganisation({
+          registrations: [
+            buildRegistration({
+              id: new ObjectId().toString(),
+              material: 'plastic',
+              registrationNumber: 'REG-001',
+              wasteProcessingType: 'exporter',
+              overseasSites: {
+                '001': { overseasSiteId: alphaSiteId.toString() },
+                '002': { overseasSiteId: 'not-a-valid-object-id' }
+              }
+            })
+          ]
+        })
+      )
+
+      const page = await repository.findPageForOverseasSitesAdminList({
+        page: 1,
+        pageSize: 10
+      })
+
+      expect(page.totalItems).toBe(1)
+      expect(page.rows).toHaveLength(1)
+      expect(page.rows[0].orsId).toBe('001')
+    })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1373](https://eaflood.atlassian.net/browse/PAE-1373)
Admin `GET /overseas-sites` was taking ~20s in production. The `$lookup` in `buildOrsAdminListBasePipeline` applied `$toString` to `$_id` on the `overseas-sites` collection, which made MongoDB evaluate a computed expression on every document instead of using the `_id` index — a COLLSCAN on the foreign collection for every unwound mapping.

Flipping the conversion so it runs on the `overseasSiteId` string instead lets the sub-pipeline hit the `_id` B-tree index. The conversion is wrapped in `$convert` with `onError: null` / `onNull: null` because `overseasSiteId` is stored as a free `Joi.string()` with no ObjectId-shape validation — a malformed value must drop the mapping silently (matching both the existing orphan behaviour in this pipeline and the fallback in `src/overseas-sites/routes/admin-list.js`), not abort the aggregation.

The lookup + `$unwind: '$site'` stays before `$facet` deliberately: `totalItems` today excludes orphaned mappings, and the existing integration test in `mongodb.test.js` relies on that. Moving the lookup into only the rows branch of `$facet` would change the count semantics, and duplicating it across both branches would cost the same as leaving it where it is once the index is usable.

Adds a test covering a mapping whose `overseasSiteId` is not a valid ObjectId hex string.

[PAE-1373]: https://eaflood.atlassian.net/browse/PAE-1373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ