### PR TITLE
PAE-1360: Migrate sqs.js testcontainers fixture to Floci

### DIFF
--- a/.vite/fixtures/sqs.js
+++ b/.vite/fixtures/sqs.js
@@ -1,13 +1,13 @@
 import { test as baseTest } from 'vitest'
-import { GenericContainer, Wait } from 'testcontainers'
+import { GenericContainer } from 'testcontainers'
 import {
   SQSClient,
   CreateQueueCommand,
   GetQueueAttributesCommand
 } from '@aws-sdk/client-sqs'
 
-const LOCALSTACK_IMAGE = 'localstack/localstack:3.0.2'
-const LOCALSTACK_PORT = 4566
+const FLOCI_IMAGE = 'hectorvent/floci:1.5.3'
+const FLOCI_PORT = 4566
 
 const REGION = 'eu-west-2'
 const CREDENTIALS = {
@@ -20,25 +20,21 @@ const DLQ_NAME_PREFIX = 'epr_backend_commands_dlq'
 
 let testCounter = 0
 
-const localstackFixture = {
-  localstack: [
+const flociFixture = {
+  floci: [
     // eslint-disable-next-line no-empty-pattern -- vitest fixtures require object destructuring
     async ({}, use) => {
-      const container = await new GenericContainer(LOCALSTACK_IMAGE)
-        .withExposedPorts(LOCALSTACK_PORT)
+      const container = await new GenericContainer(FLOCI_IMAGE)
+        .withExposedPorts(FLOCI_PORT)
         .withEnvironment({
-          SERVICES: 'sqs',
-          DEFAULT_REGION: REGION,
+          FLOCI_DEFAULT_REGION: REGION,
           AWS_ACCESS_KEY_ID: CREDENTIALS.accessKeyId,
           AWS_SECRET_ACCESS_KEY: CREDENTIALS.secretAccessKey
         })
-        .withStartupTimeout(60000)
-        .withWaitStrategy(
-          Wait.forLogMessage(/Ready\./).withStartupTimeout(60000)
-        )
+        .withStartupTimeout(90000)
         .start()
 
-      const port = container.getMappedPort(LOCALSTACK_PORT)
+      const port = container.getMappedPort(FLOCI_PORT)
       const endpoint = `http://127.0.0.1:${port}`
 
       await use({
@@ -55,11 +51,11 @@ const localstackFixture = {
 }
 
 const sqsClientFixture = {
-  sqsClient: async ({ localstack }, use) => {
+  sqsClient: async ({ floci }, use) => {
     const client = new SQSClient({
-      region: localstack.region,
-      endpoint: localstack.endpoint,
-      credentials: localstack.credentials
+      region: floci.region,
+      endpoint: floci.endpoint,
+      credentials: floci.credentials
     })
 
     // Create unique queue names for this test to ensure isolation
@@ -107,12 +103,12 @@ const sqsClientFixture = {
 /**
  * Extended test with SQS fixtures.
  * Each test gets:
- * - localstack: shared container (file scope)
+ * - floci: shared container (file scope)
  * - sqsClient: fresh client with unique queues per test (test scope)
  *
  * Access queue names via sqsClient.queueName and sqsClient.dlqName
  */
 export const it = baseTest.extend({
-  ...localstackFixture,
+  ...flociFixture,
   ...sqsClientFixture
 })

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker compose --profile stub up
 
 **Supporting services included:**
 
-- LocalStack (AWS service emulation)
+- Floci (AWS service emulation)
 - MongoDB (backend only)
 - Redis (frontend + supporting services)
 - nginx-proxy (frontend only)

--- a/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
@@ -15,7 +15,7 @@ const TEST_TIMEOUT = 30000
  * Integration tests for SQS command executor.
  *
  * These tests verify that the executor correctly sends messages to an SQS queue
- * (via LocalStack). They focus on:
+ * (via Floci). They focus on:
  * - Queue URL resolution
  * - Message format and content
  * - User context serialisation

--- a/src/server/queue-consumer/consumer.integration.test.js
+++ b/src/server/queue-consumer/consumer.integration.test.js
@@ -48,7 +48,7 @@ const stopConsumerAndWait = (consumer) => {
  * Integration tests for SQS command queue consumer.
  *
  * These tests verify the consumer's interaction with a real SQS queue
- * (via LocalStack). They focus on:
+ * (via Floci). They focus on:
  * - Queue connection and URL resolution
  * - Message receipt and deletion
  * - Error handling at the SQS level


### PR DESCRIPTION
Ticket: [PAE-1360](https://eaflood.atlassian.net/browse/PAE-1360)

Swap LocalStack for Floci (`hectorvent/floci:1.5.3`) in the Vitest testcontainers fixture under `.vite/fixtures/sqs.js`. Completes the epr-backend LocalStack retirement started by [#1082](https://github.com/DEFRA/epr-backend/pull/1082), which migrated the sibling cdp-uploader fixture.

LocalStack Community Edition was sunset in March 2026 — the new image requires an auth token and security updates are frozen. The PAE-1357 spike settled on Floci as the replacement.

## Changes

- Replace the LocalStack container with a Floci container in `.vite/fixtures/sqs.js`
- Drop LocalStack-specific `SERVICES` and `DEFAULT_REGION` env vars in favour of `FLOCI_DEFAULT_REGION`; drop the `Ready.` log-message wait strategy (testcontainers' default port-readiness wait is sufficient for this standalone Floci container, matching the pattern in `.vite/fixtures/cdp-uploader.js`)
- Rename the exported `localstack` fixture key to `floci` and the internal `localstackFixture` constant to `flociFixture`
- Update the two integration-test consumers (`src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js`, `src/server/queue-consumer/consumer.integration.test.js`) to reflect `via Floci` in JSDoc
- Update `README.md` supporting-services list from `LocalStack (AWS service emulation)` to `Floci (AWS service emulation)`, so the docs match the now fully migrated stack

[PAE-1360]: https://eaflood.atlassian.net/browse/PAE-1360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ