### PR TITLE
PAE-1339: Guard journey summary jq against orphan allure results

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -130,7 +130,8 @@ jobs:
                   if . >= 60 then "\(. / 60 | floor)m \(. % 60)s"
                   else "\(.)s"
                   end;
-                sort_by(-.stop + .start) | .[0:5][]
+                map(select(.start != null and .stop != null))
+                | sort_by(-.stop + .start) | .[0:5][]
                 | ((.stop - .start) / 1000 | round) as $secs
                 | "| \(.name) | \($secs | fmt_secs) |"
               ' allure-results/*-result.json)


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
## What
The `Write journey test summary` step in `check-pull-request.yml` now skips allure-results entries that are missing `.start` or `.stop` before sorting, instead of letting `sort_by(-.stop + .start)` blow up with `null (null) cannot be negated`.

## Why
WebdriverIO `specFileRetries` plus a flaky step can leave an orphan `*-result.json` in the allure directory with no `.stop` field, even when the overall test run passes. The orphan tripped the jq script and turned the post-step red on green runs.

Filtering is preferred over coalescing with `// 0` so orphans don't appear as 0-second entries in the "Slowest Journey Tests" table — the output stays honest.

The passed/failed/total query a dozen lines up keys on `.status`, not `.start`/`.stop`, so it was already null-safe and is untouched.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ