### PR TITLE
PAE-000: Fix fast-xml-parser vulnerability and prune stale overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1208,26 +1208,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
-      "version": "5.5.7",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
-      "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.2.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
@@ -2856,6 +2836,18 @@
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7962,6 +7954,27 @@
       "license": "MIT",
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastq": {

--- a/package.json
+++ b/package.json
@@ -100,10 +100,8 @@
     "undici": "7.24.0"
   },
   "overrides": {
-    "fast-xml-parser": "5.5.7",
-    "follow-redirects": "1.16.0",
-    "glob": "11.1.0",
-    "protobufjs": "7.5.5"
+    "fast-xml-parser": "5.7.1",
+    "glob": "11.1.0"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "4.0.18",


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
Bumps the `fast-xml-parser` override from 5.5.7 to 5.7.1 to patch GHSA-gh4j-gqv2-49f6 (XML Comment and CDATA Injection via Unescaped Delimiters). The override is needed because the AWS SDK v3 still bundles `fast-xml-parser` <5.7 through `@aws-sdk/xml-builder`, so upgrading the SDK on its own doesn't fix it.

While here, prunes two overrides that are no longer doing anything: `follow-redirects` at 1.16.0 and `protobufjs` at 7.5.5. Both were verified by removing them, resolving the lockfile, and confirming neither `npm audit` nor `snyk test` flagged anything new. The `glob` override at 11.1.0 is retained because removing it lets `exceljs > archiver > glob@7` pull in `inflight@1.0.6` (SNYK-JS-INFLIGHT-6095116).

The remaining `uuid <14.0.0` advisory (GHSA-w5hq-g745-h8pq) is out of scope — it is transitive via `exceljs` and `dockerode` / `testcontainers`, and the only `npm audit fix --force` path downgrades `exceljs` to 3.4.0 which is a breaking change.