### PR TITLE
PAE-1367: Exclude test organisations from report submissions report

### DIFF
--- a/src/reports/application/report-submissions.js
+++ b/src/reports/application/report-submissions.js
@@ -7,6 +7,9 @@ import { mergeReportingPeriods } from '#reports/domain/merge-reporting-periods.j
 import { formatMaterial, capitalize } from '#common/helpers/formatters.js'
 import { formatPeriodLabel } from '#reports/domain/period-labels.js'
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
+
+const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
 /**
  * @typedef {Object} ReportSubmissionsRow
@@ -37,14 +40,16 @@ const INCLUDED_STATUSES = new Set([
  */
 async function getRegistrations(organisationsRepository) {
   const orgs = await organisationsRepository.findAll()
-  return orgs.flatMap((org) =>
-    org.registrations
-      .filter((registration) => INCLUDED_STATUSES.has(registration.status))
-      .map((registration) => ({
-        org,
-        registration: /** @type {RegistrationApproved} */ (registration)
-      }))
-  )
+  return orgs
+    .filter((org) => !TEST_ORGANISATIONS.has(org.orgId))
+    .flatMap((org) =>
+      org.registrations
+        .filter((registration) => INCLUDED_STATUSES.has(registration.status))
+        .map((registration) => ({
+          org,
+          registration: /** @type {RegistrationApproved} */ (registration)
+        }))
+    )
 }
 
 /**

--- a/src/reports/application/report-submissions.test.js
+++ b/src/reports/application/report-submissions.test.js
@@ -346,4 +346,27 @@ describe('generateReportSubmissions (edge cases)', () => {
     expect(row.registrationNumber).toBe('REG-001')
     expect(row.accreditationNumber).toBe('')
   })
+
+  it('excludes test organisations from report submissions', async () => {
+    const testOrg = buildOrg({
+      orgId: 999999,
+      companyDetails: { name: 'Test Org Ltd' },
+      registrations: [buildRegistrationMock({ status: 'approved' })]
+    })
+    const normalOrg = buildOrg({
+      id: 'org-2',
+      orgId: 500001,
+      companyDetails: { name: 'Normal Org Ltd' },
+      registrations: [buildRegistrationMock({ status: 'approved' })]
+    })
+
+    const result = await generateReportSubmissions(
+      makeOrgsRepo([testOrg, normalOrg]),
+      makeReportsRepo()
+    )
+
+    const orgNames = result.reportSubmissions.map((r) => r.organisationName)
+    expect(orgNames).not.toContain('Test Org Ltd')
+    expect(orgNames).toContain('Normal Org Ltd')
+  })
 })


### PR DESCRIPTION
Ticket: [PAE-1367](https://eaflood.atlassian.net/browse/PAE-1367)
## Summary

- Filters out test organisations from the report submissions report, consistent with how other reports (public register, summary log uploads) handle test orgs



[PAE-1367]: https://eaflood.atlassian.net/browse/PAE-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ