### PR TITLE
PAE-250: Fix axios and postcss vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5922,9 +5922,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -11531,9 +11531,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -101,8 +101,10 @@
     "undici": "7.24.0"
   },
   "overrides": {
+    "axios": "1.15.2",
     "fast-xml-parser": "5.7.1",
     "glob": "11.1.0",
+    "postcss": "8.5.10",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Two security vulnerabilities flagged by Snyk and `npm audit` are pinned via `overrides`. None of the existing simple overrides (`fast-xml-parser`, `glob`, `uuid`) were prunable — each was verified to still be load-bearing against `npm audit` and `snyk test`.

### `axios` 1.15.0 → 1.15.2

Pulled in transitively via [`notifications-node-client@8.3.0`](https://github.com/alphagov/notifications-node-client). Snyk flags 12 advisories against axios 1.15.0, including:

- **Critical** — [HTTP Response Splitting](https://security.snyk.io/vuln/SNYK-JS-AXIOS-16298058)
- **Critical** — [Prototype Pollution](https://security.snyk.io/vuln/SNYK-JS-AXIOS-16299904)
- **High** — [Improperly Controlled Modification of Dynamically-Determined Object Attributes](https://security.snyk.io/vuln/SNYK-JS-AXIOS-16299921) (only fixed in 1.15.2, hence the choice of pin)
- **High** — [Uncontrolled Recursion](https://security.snyk.io/vuln/SNYK-JS-AXIOS-16299923)
- 8 further medium-severity issues (CRLF injection, SSRF, prototype pollution, sensitive-data leakage, allocation throttling)

`notifications-node-client` declares `axios@^1` so the override stays within the parent's accepted range.

### `postcss` <8.5.10 → 8.5.10

Pulled in transitively via `vitest > vite`. [`GHSA-qx2v-qp2m-jg93`](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) — moderate XSS via unescaped `</style>` in CSS stringify output. Pinned to 8.5.10 (later versions exist but our npm pinning gate vs. release dates rules them out for now).

## Verification

`npm audit` reports `0 vulnerabilities`; `snyk test` reports no vulnerable paths. `npm ls axios postcss` confirms both overrides applied.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ