### PR TITLE
PAE-1380: Cover rowId collision across record types at integration level

### DIFF
--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-for-reprocessor-input.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-for-reprocessor-input.test.js
@@ -264,9 +264,18 @@ describe('Submission and placeholder tests (Reprocessor Input)', () => {
       // accumulating from the rowId-keyed transaction ledger, the SENT_ON
       // row would conflate with the RECEIVED row's credit and the closing
       // balance would drift.
-      expect(balance).not.toBeNull()
+      expect(balance).toBeDefined()
       expect(balance.amount).toBe(400)
       expect(balance.availableAmount).toBe(400)
+
+      // Both rows must produce a ledger entry — a regression that silently
+      // dropped one of the colliding rows would still tally to 400 by luck
+      // in a single-upload scenario, but would leave only one transaction.
+      expect(balance.transactions).toHaveLength(2)
+      expect(
+        balance.transactions.find((t) => t.type === 'credit')
+      ).toBeDefined()
+      expect(balance.transactions.find((t) => t.type === 'debit')).toBeDefined()
     })
 
     it('should not create transaction for received load outside accreditation period', async () => {

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-for-reprocessor-input.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-for-reprocessor-input.test.js
@@ -230,6 +230,45 @@ describe('Submission and placeholder tests (Reprocessor Input)', () => {
       expect(balance.transactions[0].entities[0].id).toBe('1002')
     })
 
+    it('should compute correct balance when RECEIVED and SENT_ON rows share a rowId', async () => {
+      const env = await setupWasteBalanceIntegrationEnvironment({
+        processingType: 'reprocessor',
+        reprocessingType: 'input'
+      })
+      const { wasteBalancesRepository, accreditationId } = env
+
+      // RECEIVED requires rowId >= 1000; SENT_ON requires rowId >= 5000.
+      // The minimums are floors, not walls — a single value >= 5000 satisfies
+      // both, so a real upload can legitimately present the same rowId
+      // across the two tables.
+      const sharedRowId = 5001
+
+      const uploadData = createUploadData(
+        [{ rowId: sharedRowId, tonnageReceived: 500 }],
+        [
+          {
+            rowId: sharedRowId,
+            tonnageSent: 100,
+            dateLeft: '2025-01-20T00:00:00.000Z'
+          }
+        ]
+      )
+
+      await performSubmission(env, summaryLogId, fileId, filename, uploadData)
+
+      const balance =
+        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+
+      // 500 (credit from RECEIVED) - 100 (debit from SENT_ON) = 400.
+      // Regression guard: if the balance calculation ever reverts to
+      // accumulating from the rowId-keyed transaction ledger, the SENT_ON
+      // row would conflate with the RECEIVED row's credit and the closing
+      // balance would drift.
+      expect(balance).not.toBeNull()
+      expect(balance.amount).toBe(400)
+      expect(balance.availableAmount).toBe(400)
+    })
+
     it('should not create transaction for received load outside accreditation period', async () => {
       const env = await setupWasteBalanceIntegrationEnvironment({
         processingType: 'reprocessor',


### PR DESCRIPTION
Ticket: [PAE-1380](https://eaflood.atlassian.net/browse/PAE-1380)
## Summary

Adds an integration test covering the case where two waste records of different types share a `rowId` within a registration — the bug fixed by PAE-1380. The waste-balance calculator's unit tests (`src/domain/waste-balances/calculator.test.js`) already cover this at the domain layer; no route-level test did until now.

## Why it's worth covering

`ROW_ID_MINIMUMS` for reprocessor-input sets `RECEIVED >= 1000` and `SENT_ON >= 5000`, but those are floors, not walls — a value `>= 5000` satisfies both, so a real upload can legitimately present the same `rowId` across the two tables. (The Tilbury reproduction that prompted PAE-1380 collided in exactly this way.) Without an end-to-end test, a future change that reverted the balance calculation to accumulating from the `rowId`-keyed transaction ledger would silently drift the closing balance for any registration with cross-table `rowId` overlap, and no route test would catch it.

## What the test does

Submits a REPROCESSOR_INPUT payload with `RECEIVED rowId=5001, tonnage=500` and `SENT_ON rowId=5001, tonnage=100`, then asserts the closing balance is `400`, that both rows survive as ledger entries, and that one credit / one debit is present.

Verified as a genuine regression guard: temporarily reverting `calculator.js` to its pre-PAE-1380 return (`newAmount: currentAmount`) makes the test fail with `amount=-100 to be 400`.

[PAE-1380]: https://eaflood.atlassian.net/browse/PAE-1380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ