### PR TITLE
PAE-1367: Handle when registration is linked to unapproved/suspended accreditation

### DIFF
--- a/src/reports/application/report-submissions.js
+++ b/src/reports/application/report-submissions.js
@@ -57,7 +57,8 @@ function resolveAccreditationNumber(registration, org) {
     return ''
   }
   const accreditation = org.accreditations.find(
-    (a) => a.id === registration.accreditationId
+    (a) =>
+      a.id === registration.accreditationId && INCLUDED_STATUSES.has(a.status)
   )
   return accreditation?.accreditationNumber ?? ''
 }
@@ -118,9 +119,8 @@ async function buildSubmissionRows(
 
   /** @type {ReportSubmissionsRow[]} */
   return registrations.flatMap(({ org, registration }) => {
-    const cadence = registration.accreditationId
-      ? CADENCE.monthly
-      : CADENCE.quarterly
+    const accreditationNumber = resolveAccreditationNumber(registration, org)
+    const cadence = accreditationNumber ? CADENCE.monthly : CADENCE.quarterly
 
     const computedPeriods = generateReportingPeriods(cadence, currentYear)
     const periodicReports =
@@ -130,7 +130,6 @@ async function buildSubmissionRows(
       periodicReports,
       cadence
     )
-    const accreditationNumber = resolveAccreditationNumber(registration, org)
 
     return merged.map((mergedPeriod) => {
       const report = mergedPeriod.report

--- a/src/reports/application/report-submissions.js
+++ b/src/reports/application/report-submissions.js
@@ -56,9 +56,10 @@ function resolveAccreditationNumber(registration, org) {
   if (!registration.accreditationId) {
     return ''
   }
-  return /** @type {import('#domain/organisations/accreditation.js').AccreditationApproved} */ (
-    org.accreditations.find((a) => a.id === registration.accreditationId)
-  ).accreditationNumber
+  const accreditation = org.accreditations.find(
+    (a) => a.id === registration.accreditationId
+  )
+  return accreditation?.accreditationNumber ?? ''
 }
 
 /**

--- a/src/reports/application/report-submissions.test.js
+++ b/src/reports/application/report-submissions.test.js
@@ -258,6 +258,25 @@ describe('generateReportSubmissions (edge cases)', () => {
     expect(result.reportSubmissions[0].material).toBe('Glass-remelt')
   })
 
+  it('returns empty string for accreditationNumber when accreditation has null accreditationNumber', async () => {
+    const org = buildOrg({
+      accreditations: [{ id: 'acc-1', accreditationNumber: null }],
+      registrations: [
+        buildRegistrationMock({
+          status: 'approved',
+          accreditationId: 'acc-1'
+        })
+      ]
+    })
+
+    const result = await generateReportSubmissions(
+      makeOrgsRepo([org]),
+      makeReportsRepo()
+    )
+
+    expect(result.reportSubmissions[0].accreditationNumber).toBe('')
+  })
+
   it('formats accreditationNumber as empty for registered only operator', async () => {
     const org = buildOrg({
       registrations: [

--- a/src/reports/application/report-submissions.test.js
+++ b/src/reports/application/report-submissions.test.js
@@ -4,6 +4,7 @@ import { createInMemoryOrganisationsRepository } from '#repositories/organisatio
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import { buildApprovedOrg } from '#vite/helpers/build-approved-org.js'
 import { buildSubmittedReport } from '#vite/helpers/build-submitted-report.js'
+import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 
 const FIXED_DATE = new Date('2026-04-17T10:00:00.000Z')
 
@@ -275,6 +276,56 @@ describe('generateReportSubmissions (edge cases)', () => {
     )
 
     expect(result.reportSubmissions[0].accreditationNumber).toBe('')
+  })
+
+  it('uses quarterly cadence and empty accreditationNumber when accreditation status is not approved or suspended', async () => {
+    const org = buildOrg({
+      accreditations: [
+        { id: 'acc-1', status: 'created', accreditationNumber: 'ACC-001' }
+      ],
+      registrations: [
+        buildRegistrationMock({
+          status: REG_ACC_STATUS.APPROVED,
+          accreditationId: 'acc-1'
+        })
+      ]
+    })
+
+    const result = await generateReportSubmissions(
+      makeOrgsRepo([org]),
+      makeReportsRepo()
+    )
+
+    const row = result.reportSubmissions[0]
+    expect(row.accreditationNumber).toBe('')
+    expect(row.reportType).toBe('Quarterly')
+  })
+
+  it('uses monthly cadence and accreditationNumber when accreditation status is suspended', async () => {
+    const org = buildOrg({
+      accreditations: [
+        {
+          id: 'acc-1',
+          status: REG_ACC_STATUS.SUSPENDED,
+          accreditationNumber: 'ACC-999'
+        }
+      ],
+      registrations: [
+        buildRegistrationMock({
+          status: 'approved',
+          accreditationId: 'acc-1'
+        })
+      ]
+    })
+
+    const result = await generateReportSubmissions(
+      makeOrgsRepo([org]),
+      makeReportsRepo()
+    )
+
+    const row = result.reportSubmissions[0]
+    expect(row.accreditationNumber).toBe('ACC-999')
+    expect(row.reportType).toBe('Monthly')
   })
 
   it('formats accreditationNumber as empty for registered only operator', async () => {


### PR DESCRIPTION
- Fix cadence assigned as monthly when accreditationId is present but accreditation is not approved or suspended
- Add tests covering null accreditationNumber and unapproved accreditation status