### PR TITLE
PAE-1382: Define waste balance ledger collection, schema and indexes

### DIFF
--- a/src/waste-balances/repository/ledger-mongodb.js
+++ b/src/waste-balances/repository/ledger-mongodb.js
@@ -1,0 +1,46 @@
+/** @import { Collection, Db } from 'mongodb' */
+
+export const WASTE_BALANCE_LEDGER_COLLECTION_NAME = 'waste-balance-transactions'
+
+/**
+ * Ensures the ledger collection exists with the indexes required by ADR 0031.
+ *
+ * Safe to call multiple times — MongoDB `createIndex` is idempotent for
+ * matching specifications.
+ *
+ * @param {Db} db
+ * @returns {Promise<Collection>}
+ */
+export async function ensureLedgerCollection(db) {
+  const collection = db.collection(WASTE_BALANCE_LEDGER_COLLECTION_NAME)
+
+  await collection.createIndex(
+    { accreditationId: 1, number: 1 },
+    { name: 'accreditationId_number', unique: true }
+  )
+
+  await collection.createIndex(
+    { 'source.summaryLogRow.wasteRecordId': 1 },
+    { name: 'summaryLogRow_wasteRecordId' }
+  )
+
+  // Compound index serves both "transactions for summary log S" queries
+  // (via summaryLogId prefix) and "transactions a specific row caused"
+  // queries (full-key lookup). A standalone summaryLogId index would be
+  // strictly redundant here.
+  await collection.createIndex(
+    {
+      'source.summaryLogRow.summaryLogId': 1,
+      'source.summaryLogRow.rowId': 1,
+      'source.summaryLogRow.rowType': 1
+    },
+    { name: 'summaryLogRow_row' }
+  )
+
+  await collection.createIndex(
+    { 'source.prnOperation.prnId': 1 },
+    { name: 'prnOperation_prnId' }
+  )
+
+  return collection
+}

--- a/src/waste-balances/repository/ledger-mongodb.test.js
+++ b/src/waste-balances/repository/ledger-mongodb.test.js
@@ -1,0 +1,127 @@
+import { describe, beforeEach, expect } from 'vitest'
+import { it as mongoIt } from '#vite/fixtures/mongo.js'
+import { MongoClient } from 'mongodb'
+
+import {
+  ensureLedgerCollection,
+  WASTE_BALANCE_LEDGER_COLLECTION_NAME
+} from './ledger-mongodb.js'
+import { buildLedgerTransaction } from './ledger-test-data.js'
+
+const DATABASE_NAME = 'epr-backend'
+
+const it = mongoIt.extend({
+  mongoClient: async ({ db }, use) => {
+    const client = await MongoClient.connect(db)
+    await use(client)
+    await client.close()
+  },
+
+  ledgerCollection: async ({ mongoClient }, use) => {
+    const database = mongoClient.db(DATABASE_NAME)
+    await ensureLedgerCollection(database)
+    await use(database.collection(WASTE_BALANCE_LEDGER_COLLECTION_NAME))
+  }
+})
+
+const indexKeyFor = (indexes, name) =>
+  indexes.find((idx) => idx.name === name)?.key
+
+const indexOptionFor = (indexes, name, option) =>
+  indexes.find((idx) => idx.name === name)?.[option]
+
+describe('ensureLedgerCollection', () => {
+  beforeEach(async ({ mongoClient }) => {
+    await mongoClient
+      .db(DATABASE_NAME)
+      .collection(WASTE_BALANCE_LEDGER_COLLECTION_NAME)
+      .deleteMany({})
+  })
+
+  describe('indexes', () => {
+    it('creates the accreditationId_number compound unique index', async ({
+      ledgerCollection
+    }) => {
+      const indexes = await ledgerCollection.indexes()
+      expect(indexKeyFor(indexes, 'accreditationId_number')).toEqual({
+        accreditationId: 1,
+        number: 1
+      })
+      expect(indexOptionFor(indexes, 'accreditationId_number', 'unique')).toBe(
+        true
+      )
+    })
+
+    it('creates the summaryLogRow_wasteRecordId index', async ({
+      ledgerCollection
+    }) => {
+      const indexes = await ledgerCollection.indexes()
+      expect(indexKeyFor(indexes, 'summaryLogRow_wasteRecordId')).toEqual({
+        'source.summaryLogRow.wasteRecordId': 1
+      })
+    })
+
+    it('creates the summaryLogRow_row compound index', async ({
+      ledgerCollection
+    }) => {
+      const indexes = await ledgerCollection.indexes()
+      expect(indexKeyFor(indexes, 'summaryLogRow_row')).toEqual({
+        'source.summaryLogRow.summaryLogId': 1,
+        'source.summaryLogRow.rowId': 1,
+        'source.summaryLogRow.rowType': 1
+      })
+    })
+
+    it('creates the prnOperation_prnId index', async ({ ledgerCollection }) => {
+      const indexes = await ledgerCollection.indexes()
+      expect(indexKeyFor(indexes, 'prnOperation_prnId')).toEqual({
+        'source.prnOperation.prnId': 1
+      })
+    })
+  })
+
+  describe('unique constraint on (accreditationId, number)', () => {
+    it('allows distinct numbers for the same accreditation', async ({
+      ledgerCollection
+    }) => {
+      await ledgerCollection.insertOne(buildLedgerTransaction({ number: 1 }))
+      await expect(
+        ledgerCollection.insertOne(buildLedgerTransaction({ number: 2 }))
+      ).resolves.toBeDefined()
+    })
+
+    it('allows the same number across different accreditations', async ({
+      ledgerCollection
+    }) => {
+      await ledgerCollection.insertOne(
+        buildLedgerTransaction({ accreditationId: 'acc-1', number: 1 })
+      )
+      await expect(
+        ledgerCollection.insertOne(
+          buildLedgerTransaction({ accreditationId: 'acc-2', number: 1 })
+        )
+      ).resolves.toBeDefined()
+    })
+
+    it('rejects duplicate (accreditationId, number)', async ({
+      ledgerCollection
+    }) => {
+      await ledgerCollection.insertOne(
+        buildLedgerTransaction({ accreditationId: 'acc-1', number: 1 })
+      )
+      await expect(
+        ledgerCollection.insertOne(
+          buildLedgerTransaction({ accreditationId: 'acc-1', number: 1 })
+        )
+      ).rejects.toThrow(/duplicate key/i)
+    })
+  })
+
+  describe('idempotency', () => {
+    it('is safe to call multiple times', async ({ mongoClient }) => {
+      const database = mongoClient.db(DATABASE_NAME)
+      await ensureLedgerCollection(database)
+      await expect(ensureLedgerCollection(database)).resolves.toBeDefined()
+    })
+  })
+})

--- a/src/waste-balances/repository/ledger-schema.js
+++ b/src/waste-balances/repository/ledger-schema.js
@@ -1,0 +1,98 @@
+import Joi from 'joi'
+
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+export const LEDGER_TRANSACTION_TYPE = Object.freeze({
+  CREDIT: 'credit',
+  DEBIT: 'debit',
+  PENDING_DEBIT: 'pending_debit'
+})
+
+export const LEDGER_SOURCE_KIND = Object.freeze({
+  SUMMARY_LOG_ROW: 'summary-log-row',
+  PRN_OPERATION: 'prn-operation',
+  MANUAL_ADJUSTMENT: 'manual-adjustment'
+})
+
+export const LEDGER_PRN_OPERATION_TYPE = Object.freeze({
+  CREATION: 'creation',
+  ISSUANCE: 'issuance',
+  ACCEPTANCE: 'acceptance',
+  CANCELLATION: 'cancellation',
+  ISSUED_CANCELLATION: 'issued_cancellation'
+})
+
+const typeValues = Object.values(LEDGER_TRANSACTION_TYPE)
+const sourceKindValues = Object.values(LEDGER_SOURCE_KIND)
+const prnOperationTypeValues = Object.values(LEDGER_PRN_OPERATION_TYPE)
+const rowTypeValues = Object.values(WASTE_RECORD_TYPE)
+
+const userSummarySchema = Joi.object({
+  id: Joi.string().required(),
+  name: Joi.string().required()
+})
+
+const summaryLogRowSourceSchema = Joi.object({
+  summaryLogId: Joi.string().required(),
+  rowId: Joi.string().required(),
+  rowType: Joi.string()
+    .valid(...rowTypeValues)
+    .required(),
+  wasteRecordId: Joi.string().required(),
+  wasteRecordVersionId: Joi.string().required()
+})
+
+const prnOperationSourceSchema = Joi.object({
+  prnId: Joi.string().required(),
+  operationType: Joi.string()
+    .valid(...prnOperationTypeValues)
+    .required()
+})
+
+const manualAdjustmentSourceSchema = Joi.object({
+  userId: Joi.string().required(),
+  reason: Joi.string().required()
+})
+
+const sourceSchema = Joi.object({
+  kind: Joi.string()
+    .valid(...sourceKindValues)
+    .required(),
+  summaryLogRow: Joi.when('kind', {
+    is: LEDGER_SOURCE_KIND.SUMMARY_LOG_ROW,
+    then: summaryLogRowSourceSchema.required(),
+    otherwise: Joi.forbidden()
+  }),
+  prnOperation: Joi.when('kind', {
+    is: LEDGER_SOURCE_KIND.PRN_OPERATION,
+    then: prnOperationSourceSchema.required(),
+    otherwise: Joi.forbidden()
+  }),
+  manualAdjustment: Joi.when('kind', {
+    is: LEDGER_SOURCE_KIND.MANUAL_ADJUSTMENT,
+    then: manualAdjustmentSourceSchema.required(),
+    otherwise: Joi.forbidden()
+  })
+})
+
+export const ledgerTransactionInsertSchema = Joi.object({
+  accreditationId: Joi.string().required(),
+  organisationId: Joi.string().required(),
+  registrationId: Joi.string().required(),
+  number: Joi.number().integer().min(1).required(),
+  type: Joi.string()
+    .valid(...typeValues)
+    .required(),
+  createdAt: Joi.date().required(),
+  createdBy: userSummarySchema.optional(),
+  amount: Joi.number().required(),
+  openingAmount: Joi.number().required(),
+  closingAmount: Joi.number().required(),
+  openingAvailableAmount: Joi.number().required(),
+  closingAvailableAmount: Joi.number().required(),
+  source: sourceSchema.required()
+})
+
+export const ledgerTransactionReadSchema = ledgerTransactionInsertSchema.keys({
+  id: Joi.string().required()
+})

--- a/src/waste-balances/repository/ledger-schema.test.js
+++ b/src/waste-balances/repository/ledger-schema.test.js
@@ -1,0 +1,387 @@
+import { describe, it, expect } from 'vitest'
+import { ObjectId } from 'mongodb'
+
+import {
+  ledgerTransactionInsertSchema,
+  ledgerTransactionReadSchema,
+  LEDGER_TRANSACTION_TYPE,
+  LEDGER_SOURCE_KIND,
+  LEDGER_PRN_OPERATION_TYPE
+} from './ledger-schema.js'
+import {
+  buildLedgerTransaction,
+  buildPrnOperationLedgerTransaction,
+  buildManualAdjustmentLedgerTransaction
+} from './ledger-test-data.js'
+
+describe('ledger transaction insert schema', () => {
+  describe('valid documents', () => {
+    it('accepts a summary-log-row transaction', () => {
+      const data = buildLedgerTransaction()
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeUndefined()
+    })
+
+    it('accepts a prn-operation transaction', () => {
+      const data = buildPrnOperationLedgerTransaction()
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeUndefined()
+    })
+
+    it('accepts a manual-adjustment transaction', () => {
+      const data = buildManualAdjustmentLedgerTransaction()
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeUndefined()
+    })
+
+    it('accepts all transaction types', () => {
+      for (const type of Object.values(LEDGER_TRANSACTION_TYPE)) {
+        const data = buildLedgerTransaction({ type })
+        const { error } = ledgerTransactionInsertSchema.validate(data)
+        expect(error).toBeUndefined()
+      }
+    })
+
+    it('accepts all PRN operation types', () => {
+      for (const operationType of Object.values(LEDGER_PRN_OPERATION_TYPE)) {
+        const data = buildPrnOperationLedgerTransaction({
+          source: {
+            kind: LEDGER_SOURCE_KIND.PRN_OPERATION,
+            prnOperation: { prnId: 'prn-1', operationType }
+          }
+        })
+        const { error } = ledgerTransactionInsertSchema.validate(data)
+        expect(error).toBeUndefined()
+      }
+    })
+
+    it('accepts negative amount for debit', () => {
+      const data = buildLedgerTransaction({
+        type: LEDGER_TRANSACTION_TYPE.DEBIT,
+        amount: -5,
+        closingAmount: -5
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeUndefined()
+    })
+
+    it('accepts closing totals equal to zero', () => {
+      const data = buildLedgerTransaction({
+        amount: 0,
+        closingAmount: 0,
+        closingAvailableAmount: 0
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeUndefined()
+    })
+  })
+
+  describe('required top-level fields', () => {
+    const topLevelRequired = [
+      'accreditationId',
+      'organisationId',
+      'registrationId',
+      'number',
+      'type',
+      'createdAt',
+      'amount',
+      'openingAmount',
+      'closingAmount',
+      'openingAvailableAmount',
+      'closingAvailableAmount',
+      'source'
+    ]
+
+    for (const field of topLevelRequired) {
+      it(`rejects when ${field} is missing`, () => {
+        const data = buildLedgerTransaction()
+        delete data[field]
+        const { error } = ledgerTransactionInsertSchema.validate(data)
+        expect(error).toBeDefined()
+      })
+    }
+  })
+
+  describe('number field', () => {
+    it('rejects zero', () => {
+      const data = buildLedgerTransaction({ number: 0 })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects negative values', () => {
+      const data = buildLedgerTransaction({ number: -1 })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects non-integer values', () => {
+      const data = buildLedgerTransaction({ number: 1.5 })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('accepts any positive integer', () => {
+      const data = buildLedgerTransaction({ number: 12345 })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeUndefined()
+    })
+  })
+
+  describe('type field', () => {
+    it('rejects invalid type value', () => {
+      const data = buildLedgerTransaction({ type: 'sideways' })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+  })
+
+  describe('createdBy field', () => {
+    it('accepts when createdBy is absent (system-generated transactions)', () => {
+      const data = buildLedgerTransaction()
+      delete data.createdBy
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeUndefined()
+    })
+
+    it('rejects when createdBy.id is missing', () => {
+      const data = buildLedgerTransaction({ createdBy: { name: 'x' } })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects when createdBy.name is missing', () => {
+      const data = buildLedgerTransaction({ createdBy: { id: 'user-1' } })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+  })
+
+  describe('source discriminated union', () => {
+    it('rejects when source.kind is missing', () => {
+      const data = buildLedgerTransaction({
+        source: { summaryLogRow: { summaryLogId: 'log-1' } }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects an unknown source.kind', () => {
+      const data = buildLedgerTransaction({
+        source: { kind: 'alien-invasion' }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects summary-log-row kind when summaryLogRow is missing', () => {
+      const data = buildLedgerTransaction({
+        source: { kind: LEDGER_SOURCE_KIND.SUMMARY_LOG_ROW }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects summary-log-row kind when prnOperation is also present', () => {
+      const data = buildLedgerTransaction({
+        source: {
+          kind: LEDGER_SOURCE_KIND.SUMMARY_LOG_ROW,
+          summaryLogRow: {
+            summaryLogId: 'log-1',
+            rowId: 'row-1',
+            rowType: 'received',
+            wasteRecordId: 'wr-1',
+            wasteRecordVersionId: 'v-1'
+          },
+          prnOperation: {
+            prnId: 'prn-1',
+            operationType: LEDGER_PRN_OPERATION_TYPE.CREATION
+          }
+        }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects prn-operation kind when prnOperation is missing', () => {
+      const data = buildLedgerTransaction({
+        source: { kind: LEDGER_SOURCE_KIND.PRN_OPERATION }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects manual-adjustment kind when manualAdjustment is missing', () => {
+      const data = buildLedgerTransaction({
+        source: { kind: LEDGER_SOURCE_KIND.MANUAL_ADJUSTMENT }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+  })
+
+  describe('summary-log-row source fields', () => {
+    const required = [
+      'summaryLogId',
+      'rowId',
+      'rowType',
+      'wasteRecordId',
+      'wasteRecordVersionId'
+    ]
+
+    for (const field of required) {
+      it(`rejects when source.summaryLogRow.${field} is missing`, () => {
+        const data = buildLedgerTransaction()
+        delete data.source.summaryLogRow[field]
+        const { error } = ledgerTransactionInsertSchema.validate(data)
+        expect(error).toBeDefined()
+      })
+    }
+
+    it('rejects an unknown rowType', () => {
+      const data = buildLedgerTransaction({
+        source: {
+          kind: LEDGER_SOURCE_KIND.SUMMARY_LOG_ROW,
+          summaryLogRow: {
+            summaryLogId: 'log-1',
+            rowId: 'row-1',
+            rowType: 'mystery',
+            wasteRecordId: 'wr-1',
+            wasteRecordVersionId: 'v-1'
+          }
+        }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('accepts all documented rowType values', () => {
+      const rowTypes = ['received', 'processed', 'sentOn', 'exported']
+      for (const rowType of rowTypes) {
+        const data = buildLedgerTransaction({
+          source: {
+            kind: LEDGER_SOURCE_KIND.SUMMARY_LOG_ROW,
+            summaryLogRow: {
+              summaryLogId: 'log-1',
+              rowId: 'row-1',
+              rowType,
+              wasteRecordId: 'wr-1',
+              wasteRecordVersionId: 'v-1'
+            }
+          }
+        })
+        const { error } = ledgerTransactionInsertSchema.validate(data)
+        expect(error).toBeUndefined()
+      }
+    })
+  })
+
+  describe('prn-operation source fields', () => {
+    it('rejects when prnId is missing', () => {
+      const data = buildPrnOperationLedgerTransaction({
+        source: {
+          kind: LEDGER_SOURCE_KIND.PRN_OPERATION,
+          prnOperation: { operationType: LEDGER_PRN_OPERATION_TYPE.CREATION }
+        }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects when operationType is missing', () => {
+      const data = buildPrnOperationLedgerTransaction({
+        source: {
+          kind: LEDGER_SOURCE_KIND.PRN_OPERATION,
+          prnOperation: { prnId: 'prn-1' }
+        }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects an unknown operationType', () => {
+      const data = buildPrnOperationLedgerTransaction({
+        source: {
+          kind: LEDGER_SOURCE_KIND.PRN_OPERATION,
+          prnOperation: { prnId: 'prn-1', operationType: 'teleportation' }
+        }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+  })
+
+  describe('manual-adjustment source fields', () => {
+    it('rejects when userId is missing', () => {
+      const data = buildManualAdjustmentLedgerTransaction({
+        source: {
+          kind: LEDGER_SOURCE_KIND.MANUAL_ADJUSTMENT,
+          manualAdjustment: { reason: 'typo' }
+        }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects when reason is missing', () => {
+      const data = buildManualAdjustmentLedgerTransaction({
+        source: {
+          kind: LEDGER_SOURCE_KIND.MANUAL_ADJUSTMENT,
+          manualAdjustment: { userId: 'user-1' }
+        }
+      })
+      const { error } = ledgerTransactionInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+  })
+
+  describe('unknown fields', () => {
+    it('strips unknown top-level fields when stripUnknown is enabled', () => {
+      const data = buildLedgerTransaction({ bogus: 'field' })
+      const { error, value } = ledgerTransactionInsertSchema.validate(data, {
+        stripUnknown: true
+      })
+      expect(error).toBeUndefined()
+      expect(value.bogus).toBeUndefined()
+    })
+  })
+})
+
+describe('ledger transaction read schema', () => {
+  const buildReadDocument = (overrides = {}) => ({
+    id: '507f1f77bcf86cd799439011',
+    ...buildLedgerTransaction(),
+    ...overrides
+  })
+
+  it('accepts a valid read document with id', () => {
+    const data = buildReadDocument()
+    const { error } = ledgerTransactionReadSchema.validate(data)
+    expect(error).toBeUndefined()
+  })
+
+  it('rejects when id is missing', () => {
+    const data = buildReadDocument()
+    delete data.id
+    const { error } = ledgerTransactionReadSchema.validate(data)
+    expect(error).toBeDefined()
+  })
+
+  it('strips MongoDB _id when stripUnknown is enabled', () => {
+    const objectId = new ObjectId()
+    const data = { ...buildReadDocument(), _id: objectId }
+    const { error, value } = ledgerTransactionReadSchema.validate(data, {
+      stripUnknown: true
+    })
+    expect(error).toBeUndefined()
+    expect(value._id).toBeUndefined()
+    expect(value.id).toBeDefined()
+  })
+
+  it('rejects when required fields from insert schema are missing', () => {
+    const data = buildReadDocument()
+    delete data.source
+    const { error } = ledgerTransactionReadSchema.validate(data)
+    expect(error).toBeDefined()
+  })
+})

--- a/src/waste-balances/repository/ledger-test-data.js
+++ b/src/waste-balances/repository/ledger-test-data.js
@@ -1,0 +1,83 @@
+import {
+  LEDGER_TRANSACTION_TYPE,
+  LEDGER_SOURCE_KIND,
+  LEDGER_PRN_OPERATION_TYPE
+} from './ledger-schema.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+const DEFAULT_CREATED_AT = new Date('2026-01-15T10:00:00.000Z')
+
+const buildSummaryLogRowSource = (overrides = {}) => ({
+  summaryLogId: 'log-1',
+  rowId: 'row-1',
+  rowType: WASTE_RECORD_TYPE.RECEIVED,
+  wasteRecordId: 'waste-record-1',
+  wasteRecordVersionId: 'version-1',
+  ...overrides
+})
+
+const buildPrnOperationSource = (overrides = {}) => ({
+  prnId: 'prn-1',
+  operationType: LEDGER_PRN_OPERATION_TYPE.CREATION,
+  ...overrides
+})
+
+const buildManualAdjustmentSource = (overrides = {}) => ({
+  userId: 'user-1',
+  reason: 'Corrective adjustment',
+  ...overrides
+})
+
+/**
+ * Build a valid ledger transaction (insert shape — no `id`).
+ * @param {object} [overrides]
+ */
+export const buildLedgerTransaction = (overrides = {}) => ({
+  accreditationId: 'acc-1',
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  number: 1,
+  type: LEDGER_TRANSACTION_TYPE.CREDIT,
+  createdAt: DEFAULT_CREATED_AT,
+  createdBy: { id: 'user-1', name: 'Test User' },
+  amount: 10,
+  openingAmount: 0,
+  closingAmount: 10,
+  openingAvailableAmount: 0,
+  closingAvailableAmount: 10,
+  source: {
+    kind: LEDGER_SOURCE_KIND.SUMMARY_LOG_ROW,
+    summaryLogRow: buildSummaryLogRowSource()
+  },
+  ...overrides
+})
+
+export const buildPrnOperationLedgerTransaction = (overrides = {}) =>
+  buildLedgerTransaction({
+    type: LEDGER_TRANSACTION_TYPE.PENDING_DEBIT,
+    amount: -5,
+    openingAmount: 10,
+    closingAmount: 10,
+    openingAvailableAmount: 10,
+    closingAvailableAmount: 5,
+    source: {
+      kind: LEDGER_SOURCE_KIND.PRN_OPERATION,
+      prnOperation: buildPrnOperationSource()
+    },
+    ...overrides
+  })
+
+export const buildManualAdjustmentLedgerTransaction = (overrides = {}) =>
+  buildLedgerTransaction({
+    type: LEDGER_TRANSACTION_TYPE.DEBIT,
+    amount: -2,
+    openingAmount: 10,
+    closingAmount: 8,
+    openingAvailableAmount: 10,
+    closingAvailableAmount: 8,
+    source: {
+      kind: LEDGER_SOURCE_KIND.MANUAL_ADJUSTMENT,
+      manualAdjustment: buildManualAdjustmentSource()
+    },
+    ...overrides
+  })

--- a/src/waste-balances/repository/ledger-validation.js
+++ b/src/waste-balances/repository/ledger-validation.js
@@ -1,0 +1,36 @@
+import Boom from '@hapi/boom'
+
+import {
+  ledgerTransactionInsertSchema,
+  ledgerTransactionReadSchema
+} from './ledger-schema.js'
+
+export const validateLedgerTransactionInsert = (data) => {
+  const { error, value } = ledgerTransactionInsertSchema.validate(data, {
+    abortEarly: false,
+    stripUnknown: true
+  })
+
+  if (error) {
+    const details = error.details.map((d) => d.message).join('; ')
+    throw Boom.badData(`Invalid ledger transaction data: ${details}`)
+  }
+
+  return value
+}
+
+export const validateLedgerTransactionRead = (data) => {
+  const { error, value } = ledgerTransactionReadSchema.validate(data, {
+    abortEarly: false,
+    stripUnknown: true
+  })
+
+  if (error) {
+    const details = error.details.map((d) => d.message).join('; ')
+    throw Boom.badImplementation(
+      `Invalid ledger transaction ${data.id}: ${details}`
+    )
+  }
+
+  return value
+}

--- a/src/waste-balances/repository/ledger-validation.test.js
+++ b/src/waste-balances/repository/ledger-validation.test.js
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { ObjectId } from 'mongodb'
+
+import {
+  validateLedgerTransactionInsert,
+  validateLedgerTransactionRead
+} from './ledger-validation.js'
+import { buildLedgerTransaction } from './ledger-test-data.js'
+
+describe('validateLedgerTransactionInsert', () => {
+  it('returns validated value for valid data', () => {
+    const data = buildLedgerTransaction()
+    const result = validateLedgerTransactionInsert(data)
+    expect(result.accreditationId).toBe(data.accreditationId)
+    expect(result.number).toBe(data.number)
+    expect(result.source.kind).toBe(data.source.kind)
+  })
+
+  it('strips unknown fields', () => {
+    const data = buildLedgerTransaction({ bogus: 'field' })
+    const result = validateLedgerTransactionInsert(data)
+    expect(result.bogus).toBeUndefined()
+  })
+
+  it('throws Boom.badData for invalid data', () => {
+    const data = buildLedgerTransaction()
+    delete data.organisationId
+
+    let thrownError
+    try {
+      validateLedgerTransactionInsert(data)
+    } catch (e) {
+      thrownError = e
+    }
+
+    expect(thrownError?.isBoom).toBe(true)
+    expect(thrownError?.output.statusCode).toBe(422)
+    expect(thrownError?.message).toContain('Invalid ledger transaction data')
+  })
+
+  it('reports all validation errors, not just the first', () => {
+    const data = buildLedgerTransaction()
+    delete data.organisationId
+    delete data.registrationId
+    delete data.number
+
+    let thrownError
+    try {
+      validateLedgerTransactionInsert(data)
+    } catch (e) {
+      thrownError = e
+    }
+
+    expect(thrownError?.message).toContain('organisationId')
+    expect(thrownError?.message).toContain('registrationId')
+    expect(thrownError?.message).toContain('number')
+  })
+})
+
+describe('validateLedgerTransactionRead', () => {
+  const buildReadDocument = (overrides = {}) => ({
+    id: '507f1f77bcf86cd799439011',
+    ...buildLedgerTransaction(),
+    ...overrides
+  })
+
+  it('returns validated value for valid read document', () => {
+    const data = buildReadDocument()
+    const result = validateLedgerTransactionRead(data)
+    expect(result.id).toBe('507f1f77bcf86cd799439011')
+    expect(result.accreditationId).toBe(data.accreditationId)
+  })
+
+  it('strips MongoDB _id from read documents', () => {
+    const objectId = new ObjectId()
+    const data = { ...buildReadDocument(), _id: objectId }
+    const result = validateLedgerTransactionRead(data)
+    expect(result._id).toBeUndefined()
+    expect(result.id).toBe('507f1f77bcf86cd799439011')
+  })
+
+  it('throws Boom.badImplementation for invalid read data', () => {
+    const data = buildReadDocument()
+    delete data.id
+
+    let thrownError
+    try {
+      validateLedgerTransactionRead(data)
+    } catch (e) {
+      thrownError = e
+    }
+
+    expect(thrownError?.isBoom).toBe(true)
+    expect(thrownError?.output.statusCode).toBe(500)
+    expect(thrownError?.message).toContain('Invalid ledger transaction')
+  })
+
+  it('includes the document id in the error message', () => {
+    const data = buildReadDocument({ id: 'abc-123' })
+    delete data.source
+
+    let thrownError
+    try {
+      validateLedgerTransactionRead(data)
+    } catch (e) {
+      thrownError = e
+    }
+
+    expect(thrownError?.message).toContain('abc-123')
+  })
+
+  it('reports all validation errors, not just the first', () => {
+    const data = buildReadDocument()
+    delete data.id
+    delete data.organisationId
+    delete data.source
+
+    let thrownError
+    try {
+      validateLedgerTransactionRead(data)
+    } catch (e) {
+      thrownError = e
+    }
+
+    expect(thrownError?.message).toContain('id')
+    expect(thrownError?.message).toContain('organisationId')
+    expect(thrownError?.message).toContain('source')
+  })
+})

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -6,6 +6,7 @@ import {
   performCreditAvailableBalanceForPrnCancellation,
   performCreditFullBalanceForIssuedPrnCancellation
 } from './helpers.js'
+import { ensureLedgerCollection } from './ledger-mongodb.js'
 
 const WASTE_BALANCE_COLLECTION_NAME = 'waste-balances'
 
@@ -111,6 +112,7 @@ export const saveBalance = (db) => async (updatedBalance, newTransactions) => {
  */
 export const createWasteBalancesRepository = async (db, dependencies = {}) => {
   await ensureCollection(db)
+  await ensureLedgerCollection(db)
 
   return () => ({
     findByAccreditationId: performFindByAccreditationId(db),

--- a/src/waste-balances/repository/mongodb.test.js
+++ b/src/waste-balances/repository/mongodb.test.js
@@ -3,6 +3,7 @@ import { it as mongoIt } from '#vite/fixtures/mongo.js'
 import { MongoClient } from 'mongodb'
 import { createWasteBalancesRepository } from './mongodb.js'
 import { testWasteBalancesRepositoryContract } from './port.contract.js'
+import { WASTE_BALANCE_LEDGER_COLLECTION_NAME } from './ledger-mongodb.js'
 
 const DATABASE_NAME = 'epr-backend'
 const WASTE_BALANCE_COLLECTION_NAME = 'waste-balances'
@@ -47,6 +48,22 @@ describe('MongoDB waste balances repository', () => {
       const instance = repository()
       expect(instance).toBeDefined()
       expect(instance.findByAccreditationId).toBeTypeOf('function')
+    })
+
+    it('ensures the ledger collection indexes exist', async ({
+      mongoClient
+    }) => {
+      const database = mongoClient.db(DATABASE_NAME)
+      await createWasteBalancesRepository(database)
+
+      const indexes = await database
+        .collection(WASTE_BALANCE_LEDGER_COLLECTION_NAME)
+        .indexes()
+      const names = indexes.map((idx) => idx.name)
+      expect(names).toContain('accreditationId_number')
+      expect(names).toContain('summaryLogRow_wasteRecordId')
+      expect(names).toContain('summaryLogRow_row')
+      expect(names).toContain('prnOperation_prnId')
     })
   })
 


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

Introduce the `waste-balance-transactions` MongoDB collection that will become the authoritative store of waste balance state per [ADR 0031](https://github.com/DEFRA/epr-re-ex-service/blob/main/docs/architecture/decisions/0031-waste-balance-transaction-ledger.md). Scope is deliberately narrow — schema, collection, and indexes only — so reviewers can check the shape in isolation before any read or write path is switched over.

Each ledger transaction carries its own running totals (`openingAmount`, `closingAmount`, `openingAvailableAmount`, `closingAvailableAmount`) plus a discriminated `source` identifying both the upstream event (summary-log row, PRN operation, or manual adjustment) and the affected entity. `(accreditationId, number)` is enforced as the sole business identifier via a compound unique index; the same index serves the latest-transaction-by-accreditation read path.

No behaviour changes — the existing embedded `transactions[]` path on `waste-balances` is untouched. The new collection is provisioned at startup by `createWasteBalancesRepository` but has no writers until feature-flagged paths land in later beads (`wasteBalanceLedger` scaffolding, summary-log and PRN write migrations, balance read migration).

## What changed

- `ledger-schema.js` — Joi schemas for insert and read shapes with a discriminated `source` union (`summary-log-row` / `prn-operation` / `manual-adjustment`). Cross-kind sub-objects are explicitly forbidden via `Joi.when` + `Joi.forbidden()`.
- `ledger-validation.js` — `validateLedgerTransactionInsert` (`Boom.badData` on bad input) and `validateLedgerTransactionRead` (`Boom.badImplementation` on bad output), mirroring the PRN `repository/validation.js` pattern.
- `ledger-mongodb.js` — `ensureLedgerCollection(db)` creates the compound unique index on `(accreditationId, number)` plus supporting indexes on `source.summaryLogRow.wasteRecordId`, the compound `(summaryLogId, rowId, rowType)`, and `source.prnOperation.prnId`.
- `mongodb.js` — factory now calls `ensureLedgerCollection(db)` alongside the existing `ensureCollection(db)`.
- Paired test files plus a test-data builder covering all three source kinds.

## Intentionally deferred

- **Amount field typing against `Decimal128`.** Joi validation uses `Joi.number()`. The existing waste-balance read path does not validate amounts at all, so the Decimal128 round-trip is a concrete concern only when the ledger read/write primitives land. Will be sorted in the read-primitive bead.
- **Ledger factory extraction.** `ensureLedgerCollection` is wired inline into `createWasteBalancesRepository`. Splitting it into its own factory makes sense once ledger read/write primitives exist — YAGNI until then.
- **Cross-product constraints between `type` and `source.kind`.** ADR 0031 is silent on which transaction types each source kind may produce. Schema accepts all combinations for now; tighten when the write primitives enumerate the valid producers.

## Out of scope

- `wasteBalanceLedger` feature flag scaffolding
- Any read or write primitive against the ledger
- Migration of existing embedded transactions to the ledger

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ