### PR TITLE
PAE-1385: validate pr-preparation pin-check (do not merge)

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -21,7 +21,7 @@ jobs:
       docs-only: ${{ steps.check.outputs.docs-only }}
     steps:
       - name: Prepare PR
-        uses: DEFRA/epr-re-ex-service/.github/actions/pr-preparation@main
+        uses: DEFRA/epr-re-ex-service/.github/actions/pr-preparation@PAE-1385-add-ci-pin-check
 
       - name: Check for docs-only changes
         id: check


### PR DESCRIPTION
Ticket: [PAE-1385](https://eaflood.atlassian.net/browse/PAE-1385)
validation-only PR for PAE-1385 child 2 (https://github.com/DEFRA/epr-re-ex-service/pull/191).

points this repo's check-pull-request workflow at the `PAE-1385-add-ci-pin-check` branch of the shared action. expected CI result: the new pin-check step fails because epr-backend currently has 4 caret-pinned entries in package.json.

- `dependencies.@aws-sdk/lib-storage` -> ^3.1000.0
- `overrides.fast-xml-parser` -> ^5.5.7
- `overrides.follow-redirects` -> ^1.16.0
- `overrides.protobufjs` -> ^7.5.5

**do not merge.** this PR will be closed once CI has confirmed the failure. PAE-1385 child 1 will separately flatten the offending entries.

[PAE-1385]: https://eaflood.atlassian.net/browse/PAE-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ