### PR TITLE
PAE-1380: Derive waste balance from waste records, not rowId-keyed ledger

### DIFF
--- a/src/domain/waste-balances/calculator.js
+++ b/src/domain/waste-balances/calculator.js
@@ -110,23 +110,32 @@ const isPrnTransaction = (transaction) =>
   )
 
 /**
+ * @typedef {'openingAmount' | 'closingAmount' | 'openingAvailableAmount' | 'closingAvailableAmount'} WasteBalanceField
+ */
+
+/**
  * Sums the net effect of PRN transactions on a balance field. Waste-record
  * transactions are excluded because they are keyed by naked rowId and can
  * silently lose data under a rowId collision (PAE-1380); the waste-record
  * contribution is derived directly from the waste records themselves.
  *
  * @param {Array<import('#domain/waste-balances/model.js').WasteBalanceTransaction>} transactions
- * @param {'Amount' | 'AvailableAmount'} field
+ * @param {WasteBalanceField} closingField
+ * @param {WasteBalanceField} openingField
  * @returns {number}
  */
-const sumPrnTransactionAdjustment = (transactions, field) => {
+const sumPrnTransactionAdjustment = (
+  transactions,
+  closingField,
+  openingField
+) => {
   let adjustment = 0
   for (const transaction of transactions) {
     if (!isPrnTransaction(transaction)) {
       continue
     }
-    const closing = transaction[`closing${field}`] ?? 0
-    const opening = transaction[`opening${field}`] ?? 0
+    const closing = transaction[closingField] ?? 0
+    const opening = transaction[openingField] ?? 0
     adjustment = toNumber(add(adjustment, subtract(closing, opening)))
   }
   return adjustment
@@ -235,11 +244,13 @@ export const calculateWasteBalanceUpdates = ({
   // collision-free, so their net adjustment is safe to pull from the ledger.
   const prnAmountAdjustment = sumPrnTransactionAdjustment(
     historicTransactions,
-    'Amount'
+    'closingAmount',
+    'openingAmount'
   )
   const prnAvailableAmountAdjustment = sumPrnTransactionAdjustment(
     historicTransactions,
-    'AvailableAmount'
+    'closingAvailableAmount',
+    'openingAvailableAmount'
   )
 
   return {

--- a/src/domain/waste-balances/calculator.js
+++ b/src/domain/waste-balances/calculator.js
@@ -110,35 +110,39 @@ const isPrnTransaction = (transaction) =>
   )
 
 /**
- * @typedef {'openingAmount' | 'closingAmount' | 'openingAvailableAmount' | 'closingAvailableAmount'} WasteBalanceField
- */
-
-/**
- * Sums the net effect of PRN transactions on a balance field. Waste-record
- * transactions are excluded because they are keyed by naked rowId and can
- * silently lose data under a rowId collision (PAE-1380); the waste-record
- * contribution is derived directly from the waste records themselves.
+ * Sums the net effect of PRN transactions on both balance fields in a single
+ * pass. Waste-record transactions are excluded because they are keyed by
+ * naked rowId and can silently lose data under a rowId collision (PAE-1380);
+ * the waste-record contribution is derived directly from the waste records
+ * themselves.
  *
  * @param {Array<import('#domain/waste-balances/model.js').WasteBalanceTransaction>} transactions
- * @param {WasteBalanceField} closingField
- * @param {WasteBalanceField} openingField
- * @returns {number}
+ * @returns {{ amount: number, availableAmount: number }}
  */
-const sumPrnTransactionAdjustment = (
-  transactions,
-  closingField,
-  openingField
-) => {
-  let adjustment = 0
+const sumPrnTransactionAdjustments = (transactions) => {
+  let amount = 0
+  let availableAmount = 0
   for (const transaction of transactions) {
     if (!isPrnTransaction(transaction)) {
       continue
     }
-    const closing = transaction[closingField] ?? 0
-    const opening = transaction[openingField] ?? 0
-    adjustment = toNumber(add(adjustment, subtract(closing, opening)))
+    amount = toNumber(
+      add(
+        amount,
+        subtract(transaction.closingAmount ?? 0, transaction.openingAmount ?? 0)
+      )
+    )
+    availableAmount = toNumber(
+      add(
+        availableAmount,
+        subtract(
+          transaction.closingAvailableAmount ?? 0,
+          transaction.openingAvailableAmount ?? 0
+        )
+      )
+    )
   }
-  return adjustment
+  return { amount, availableAmount }
 }
 
 /**
@@ -242,16 +246,10 @@ export const calculateWasteBalanceUpdates = ({
   // (PAE-1380); waste records are the authoritative source and are uniquely
   // keyed by (type, rowId). PRN transactions use prnId entity ids and are
   // collision-free, so their net adjustment is safe to pull from the ledger.
-  const prnAmountAdjustment = sumPrnTransactionAdjustment(
-    historicTransactions,
-    'closingAmount',
-    'openingAmount'
-  )
-  const prnAvailableAmountAdjustment = sumPrnTransactionAdjustment(
-    historicTransactions,
-    'closingAvailableAmount',
-    'openingAvailableAmount'
-  )
+  const {
+    amount: prnAmountAdjustment,
+    availableAmount: prnAvailableAmountAdjustment
+  } = sumPrnTransactionAdjustments(historicTransactions)
 
   return {
     newTransactions,

--- a/src/domain/waste-balances/calculator.js
+++ b/src/domain/waste-balances/calculator.js
@@ -93,6 +93,42 @@ const updateCreditedAmountMap = (creditedAmountMap, transaction) => {
   }
 }
 
+const PRN_ENTITY_TYPES = new Set([
+  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_CREATED,
+  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_ISSUED,
+  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_ACCEPTED,
+  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_CANCELLED,
+  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_CANCELLED_POST_ISSUE
+])
+
+const isPrnTransaction = (transaction) =>
+  (transaction.entities || []).some((entity) =>
+    PRN_ENTITY_TYPES.has(entity.type)
+  )
+
+/**
+ * Sums the net effect of PRN transactions on a balance field. Waste-record
+ * transactions are excluded because they are keyed by naked rowId and can
+ * silently lose data under a rowId collision (PAE-1380); the waste-record
+ * contribution is derived directly from the waste records themselves.
+ *
+ * @param {Array<import('#domain/waste-balances/model.js').WasteBalanceTransaction>} transactions
+ * @param {'Amount' | 'AvailableAmount'} field
+ * @returns {number}
+ */
+const sumPrnTransactionAdjustment = (transactions, field) => {
+  let adjustment = 0
+  for (const transaction of transactions) {
+    if (!isPrnTransaction(transaction)) {
+      continue
+    }
+    const closing = transaction[`closing${field}`] ?? 0
+    const opening = transaction[`opening${field}`] ?? 0
+    adjustment = toNumber(add(adjustment, subtract(closing, opening)))
+  }
+  return adjustment
+}
+
 /**
  * Calculates the target amount for a waste record based on accreditation.
  * @param {import('#domain/waste-records/model.js').WasteRecord} record
@@ -147,31 +183,31 @@ export const calculateWasteBalanceUpdates = ({
   const newTransactions = []
   let currentAmount = currentBalance.amount || 0
   let currentAvailableAmount = currentBalance.availableAmount || 0
+  const historicTransactions = currentBalance.transactions || []
 
-  // Optimization: Pre-calculate credited amounts to avoid O(N*M) complexity
+  // Per-record transactions remain the audit ledger. They still drive the
+  // per-row delta and closing-amount bookkeeping exactly as before.
   const creditedAmountMap = new Map()
-
-  // Initialize map with existing transactions
-  ;(currentBalance.transactions || []).forEach((transaction) =>
+  historicTransactions.forEach((transaction) =>
     updateCreditedAmountMap(creditedAmountMap, transaction)
   )
 
+  let wasteRecordTotal = 0
+
   for (const record of wasteRecords) {
     const targetAmount = getTargetAmount(record, accreditation, overseasSites)
+    wasteRecordTotal = toNumber(add(wasteRecordTotal, targetAmount))
 
-    // Calculate Already Credited Amount
     const alreadyCreditedAmount =
       creditedAmountMap.get(String(record.rowId)) || 0
 
     const delta = subtract(targetAmount, alreadyCreditedAmount)
 
-    // Only create transaction if there is a difference (exact decimal comparison)
     if (!isZero(delta)) {
       const type = greaterThan(delta, 0)
         ? WASTE_BALANCE_TRANSACTION_TYPE.CREDIT
         : WASTE_BALANCE_TRANSACTION_TYPE.DEBIT
 
-      // Create Transaction
       const transaction = buildTransaction(
         record,
         toNumber(abs(delta)),
@@ -180,19 +216,34 @@ export const calculateWasteBalanceUpdates = ({
         type
       )
 
-      // Update State
       currentAmount = transaction.closingAmount
       currentAvailableAmount = transaction.closingAvailableAmount
       newTransactions.push(transaction)
 
-      // Update map for next iteration
       updateCreditedAmountMap(creditedAmountMap, transaction)
     }
   }
 
+  // Balance totals come directly from the waste records and PRN transactions,
+  // not from accumulated waste-record deltas. Waste-record transactions key
+  // entities by naked rowId and silently lose data under rowId collisions
+  // (PAE-1380); waste records are the authoritative source and are uniquely
+  // keyed by (type, rowId). PRN transactions use prnId entity ids and are
+  // collision-free, so their net adjustment is safe to pull from the ledger.
+  const prnAmountAdjustment = sumPrnTransactionAdjustment(
+    historicTransactions,
+    'Amount'
+  )
+  const prnAvailableAmountAdjustment = sumPrnTransactionAdjustment(
+    historicTransactions,
+    'AvailableAmount'
+  )
+
   return {
     newTransactions,
-    newAmount: currentAmount,
-    newAvailableAmount: currentAvailableAmount
+    newAmount: toNumber(add(wasteRecordTotal, prnAmountAdjustment)),
+    newAvailableAmount: toNumber(
+      add(wasteRecordTotal, prnAvailableAmountAdjustment)
+    )
   }
 }

--- a/src/domain/waste-balances/calculator.js
+++ b/src/domain/waste-balances/calculator.js
@@ -93,6 +93,9 @@ const updateCreditedAmountMap = (creditedAmountMap, transaction) => {
   }
 }
 
+// PRN_ACCEPTED has no builder today; included for forward-compat so any future
+// PRN_ACCEPTED transaction that conserves opening/closing semantics is picked
+// up without another diff here.
 const PRN_ENTITY_TYPES = new Set([
   WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_CREATED,
   WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_ISSUED,

--- a/src/domain/waste-balances/calculator.test.js
+++ b/src/domain/waste-balances/calculator.test.js
@@ -714,6 +714,206 @@ describe('Waste Balance Calculator', () => {
     expect(result.newTransactions[0].amount).toBe(10.0)
   })
 
+  describe('rowId collision across waste record types (PAE-1380)', () => {
+    it('computes newAmount from the waste records themselves so a colliding SENT_ON rowId cannot offset an EXPORTED credit', () => {
+      const sharedRowId = 1000
+
+      const exportedRecord = buildWasteRecord({
+        rowId: sharedRowId,
+        type: WASTE_RECORD_TYPE.EXPORTED,
+        versions: [
+          {
+            id: 'exported-v1',
+            createdAt: '2025-01-20T10:00:00.000Z',
+            status: VERSION_STATUS.CREATED,
+            summaryLog: { id: 'log-1', uri: 's3://...' },
+            data: {}
+          }
+        ],
+        data: {
+          [FIELDS.WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE]: 'No',
+          [FIELDS.DATE_OF_EXPORT]: '2023-06-01',
+          [FIELDS.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED]: '10.0'
+        }
+      })
+
+      const sentOnRecord = buildWasteRecord({
+        rowId: sharedRowId,
+        type: WASTE_RECORD_TYPE.SENT_ON,
+        versions: [
+          {
+            id: 'sent-on-v1',
+            createdAt: '2025-01-20T10:00:00.000Z',
+            status: VERSION_STATUS.CREATED,
+            summaryLog: { id: 'log-1', uri: 's3://...' },
+            data: {}
+          }
+        ],
+        data: {
+          processingType: PROCESSING_TYPES.EXPORTER,
+          [SENT_ON_FIELDS.ROW_ID]: sharedRowId,
+          [SENT_ON_FIELDS.DATE_LOAD_LEFT_SITE]: '2023-06-01',
+          [SENT_ON_FIELDS.TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON]: '5.0'
+        }
+      })
+
+      const result = calculateWasteBalanceUpdates({
+        currentBalance: emptyBalance,
+        wasteRecords: [exportedRecord, sentOnRecord],
+        accreditation,
+        overseasSites: ORS_VALIDATION_DISABLED
+      })
+
+      expect(result.newAmount).toBe(10.0)
+      expect(result.newAvailableAmount).toBe(10.0)
+    })
+
+    it('preserves a PRN issuance debit in newAmount when re-calculating against the same waste records', () => {
+      const record = buildWasteRecord({
+        rowId: 1000,
+        type: WASTE_RECORD_TYPE.EXPORTED,
+        data: {
+          [FIELDS.WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE]: 'No',
+          [FIELDS.DATE_OF_EXPORT]: '2023-06-01',
+          [FIELDS.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED]: '10.0'
+        }
+      })
+
+      const prnIssuedTransaction = {
+        id: 'tx-prn-issued',
+        type: WASTE_BALANCE_TRANSACTION_TYPE.DEBIT,
+        amount: 3.0,
+        entities: [
+          {
+            id: 'prn-1',
+            type: WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_ISSUED,
+            currentVersionId: 'prn-1',
+            previousVersionIds: []
+          }
+        ],
+        createdAt: '2023-07-01T00:00:00.000Z',
+        createdBy: { id: 'user-1', name: 'Test User' },
+        openingAmount: 10.0,
+        closingAmount: 7.0,
+        openingAvailableAmount: 10.0,
+        closingAvailableAmount: 10.0
+      }
+
+      const currentBalance = {
+        ...emptyBalance,
+        amount: 7.0,
+        availableAmount: 10.0,
+        transactions: [prnIssuedTransaction]
+      }
+
+      const result = calculateWasteBalanceUpdates({
+        currentBalance,
+        wasteRecords: [record],
+        accreditation,
+        overseasSites: ORS_VALIDATION_DISABLED
+      })
+
+      // wasteRecordTotal 10 + PRN issuance debit (-3) = 7; available 10 + 0 (no PRN ringfence) = 10
+      expect(result.newAmount).toBe(7.0)
+      expect(result.newAvailableAmount).toBe(10.0)
+    })
+
+    it('treats missing opening/closing amounts on a PRN transaction as no adjustment', () => {
+      const record = buildWasteRecord({
+        rowId: 1000,
+        type: WASTE_RECORD_TYPE.EXPORTED,
+        data: {
+          [FIELDS.WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE]: 'No',
+          [FIELDS.DATE_OF_EXPORT]: '2023-06-01',
+          [FIELDS.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED]: '10.0'
+        }
+      })
+
+      const malformedPrnTransaction = {
+        id: 'tx-prn-malformed',
+        type: WASTE_BALANCE_TRANSACTION_TYPE.DEBIT,
+        amount: 3.0,
+        entities: [
+          {
+            id: 'prn-1',
+            type: WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_ISSUED,
+            currentVersionId: 'prn-1',
+            previousVersionIds: []
+          }
+        ],
+        createdAt: '2023-07-01T00:00:00.000Z',
+        createdBy: { id: 'user-1', name: 'Test User' }
+        // openingAmount/closingAmount/openingAvailableAmount/closingAvailableAmount missing
+      }
+
+      const currentBalance = {
+        ...emptyBalance,
+        amount: 10.0,
+        availableAmount: 10.0,
+        transactions: [malformedPrnTransaction]
+      }
+
+      const result = calculateWasteBalanceUpdates({
+        currentBalance,
+        wasteRecords: [record],
+        accreditation,
+        overseasSites: ORS_VALIDATION_DISABLED
+      })
+
+      expect(result.newAmount).toBe(10.0)
+      expect(result.newAvailableAmount).toBe(10.0)
+    })
+
+    it('preserves a PRN creation ringfence in newAvailableAmount', () => {
+      const record = buildWasteRecord({
+        rowId: 1000,
+        type: WASTE_RECORD_TYPE.EXPORTED,
+        data: {
+          [FIELDS.WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE]: 'No',
+          [FIELDS.DATE_OF_EXPORT]: '2023-06-01',
+          [FIELDS.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED]: '10.0'
+        }
+      })
+
+      const prnCreatedTransaction = {
+        id: 'tx-prn-created',
+        type: WASTE_BALANCE_TRANSACTION_TYPE.DEBIT,
+        amount: 4.0,
+        entities: [
+          {
+            id: 'prn-1',
+            type: WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_CREATED,
+            currentVersionId: 'prn-1',
+            previousVersionIds: []
+          }
+        ],
+        createdAt: '2023-07-01T00:00:00.000Z',
+        createdBy: { id: 'user-1', name: 'Test User' },
+        openingAmount: 10.0,
+        closingAmount: 10.0,
+        openingAvailableAmount: 10.0,
+        closingAvailableAmount: 6.0
+      }
+
+      const currentBalance = {
+        ...emptyBalance,
+        amount: 10.0,
+        availableAmount: 6.0,
+        transactions: [prnCreatedTransaction]
+      }
+
+      const result = calculateWasteBalanceUpdates({
+        currentBalance,
+        wasteRecords: [record],
+        accreditation,
+        overseasSites: ORS_VALIDATION_DISABLED
+      })
+
+      expect(result.newAmount).toBe(10.0)
+      expect(result.newAvailableAmount).toBe(6.0)
+    })
+  })
+
   describe('buildTransaction', async () => {
     const { buildTransaction } = await import('./calculator.js')
 

--- a/src/repositories/waste-balances/contract/updateWasteBalanceTransactions.contract.js
+++ b/src/repositories/waste-balances/contract/updateWasteBalanceTransactions.contract.js
@@ -107,10 +107,13 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
         overseasSites: ORS_VALIDATION_DISABLED
       })
 
-      // Assert
+      // Assert: balance totals are recomputed directly from the waste records
+      // passed in (plus any PRN transactions). The pre-existing anonymous
+      // transaction does not contribute. The new per-record transaction is
+      // appended to the ledger for audit.
       const balance = await repository.findByAccreditationId(accreditation.id)
       expect(balance.transactions).toHaveLength(2)
-      expect(balance.amount).toBe(15.5)
+      expect(balance.amount).toBe(10.5)
     })
 
     it('Should not update if no transactions generated', async ({
@@ -178,10 +181,12 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
         overseasSites: ORS_VALIDATION_DISABLED
       })
 
-      // Assert
+      // Assert: balance totals come directly from the waste records (plus PRN
+      // transactions). The stray pre-existing amount without a corresponding
+      // waste record is not carried forward.
       const balance = await repository.findByAccreditationId(accreditation.id)
       expect(balance.transactions).toHaveLength(1)
-      expect(balance.amount).toBe(15.5)
+      expect(balance.amount).toBe(10.5)
     })
 
     it('Should ignore records with outcome other than INCLUDED', async ({

--- a/src/repositories/waste-balances/contract/updateWasteBalanceTransactions.contract.js
+++ b/src/repositories/waste-balances/contract/updateWasteBalanceTransactions.contract.js
@@ -1,5 +1,5 @@
 import { describe, expect, vi } from 'vitest'
-import { buildWasteRecord } from './test-data.js'
+import { buildWasteBalance, buildWasteRecord } from './test-data.js'
 import { RECEIVED_LOADS_FIELDS as FIELDS } from '#domain/summary-logs/table-schemas/exporter/fields.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
@@ -78,15 +78,10 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
       const repository = await wasteBalancesRepository()
       const user = { id: 'user-1', name: 'Test User' }
 
-      const existingBalance = {
+      const existingBalance = buildWasteBalance({
         accreditationId: accreditation.id,
-        organisationId: 'org-1',
-        amount: 5,
-        availableAmount: 5,
-        transactions: [{ id: 'tx-1', amount: 5 }],
-        version: 1,
-        schemaVersion: 1
-      }
+        organisationId: 'org-1'
+      })
       await insertWasteBalance(existingBalance)
 
       const record = buildWasteRecord({
@@ -107,10 +102,12 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
         overseasSites: ORS_VALIDATION_DISABLED
       })
 
-      // Assert: balance totals are recomputed directly from the waste records
-      // passed in (plus any PRN transactions). The pre-existing anonymous
-      // transaction does not contribute. The new per-record transaction is
-      // appended to the ledger for audit.
+      // Assert: the prior balance document is updated in place (not
+      // recreated) — the new transaction is appended to the existing
+      // ledger, giving two entries. The total is derived from the waste
+      // records passed in; prior non-PRN transactions do not carry
+      // forward under the new calculator, so amount reflects the single
+      // new record.
       const balance = await repository.findByAccreditationId(accreditation.id)
       expect(balance.transactions).toHaveLength(2)
       expect(balance.amount).toBe(10.5)
@@ -152,12 +149,16 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
       const repository = await wasteBalancesRepository()
       const user = { id: 'user-1', name: 'Test User' }
 
+      // Intentionally omits the `transactions` field to exercise the
+      // calculator's defensive `currentBalance.transactions || []` guard.
+      // Other contract tests use `buildWasteBalance`, which always seeds a
+      // transactions array — this is the one shape that builder can't
+      // produce.
       const existingBalance = {
         accreditationId: accreditation.id,
         organisationId: 'org-1',
         amount: 5,
         availableAmount: 5,
-        // transactions missing
         version: 1,
         schemaVersion: 1
       }
@@ -181,9 +182,9 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
         overseasSites: ORS_VALIDATION_DISABLED
       })
 
-      // Assert: balance totals come directly from the waste records (plus PRN
-      // transactions). The stray pre-existing amount without a corresponding
-      // waste record is not carried forward.
+      // Assert: the nullish-guard handles the missing `transactions` field
+      // without crashing, and the new transaction becomes the only entry.
+      // amount is derived from the single passed-in record.
       const balance = await repository.findByAccreditationId(accreditation.id)
       expect(balance.transactions).toHaveLength(1)
       expect(balance.amount).toBe(10.5)

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
@@ -323,6 +323,48 @@ describe('Waste balance arithmetic integration tests', () => {
       // Available = 350 - 200 = 150
     })
 
+    it('preserves an issued PRN debit in amount when the same rows are re-uploaded (PAE-1380)', async () => {
+      const env = await setupWasteBalanceIntegrationEnvironment({
+        processingType: 'exporter'
+      })
+      const { wasteBalancesRepository, accreditationId } = env
+
+      await performSummaryLogSubmission(
+        env,
+        'log-issue-1',
+        'file-issue-1',
+        'waste-issue-1.xlsx',
+        createUploadData([{ rowId: 1001, exportTonnage: 200 }])
+      )
+
+      let balance =
+        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      expect(balance.amount).toBe(200)
+      expect(balance.availableAmount).toBe(200)
+
+      const prn = await createPrn(env, 50)
+      await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION)
+      await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_ACCEPTANCE)
+
+      balance =
+        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      expect(balance.amount).toBe(150)
+      expect(balance.availableAmount).toBe(150)
+
+      await performSummaryLogSubmission(
+        env,
+        'log-issue-2',
+        'file-issue-2',
+        'waste-issue-2.xlsx',
+        createUploadData([{ rowId: 1001, exportTonnage: 200 }])
+      )
+
+      balance =
+        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      expect(balance.amount).toBe(150)
+      expect(balance.availableAmount).toBe(150)
+    })
+
     it('should handle decimal tonnage values correctly', async () => {
       const env = await setupWasteBalanceIntegrationEnvironment({
         processingType: 'exporter'


### PR DESCRIPTION
Ticket: [PAE-1380](https://eaflood.atlassian.net/browse/PAE-1380)
## Summary

The waste-records collection is uniquely keyed by `(organisationId, registrationId, type, rowId)`, but waste-balance transactions key their entity ids by naked `String(rowId)`. When records of different types share a numeric rowId under the same accreditation (e.g. REPROCESSOR_INPUT with Received rows running past 4000 and colliding with Reprocessed rows 4000-4280), the later-processed record's target silently offsets the earlier record's credit, corrupting the closing balance.

The fix leaves the per-record transaction ledger untouched — transactions still get written exactly as before for audit purposes. What changes is how the balance totals on the waste-balance document are computed:

- `newAmount` and `newAvailableAmount` are now derived directly from the current waste records (via `sum(getTargetAmount(r))`) plus the net adjustment from PRN transactions in the historic ledger.
- PRN transactions use `prnId` as the entity id and do not suffer the collision, so their net effect is safely pulled from the existing ledger by matching on `prn:*` entity types.

Remediating the seven accreditations that already hold corrupt balances is covered by a separate ticket.

## Changes

- `src/domain/waste-balances/calculator.js` — add `sumPrnTransactionAdjustment` and use it together with a direct sum of waste-record target amounts to compute `newAmount` and `newAvailableAmount`. Per-record transaction generation (and its delta-on-`creditedAmountMap` bookkeeping) is unchanged.
- `src/domain/waste-balances/calculator.test.js` — adds scenarios covering the rowId collision, a re-upload after a PRN_ISSUED debit, a re-upload against a PRN_CREATED ringfence, and a malformed PRN transaction missing opening/closing fields.
- `src/repositories/waste-balances/contract/updateWasteBalanceTransactions.contract.js` — updates two assertions that previously relied on carry-forward of an anonymous opening balance. Under the new semantics, the balance totals are fully derived from the waste records plus PRN transactions, so stray prior amounts without a corresponding waste record or PRN transaction are not retained.
- `src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js` — adds an end-to-end scenario that uploads records, issues a PRN (reducing total `amount`), re-uploads the same rows, and verifies the issued debit survives the re-upload.

[PAE-1380]: https://eaflood.atlassian.net/browse/PAE-1380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ