### PR TITLE
PAE-1389: Add applicationContactDetails to registration document

### DIFF
--- a/src/domain/organisations/registration.js
+++ b/src/domain/organisations/registration.js
@@ -43,6 +43,7 @@
  *  site: RegistrationSite;
  *  submittedToRegulator: string;
  *  submitterContactDetails: User;
+ *  applicationContactDetails?: User;
  *  wasteProcessingType: string;
  *  reprocessingType?: ReprocessingType;
  *  overseasSites?: Record<string, {overseasSiteId: string}>;

--- a/src/forms-submission-data/registration/extract-contacts.js
+++ b/src/forms-submission-data/registration/extract-contacts.js
@@ -15,6 +15,27 @@ export function getSubmitterDetails(answersByShortDescription) {
   }
 }
 
+export function getApplicationContactDetails(answersByShortDescription) {
+  return {
+    fullName:
+      answersByShortDescription[
+        REGISTRATION.APPLICATION_CONTACT_DETAILS.fields.NAME
+      ],
+    email:
+      answersByShortDescription[
+        REGISTRATION.APPLICATION_CONTACT_DETAILS.fields.EMAIL
+      ],
+    phone:
+      answersByShortDescription[
+        REGISTRATION.APPLICATION_CONTACT_DETAILS.fields.TELEPHONE_NUMBER
+      ],
+    jobTitle:
+      answersByShortDescription[
+        REGISTRATION.APPLICATION_CONTACT_DETAILS.fields.JOB_TITLE
+      ]
+  }
+}
+
 export function getApprovedPersons(answersByShortDescription) {
   const approvedPerson = {
     fullName:

--- a/src/forms-submission-data/registration/form-field-constants.js
+++ b/src/forms-submission-data/registration/form-field-constants.js
@@ -95,6 +95,14 @@ export const REGISTRATION = {
       JOB_TITLE: APP_CONTACT_JOB_TITLE
     }
   },
+  APPLICATION_CONTACT_DETAILS: {
+    fields: {
+      NAME: APP_CONTACT_NAME,
+      EMAIL: APP_CONTACT_EMAIL,
+      TELEPHONE_NUMBER: APP_CONTACT_TELEPHONE,
+      JOB_TITLE: APP_CONTACT_JOB_TITLE
+    }
+  },
   ENV_PERMIT_DETAILS: {
     title: 'Environmental permit or waste management licence details',
     fields: {

--- a/src/forms-submission-data/registration/transform-registration.js
+++ b/src/forms-submission-data/registration/transform-registration.js
@@ -18,6 +18,7 @@ import { WASTE_PROCESSING_TYPE } from '#domain/organisations/model.js'
 import { getWasteManagementPermits } from '#formsubmission/registration/extract-permits.js'
 import { getSiteDetails } from '#formsubmission/registration/extract-site.js'
 import {
+  getApplicationContactDetails,
   getSubmitterDetails,
   getApprovedPersons
 } from '#formsubmission/registration/extract-contacts.js'
@@ -69,6 +70,9 @@ function buildParsedRegistration(id, rawSubmissionData) {
         REGISTRATION.ORGANISATION_DETAILS.fields.ORG_NAME
       ],
     submitterContactDetails: getSubmitterDetails(answersByShortDescription),
+    applicationContactDetails: getApplicationContactDetails(
+      answersByShortDescription
+    ),
     site: isReprocessor
       ? getSiteDetails(answersByShortDescription, answersByPages)
       : undefined,

--- a/src/forms-submission-data/registration/transform-registration.test.js
+++ b/src/forms-submission-data/registration/transform-registration.test.js
@@ -51,6 +51,12 @@ describe('parseRegistrationSubmission - Integration Tests with Fixture Data', ()
         phone: '1234567890',
         jobTitle: 'Packaging Compliance Officer'
       },
+      applicationContactDetails: {
+        fullName: 'Sarah Mitchell',
+        email: 'reexserviceteam@defra.gov.uk',
+        phone: '1234567890',
+        jobTitle: 'Packaging Compliance Officer'
+      },
       site: undefined,
       noticeAddress: {
         line1: '45',
@@ -180,6 +186,12 @@ describe('parseRegistrationSubmission - Integration Tests with Fixture Data', ()
         'Optical sorting machine (Model XR-500), industrial crusher producing 10-40mm cullet, trommel screen (50mm aperture), magnetic separator, vibrating screens for grading, wash and rinse facility, rotary dryer, storage bunkers (50 tonne capacity), conveyor belt system (50m length), bag splitter, dust extraction system, weighbridge (60 tonne)',
       exportPorts: undefined,
       submitterContactDetails: {
+        fullName: 'James Patterson',
+        email: 'reexserviceteam@defra.gov.uk',
+        phone: '020 7946 0123',
+        jobTitle: 'Director'
+      },
+      applicationContactDetails: {
         fullName: 'James Patterson',
         email: 'reexserviceteam@defra.gov.uk',
         phone: '020 7946 0123',

--- a/src/repositories/organisations/schema/registration.js
+++ b/src/repositories/organisations/schema/registration.js
@@ -148,6 +148,7 @@ export const registrationSchema = Joi.object({
   ),
   plantEquipmentDetails: requiredForReprocessor(Joi.string()),
   submitterContactDetails: userSchema.required(),
+  applicationContactDetails: userSchema.optional(),
   samplingInspectionPlanPart1FileUploads: Joi.array()
     .items(formFileUploadSchema)
     .required(),


### PR DESCRIPTION
Ticket: [PAE-1389](https://eaflood.atlassian.net/browse/PAE-1389)
## Changes

- Add `APPLICATION_CONTACT_DETAILS` section to `REGISTRATION` form-field constants grouping the existing `APP_CONTACT_*` fields
- Add `getApplicationContactDetails` extractor in `extract-contacts.js` and wire it into `buildParsedRegistration`
- Add optional `applicationContactDetails` field to `registrationSchema` (optional to avoid breaking validation for existing documents pre-migration)
- Add `applicationContactDetails` to `RegistrationBase` typedef and assert it in exporter/reprocessor test cases

[PAE-1389]: https://eaflood.atlassian.net/browse/PAE-1389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ