### PR TITLE
PAE-1288: Show raw body when DLQ message is not valid JSON

### DIFF
--- a/src/plugins/dlq-admin.js
+++ b/src/plugins/dlq-admin.js
@@ -20,7 +20,7 @@ import {
  * @property {string} messageId
  * @property {string|null} sentTimestamp - ISO 8601 timestamp, or null if unavailable
  * @property {number} approximateReceiveCount
- * @property {object|null} command - Parsed message body, or null if not valid JSON
+ * @property {object|string} command - Parsed message body, or raw body string if not valid JSON
  * @property {string} body - Raw message body
  */
 
@@ -73,11 +73,11 @@ export const dlqAdminPlugin = {
         ])
 
         const messages = rawMessages.map((msg) => {
-          let command = null
+          let command
           try {
             command = JSON.parse(msg.body)
           } catch {
-            // body is not valid JSON — leave command as null
+            command = msg.body
           }
 
           return { ...msg, command }

--- a/src/plugins/dlq-admin.test.js
+++ b/src/plugins/dlq-admin.test.js
@@ -132,7 +132,7 @@ describe('dlqAdminPlugin', () => {
     expect(purgeResponse.result).toEqual({ purged: true })
   })
 
-  it('sets command to null when body is not valid JSON', async () => {
+  it('sets command to the raw body string when body is not valid JSON', async () => {
     vi.mocked(getApproximateMessageCount).mockResolvedValue(1)
     vi.mocked(receiveMessages).mockResolvedValue([
       {
@@ -156,7 +156,7 @@ describe('dlqAdminPlugin', () => {
       url: '/test-messages'
     })
 
-    expect(response.result.messages[0].command).toBeNull()
+    expect(response.result.messages[0].command).toBe('not-json')
   })
 
   it('destroys SQS client on server stop', async () => {


### PR DESCRIPTION
Ticket: [PAE-1288](https://eaflood.atlassian.net/browse/PAE-1288)
## What

When a DLQ message body cannot be parsed as JSON, the `command` field was set to `null`, leaving the admin UI blank with no indication of what the message contained.

## Why

Operators using the DLQ admin interface had no visibility into malformed messages. The raw body string is more useful than a blank field — it lets operators diagnose what was in the message.

## Change

Fall back to the raw body string instead of `null` when JSON parsing fails.

## Testing

Updated the existing test for this behaviour to assert the raw string is returned rather than `null`.

[PAE-1288]: https://eaflood.atlassian.net/browse/PAE-1288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ