### PR TITLE
PAE-250: Fix uuid vulnerability via override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6974,20 +6974,6 @@
         "tar-stream": "^2.1.4"
       }
     },
-    "node_modules/dockerode/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -13657,12 +13643,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validator": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
   },
   "overrides": {
     "fast-xml-parser": "5.7.1",
-    "glob": "11.1.0"
+    "glob": "11.1.0",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "4.0.18",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "overrides": {
     "fast-xml-parser": "5.7.1",
     "glob": "11.1.0",
-    "uuid": "^14.0.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "4.0.18",


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
The `uuid` package below 14.0.0 has a missing buffer bounds check in v3/v5/v6 when `buf` is provided ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq), [SNYK-JS-UUID-16133035](https://security.snyk.io/vuln/SNYK-JS-UUID-16133035)). It reaches this repo transitively via `exceljs` (spreadsheet generation) and `dockerode` (testcontainers for integration tests).

Both introducers still ship older uuid ranges, so this pins `uuid` to `^14.0.0` via an `overrides` entry in `package.json` rather than downgrading `exceljs` or `dockerode`. The consumers only use `uuid.v4()`, which is unchanged in v14.

After the override, `npm audit` and `snyk test` both report zero vulnerable paths.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ