### PR TITLE
PAE-1385: pin unpinned dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-s3": "3.1000.0",
         "@aws-sdk/client-sqs": "3.1000.0",
         "@aws-sdk/credential-providers": "3.1000.0",
-        "@aws-sdk/lib-storage": "^3.1000.0",
+        "@aws-sdk/lib-storage": "3.1000.0",
         "@aws-sdk/s3-request-presigner": "3.1000.0",
         "@defra/cdp-auditing": "0.6.0",
         "@defra/hapi-secure-context": "0.4.0",
@@ -1206,6 +1206,26 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
+      "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
@@ -2836,18 +2856,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
-    },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7954,27 +7962,6 @@
       "license": "MIT",
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastq": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/client-s3": "3.1000.0",
     "@aws-sdk/client-sqs": "3.1000.0",
     "@aws-sdk/credential-providers": "3.1000.0",
-    "@aws-sdk/lib-storage": "^3.1000.0",
+    "@aws-sdk/lib-storage": "3.1000.0",
     "@aws-sdk/s3-request-presigner": "3.1000.0",
     "@defra/cdp-auditing": "0.6.0",
     "@defra/hapi-secure-context": "0.4.0",
@@ -100,10 +100,10 @@
     "undici": "7.24.0"
   },
   "overrides": {
-    "fast-xml-parser": "^5.5.7",
-    "follow-redirects": "^1.16.0",
+    "fast-xml-parser": "5.5.7",
+    "follow-redirects": "1.16.0",
     "glob": "11.1.0",
-    "protobufjs": "^7.5.5"
+    "protobufjs": "7.5.5"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "4.0.18",


### PR DESCRIPTION
Ticket: [PAE-1385](https://eaflood.atlassian.net/browse/PAE-1385)
pins unpinned caret/tilde dependency ranges in package.json so the new shared CI pin-check (PAE-1385 child 2) stops blocking PRs.

- flattens offending entries to exact versions
- regenerates package-lock.json (no runtime change -- lockfile already resolves to the same versions)

child 1 of PAE-1385; sibling flatten PRs in the other affected repos.

[PAE-1385]: https://eaflood.atlassian.net/browse/PAE-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ