### PR TITLE
PAE-000: Add system-logs to org deletion cascade

### DIFF
--- a/src/non-prod-data-reset/mongodb.js
+++ b/src/non-prod-data-reset/mongodb.js
@@ -20,7 +20,8 @@ const COLLECTIONS = {
   REPORTS: 'reports',
   WASTE_RECORDS: 'waste-records',
   SUMMARY_LOGS: 'summary-logs',
-  OVERSEAS_SITES: 'overseas-sites'
+  OVERSEAS_SITES: 'overseas-sites',
+  SYSTEM_LOGS: 'system-logs'
 }
 
 const EMPTY_COUNTS = Object.freeze({
@@ -30,6 +31,7 @@ const EMPTY_COUNTS = Object.freeze({
   'waste-records': 0,
   'summary-logs': 0,
   'overseas-sites': 0,
+  'system-logs': 0,
   registration: 0,
   accreditation: 0,
   'epr-organisations': 0,
@@ -116,6 +118,11 @@ const buildCascadeSteps = (
       overseasSiteIds.length === 0
         ? null
         : { _id: { $in: overseasSiteIds.map(toObjectId) } }
+  },
+  {
+    label: 'system-logs',
+    collection: COLLECTIONS.SYSTEM_LOGS,
+    filter: { 'context.organisationId': mongoIdHex }
   },
   {
     label: 'registration',

--- a/src/non-prod-data-reset/mongodb.test.js
+++ b/src/non-prod-data-reset/mongodb.test.js
@@ -17,6 +17,7 @@ import {
 import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
 import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
 import { buildWasteBalance } from '#waste-balances/repository/contract/test-data.js'
 import {
   createWasteBalancesRepository,
@@ -48,7 +49,8 @@ const COLLECTIONS = [
   'reports',
   'waste-records',
   'summary-logs',
-  'overseas-sites'
+  'overseas-sites',
+  'system-logs'
 ]
 
 const mockS3Config = { s3Client: {}, preSignedUrlExpiry: 60 }
@@ -88,6 +90,7 @@ const it = mongoIt.extend({
       mockS3Config
     )
     const overseasSitesFactory = await createOverseasSitesRepository(database)
+    const systemLogsFactory = await createSystemLogsRepository(database)
 
     await use({
       organisations: organisationsFactory(),
@@ -97,6 +100,7 @@ const it = mongoIt.extend({
       wasteRecords: wasteRecordsFactory(),
       summaryLogs: summaryLogsFactory(mockLogger),
       overseasSites: overseasSitesFactory(),
+      systemLogs: systemLogsFactory(mockLogger),
       wasteBalancesSave: saveBalance(database)
     })
   },
@@ -197,6 +201,17 @@ const seedDownstreamForOrganisation = async (
     `summary-log-${randomUUID()}`,
     summaryLogFactory.validating({ organisationId, registrationId })
   )
+
+  await repositories.systemLogs.insert({
+    createdAt: new Date(),
+    createdBy: { id: 'user-001', email: 'test@example.com', scope: [] },
+    event: {
+      category: 'entity',
+      subCategory: 'epr-organisations',
+      action: 'update'
+    },
+    context: { organisationId }
+  })
 }
 
 // The 'organisation' collection is written by the journey-test apply path and
@@ -234,6 +249,7 @@ const EMPTY_COUNTS = {
   'waste-records': 0,
   'summary-logs': 0,
   'overseas-sites': 0,
+  'system-logs': 0,
   registration: 0,
   accreditation: 0,
   'epr-organisations': 0,
@@ -271,6 +287,7 @@ describe('non-prod data reset (mongo)', () => {
         'waste-records': 1,
         'summary-logs': 1,
         'overseas-sites': 2,
+        'system-logs': 1,
         registration: 1,
         accreditation: 1,
         'epr-organisations': 1,
@@ -337,6 +354,11 @@ describe('non-prod data reset (mongo)', () => {
           }
         })
       ).toBe(2)
+      expect(
+        await database.collection('system-logs').countDocuments({
+          'context.organisationId': other.organisationId
+        })
+      ).toBe(1)
       expect(
         await database.collection('epr-organisations').countDocuments({
           _id: ObjectId.createFromHexString(other.organisationId)

--- a/src/non-prod-data-reset/mongodb.test.js
+++ b/src/non-prod-data-reset/mongodb.test.js
@@ -17,6 +17,7 @@ import {
 import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
 import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.js'
+import { buildSystemLog } from '#repositories/system-logs/contract/test-data.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
 import { buildWasteBalance } from '#waste-balances/repository/contract/test-data.js'
 import {
@@ -202,16 +203,7 @@ const seedDownstreamForOrganisation = async (
     summaryLogFactory.validating({ organisationId, registrationId })
   )
 
-  await repositories.systemLogs.insert({
-    createdAt: new Date(),
-    createdBy: { id: 'user-001', email: 'test@example.com', scope: [] },
-    event: {
-      category: 'entity',
-      subCategory: 'epr-organisations',
-      action: 'update'
-    },
-    context: { organisationId }
-  })
+  await repositories.systemLogs.insert(buildSystemLog({ organisationId }))
 }
 
 // The 'organisation' collection is written by the journey-test apply path and

--- a/src/repositories/system-logs/contract/test-data.js
+++ b/src/repositories/system-logs/contract/test-data.js
@@ -1,0 +1,27 @@
+/**
+ * @param {object} [overrides]
+ * @param {string} [overrides.organisationId]
+ * @param {Date} [overrides.createdAt]
+ * @param {string} [overrides.email]
+ * @param {string} [overrides.subCategory]
+ * @param {*} [overrides.id]
+ */
+export const buildSystemLog = ({
+  organisationId,
+  createdAt = new Date(),
+  email = 'user@email.com',
+  subCategory = 'test-sub-category',
+  id
+} = {}) => ({
+  createdAt,
+  createdBy: { id: 'user-001', email, scope: [] },
+  event: {
+    category: 'test-category',
+    subCategory,
+    action: 'test-action'
+  },
+  context: {
+    ...(organisationId !== undefined && { organisationId }),
+    ...(id !== undefined && { id })
+  }
+})

--- a/src/repositories/system-logs/port.contract.js
+++ b/src/repositories/system-logs/port.contract.js
@@ -1,29 +1,11 @@
 import { describe, expect } from 'vitest'
 import { randomUUID } from 'crypto'
 
+import { buildSystemLog } from './contract/test-data.js'
+
 /** @import {SystemLogsRepository} from './port.js' */
 
 const DEFAULT_LIMIT = 100
-
-const buildSystemLog = ({
-  organisationId,
-  createdAt = new Date(),
-  email = 'user@email.com',
-  subCategory = 'test-sub-category',
-  id
-} = {}) => ({
-  createdAt,
-  createdBy: { id: 'user-001', email, scope: [] },
-  event: {
-    category: 'test-category',
-    subCategory,
-    action: 'test-action'
-  },
-  context: {
-    ...(organisationId !== undefined && { organisationId }),
-    ...(id !== undefined && { id })
-  }
-})
 
 export const testSystemLogsRepositoryContract = (it) => {
   describe('filtering', () => {


### PR DESCRIPTION
## Summary

The non-prod data reset endpoint (`DELETE /v1/dev/organisations/{id}`) cascades through organisation-scoped collections but was missing `system-logs`. Audit log documents referencing a deleted organisation remained as orphans.

This adds a `system-logs` cascade step that filters on `context.organisationId`, bringing the cleanup to 11 collections.

Also extracts the `buildSystemLog` test helper from `port.contract.js` into `contract/test-data.js`, following the pattern used by every other repository.