### PR TITLE
PAE-1391: Detect saxes parse errors by stack-trace origin

### DIFF
--- a/src/adapters/parsers/summary-logs/exceljs-parser.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.js
@@ -50,12 +50,21 @@ const CORRUPT_ZIP_MESSAGE =
   /central directory|invalid signature|compressed\/uncompressed size|corrupted zip|end of data reached/i
 
 /**
- * Error messages from saxes (or exceljs' XML layer) when an xlsx's XML
- * parts are malformed. Errors of class `SaxesError` are also matched
- * separately by `error.name`.
+ * Error messages from exceljs' own XML layer when an xlsx's XML parts are
+ * malformed. Saxes-originated errors are detected separately via stack
+ * origin (see `SAXES_STACK_ORIGIN`).
  */
 const MALFORMED_XML_MESSAGE =
   /invalid character in xml|xml parsing|unexpected token in xml/i
+
+/**
+ * Stack-trace marker for errors originating inside the saxes XML parser.
+ * Saxes's `makeError` creates plain `Error` instances with `line:column:`
+ * prefixed messages ("3:31: unexpected close tag."), so neither `error.name`
+ * nor the message wording is a reliable signal on its own. The stack
+ * origin is.
+ */
+const SAXES_STACK_ORIGIN = /node_modules[\\/]saxes[\\/]/
 
 /**
  * Decide whether an error thrown during workbook load should be wrapped
@@ -93,7 +102,10 @@ export const shouldWrapAsSpreadsheetError = (error) => {
     return true
   }
 
-  if (error.name === 'SaxesError') {
+  if (
+    error.name === 'SaxesError' ||
+    SAXES_STACK_ORIGIN.test(error.stack ?? '')
+  ) {
     return true
   }
 

--- a/src/adapters/parsers/summary-logs/exceljs-parser.test.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.test.js
@@ -2529,6 +2529,25 @@ describe('shouldWrapAsSpreadsheetError', () => {
     expect(shouldWrapAsSpreadsheetError(error)).toBe(true)
   })
 
+  it('should wrap saxes-originated errors by stack trace', () => {
+    const error = new Error('3:31: unexpected close tag.')
+    error.stack = [
+      'Error: 3:31: unexpected close tag.',
+      '    at SaxesParser.makeError (/home/node/node_modules/saxes/saxes.js:410:16)',
+      '    at SaxesParser.fail (/home/node/node_modules/saxes/saxes.js:422:26)',
+      '    at SaxesParser.closeTag (/home/node/node_modules/saxes/saxes.js:2019:18)'
+    ].join('\n')
+
+    expect(shouldWrapAsSpreadsheetError(error)).toBe(true)
+  })
+
+  it('should not wrap an Error with no stack trace', () => {
+    const error = new Error('some random failure')
+    delete error.stack
+
+    expect(shouldWrapAsSpreadsheetError(error)).toBe(false)
+  })
+
   it('should wrap XML parse failures by message', () => {
     const error = new Error('Invalid character in XML at line 3')
 


### PR DESCRIPTION
Ticket: [PAE-1391](https://eaflood.atlassian.net/browse/PAE-1391)
## Summary
Follow-up to the earlier parser error wrapping work.

A saxes XML parse error (malformed xlsx with an unclosed tag) was still logging at error level instead of being wrapped as a `SpreadsheetValidationError`. The existing saxes detection relied on `error.name === 'SaxesError'` and a narrow message regex, but saxes's `makeError` creates plain `Error` instances with `line:column:` prefixed messages that match neither. Detection now also keys off the stack trace, which reliably shows a saxes origin regardless of how the library names or words the error.

## What Changed
- Added a `SAXES_STACK_ORIGIN` pattern matching `node_modules/saxes/`. The saxes check in `shouldWrapAsSpreadsheetError` now triggers on either the existing name match or a stack-trace origin match.
- Clarified the JSDoc on `MALFORMED_XML_MESSAGE` to reflect that it now handles non-saxes XML errors only.
- Added unit tests: one mirroring the exact error shape QA reported (plain `Error`, `3:31: unexpected close tag.`, saxes stack frames), and one covering the defensive fallback when an Error has no stack.

## Why
Message-based detection is fragile, it needs updating every time saxes tweaks its wording. Stack-trace origin doesn't change between versions, so this is both a fix for the reported case and a more durable detection strategy. Behaviour for unrecognised errors is unchanged: they still propagate to the existing error-level log and fire the backend alert, so genuine library defects remain visible.

[PAE-1391]: https://eaflood.atlassian.net/browse/PAE-1391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ