### PR TITLE
PAE-1197: Copy operator uploaded files during forms data migration

### DIFF
--- a/src/forms-submission-data/migration/copy-operator-uploaded-files.js
+++ b/src/forms-submission-data/migration/copy-operator-uploaded-files.js
@@ -1,0 +1,49 @@
+import { logger } from '#common/helpers/logging/logger.js'
+
+function extractFilesFromSubmission(submission) {
+  const regulator = submission.submittedToRegulator
+  return [
+    ...(submission.samplingInspectionPlanPart1FileUploads ?? []),
+    ...(submission.samplingInspectionPlanPart2FileUploads ?? []),
+    ...(submission.orsFileUploads ?? [])
+  ].map((f) => ({ fileId: f.defraFormUploadedFileId, regulator }))
+}
+
+/**
+ * Copy uploaded files for newly migrated reg/acc submissions.
+ * Errors are logged but do not abort processing.
+ *
+ * @param {Array} registrations - Transformed registration objects
+ * @param {Array} accreditations - Transformed accreditation objects
+ * @param {object} formsFileUploadsRepository
+ */
+export async function copyOperatorUploadedFiles(
+  registrations,
+  accreditations,
+  formsFileUploadsRepository
+) {
+  const filesToCopy = [...registrations, ...accreditations].flatMap(
+    extractFilesFromSubmission
+  )
+
+  logger.info({
+    message: `Copying ${filesToCopy.length} operator uploaded files for ${registrations.length} registrations and ${accreditations.length} accreditations`
+  })
+
+  let failedCount = 0
+  for (const { fileId, regulator } of filesToCopy) {
+    try {
+      await formsFileUploadsRepository.copyFormFileToS3({ fileId, regulator })
+    } catch (error) {
+      failedCount++
+      logger.error({
+        err: error,
+        message: `Failed to copy operator uploaded file — fileId: ${fileId}`
+      })
+    }
+  }
+
+  logger.info({
+    message: `Finished copying operator uploaded files, total: ${filesToCopy.length}, failed: ${failedCount}`
+  })
+}

--- a/src/forms-submission-data/migration/copy-operator-uploaded-files.test.js
+++ b/src/forms-submission-data/migration/copy-operator-uploaded-files.test.js
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { copyOperatorUploadedFiles } from './copy-operator-uploaded-files.js'
+import { createInMemoryFormsFileUploadsRepository } from '#adapters/repositories/forms-submissions/inmemory.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const { logger } = await import('#common/helpers/logging/logger.js')
+
+function fileRef(id) {
+  return { defraFormUploadedFileId: id }
+}
+
+describe('copyOperatorUploadedFiles', () => {
+  let repository
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    repository = createInMemoryFormsFileUploadsRepository()
+  })
+
+  it('copies files from all upload arrays across registrations and accreditations', async () => {
+    const registrations = [
+      {
+        submittedToRegulator: 'ea',
+        samplingInspectionPlanPart1FileUploads: [
+          fileRef('p1-a'),
+          fileRef('p1-b')
+        ],
+        orsFileUploads: [fileRef('ors-a')]
+      }
+    ]
+    const accreditations = [
+      {
+        submittedToRegulator: 'niea',
+        samplingInspectionPlanPart2FileUploads: [fileRef('p2-a')]
+      }
+    ]
+
+    await copyOperatorUploadedFiles(registrations, accreditations, repository)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          '4 operator uploaded files for 1 registrations and 1 accreditations'
+        )
+      })
+    )
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Finished copying operator uploaded files, total: 4, failed: 0'
+    })
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('logs error and continues when a file copy fails', async () => {
+    const copyError = new Error('S3 unavailable')
+    const failingRepo = {
+      copyFormFileToS3: vi
+        .fn()
+        .mockRejectedValueOnce(copyError)
+        .mockResolvedValue(undefined)
+    }
+
+    const registrations = [
+      {
+        submittedToRegulator: 'ea',
+        samplingInspectionPlanPart1FileUploads: [
+          fileRef('file-fail'),
+          fileRef('file-ok')
+        ]
+      }
+    ]
+
+    await copyOperatorUploadedFiles(registrations, [], failingRepo)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: copyError,
+      message: 'Failed to copy operator uploaded file — fileId: file-fail'
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Finished copying operator uploaded files, total: 2, failed: 1'
+    })
+    expect(failingRepo.copyFormFileToS3).toHaveBeenCalledTimes(2)
+  })
+
+  it('does nothing when submissions have no files', async () => {
+    await copyOperatorUploadedFiles(
+      [{ submittedToRegulator: 'ea' }],
+      [{ submittedToRegulator: 'sepa' }],
+      repository
+    )
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Finished copying operator uploaded files, total: 0, failed: 0'
+    })
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+})

--- a/src/forms-submission-data/migration/migration-orchestrator.js
+++ b/src/forms-submission-data/migration/migration-orchestrator.js
@@ -8,6 +8,7 @@ import { systemReferencesRequiringOrgIdMatch } from '#formsubmission/data-migrat
 import { transformAll } from './submission-transformer.js'
 import { getSubmissionsToMigrate } from './migration-delta-calculator.js'
 import { upsertOrganisations } from './organisation-persistence.js'
+import { copyOperatorUploadedFiles } from './copy-operator-uploaded-files.js'
 
 /**
  * @import {FormSubmissionsRepository} from '#repositories/form-submissions/port.js'
@@ -21,15 +22,18 @@ export class MigrationOrchestrator {
    * @param {FormSubmissionsRepository} formsSubmissionRepository
    * @param {OrganisationsRepository} organisationsRepository
    * @param {SystemLogsRepository} systemLogsRepository
+   * @param {object} formsFileUploadsRepository
    */
   constructor(
     formsSubmissionRepository,
     organisationsRepository,
-    systemLogsRepository
+    systemLogsRepository,
+    formsFileUploadsRepository
   ) {
     this.formsSubmissionRepository = formsSubmissionRepository
     this.organisationsRepository = organisationsRepository
     this.systemLogsRepository = systemLogsRepository
+    this.formsFileUploadsRepository = formsFileUploadsRepository
   }
 
   linkRegistrations(organisations, registrations) {
@@ -110,7 +114,13 @@ export class MigrationOrchestrator {
       accreditations
     )
 
-    return linkRegistrationToAccreditations(organisationsWithAccreditations)
+    return {
+      organisations: linkRegistrationToAccreditations(
+        organisationsWithAccreditations
+      ),
+      registrations,
+      accreditations
+    }
   }
 
   prepareMigrationItems(organisations, submissionsToMigrate) {
@@ -161,7 +171,7 @@ export class MigrationOrchestrator {
       accreditations: migratedIds.accreditations
     }
 
-    const organisations = await this.transformAndLinkAllNewSubmissions(
+    const { organisations } = await this.transformAndLinkAllNewSubmissions(
       migrated,
       pendingMigration
     )
@@ -210,10 +220,8 @@ export class MigrationOrchestrator {
       message: `Found ${pendingMigration.organisations.size} organisations, ${pendingMigration.registrations.size} registrations, ${pendingMigration.accreditations.size} accreditations to migrate`
     })
 
-    const organisations = await this.transformAndLinkAllNewSubmissions(
-      migrated,
-      pendingMigration
-    )
+    const { organisations, registrations, accreditations } =
+      await this.transformAndLinkAllNewSubmissions(migrated, pendingMigration)
 
     const migrationItems = this.prepareMigrationItems(
       organisations,
@@ -225,6 +233,12 @@ export class MigrationOrchestrator {
       this.systemLogsRepository,
       migrationItems
     )
+
+    await copyOperatorUploadedFiles(
+      registrations,
+      accreditations,
+      this.formsFileUploadsRepository
+    )
   }
 }
 
@@ -232,17 +246,20 @@ export class MigrationOrchestrator {
  * @param {FormSubmissionsRepository} formsSubmissionRepository
  * @param {OrganisationsRepository} organisationsRepository
  * @param {SystemLogsRepository} systemLogsRepository
+ * @param {object} formsFileUploadsRepository
  * @returns {FormDataMigrator}
  */
 export function createFormDataMigrator(
   formsSubmissionRepository,
   organisationsRepository,
-  systemLogsRepository
+  systemLogsRepository,
+  formsFileUploadsRepository
 ) {
   const orchestrator = new MigrationOrchestrator(
     formsSubmissionRepository,
     organisationsRepository,
-    systemLogsRepository
+    systemLogsRepository,
+    formsFileUploadsRepository
   )
 
   /** @type {FormDataMigrator} */

--- a/src/forms-submission-data/migration/migration-orchestrator.test.js
+++ b/src/forms-submission-data/migration/migration-orchestrator.test.js
@@ -8,6 +8,7 @@ import {
 import { transformAll } from './submission-transformer.js'
 import { getSubmissionsToMigrate } from './migration-delta-calculator.js'
 import { upsertOrganisations } from './organisation-persistence.js'
+import { copyOperatorUploadedFiles } from './copy-operator-uploaded-files.js'
 import {
   linkItemsToOrganisations,
   linkRegistrationToAccreditations
@@ -33,6 +34,10 @@ vi.mock('./organisation-persistence.js', () => ({
   upsertOrganisations: vi.fn().mockResolvedValue({ successful: [], failed: [] })
 }))
 
+vi.mock('./copy-operator-uploaded-files.js', () => ({
+  copyOperatorUploadedFiles: vi.fn().mockResolvedValue(undefined)
+}))
+
 vi.mock('#formsubmission/link-form-submissions.js', () => ({
   linkItemsToOrganisations: vi.fn(),
   linkRegistrationToAccreditations: vi.fn()
@@ -46,6 +51,7 @@ describe('MigrationOrchestrator', () => {
   let formsSubmissionRepository
   let organisationsRepository
   let systemLogsRepository
+  let formsFileUploadsRepository
   let migrator
 
   // Reusable mock helpers
@@ -116,10 +122,15 @@ describe('MigrationOrchestrator', () => {
       insert: vi.fn()
     }
 
+    formsFileUploadsRepository = {
+      copyFormFileToS3: vi.fn().mockResolvedValue(undefined)
+    }
+
     migrator = createFormDataMigrator(
       formsSubmissionRepository,
       organisationsRepository,
-      systemLogsRepository
+      systemLogsRepository,
+      formsFileUploadsRepository
     )
 
     // Default mock implementations
@@ -276,6 +287,42 @@ describe('MigrationOrchestrator', () => {
         ])
       )
     })
+
+    it('should call copyOperatorUploadedFiles with transformed registrations and accreditations after upsert', async () => {
+      const orgId = new ObjectId().toString()
+      const regId = new ObjectId().toString()
+      const accrId = new ObjectId().toString()
+
+      getSubmissionsToMigrate.mockResolvedValue(
+        createMockDelta([], [orgId], [regId], [accrId])
+      )
+
+      const org = createOrg(orgId)
+      const reg = createReg(regId, orgId)
+      const accr = createAccr(accrId, orgId)
+
+      transformAll.mockResolvedValue({
+        organisations: [org],
+        registrations: [reg],
+        accreditations: [accr]
+      })
+
+      await migrator.migrate()
+
+      expect(copyOperatorUploadedFiles).toHaveBeenCalledWith(
+        [reg],
+        [accr],
+        formsFileUploadsRepository
+      )
+    })
+
+    it('should not call copyOperatorUploadedFiles when there are no submissions to migrate', async () => {
+      getSubmissionsToMigrate.mockResolvedValue(createMockDelta())
+
+      await migrator.migrate()
+
+      expect(copyOperatorUploadedFiles).not.toHaveBeenCalled()
+    })
   })
 
   describe('migrateById()', () => {
@@ -288,7 +335,8 @@ describe('MigrationOrchestrator', () => {
       orchestrator = new MigrationOrchestrator(
         formsSubmissionRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        formsFileUploadsRepository
       )
     })
 

--- a/src/routes/v1/dev/form-submissions/migrate/post.js
+++ b/src/routes/v1/dev/form-submissions/migrate/post.js
@@ -3,6 +3,9 @@ import { StatusCodes } from 'http-status-codes'
 import Joi from 'joi'
 
 import { MigrationOrchestrator } from '#formsubmission/migration/migration-orchestrator.js'
+import { createS3Client } from '#common/helpers/s3/s3-client.js'
+import { createFormsFileUploadsRepository } from '#adapters/repositories/forms-submissions/forms-file-uploads.js'
+import { config } from '../../../../../config.js'
 
 /** @import {HapiRequest} from '#common/hapi-types.js' */
 /** @import {FormSubmissionsRepository} from '#repositories/form-submissions/port.js' */
@@ -43,10 +46,20 @@ async function handler(request, h) {
   } = request
   const { id } = request.params
 
+  const s3Client = createS3Client({
+    region: config.get('awsRegion'),
+    endpoint: config.get('s3Endpoint'),
+    forcePathStyle: config.get('isDevelopment')
+  })
+  const formsFileUploadsRepository = createFormsFileUploadsRepository({
+    s3Client
+  })
+
   const orchestrator = new MigrationOrchestrator(
     formSubmissionsRepository,
     organisationsRepository,
-    systemLogsRepository
+    systemLogsRepository,
+    formsFileUploadsRepository
   )
 
   const result = await orchestrator.migrateById(id)

--- a/src/server/run-forms-data-migration.js
+++ b/src/server/run-forms-data-migration.js
@@ -3,6 +3,9 @@ import { createFormDataMigrator } from '#formsubmission/migration/migration-orch
 import { createFormSubmissionsRepository } from '#repositories/form-submissions/mongodb.js'
 import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
+import { createS3Client } from '#common/helpers/s3/s3-client.js'
+import { createFormsFileUploadsRepository } from '#adapters/repositories/forms-submissions/forms-file-uploads.js'
+import { config } from '../config.js'
 
 export const runFormsDataMigration = async (server) => {
   try {
@@ -28,10 +31,20 @@ export const runFormsDataMigration = async (server) => {
         await createSystemLogsRepository(server.db)
       )(logger)
 
+      const s3Client = createS3Client({
+        region: config.get('awsRegion'),
+        endpoint: config.get('s3Endpoint'),
+        forcePathStyle: config.get('isDevelopment')
+      })
+      const formsFileUploadsRepository = createFormsFileUploadsRepository({
+        s3Client
+      })
+
       const formsDataMigration = createFormDataMigrator(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        formsFileUploadsRepository
       )
 
       await formsDataMigration.migrate()


### PR DESCRIPTION
Ticket: [PAE-1197](https://eaflood.atlassian.net/browse/PAE-1197)
- Add `copy-operator-uploaded-files.js` to extract file IDs from transformed reg/acc submissions and copy each to S3 via `formsFileUploadsRepository.copyFormFileToS3`
- Update `MigrationOrchestrator` to accept `formsFileUploadsRepository` as a 4th constructor param and call file copy after `upsertOrganisations()` in `migrate()`
- Change `transformAndLinkAllNewSubmissions` to return `{ organisations, registrations, accreditations }` so the flat arrays are available to the file copy step
- Wire up S3 client and `formsFileUploadsRepository` creation in `run-forms-data-migration.js`

[PAE-1197]: https://eaflood.atlassian.net/browse/PAE-1197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ