### PR TITLE
PAE-1379: Fix cadence and category for registrations with unapproved accreditation

### DIFF
--- a/src/reports/application/report-service.test.js
+++ b/src/reports/application/report-service.test.js
@@ -11,20 +11,33 @@ import {
 } from './report-service.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
-const buildRegistration = (overrides = {}) => ({
-  id: new ObjectId().toString(),
-  accreditationId: new ObjectId().toString(),
-  material: 'plastic',
-  wasteProcessingType: 'reprocessor',
-  site: {
-    address: {
-      line1: '1 Recycling Lane',
-      town: 'Greenville',
-      postcode: 'GR1 1AA'
-    }
-  },
-  ...overrides
-})
+const buildRegistration = (overrides = {}) => {
+  const hasAccreditationIdOverride = 'accreditationId' in overrides
+  const accreditationId = hasAccreditationIdOverride
+    ? overrides.accreditationId
+    : new ObjectId().toString()
+  const defaultAccreditation = accreditationId ? { status: 'approved' } : null
+  const accreditation =
+    'accreditation' in overrides
+      ? overrides.accreditation
+      : defaultAccreditation
+  const { accreditation: _a, accreditationId: _b, ...rest } = overrides
+  return {
+    id: new ObjectId().toString(),
+    accreditationId,
+    accreditation,
+    material: 'plastic',
+    wasteProcessingType: 'reprocessor',
+    site: {
+      address: {
+        line1: '1 Recycling Lane',
+        town: 'Greenville',
+        postcode: 'GR1 1AA'
+      }
+    },
+    ...rest
+  }
+}
 
 const buildWasteRecord = ({
   data = {},

--- a/src/reports/domain/is-registration-accredited.js
+++ b/src/reports/domain/is-registration-accredited.js
@@ -1,0 +1,18 @@
+import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+
+/**
+ * Returns true when the registration is linked to an accreditation that is
+ * live (approved or suspended). Presence of accreditationId alone is not
+ * sufficient — an accreditation in 'created', 'rejected', or 'cancelled'
+ * state has never been active and must be treated as registered-only.
+ *
+ * @param {{ accreditation?: { status?: string } | null }} [registration]
+ * @returns {boolean}
+ */
+export function isRegistrationAccredited(registration) {
+  const status = registration?.accreditation?.status
+
+  return (
+    status === REG_ACC_STATUS.APPROVED || status === REG_ACC_STATUS.SUSPENDED
+  )
+}

--- a/src/reports/domain/is-registration-accredited.js
+++ b/src/reports/domain/is-registration-accredited.js
@@ -6,11 +6,11 @@ import { REG_ACC_STATUS } from '#domain/organisations/model.js'
  * sufficient — an accreditation in 'created', 'rejected', or 'cancelled'
  * state has never been active and must be treated as registered-only.
  *
- * @param {{ accreditation?: { status?: string } | null }} [registration]
+ * @param {{ accreditation: { status?: string } | null }} registration
  * @returns {boolean}
  */
 export function isRegistrationAccredited(registration) {
-  const status = registration?.accreditation?.status
+  const status = registration.accreditation?.status
 
   return (
     status === REG_ACC_STATUS.APPROVED || status === REG_ACC_STATUS.SUSPENDED

--- a/src/reports/domain/is-registration-accredited.test.js
+++ b/src/reports/domain/is-registration-accredited.test.js
@@ -20,24 +20,12 @@ describe('isRegistrationAccredited', () => {
     }
   )
 
-  it('returns false when accreditation is null', () => {
+  it('returns false when accreditation is null (accreditationId points to nothing)', () => {
     expect(
       isRegistrationAccredited({
         accreditationId: 'acc-1',
         accreditation: null
       })
     ).toBe(false)
-  })
-
-  it('returns false when accreditation field is absent', () => {
-    expect(isRegistrationAccredited({})).toBe(false)
-  })
-
-  it('returns false when registration is undefined', () => {
-    expect(isRegistrationAccredited()).toBe(false)
-  })
-
-  it('returns false when registration is null', () => {
-    expect(isRegistrationAccredited(null)).toBe(false)
   })
 })

--- a/src/reports/domain/is-registration-accredited.test.js
+++ b/src/reports/domain/is-registration-accredited.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { isRegistrationAccredited } from './is-registration-accredited.js'
+
+describe('isRegistrationAccredited', () => {
+  it.each([
+    { status: 'approved', expected: true },
+    { status: 'suspended', expected: true },
+    { status: 'created', expected: false },
+    { status: 'rejected', expected: false },
+    { status: 'cancelled', expected: false }
+  ])(
+    'returns $expected when linked accreditation status is $status',
+    ({ status, expected }) => {
+      expect(
+        isRegistrationAccredited({
+          accreditationId: 'acc-1',
+          accreditation: { status }
+        })
+      ).toBe(expected)
+    }
+  )
+
+  it('returns false when accreditation is null', () => {
+    expect(
+      isRegistrationAccredited({
+        accreditationId: 'acc-1',
+        accreditation: null
+      })
+    ).toBe(false)
+  })
+
+  it('returns false when accreditation field is absent', () => {
+    expect(isRegistrationAccredited({})).toBe(false)
+  })
+
+  it('returns false when registration is undefined', () => {
+    expect(isRegistrationAccredited()).toBe(false)
+  })
+
+  it('returns false when registration is null', () => {
+    expect(isRegistrationAccredited(null)).toBe(false)
+  })
+})

--- a/src/reports/domain/operator-category.js
+++ b/src/reports/domain/operator-category.js
@@ -42,7 +42,7 @@ const OPERATOR_CATEGORY_BY_WASTE_PROCESSING_TYPE = Object.freeze({
 /**
  * Derives the operator category from a registration.
  *
- * @param {{ wasteProcessingType: string, accreditationId?: string, accreditation?: { status?: string } | null }} registration
+ * @param {{ wasteProcessingType: string, accreditationId?: string, accreditation: { status?: string } | null }} registration
  * @returns {OperatorCategory}
  */
 export function getOperatorCategory(registration) {

--- a/src/reports/domain/operator-category.js
+++ b/src/reports/domain/operator-category.js
@@ -1,4 +1,5 @@
 import { WASTE_PROCESSING_TYPE } from '#domain/organisations/model.js'
+import { isRegistrationAccredited } from './is-registration-accredited.js'
 
 /**
  * @import { WasteProcessingTypeValue } from '#domain/organisations/model.js'
@@ -41,7 +42,7 @@ const OPERATOR_CATEGORY_BY_WASTE_PROCESSING_TYPE = Object.freeze({
 /**
  * Derives the operator category from a registration.
  *
- * @param {{ wasteProcessingType: string, accreditationId?: string }} registration
+ * @param {{ wasteProcessingType: string, accreditationId?: string, accreditation?: { status?: string } | null }} registration
  * @returns {OperatorCategory}
  */
 export function getOperatorCategory(registration) {
@@ -56,7 +57,7 @@ export function getOperatorCategory(registration) {
     )
   }
 
-  return registration.accreditationId
+  return isRegistrationAccredited(registration)
     ? category.accredited
     : category.registeredOnly
 }

--- a/src/reports/domain/operator-category.test.js
+++ b/src/reports/domain/operator-category.test.js
@@ -10,30 +10,113 @@ describe('OPERATOR_CATEGORY', () => {
 describe('getOperatorCategory', () => {
   it.each([
     {
-      scenario: 'registered-only exporter',
+      scenario: 'registered-only exporter (no accreditationId)',
       registration: { wasteProcessingType: 'exporter' },
       expected: 'EXPORTER_REGISTERED_ONLY'
     },
     {
-      scenario: 'accredited exporter',
+      scenario: 'accredited exporter (approved)',
       registration: {
         wasteProcessingType: 'exporter',
-        accreditationId: 'acc-123'
+        accreditationId: 'acc-123',
+        accreditation: { status: 'approved' }
       },
       expected: 'EXPORTER'
     },
     {
-      scenario: 'registered-only reprocessor',
+      scenario: 'accredited exporter (suspended)',
+      registration: {
+        wasteProcessingType: 'exporter',
+        accreditationId: 'acc-123',
+        accreditation: { status: 'suspended' }
+      },
+      expected: 'EXPORTER'
+    },
+    {
+      scenario: 'exporter with created accreditation (not yet approved)',
+      registration: {
+        wasteProcessingType: 'exporter',
+        accreditationId: 'acc-123',
+        accreditation: { status: 'created' }
+      },
+      expected: 'EXPORTER_REGISTERED_ONLY'
+    },
+    {
+      scenario: 'exporter with rejected accreditation',
+      registration: {
+        wasteProcessingType: 'exporter',
+        accreditationId: 'acc-123',
+        accreditation: { status: 'rejected' }
+      },
+      expected: 'EXPORTER_REGISTERED_ONLY'
+    },
+    {
+      scenario: 'exporter with cancelled accreditation',
+      registration: {
+        wasteProcessingType: 'exporter',
+        accreditationId: 'acc-123',
+        accreditation: { status: 'cancelled' }
+      },
+      expected: 'EXPORTER_REGISTERED_ONLY'
+    },
+    {
+      scenario: 'exporter with accreditationId but no hydrated accreditation',
+      registration: {
+        wasteProcessingType: 'exporter',
+        accreditationId: 'acc-123',
+        accreditation: null
+      },
+      expected: 'EXPORTER_REGISTERED_ONLY'
+    },
+    {
+      scenario: 'registered-only reprocessor (no accreditationId)',
       registration: { wasteProcessingType: 'reprocessor' },
       expected: 'REPROCESSOR_REGISTERED_ONLY'
     },
     {
-      scenario: 'accredited reprocessor',
+      scenario: 'accredited reprocessor (approved)',
       registration: {
         wasteProcessingType: 'reprocessor',
-        accreditationId: 'acc-456'
+        accreditationId: 'acc-456',
+        accreditation: { status: 'approved' }
       },
       expected: 'REPROCESSOR'
+    },
+    {
+      scenario: 'accredited reprocessor (suspended)',
+      registration: {
+        wasteProcessingType: 'reprocessor',
+        accreditationId: 'acc-456',
+        accreditation: { status: 'suspended' }
+      },
+      expected: 'REPROCESSOR'
+    },
+    {
+      scenario: 'reprocessor with created accreditation (not yet approved)',
+      registration: {
+        wasteProcessingType: 'reprocessor',
+        accreditationId: 'acc-456',
+        accreditation: { status: 'created' }
+      },
+      expected: 'REPROCESSOR_REGISTERED_ONLY'
+    },
+    {
+      scenario: 'reprocessor with rejected accreditation',
+      registration: {
+        wasteProcessingType: 'reprocessor',
+        accreditationId: 'acc-456',
+        accreditation: { status: 'rejected' }
+      },
+      expected: 'REPROCESSOR_REGISTERED_ONLY'
+    },
+    {
+      scenario: 'reprocessor with cancelled accreditation',
+      registration: {
+        wasteProcessingType: 'reprocessor',
+        accreditationId: 'acc-456',
+        accreditation: { status: 'cancelled' }
+      },
+      expected: 'REPROCESSOR_REGISTERED_ONLY'
     }
   ])('returns $expected for $scenario', ({ registration, expected }) => {
     expect(getOperatorCategory(registration)).toBe(expected)

--- a/src/reports/routes/get-detail.test.js
+++ b/src/reports/routes/get-detail.test.js
@@ -8,6 +8,7 @@ import { createInMemoryOrganisationsRepository } from '#repositories/organisatio
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
 import {
   buildOrganisation,
+  buildOrganisationWithRegistration,
   buildRegistration
 } from '#repositories/organisations/contract/test-data.js'
 import { buildWasteRecord } from '#repositories/waste-records/contract/test-data.js'
@@ -24,17 +25,19 @@ describe(`GET ${reportsGetDetailPath}`, () => {
   describe('when feature flag is enabled', () => {
     const createServer = async (
       registrationOverrides = {},
-      wasteRecordOverrides = []
+      wasteRecordOverrides = [],
+      accreditationStatus
     ) => {
       const registration = buildRegistration(registrationOverrides)
-      const org = buildOrganisation({
-        registrations: [registration]
-      })
+      const org = buildOrganisationWithRegistration(
+        registration,
+        accreditationStatus
+      )
 
+      // Use initial-org pattern to preserve accreditation statusHistory
+      // (insert() overrides statusHistory to the default 'created' entry).
       const organisationsRepositoryFactory =
-        createInMemoryOrganisationsRepository()
-      const organisationsRepository = organisationsRepositoryFactory()
-      await organisationsRepository.insert(org)
+        createInMemoryOrganisationsRepository([org])
 
       const wasteRecords = wasteRecordOverrides.map((overrides) =>
         buildWasteRecord({
@@ -321,10 +324,14 @@ describe(`GET ${reportsGetDetailPath}`, () => {
     describe('accredited reprocessor', () => {
       it('returns 200 with monthly cadence', async () => {
         const accreditationId = new ObjectId().toString()
-        const { server, organisationId, registrationId } = await createServer({
-          wasteProcessingType: 'reprocessor',
-          accreditationId
-        })
+        const { server, organisationId, registrationId } = await createServer(
+          {
+            wasteProcessingType: 'reprocessor',
+            accreditationId
+          },
+          [],
+          'approved'
+        )
 
         const response = await makeRequest(
           server,
@@ -346,10 +353,14 @@ describe(`GET ${reportsGetDetailPath}`, () => {
       })
 
       it('returns registration details', async () => {
-        const { server, organisationId, registrationId } = await createServer({
-          wasteProcessingType: 'reprocessor',
-          accreditationId: new ObjectId().toString()
-        })
+        const { server, organisationId, registrationId } = await createServer(
+          {
+            wasteProcessingType: 'reprocessor',
+            accreditationId: new ObjectId().toString()
+          },
+          [],
+          'approved'
+        )
 
         const response = await makeRequest(
           server,
@@ -396,7 +407,8 @@ describe(`GET ${reportsGetDetailPath}`, () => {
                 ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Collector'
               }
             }
-          ]
+          ],
+          'approved'
         )
 
         const response = await makeRequest(
@@ -637,10 +649,14 @@ describe(`GET ${reportsGetDetailPath}`, () => {
 
     describe('accredited exporter', () => {
       it('returns 200 with monthly cadence', async () => {
-        const { server, organisationId, registrationId } = await createServer({
-          wasteProcessingType: 'exporter',
-          accreditationId: new ObjectId().toString()
-        })
+        const { server, organisationId, registrationId } = await createServer(
+          {
+            wasteProcessingType: 'exporter',
+            accreditationId: new ObjectId().toString()
+          },
+          [],
+          'approved'
+        )
 
         const response = await makeRequest(
           server,
@@ -688,7 +704,8 @@ describe(`GET ${reportsGetDetailPath}`, () => {
                 OSR_ID: '096'
               }
             }
-          ]
+          ],
+          'approved'
         )
 
         const response = await makeRequest(
@@ -741,7 +758,8 @@ describe(`GET ${reportsGetDetailPath}`, () => {
                 OSR_ID: '096'
               }
             }
-          ]
+          ],
+          'approved'
         )
 
         const response = await makeRequest(
@@ -779,7 +797,8 @@ describe(`GET ${reportsGetDetailPath}`, () => {
                 OSR_ID: '001'
               }
             }
-          ]
+          ],
+          'approved'
         )
 
         const januaryResponse = await makeRequest(
@@ -810,10 +829,14 @@ describe(`GET ${reportsGetDetailPath}`, () => {
       })
 
       it('returns empty sections when no records exist', async () => {
-        const { server, organisationId, registrationId } = await createServer({
-          wasteProcessingType: 'exporter',
-          accreditationId: new ObjectId().toString()
-        })
+        const { server, organisationId, registrationId } = await createServer(
+          {
+            wasteProcessingType: 'exporter',
+            accreditationId: new ObjectId().toString()
+          },
+          [],
+          'approved'
+        )
 
         const response = await makeRequest(
           server,
@@ -857,7 +880,8 @@ describe(`GET ${reportsGetDetailPath}`, () => {
                 ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Baler'
               }
             }
-          ]
+          ],
+          'approved'
         )
 
         const response = await makeRequest(

--- a/src/reports/routes/get.js
+++ b/src/reports/routes/get.js
@@ -5,6 +5,7 @@ import { ROLES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { CADENCE } from '#reports/domain/cadence.js'
 import { generateReportingPeriods } from '#reports/domain/generate-reporting-periods.js'
+import { isRegistrationAccredited } from '#reports/domain/is-registration-accredited.js'
 import { mergeReportingPeriods } from '#reports/domain/merge-reporting-periods.js'
 
 export const reportsGetPath =
@@ -32,8 +33,9 @@ export const reportsGet = {
       registrationId
     )
 
-    const isAccredited = Boolean(registration.accreditationId)
-    const cadence = isAccredited ? CADENCE.monthly : CADENCE.quarterly
+    const cadence = isRegistrationAccredited(registration)
+      ? CADENCE.monthly
+      : CADENCE.quarterly
 
     /**
      * We simply return for the current year for now for both Registered-Only

--- a/src/reports/routes/get.test.js
+++ b/src/reports/routes/get.test.js
@@ -7,7 +7,7 @@ import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemor
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import {
-  buildOrganisation,
+  buildOrganisationWithRegistration,
   buildRegistration
 } from '#repositories/organisations/contract/test-data.js'
 import { reportsGetPath } from './get.js'
@@ -21,17 +21,19 @@ describe(`GET ${reportsGetPath}`, () => {
   describe('when feature flag is enabled', () => {
     const createServer = async (
       registrationOverrides = {},
-      reportsRepositoryFactory
+      reportsRepositoryFactory,
+      accreditationStatus
     ) => {
       const registration = buildRegistration(registrationOverrides)
-      const org = buildOrganisation({
-        registrations: [registration]
-      })
+      const org = buildOrganisationWithRegistration(
+        registration,
+        accreditationStatus
+      )
 
+      // Use initial-org pattern to preserve accreditation statusHistory
+      // (insert() overrides statusHistory to the default 'created' entry).
       const organisationsRepositoryFactory =
-        createInMemoryOrganisationsRepository()
-      const organisationsRepository = organisationsRepositoryFactory()
-      await organisationsRepository.insert(org)
+        createInMemoryOrganisationsRepository([org])
 
       const server = await createTestServer({
         repositories: {
@@ -170,10 +172,34 @@ describe(`GET ${reportsGetPath}`, () => {
       const currentYear = new Date().getUTCFullYear()
 
       it('returns monthly cadence', async () => {
-        const { server, organisationId, registrationId } = await createServer({
-          wasteProcessingType: 'exporter',
-          accreditationId: new ObjectId().toString()
-        })
+        const { server, organisationId, registrationId } = await createServer(
+          {
+            wasteProcessingType: 'exporter',
+            accreditationId: new ObjectId().toString()
+          },
+          undefined,
+          'approved'
+        )
+
+        const response = await makeRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+        const payload = JSON.parse(response.payload)
+
+        expect(payload.cadence).toBe('monthly')
+      })
+
+      it('returns monthly cadence for suspended accreditation', async () => {
+        const { server, organisationId, registrationId } = await createServer(
+          {
+            wasteProcessingType: 'exporter',
+            accreditationId: new ObjectId().toString()
+          },
+          undefined,
+          'suspended'
+        )
 
         const response = await makeRequest(
           server,
@@ -186,10 +212,14 @@ describe(`GET ${reportsGetPath}`, () => {
       })
 
       it('returns only ended monthly periods', async () => {
-        const { server, organisationId, registrationId } = await createServer({
-          wasteProcessingType: 'exporter',
-          accreditationId: new ObjectId().toString()
-        })
+        const { server, organisationId, registrationId } = await createServer(
+          {
+            wasteProcessingType: 'exporter',
+            accreditationId: new ObjectId().toString()
+          },
+          undefined,
+          'approved'
+        )
 
         const response = await makeRequest(
           server,
@@ -205,10 +235,14 @@ describe(`GET ${reportsGetPath}`, () => {
       })
 
       it('includes dueDate for each monthly period', async () => {
-        const { server, organisationId, registrationId } = await createServer({
-          wasteProcessingType: 'exporter',
-          accreditationId: new ObjectId().toString()
-        })
+        const { server, organisationId, registrationId } = await createServer(
+          {
+            wasteProcessingType: 'exporter',
+            accreditationId: new ObjectId().toString()
+          },
+          undefined,
+          'approved'
+        )
 
         const response = await makeRequest(
           server,
@@ -222,6 +256,48 @@ describe(`GET ${reportsGetPath}`, () => {
       })
     })
 
+    describe('registration with unapproved accreditation', () => {
+      it.each(['created', 'rejected', 'cancelled'])(
+        'returns quarterly cadence when linked accreditation status is %s',
+        async (accreditationStatus) => {
+          const { server, organisationId, registrationId } = await createServer(
+            {
+              wasteProcessingType: 'exporter',
+              accreditationId: new ObjectId().toString()
+            },
+            undefined,
+            accreditationStatus
+          )
+
+          const response = await makeRequest(
+            server,
+            organisationId,
+            registrationId
+          )
+          const payload = JSON.parse(response.payload)
+
+          expect(payload.cadence).toBe('quarterly')
+        }
+      )
+
+      it('returns quarterly cadence when accreditationId points to nothing (unhydrated)', async () => {
+        // No accreditation in org, so registration.accreditation hydrates to null
+        const { server, organisationId, registrationId } = await createServer({
+          wasteProcessingType: 'exporter',
+          accreditationId: new ObjectId().toString()
+        })
+
+        const response = await makeRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+        const payload = JSON.parse(response.payload)
+
+        expect(payload.cadence).toBe('quarterly')
+      })
+    })
+
     describe('with persisted reports', () => {
       it('includes report object for period with persisted report', async () => {
         const reportsRepositoryFactory = createInMemoryReportsRepository()
@@ -230,7 +306,8 @@ describe(`GET ${reportsGetPath}`, () => {
             wasteProcessingType: 'exporter',
             accreditationId: new ObjectId().toString()
           },
-          reportsRepositoryFactory
+          reportsRepositoryFactory,
+          'approved'
         )
 
         const reportsRepository = reportsRepositoryFactory()
@@ -286,7 +363,8 @@ describe(`GET ${reportsGetPath}`, () => {
             wasteProcessingType: 'exporter',
             accreditationId: new ObjectId().toString()
           },
-          reportsRepositoryFactory
+          reportsRepositoryFactory,
+          'approved'
         )
 
         const reportsRepository = reportsRepositoryFactory()
@@ -348,7 +426,8 @@ describe(`GET ${reportsGetPath}`, () => {
             wasteProcessingType: 'exporter',
             accreditationId: new ObjectId().toString()
           },
-          reportsRepositoryFactory
+          reportsRepositoryFactory,
+          'approved'
         )
 
         const reportsRepository = reportsRepositoryFactory()

--- a/src/reports/routes/status.test.js
+++ b/src/reports/routes/status.test.js
@@ -8,7 +8,7 @@ import { createInMemoryOrganisationsRepository } from '#repositories/organisatio
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import {
-  buildOrganisation,
+  buildOrganisationWithRegistration,
   buildRegistration
 } from '#repositories/organisations/contract/test-data.js'
 import { buildCreateReportParams } from '#reports/repository/contract/test-data.js'
@@ -55,17 +55,30 @@ describe(`POST ${reportsStatusPath}`, () => {
       }
     }
 
-    const createServerWithReport = async (
-      registrationOverrides = {},
-      reportOverrides = {}
+    const buildOrgWithRegistration = (
+      registrationOverrides,
+      accreditationStatus
     ) => {
       const registration = buildRegistration(registrationOverrides)
-      const org = buildOrganisation({ registrations: [registration] })
+      const org = buildOrganisationWithRegistration(
+        registration,
+        accreditationStatus
+      )
+      return { org, registration }
+    }
+
+    const createServerWithReport = async (
+      registrationOverrides = {},
+      reportOverrides = {},
+      accreditationStatus
+    ) => {
+      const { org, registration } = buildOrgWithRegistration(
+        registrationOverrides,
+        accreditationStatus
+      )
 
       const organisationsRepositoryFactory =
-        createInMemoryOrganisationsRepository()
-      const organisationsRepository = organisationsRepositoryFactory()
-      await organisationsRepository.insert(org)
+        createInMemoryOrganisationsRepository([org])
 
       const reportsRepositoryFactory = createInMemoryReportsRepository()
       const reportsRepository = reportsRepositoryFactory()
@@ -103,14 +116,17 @@ describe(`POST ${reportsStatusPath}`, () => {
       }
     }
 
-    const createServerWithoutReport = async (registrationOverrides = {}) => {
-      const registration = buildRegistration(registrationOverrides)
-      const org = buildOrganisation({ registrations: [registration] })
+    const createServerWithoutReport = async (
+      registrationOverrides = {},
+      accreditationStatus
+    ) => {
+      const { org, registration } = buildOrgWithRegistration(
+        registrationOverrides,
+        accreditationStatus
+      )
 
       const organisationsRepositoryFactory =
-        createInMemoryOrganisationsRepository()
-      const organisationsRepository = organisationsRepositoryFactory()
-      await organisationsRepository.insert(org)
+        createInMemoryOrganisationsRepository([org])
 
       const server = await createTestServer({
         repositories: {
@@ -256,7 +272,7 @@ describe(`POST ${reportsStatusPath}`, () => {
       it('returns 400 when transitioning an accredited reprocessor report to ready_to_submit with prn.totalRevenue null', async () => {
         const { server, organisationId, registrationId } =
           await createServerWithReport(
-            { wasteProcessingType: 'reprocessor' }, // accreditationId set by buildRegistration default
+            { wasteProcessingType: 'reprocessor' },
             {
               prn: {
                 issuedTonnage: 100,
@@ -264,7 +280,8 @@ describe(`POST ${reportsStatusPath}`, () => {
                 freeTonnage: 0,
                 averagePricePerTonne: null
               }
-            }
+            },
+            'approved'
           )
 
         const response = await postStatus(
@@ -276,6 +293,34 @@ describe(`POST ${reportsStatusPath}`, () => {
 
         expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
       })
+
+      it.each(['created', 'rejected', 'cancelled'])(
+        'allows transition for reprocessor with %s accreditation (treated as registered-only, prn fields not required)',
+        async (accreditationStatus) => {
+          const { server, organisationId, registrationId } =
+            await createServerWithReport(
+              { wasteProcessingType: 'reprocessor' },
+              {
+                prn: {
+                  issuedTonnage: 100,
+                  totalRevenue: null,
+                  freeTonnage: 0,
+                  averagePricePerTonne: null
+                }
+              },
+              accreditationStatus
+            )
+
+          const response = await postStatus(
+            server,
+            organisationId,
+            registrationId,
+            { status: 'ready_to_submit', version: 1 }
+          )
+
+          expect(response.statusCode).toBe(StatusCodes.OK)
+        }
+      )
 
       it('allows transition to ready_to_submit when all required fields for the operator category are populated', async () => {
         const { server, organisationId, registrationId } =

--- a/src/repositories/organisations/contract/test-data.js
+++ b/src/repositories/organisations/contract/test-data.js
@@ -130,6 +130,38 @@ export const buildOrganisation = (overrides = {}) => {
   return org
 }
 
+/**
+ * Builds an organisation with the given registration, optionally linking a
+ * matching accreditation with a specific status. When accreditationStatus is
+ * provided, the returned org should be passed as an initial org to
+ * createInMemoryOrganisationsRepository — otherwise insert() will overwrite
+ * the statusHistory with the default 'created' entry.
+ *
+ * @param {object} registration - From buildRegistration
+ * @param {string} [accreditationStatus] - If set, links a matching accreditation
+ * @returns {object}
+ */
+export const buildOrganisationWithRegistration = (
+  registration,
+  accreditationStatus
+) => {
+  const orgOptions = { registrations: [registration] }
+
+  if (accreditationStatus && registration.accreditationId) {
+    const accreditation = buildAccreditation({
+      id: registration.accreditationId,
+      wasteProcessingType: registration.wasteProcessingType,
+      statusHistory: [
+        { status: 'created', updatedAt: new Date('2024-01-01') },
+        { status: accreditationStatus, updatedAt: new Date('2024-02-01') }
+      ]
+    })
+    orgOptions.accreditations = [accreditation]
+  }
+
+  return buildOrganisation(orgOptions)
+}
+
 const mergeArrayById = (existing, updates) => {
   const updatesById = new Map(updates.map((item) => [item.id, item]))
   const merged = existing.map((item) => updatesById.get(item.id) || item)


### PR DESCRIPTION
Ticket: [PAE-1379](https://eaflood.atlassian.net/browse/PAE-1379)
## Summary
Registrations linked to an accreditation that has not been approved were being treated as fully accredited - getting monthly report cadence and the accredited operator category. This change makes the determination consider the accreditation's status, not just the presence of a linked ID.

## What Changed
- Added a domain helper that treats a registration as accredited only when its linked accreditation is currently `approved` or `suspended`
- Wired the helper into the reports calendar route (cadence) and the operator category derivation (report sections, completeness rules)
- Extended unit and integration tests to cover the full status matrix, including the unapproved cases (`created`, `rejected`, `cancelled`) and the edge case where an accreditation ID points at nothing

## Why
An approved registration can be linked to an accreditation that is still in `created`, `rejected`, or `cancelled` state. Previously the backend only checked whether `accreditationId` was present, so such operators were asked for monthly submissions instead of quarterly and routed down the wrong validation path. The fix is backend-only and preserves the existing API contract, so no coordinated deployment with the frontend is required.

[PAE-1379]: https://eaflood.atlassian.net/browse/PAE-1379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ