### PR TITLE
PAE-0000: Add generic Boom error logger plugin

### DIFF
--- a/src/plugins/boom-error-logger.js
+++ b/src/plugins/boom-error-logger.js
@@ -1,0 +1,76 @@
+import { StatusCodes } from 'http-status-codes'
+
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/event.js'
+
+const SERVER_ERROR_THRESHOLD = 500
+
+export const boomErrorLogger = {
+  plugin: {
+    name: 'boom-error-logger',
+    version: '1.0.0',
+    /**
+     * @param {import('#common/hapi-types.js').HapiServer} server
+     */
+    register: (server) => {
+      server.ext(
+        'onPreResponse',
+        /**
+         * @param {import('#common/hapi-types.js').HapiRequest} request
+         * @param {import('#common/hapi-types.js').HapiResponseToolkit} h
+         */
+        (request, h) => {
+          const response = request.response
+
+          if (!('isBoom' in response) || !response.isBoom) {
+            return h.continue
+          }
+
+          const boom = /** @type {import('@hapi/boom').Boom} */ (response)
+          const statusCode = boom.output.statusCode
+
+          // 401 is already logged by authFailureLogger; skip to avoid duplicates
+          if (statusCode === StatusCodes.UNAUTHORIZED) {
+            return h.continue
+          }
+
+          const isServerError = statusCode >= SERVER_ERROR_THRESHOLD
+          const level = isServerError ? 'error' : 'warn'
+          const action = isServerError
+            ? LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+            : LOGGING_EVENT_ACTIONS.REQUEST_FAILURE
+
+          // Boom messages are PII-safe by convention (see PAE-1384). We do not
+          // read boom.output.payload (Joi validation echoes input), boom.data
+          // (arbitrary developer-attached payload), or boom.stack (the first
+          // line of a stack trace echoes the error message, which can leak
+          // PII when an upstream Error was constructed from user input).
+          request.logger[level]({
+            message: boom.message,
+            error: {
+              code: String(statusCode),
+              id: request.info.id,
+              message: boom.message,
+              type: boom.output.payload.error
+            },
+            event: {
+              category: LOGGING_EVENT_CATEGORIES.HTTP,
+              action,
+              kind: 'event',
+              outcome: 'failure'
+            },
+            http: {
+              response: {
+                status_code: statusCode
+              }
+            }
+          })
+
+          return h.continue
+        }
+      )
+    }
+  }
+}

--- a/src/plugins/boom-error-logger.test.js
+++ b/src/plugins/boom-error-logger.test.js
@@ -1,0 +1,147 @@
+import Boom from '@hapi/boom'
+
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/event.js'
+
+import { boomErrorLogger } from './boom-error-logger.js'
+
+describe('boom-error-logger plugin', () => {
+  let server
+  let mockLogger
+
+  beforeEach(async () => {
+    const { default: Hapi } = await import('@hapi/hapi')
+    server = Hapi.server()
+
+    mockLogger = { warn: vi.fn(), error: vi.fn() }
+
+    server.ext('onRequest', (request, h) => {
+      request.logger = mockLogger
+      return h.continue
+    })
+
+    await server.register({ plugin: boomErrorLogger.plugin })
+
+    server.route([
+      {
+        method: 'GET',
+        path: '/ok',
+        handler: (_request, h) => h.response({ ok: true })
+      },
+      {
+        method: 'GET',
+        path: '/bad-request',
+        handler: () => {
+          throw Boom.badRequest('Validation failed')
+        }
+      },
+      {
+        method: 'GET',
+        path: '/not-found',
+        handler: () => {
+          throw Boom.notFound('Resource missing')
+        }
+      },
+      {
+        method: 'GET',
+        path: '/unauthorized',
+        handler: () => {
+          throw Boom.unauthorized('Bad token')
+        }
+      },
+      {
+        method: 'GET',
+        path: '/internal',
+        handler: () => {
+          throw Boom.internal('Database died')
+        }
+      }
+    ])
+
+    await server.initialize()
+  })
+
+  it('warns for 4xx Boom errors with PII-safe ECS error fields', async () => {
+    await server.inject({ method: 'GET', url: '/bad-request' })
+
+    expect(mockLogger.warn).toHaveBeenCalledWith({
+      message: 'Validation failed',
+      error: {
+        code: '400',
+        id: expect.any(String),
+        message: 'Validation failed',
+        type: 'Bad Request'
+      },
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.HTTP,
+        action: LOGGING_EVENT_ACTIONS.REQUEST_FAILURE,
+        kind: 'event',
+        outcome: 'failure'
+      },
+      http: { response: { status_code: 400 } }
+    })
+  })
+
+  it('does not log stack_trace (the first line can leak PII from upstream errors)', async () => {
+    await server.inject({ method: 'GET', url: '/bad-request' })
+
+    const logCall = mockLogger.warn.mock.calls[0][0]
+    expect(logCall.error).not.toHaveProperty('stack_trace')
+  })
+
+  it('uses the standard HTTP class string as error.type for 404', async () => {
+    await server.inject({ method: 'GET', url: '/not-found' })
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: '404',
+          type: 'Not Found',
+          message: 'Resource missing'
+        })
+      })
+    )
+  })
+
+  it('errors for 5xx Boom errors with response_failure action', async () => {
+    await server.inject({ method: 'GET', url: '/internal' })
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: '500',
+          type: 'Internal Server Error'
+        }),
+        event: expect.objectContaining({
+          action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE,
+          outcome: 'failure'
+        }),
+        http: { response: { status_code: 500 } }
+      })
+    )
+  })
+
+  it('populates error.id from the Hapi request id', async () => {
+    await server.inject({ method: 'GET', url: '/bad-request' })
+
+    const logCall = mockLogger.warn.mock.calls[0][0]
+    expect(logCall.error.id).toBeTruthy()
+    expect(typeof logCall.error.id).toBe('string')
+  })
+
+  it('skips 401 to avoid duplication with authFailureLogger', async () => {
+    await server.inject({ method: 'GET', url: '/unauthorized' })
+
+    expect(mockLogger.warn).not.toHaveBeenCalled()
+    expect(mockLogger.error).not.toHaveBeenCalled()
+  })
+
+  it('does not log for successful responses', async () => {
+    await server.inject({ method: 'GET', url: '/ok' })
+
+    expect(mockLogger.warn).not.toHaveBeenCalled()
+    expect(mockLogger.error).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -25,6 +25,7 @@ import { packagingRecyclingNotesRepositoryPlugin } from '#packaging-recycling-no
 import { authFailureLogger } from '#plugins/auth-failure-logger.js'
 import { authPlugin } from '#plugins/auth/auth-plugin.js'
 import { externalApiAuthPlugin } from '#plugins/auth/external-api-auth-plugin.js'
+import { boomErrorLogger } from '#plugins/boom-error-logger.js'
 import { cacheControl } from '#plugins/cache-control.js'
 import { externalApiErrorFormatter } from '#plugins/external-api-error-formatter.js'
 import { featureFlags } from '#plugins/feature-flags.js'
@@ -167,6 +168,7 @@ async function createServer(options = {}) {
   // Jwt            - JWT authentication plugin
   // authPlugin     - sets up authentication strategies
   // authFailureLogger - logs 401 authentication failures
+  // boomErrorLogger    - logs all other Boom errors with PII-safe ECS error fields
   const plugins = [
     requestLogger,
     requestTracing,
@@ -180,6 +182,7 @@ async function createServer(options = {}) {
       options: { config }
     },
     authFailureLogger,
+    boomErrorLogger,
     externalApiErrorFormatter
   ]
 


### PR DESCRIPTION
Ticket: [PAE-0000](https://eaflood.atlassian.net/browse/PAE-0000)
## Summary

- Adds an `onPreResponse` plugin that surfaces every 4xx and 5xx Boom error with PII-safe ECS error fields, regardless of `FEATURE_FLAG_ALLOW_FULL_ERROR_OUTPUT`.
- Closes the visibility gap where handler-thrown 4xx Booms left no clue what failed — only the response status code was being logged.
- Reads only PII-safe sources (`boom.message` is safe by PAE-1384 convention; `output.payload.error` and `statusCode` are bounded). Skips `stack_trace` (first line can echo upstream error messages) and skips 401 (already covered by `authFailureLogger`).

## Changes

- `src/plugins/boom-error-logger.js` — new plugin. Maps Boom errors to ECS `error.{code,id,message,type}`, plus `event.{category,action,kind,outcome}` and `http.response.status_code`. 4xx → `warn` / `REQUEST_FAILURE`, 5xx → `error` / `RESPONSE_FAILURE`.
- `src/plugins/boom-error-logger.test.js` — behaviour tests covering 4xx/5xx field shape, the explicit no-`stack_trace` guard, the 401 skip, and the success path.
- `src/server/server.js` — registers `boomErrorLogger` after `authFailureLogger` in the plugins array.
