### PR TITLE
PAE-1382: Add wasteBalanceLedger feature flag scaffolding

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -359,6 +359,12 @@ const baseConfig = {
       format: Boolean,
       default: false,
       env: 'FEATURE_FLAG_ALLOW_FULL_ERROR_OUTPUT'
+    },
+    wasteBalanceLedger: {
+      doc: 'Feature Flag: Write and read waste balance transactions via the append-only ledger collection (ADR 0031)',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_FLAG_WASTE_BALANCE_LEDGER'
     }
   },
   formSubmissionOverrides: {

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -13,5 +13,8 @@ export const createConfigFeatureFlags = (config) => ({
   },
   isOrsWasteBalanceValidationEnabled() {
     return config.get('featureFlags.orsWasteBalanceValidation')
+  },
+  isWasteBalanceLedgerEnabled() {
+    return config.get('featureFlags.wasteBalanceLedger')
   }
 })

--- a/src/feature-flags/feature-flags.config.test.js
+++ b/src/feature-flags/feature-flags.config.test.js
@@ -51,4 +51,17 @@ describe('createConfigFeatureFlags', () => {
     const flags = createConfigFeatureFlags(config)
     expect(flags.isOrsWasteBalanceValidationEnabled()).toBe(false)
   })
+
+  it('returns true when wasteBalanceLedger flag is enabled', () => {
+    const config = { get: vi.fn().mockReturnValue(true) }
+    const flags = createConfigFeatureFlags(config)
+    expect(flags.isWasteBalanceLedgerEnabled()).toBe(true)
+    expect(config.get).toHaveBeenCalledWith('featureFlags.wasteBalanceLedger')
+  })
+
+  it('returns false when wasteBalanceLedger flag is disabled', () => {
+    const config = { get: vi.fn().mockReturnValue(false) }
+    const flags = createConfigFeatureFlags(config)
+    expect(flags.isWasteBalanceLedgerEnabled()).toBe(false)
+  })
 })

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -13,5 +13,8 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   },
   isOrsWasteBalanceValidationEnabled() {
     return flags.orsWasteBalanceValidation ?? false
+  },
+  isWasteBalanceLedgerEnabled() {
+    return flags.wasteBalanceLedger ?? false
   }
 })

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -65,4 +65,19 @@ describe('createInMemoryFeatureFlags', () => {
     const flags = createInMemoryFeatureFlags({})
     expect(flags.isOrsWasteBalanceValidationEnabled()).toBe(false)
   })
+
+  it('returns true when wasteBalanceLedger flag is enabled', () => {
+    const flags = createInMemoryFeatureFlags({ wasteBalanceLedger: true })
+    expect(flags.isWasteBalanceLedgerEnabled()).toBe(true)
+  })
+
+  it('returns false when wasteBalanceLedger flag is disabled', () => {
+    const flags = createInMemoryFeatureFlags({ wasteBalanceLedger: false })
+    expect(flags.isWasteBalanceLedgerEnabled()).toBe(false)
+  })
+
+  it('returns false when wasteBalanceLedger flag is not provided', () => {
+    const flags = createInMemoryFeatureFlags({})
+    expect(flags.isWasteBalanceLedgerEnabled()).toBe(false)
+  })
 })

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -4,6 +4,7 @@
  * @property {() => boolean} isCopyFormFilesToS3Enabled
  * @property {() => boolean} isReportsEnabled
  * @property {() => boolean} isOrsWasteBalanceValidationEnabled
+ * @property {() => boolean} isWasteBalanceLedgerEnabled
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
Introduces a Boolean feature flag to gate the forthcoming waste balance ledger work ([ADR 0031](https://github.com/DEFRA/epr-re-ex-service/blob/main/docs/architecture/decisions/0031-waste-balance-transaction-ledger.md)). The flag is dormant scaffolding: it defaults to `false` and has no call sites yet. Migration beads will wrap reads and writes as the ledger lands.

## Changes

- `src/config.js` — convict entry `featureFlags.wasteBalanceLedger` (`FEATURE_FLAG_WASTE_BALANCE_LEDGER`, default `false`, doc references ADR 0031).
- `src/feature-flags/feature-flags.port.js` — add `isWasteBalanceLedgerEnabled()` to the JSDoc typedef.
- `src/feature-flags/feature-flags.config.js` + test — accessor reads `featureFlags.wasteBalanceLedger` from convict.
- `src/feature-flags/feature-flags.inmemory.js` + test — accessor reads `wasteBalanceLedger` from the plain-object flag bag, defaulting to `false` when unset.

## Related

- Cross-environment baseline (`FEATURE_FLAG_WASTE_BALANCE_LEDGER=false` in `cdp-app-config`): coming in a separate PR against that repo.
- Per-environment enablement: deferred until the rollout spike is settled.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ