### PR TITLE
PAE-1384: drop error.cause enrichment, ratchet log-schema validator to strict

### DIFF
--- a/src/adapters/parsers/summary-logs/exceljs-parser.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.js
@@ -650,8 +650,7 @@ export const parse = async (buffer, options = {}) => {
     if (shouldWrapAsSpreadsheetError(error)) {
       throw new SpreadsheetValidationError(
         `Failed to parse spreadsheet: ${error.message}`,
-        VALIDATION_CODE.SPREADSHEET_INVALID_ERROR,
-        { cause: error }
+        VALIDATION_CODE.SPREADSHEET_INVALID_ERROR
       )
     }
 

--- a/src/adapters/parsers/summary-logs/exceljs-parser.test.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.test.js
@@ -51,17 +51,6 @@ describe('ExcelJSSummaryLogsParser', () => {
     await expect(parse(emptyBuffer)).rejects.toThrow(SpreadsheetValidationError)
   })
 
-  it('should preserve the original exceljs error as cause', async () => {
-    const invalidBuffer = Buffer.from('not an excel file')
-
-    await expect(parse(invalidBuffer)).rejects.toSatisfy(
-      (error) =>
-        error instanceof SpreadsheetValidationError &&
-        error.cause !== undefined &&
-        !(error.cause instanceof SpreadsheetValidationError)
-    )
-  })
-
   it('should rethrow unrecognised errors from the load call unchanged', async () => {
     const unexpected = new RangeError('this looks like a bug, not bad data')
     function MockWorkbook() {
@@ -2465,17 +2454,6 @@ describe('SpreadsheetValidationError', () => {
 
     expect(error.code).toBe(VALIDATION_CODE.SPREADSHEET_MALFORMED_MARKERS)
     expect(error.message).toBe('Duplicate marker')
-  })
-
-  it('should preserve cause when provided via options', () => {
-    const original = new TypeError('underlying failure')
-    const error = new SpreadsheetValidationError(
-      'Wrapped failure',
-      VALIDATION_CODE.SPREADSHEET_INVALID_ERROR,
-      { cause: original }
-    )
-
-    expect(error.cause).toBe(original)
   })
 })
 

--- a/src/adapters/repositories/uploads/s3-uri.js
+++ b/src/adapters/repositories/uploads/s3-uri.js
@@ -9,8 +9,8 @@ export const parseS3Uri = (uri) => {
   let url
   try {
     url = new URL(uri)
-  } catch (error) {
-    throw new Error(`Malformed URI: ${uri}`, { cause: error })
+  } catch {
+    throw new Error(`Malformed URI: ${uri}`)
   }
 
   if (url.protocol !== 's3:') {

--- a/src/common/enums/error-codes.js
+++ b/src/common/enums/error-codes.js
@@ -1,0 +1,3 @@
+export const errorCodes = {
+  externalFetchFailed: 'external_fetch_failed'
+}

--- a/src/common/helpers/fetch-json.js
+++ b/src/common/helpers/fetch-json.js
@@ -1,10 +1,7 @@
 import Boom from '@hapi/boom'
 import { withTraceId } from '@defra/hapi-tracing'
+import { internal } from './enrich-boom.js'
 import { getTracingHeaderName } from './request-tracing.js'
-
-/**
- * @import { EnrichedBoom } from '#common/types/enriched-boom.js'
- */
 
 /**
  * Fetch JSON from a given url
@@ -52,14 +49,15 @@ export const fetchJson = async (url, options) => {
     // (URL query strings, response body fragments). Bounded classifiers from
     // the underlying error (name, code) land in event.reason instead, where
     // they are CDP-allowlisted and indexed in OpenSearch.
-    const boom = /** @type {EnrichedBoom} */ (
-      Boom.internal(`Failed to fetch from url: ${url}`)
+    throw internal(
+      `Failed to fetch from url: ${url}`,
+      'EXTERNAL_FETCH_FAILED',
+      {
+        event: {
+          action: 'external_fetch',
+          reason: `type=${error?.name ?? 'Error'} code=${error?.code ?? 'unknown'}`
+        }
+      }
     )
-    boom.code = 'EXTERNAL_FETCH_FAILED'
-    boom.event = {
-      action: 'external_fetch',
-      reason: `type=${error?.name ?? 'Error'} code=${error?.code ?? 'unknown'}`
-    }
-    throw boom
   }
 }

--- a/src/common/helpers/fetch-json.js
+++ b/src/common/helpers/fetch-json.js
@@ -3,6 +3,10 @@ import { withTraceId } from '@defra/hapi-tracing'
 import { getTracingHeaderName } from './request-tracing.js'
 
 /**
+ * @import { EnrichedBoom } from '#common/types/enriched-boom.js'
+ */
+
+/**
  * Fetch JSON from a given url
  * @param {string} url -
  * @param {RequestInit} [options] - Fetch API options (method, headers, body, etc.)
@@ -44,13 +48,18 @@ export const fetchJson = async (url, options) => {
       throw error
     }
 
-    // For network errors or other non-HTTP errors, create a 500 Boom error.
     // error.message is not interpolated because it can echo unbounded content
-    // (e.g. URL query strings, response body fragments). The original error is
-    // attached as .cause so the logger can surface bounded classifiers
-    // (name, code) via the err serializer without exposing the message.
-    const boom = Boom.internal(`Failed to fetch from url: ${url}`)
-    boom.cause = error
+    // (URL query strings, response body fragments). Bounded classifiers from
+    // the underlying error (name, code) land in event.reason instead, where
+    // they are CDP-allowlisted and indexed in OpenSearch.
+    const boom = /** @type {EnrichedBoom} */ (
+      Boom.internal(`Failed to fetch from url: ${url}`)
+    )
+    boom.code = 'EXTERNAL_FETCH_FAILED'
+    boom.event = {
+      action: 'external_fetch',
+      reason: `type=${error?.name ?? 'Error'} code=${error?.code ?? 'unknown'}`
+    }
     throw boom
   }
 }

--- a/src/common/helpers/fetch-json.js
+++ b/src/common/helpers/fetch-json.js
@@ -1,5 +1,6 @@
 import Boom from '@hapi/boom'
 import { withTraceId } from '@defra/hapi-tracing'
+import { errorCodes } from '#common/enums/error-codes.js'
 import { internal } from './enrich-boom.js'
 import { getTracingHeaderName } from './request-tracing.js'
 
@@ -51,7 +52,7 @@ export const fetchJson = async (url, options) => {
     // they are CDP-allowlisted and indexed in OpenSearch.
     throw internal(
       `Failed to fetch from url: ${url}`,
-      'EXTERNAL_FETCH_FAILED',
+      errorCodes.externalFetchFailed,
       {
         event: {
           action: 'external_fetch',

--- a/src/common/helpers/fetch-json.test.js
+++ b/src/common/helpers/fetch-json.test.js
@@ -270,7 +270,7 @@ describe('#fetchJson', () => {
       global.fetch = vi.fn().mockRejectedValue(networkError)
 
       await expect(fetchJson(url)).rejects.toMatchObject({
-        code: 'EXTERNAL_FETCH_FAILED',
+        code: 'external_fetch_failed',
         event: {
           action: 'external_fetch',
           reason: 'type=Error code=ENETUNREACH'

--- a/src/common/helpers/fetch-json.test.js
+++ b/src/common/helpers/fetch-json.test.js
@@ -264,14 +264,21 @@ describe('#fetchJson', () => {
       })
     })
 
-    test('attaches the original error as Boom.cause for observability', async () => {
+    test('attaches code EXTERNAL_FETCH_FAILED and event encoding the cause classifier for indexed logging', async () => {
       const networkError = new Error('Network request failed')
+      networkError.code = 'ENETUNREACH'
       global.fetch = vi.fn().mockRejectedValue(networkError)
 
-      await expect(fetchJson(url)).rejects.toHaveProperty('cause', networkError)
+      await expect(fetchJson(url)).rejects.toMatchObject({
+        code: 'EXTERNAL_FETCH_FAILED',
+        event: {
+          action: 'external_fetch',
+          reason: 'type=Error code=ENETUNREACH'
+        }
+      })
     })
 
-    test('preserves error.code on cause so classifiers land in logs (e.g. ECONNREFUSED)', async () => {
+    test('encodes ECONNREFUSED into event.reason without leaking the original message', async () => {
       const connRefused = new Error('connection refused — system detail')
       connRefused.code = 'ECONNREFUSED'
       global.fetch = vi.fn().mockRejectedValue(connRefused)
@@ -279,7 +286,24 @@ describe('#fetchJson', () => {
       await expect(fetchJson(url)).rejects.toMatchObject({
         isBoom: true,
         message: `Failed to fetch from url: ${url}`,
-        cause: { code: 'ECONNREFUSED' }
+        event: { reason: expect.stringContaining('ECONNREFUSED') }
+      })
+    })
+
+    test('falls back to code=unknown in event.reason when the cause has no code', async () => {
+      const noCode = new TypeError('something went wrong')
+      global.fetch = vi.fn().mockRejectedValue(noCode)
+
+      await expect(fetchJson(url)).rejects.toMatchObject({
+        event: { reason: 'type=TypeError code=unknown' }
+      })
+    })
+
+    test('falls back to type=Error and code=unknown when fetch rejects with a non-Error value', async () => {
+      global.fetch = vi.fn().mockRejectedValue('plain string thrown')
+
+      await expect(fetchJson(url)).rejects.toMatchObject({
+        event: { reason: 'type=Error code=unknown' }
       })
     })
 

--- a/src/common/helpers/logging/err-serializer.js
+++ b/src/common/helpers/logging/err-serializer.js
@@ -3,6 +3,11 @@
  * applies before logs reach OpenSearch. Extracted so tests can apply the same
  * transform when validating log shapes against the CDP schema.
  *
+ * Emits only fields in the CDP indexed-fields allowlist (message, stack_trace,
+ * type, code). The `.cause` chain is not surfaced — `error.cause.*` is not in
+ * the allowlist, so cause classifiers must be encoded into `error.code` or
+ * `event.reason` at the throw site instead (see fetch-json.js, mongodb.js).
+ *
  * @param {unknown} err
  */
 export const errSerializer = (err) => {
@@ -21,17 +26,6 @@ export const errSerializer = (err) => {
   if (err.code) {
     // @ts-ignore
     errorObj.code = err.code
-  }
-
-  // Surface bounded classifiers from the .cause chain — name and code are
-  // enum-shaped identifiers (ECONNREFUSED, AbortError, etc.) that classify
-  // the failure without leaking cause.message or cause.stack content.
-  if (err.cause instanceof Error) {
-    const cause = /** @type {Error & { code?: string | number }} */ (err.cause)
-    errorObj.cause = {
-      type: cause.name,
-      code: cause.code
-    }
   }
 
   return errorObj

--- a/src/common/helpers/logging/log-schema.test-helper.js
+++ b/src/common/helpers/logging/log-schema.test-helper.js
@@ -32,20 +32,3 @@ export const expectLogToBeCdpCompliant = (logObject) => {
 
   expect(error, message).toBeUndefined()
 }
-
-/**
- * Advisory variant: validates the log shape and prints a console warning when
- * non-compliant, but does not fail the test. Use this to surface drift while
- * the cleanup PR is still in flight; flip to `expectLogToBeCdpCompliant` once
- * the underlying violation is resolved.
- *
- * @param {Record<string, unknown>} logObject
- */
-export const warnIfLogNotCdpCompliant = (logObject) => {
-  const transformed = applyEcsErrTransform(logObject)
-  const { error } = logSchema.validate(transformed)
-  if (!error) return
-  console.warn(
-    `[log-schema] non-compliant: ${error.message}\n${JSON.stringify(transformed, null, 2)}`
-  )
-}

--- a/src/common/helpers/logging/log-schema.test-helper.test.js
+++ b/src/common/helpers/logging/log-schema.test-helper.test.js
@@ -1,8 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import {
-  expectLogToBeCdpCompliant,
-  warnIfLogNotCdpCompliant
-} from './log-schema.test-helper.js'
+import { describe, it, expect } from 'vitest'
+import { expectLogToBeCdpCompliant } from './log-schema.test-helper.js'
 
 describe('expectLogToBeCdpCompliant', () => {
   it('should not throw for a CDP-compliant log shape', () => {
@@ -56,35 +53,5 @@ describe('expectLogToBeCdpCompliant', () => {
         err: { message: 'a string-shaped not-Error' }
       })
     ).not.toThrow()
-  })
-})
-
-describe('warnIfLogNotCdpCompliant', () => {
-  it('should not warn for a CDP-compliant log shape', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-    warnIfLogNotCdpCompliant({ message: 'hi' })
-
-    expect(warnSpy).not.toHaveBeenCalled()
-    warnSpy.mockRestore()
-  })
-
-  it('should print a console warning naming the offending key for non-compliant shapes', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-    warnIfLogNotCdpCompliant({ message: 'hi', somethingNotIndexed: 'x' })
-
-    expect(warnSpy).toHaveBeenCalledOnce()
-    expect(warnSpy.mock.calls[0][0]).toMatch(/somethingNotIndexed/)
-    warnSpy.mockRestore()
-  })
-
-  it('should not throw on non-compliant shapes', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-    expect(() =>
-      warnIfLogNotCdpCompliant({ message: 'hi', somethingNotIndexed: 'x' })
-    ).not.toThrow()
-    warnSpy.mockRestore()
   })
 })

--- a/src/common/helpers/logging/log-schema.test-helper.test.js
+++ b/src/common/helpers/logging/log-schema.test-helper.test.js
@@ -40,13 +40,13 @@ describe('expectLogToBeCdpCompliant', () => {
     ).not.toThrow()
   })
 
-  it('should reject when err.cause adds an indexed field that the CDP allowlist does not include', () => {
+  it('should accept err with a .cause chain since the serializer no longer surfaces cause', () => {
     const err = new Error('outer')
     err.cause = new Error('inner')
 
     expect(() =>
       expectLogToBeCdpCompliant({ message: 'something failed', err })
-    ).toThrow(/cause/)
+    ).not.toThrow()
   })
 
   it('should pass-through non-Error values in err per the pino serializer contract', () => {

--- a/src/common/helpers/logging/log-schema.test.js
+++ b/src/common/helpers/logging/log-schema.test.js
@@ -11,7 +11,7 @@ describe('logSchema', () => {
   it('should accept a log with indexed nested error and event fields', () => {
     const { error } = logSchema.validate({
       message: 'something failed',
-      error: { code: 'CADENCE_MISMATCH', message: 'oops' },
+      error: { code: 'cadence_mismatch', message: 'oops' },
       event: { category: 'http', action: 'create_report' },
       http: { response: { status_code: 400 } }
     })

--- a/src/common/helpers/logging/logger.test.js
+++ b/src/common/helpers/logging/logger.test.js
@@ -94,65 +94,18 @@ describe('loggerOptions.serializers.err', () => {
 describe('loggerOptions.serializers.err with cause', () => {
   const { err: errorSerializer } = loggerOptions.serializers
 
-  test('surfaces bounded classifiers (type and code) from err.cause', () => {
-    const originalError = new Error(
-      'connect ECONNREFUSED 127.0.0.1:27017 — possibly leaky detail'
-    )
-    originalError.code = 'ECONNREFUSED'
+  test('emits only allowlisted fields when err has a .cause chain', () => {
+    const inner = new Error('inner detail')
+    inner.code = 'ECONNREFUSED'
+    const outer = new Error('outer message', { cause: inner })
 
-    const boomError = new Error('Failed to fetch from url: http://example.com')
-    boomError.cause = originalError
+    const result = errorSerializer(outer)
 
-    const result = errorSerializer(boomError)
-
-    expect(result.cause).toEqual({ type: 'Error', code: 'ECONNREFUSED' })
-  })
-
-  test('does not surface cause.message or cause.stack (PII safety)', () => {
-    const originalError = new Error(
-      'leaky content: alice@example.com and tokens'
-    )
-    originalError.code = 'SOMETHING'
-
-    const boomError = new Error('clean boom message')
-    boomError.cause = originalError
-
-    const result = errorSerializer(boomError)
-
-    expect(result.cause).not.toHaveProperty('message')
-    expect(result.cause).not.toHaveProperty('stack')
-    expect(result.cause).not.toHaveProperty('stack_trace')
-    expect(JSON.stringify(result.cause)).not.toContain('alice@example.com')
-  })
-
-  test('omits cause field when the error has no cause', () => {
-    const boomError = new Error('no cause here')
-
-    const result = errorSerializer(boomError)
-
-    expect(result).not.toHaveProperty('cause')
-  })
-
-  test('omits cause field when the cause is not an Error instance', () => {
-    const boomError = new Error('weird cause')
-    boomError.cause = 'a string, not an Error'
-
-    const result = errorSerializer(boomError)
-
-    expect(result).not.toHaveProperty('cause')
-  })
-
-  test('surfaces cause classifiers for non-Boom errors too', () => {
-    const originalError = new Error('original leaky content')
-    originalError.code = 'ENOENT'
-
-    const wrappingError = new Error('wrapper message', {
-      cause: originalError
+    expect(result).toEqual({
+      message: 'outer message',
+      stack_trace: expect.stringContaining('Error: outer message'),
+      type: 'Error'
     })
-
-    const result = errorSerializer(wrappingError)
-
-    expect(result.cause).toEqual({ type: 'Error', code: 'ENOENT' })
   })
 })
 

--- a/src/common/helpers/validate-config.js
+++ b/src/common/helpers/validate-config.js
@@ -2,12 +2,9 @@ export function validateConfig(config) {
   let serviceMaintainers
   try {
     serviceMaintainers = JSON.parse(config.get('roles.serviceMaintainers'))
-  } catch (error) {
+  } catch {
     throw new Error(
-      'Invalid roles.serviceMaintainers configuration: malformed JSON',
-      {
-        cause: error
-      }
+      'Invalid roles.serviceMaintainers configuration: malformed JSON'
     )
   }
 

--- a/src/common/helpers/validate-config.test.js
+++ b/src/common/helpers/validate-config.test.js
@@ -43,7 +43,7 @@ describe('#validateConfig', () => {
   })
 
   describe('when roles.serviceMaintainers contains malformed JSON', () => {
-    test('throws error with cause when JSON is invalid', () => {
+    test('throws when JSON is invalid', () => {
       const mockConfig = {
         get: vi.fn().mockReturnValue('not valid json')
       }
@@ -53,7 +53,7 @@ describe('#validateConfig', () => {
       )
     })
 
-    test('throws error with cause when JSON is incomplete', () => {
+    test('throws when JSON is incomplete', () => {
       const mockConfig = {
         get: vi.fn().mockReturnValue('["user1", "user2"')
       }
@@ -63,7 +63,7 @@ describe('#validateConfig', () => {
       )
     })
 
-    test('throws error with cause when JSON has trailing comma', () => {
+    test('throws when JSON has trailing comma', () => {
       const mockConfig = {
         get: vi.fn().mockReturnValue('["user1", "user2",]')
       }
@@ -71,25 +71,6 @@ describe('#validateConfig', () => {
       expect(() => validateConfig(mockConfig)).toThrow(
         'Invalid roles.serviceMaintainers configuration: malformed JSON'
       )
-    })
-
-    test('includes original error as cause when JSON parsing fails', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('invalid json')
-      }
-
-      let thrownError
-      try {
-        validateConfig(mockConfig)
-      } catch (e) {
-        thrownError = e
-      }
-
-      expect(thrownError?.message).toBe(
-        'Invalid roles.serviceMaintainers configuration: malformed JSON'
-      )
-      expect(thrownError?.cause).toBeDefined()
-      expect(thrownError?.cause).toBeInstanceOf(SyntaxError)
     })
   })
 

--- a/src/overseas-sites/application/process-import-file.test.js
+++ b/src/overseas-sites/application/process-import-file.test.js
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { processImportFile } from './process-import-file.js'
 import { ORS_FILE_RESULT_STATUS } from '#overseas-sites/domain/import-status.js'
 import { SpreadsheetValidationError } from '#adapters/parsers/summary-logs/exceljs-parser.js'
-import { warnIfLogNotCdpCompliant } from '#common/helpers/logging/log-schema.test-helper.js'
+import { expectLogToBeCdpCompliant } from '#common/helpers/logging/log-schema.test-helper.js'
 
 vi.mock('../parsers/ors-spreadsheet-parser.js')
 
@@ -221,9 +221,10 @@ describe('processImportFile', () => {
         "Invalid ORS spreadsheet structure: Missing required 'ORS ID Log' worksheet"
     })
     expect(logger.error).not.toHaveBeenCalled()
+    expectLogToBeCdpCompliant(logger.warn.mock.calls[0][0])
   })
 
-  it('emits a non-CDP-compliant warn log when SpreadsheetValidationError carries an underlying cause (advisory: surfaces error.cause drift)', async () => {
+  it('emits a CDP-compliant warn log when SpreadsheetValidationError carries an underlying cause', async () => {
     const buffer = Buffer.from('malformed-zip')
     const innerExcelError = new TypeError('saxes: invalid characters in <c>')
     const validationError = new SpreadsheetValidationError(
@@ -232,14 +233,12 @@ describe('processImportFile', () => {
       { cause: innerExcelError }
     )
     parse.mockRejectedValue(validationError)
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     await processImportFile(buffer, deps())
-    warnIfLogNotCdpCompliant(logger.warn.mock.calls[0][0])
+    const logged = logger.warn.mock.calls[0][0]
 
-    expect(warnSpy).toHaveBeenCalledOnce()
-    expect(warnSpy.mock.calls[0][0]).toMatch(/cause/)
-    warnSpy.mockRestore()
+    expect(logged).toBeDefined()
+    expectLogToBeCdpCompliant(logged)
   })
 
   it('returns failure when organisation is not found', async () => {

--- a/src/reports/application/assert-cadence.js
+++ b/src/reports/application/assert-cadence.js
@@ -1,5 +1,6 @@
 import { badRequest } from '#common/helpers/enrich-boom.js'
 import { CADENCE } from '#reports/domain/cadence.js'
+import { errorCodes } from '#reports/enums/error-codes.js'
 
 /**
  * @import { Cadence } from '#reports/domain/cadence.js'
@@ -22,7 +23,7 @@ export const assertCadence = (cadence, registration) => {
   if (cadence !== expected) {
     throw badRequest(
       `Cadence '${cadence}' does not match registration type — expected '${expected}'`,
-      'CADENCE_MISMATCH',
+      errorCodes.cadenceMismatch,
       {
         event: {
           action: 'create_report',

--- a/src/reports/application/assert-cadence.test.js
+++ b/src/reports/application/assert-cadence.test.js
@@ -39,7 +39,7 @@ describe('assertCadence', () => {
     expect(boom.message).toBe(
       "Cadence 'monthly' does not match registration type — expected 'quarterly'"
     )
-    expect(boom.code).toBe('CADENCE_MISMATCH')
+    expect(boom.code).toBe('cadence_mismatch')
     expect(boom.event).toEqual({
       action: 'create_report',
       reason: 'actual=monthly expected=quarterly'
@@ -55,7 +55,7 @@ describe('assertCadence', () => {
       assertCadence('quarterly', { accreditationId: 'acc-1' })
     )
 
-    expect(boom.code).toBe('CADENCE_MISMATCH')
+    expect(boom.code).toBe('cadence_mismatch')
     expect(boom.event).toEqual({
       action: 'create_report',
       reason: 'actual=quarterly expected=monthly'

--- a/src/reports/application/assert-report-complete.js
+++ b/src/reports/application/assert-report-complete.js
@@ -6,6 +6,7 @@ import {
 } from '#reports/repository/schema.js'
 import Joi from 'joi'
 import { badRequest } from '#common/helpers/enrich-boom.js'
+import { errorCodes } from '#reports/enums/error-codes.js'
 
 /**
  * @import { OperatorCategory } from '#reports/domain/operator-category.js'
@@ -82,7 +83,7 @@ export const assertReportComplete = (report, operatorCategory) => {
   if (missingFields.length) {
     throw badRequest(
       `Report is incomplete; ${missingFields.length} required field(s) not populated`,
-      'REPORT_INCOMPLETE',
+      errorCodes.reportIncomplete,
       {
         event: {
           action: 'update_report_status',

--- a/src/reports/application/assert-report-complete.test.js
+++ b/src/reports/application/assert-report-complete.test.js
@@ -184,7 +184,7 @@ describe('assertReportComplete', () => {
         OPERATOR_CATEGORY.REPROCESSOR_REGISTERED_ONLY
       )
 
-      expect(boom.code).toBe('REPORT_INCOMPLETE')
+      expect(boom.code).toBe('report_incomplete')
       expect(boom.event).toEqual({
         action: 'update_report_status',
         reason:

--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -4,6 +4,7 @@ import { getIssuedTonnage } from '#packaging-recycling-notes/application/get-iss
 import { aggregateReportDetail } from '#reports/domain/aggregation/aggregate-report-detail.js'
 import { generateAllPeriodsForYear } from '#reports/domain/generate-reporting-periods.js'
 import { getOperatorCategory } from '#reports/domain/operator-category.js'
+import { errorCodes } from '#reports/enums/error-codes.js'
 
 /**
  * @import { PeriodicReport } from '#reports/repository/port.js'
@@ -110,7 +111,7 @@ const assertValidPeriod = (period, cadence, allPeriods) => {
     const validPeriods = allPeriods.map((p) => p.period)
     throw badRequest(
       `Invalid period ${period} for cadence ${cadence}`,
-      'INVALID_PERIOD',
+      errorCodes.invalidPeriod,
       {
         event: {
           action: 'create_report',
@@ -141,7 +142,7 @@ const assertPeriodEnded = (periodInfo, period, cadence) => {
 
     throw badRequest(
       `Cannot create report for period ${period} — period has not yet ended`,
-      'PERIOD_NOT_ENDED',
+      errorCodes.periodNotEnded,
       {
         event: {
           action: 'create_report',
@@ -175,7 +176,7 @@ const assertNoExistingReport = (periodicReports, year, cadence, period) => {
   if (id) {
     throw conflict(
       `Report already exists for ${cadence} period ${period} of ${year}`,
-      'REPORT_ALREADY_EXISTS',
+      errorCodes.reportAlreadyExists,
       {
         event: {
           action: 'create_report',

--- a/src/reports/enums/error-codes.js
+++ b/src/reports/enums/error-codes.js
@@ -1,0 +1,7 @@
+export const errorCodes = {
+  cadenceMismatch: 'cadence_mismatch',
+  reportIncomplete: 'report_incomplete',
+  invalidPeriod: 'invalid_period',
+  periodNotEnded: 'period_not_ended',
+  reportAlreadyExists: 'report_already_exists'
+}

--- a/src/reports/routes/post.test.js
+++ b/src/reports/routes/post.test.js
@@ -306,7 +306,7 @@ describe(`POST ${reportsPostPath}`, () => {
           message:
             "Cadence 'monthly' does not match registration type — expected 'quarterly'",
           error: {
-            code: 'CADENCE_MISMATCH',
+            code: 'cadence_mismatch',
             id: expect.any(String),
             message:
               "Cadence 'monthly' does not match registration type — expected 'quarterly'",
@@ -341,7 +341,7 @@ describe(`POST ${reportsPostPath}`, () => {
         expect(server.loggerMocks.warn).toHaveBeenCalledWith({
           message: 'Invalid period 5 for cadence quarterly',
           error: {
-            code: 'INVALID_PERIOD',
+            code: 'invalid_period',
             id: expect.any(String),
             message: 'Invalid period 5 for cadence quarterly',
             type: 'Bad Request'
@@ -376,7 +376,7 @@ describe(`POST ${reportsPostPath}`, () => {
           message:
             'Cannot create report for period 1 — period has not yet ended',
           error: {
-            code: 'PERIOD_NOT_ENDED',
+            code: 'period_not_ended',
             id: expect.any(String),
             message:
               'Cannot create report for period 1 — period has not yet ended',
@@ -408,7 +408,7 @@ describe(`POST ${reportsPostPath}`, () => {
         expect(server.loggerMocks.warn).toHaveBeenCalledWith({
           message: 'Report already exists for quarterly period 1 of 2025',
           error: {
-            code: 'REPORT_ALREADY_EXISTS',
+            code: 'report_already_exists',
             id: expect.any(String),
             message: 'Report already exists for quarterly period 1 of 2025',
             type: 'Conflict'
@@ -496,7 +496,7 @@ describe(`POST ${reportsPostPath}`, () => {
         expect(server.loggerMocks.warn).toHaveBeenCalledWith({
           message: 'Report already exists for quarterly period 1 of 2025',
           error: {
-            code: 'REPORT_ALREADY_EXISTS',
+            code: 'report_already_exists',
             id: expect.any(String),
             message: 'Report already exists for quarterly period 1 of 2025',
             type: 'Conflict'

--- a/src/reports/routes/status.test.js
+++ b/src/reports/routes/status.test.js
@@ -327,7 +327,7 @@ describe(`POST ${reportsStatusPath}`, () => {
         expect(server.loggerMocks.warn).toHaveBeenCalledWith({
           message: 'Report is incomplete; 2 required field(s) not populated',
           error: {
-            code: 'REPORT_INCOMPLETE',
+            code: 'report_incomplete',
             id: expect.any(String),
             message: 'Report is incomplete; 2 required field(s) not populated',
             type: 'Bad Request'

--- a/src/repositories/organisations/enums/error-codes.js
+++ b/src/repositories/organisations/enums/error-codes.js
@@ -1,0 +1,3 @@
+export const errorCodes = {
+  organisationDuplicateKey: 'organisation_duplicate_key'
+}

--- a/src/repositories/organisations/inmemory.js
+++ b/src/repositories/organisations/inmemory.js
@@ -96,10 +96,8 @@ const performReplace =
 const performFindById = (staleCache) => (id) => {
   try {
     validateId(id)
-  } catch (validationError) {
-    throw Boom.notFound(`Organisation with id ${id} not found`, {
-      cause: validationError
-    })
+  } catch {
+    throw Boom.notFound(`Organisation with id ${id} not found`)
   }
 
   const found = staleCache.find((o) => o._id === id)

--- a/src/repositories/organisations/mongodb.js
+++ b/src/repositories/organisations/mongodb.js
@@ -10,6 +10,7 @@ import {
   prepareForReplace,
   SCHEMA_VERSION
 } from './helpers.js'
+import { errorCodes } from './enums/error-codes.js'
 import { getCurrentStatus } from './status.js'
 import { validateId, validateOrganisationInsert } from './schema/index.js'
 
@@ -85,7 +86,7 @@ const throwCuratedDuplicateKeyBoom = (error, id) => {
     : 'unknown'
   throw conflict(
     `Duplicate key conflict updating organisation ${id} (${conflictFields})`,
-    'ORGANISATION_DUPLICATE_KEY',
+    errorCodes.organisationDuplicateKey,
     {
       event: {
         action: 'update_organisation',

--- a/src/repositories/organisations/mongodb.js
+++ b/src/repositories/organisations/mongodb.js
@@ -1,6 +1,7 @@
 import { REG_ACC_STATUS, USER_ROLES } from '#domain/organisations/model.js'
 import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
+import { conflict } from '#common/helpers/enrich-boom.js'
 import {
   createInitialStatusHistory,
   mapDocumentWithCurrentStatuses,
@@ -11,10 +12,6 @@ import {
 } from './helpers.js'
 import { getCurrentStatus } from './status.js'
 import { validateId, validateOrganisationInsert } from './schema/index.js'
-
-/**
- * @import { EnrichedBoom } from '#common/types/enriched-boom.js'
- */
 
 const COLLECTION_NAME = 'epr-organisations'
 const MONGODB_DUPLICATE_KEY_ERROR_CODE = 11000
@@ -86,17 +83,16 @@ const throwCuratedDuplicateKeyBoom = (error, id) => {
   const conflictFields = error.keyPattern
     ? Object.keys(error.keyPattern).join(', ')
     : 'unknown'
-  const boom = /** @type {EnrichedBoom} */ (
-    Boom.conflict(
-      `Duplicate key conflict updating organisation ${id} (${conflictFields})`
-    )
+  throw conflict(
+    `Duplicate key conflict updating organisation ${id} (${conflictFields})`,
+    'ORGANISATION_DUPLICATE_KEY',
+    {
+      event: {
+        action: 'update_organisation',
+        reason: `fields=${conflictFields}`
+      }
+    }
   )
-  boom.code = 'ORGANISATION_DUPLICATE_KEY'
-  boom.event = {
-    action: 'update_organisation',
-    reason: `fields=${conflictFields}`
-  }
-  throw boom
 }
 
 const performReplace = (db) => async (id, version, updates) => {

--- a/src/repositories/organisations/mongodb.js
+++ b/src/repositories/organisations/mongodb.js
@@ -12,6 +12,10 @@ import {
 import { getCurrentStatus } from './status.js'
 import { validateId, validateOrganisationInsert } from './schema/index.js'
 
+/**
+ * @import { EnrichedBoom } from '#common/types/enriched-boom.js'
+ */
+
 const COLLECTION_NAME = 'epr-organisations'
 const MONGODB_DUPLICATE_KEY_ERROR_CODE = 11000
 
@@ -82,10 +86,16 @@ const throwCuratedDuplicateKeyBoom = (error, id) => {
   const conflictFields = error.keyPattern
     ? Object.keys(error.keyPattern).join(', ')
     : 'unknown'
-  const boom = Boom.conflict(
-    `Duplicate key conflict updating organisation ${id} (${conflictFields})`
+  const boom = /** @type {EnrichedBoom} */ (
+    Boom.conflict(
+      `Duplicate key conflict updating organisation ${id} (${conflictFields})`
+    )
   )
-  boom.cause = error
+  boom.code = 'ORGANISATION_DUPLICATE_KEY'
+  boom.event = {
+    action: 'update_organisation',
+    reason: `fields=${conflictFields}`
+  }
   throw boom
 }
 

--- a/src/repositories/organisations/mongodb.test.js
+++ b/src/repositories/organisations/mongodb.test.js
@@ -175,6 +175,33 @@ describe('MongoDB organisations repository', () => {
       ).rejects.toThrow('Unexpected database error')
     })
 
+    it('should attach code ORGANISATION_DUPLICATE_KEY and event with conflicting fields for indexed logging', async () => {
+      const dbMock = {
+        collection: () => ({
+          createIndex: async () => {},
+          replaceOne: async () => {
+            const error = new Error('E11000 duplicate key error')
+            error.code = 11000
+            error.keyPattern = { 'registrations.id': 1, orgId: 1 }
+            throw error
+          }
+        })
+      }
+      const factory = await createOrganisationsRepository(dbMock)
+      const repository = factory()
+      const anyOrg = buildOrganisation()
+
+      await expect(
+        repository.replaceRaw(anyOrg.id, 1, { orgId: 'x' })
+      ).rejects.toMatchObject({
+        code: 'ORGANISATION_DUPLICATE_KEY',
+        event: {
+          action: 'update_organisation',
+          reason: 'fields=registrations.id, orgId'
+        }
+      })
+    })
+
     it('falls back to "unknown" in the dup-key message when keyPattern is absent', async () => {
       const dbMock = {
         collection: () => ({

--- a/src/repositories/organisations/mongodb.test.js
+++ b/src/repositories/organisations/mongodb.test.js
@@ -194,7 +194,7 @@ describe('MongoDB organisations repository', () => {
       await expect(
         repository.replaceRaw(anyOrg.id, 1, { orgId: 'x' })
       ).rejects.toMatchObject({
-        code: 'ORGANISATION_DUPLICATE_KEY',
+        code: 'organisation_duplicate_key',
         event: {
           action: 'update_organisation',
           reason: 'fields=registrations.id, orgId'


### PR DESCRIPTION
Ticket: [PAE-1384](https://eaflood.atlassian.net/browse/PAE-1384)
follow-up to #1127. addresses the `error.cause` drift surfaced by the advisory validator, flips the validator to strict mode, and standardises error-code constants per domain.

depends on #1127 — review/merge that one first.

## what this changes

### cause cleanup (drives flip to strict)
- drops the `error.cause` block from `err-serializer.js`. cdp's allowlist does not include `error/cause/*`, so those fields landed in the dropped-fields s3 sink. classifier signal now goes into `event.reason` at the throw site instead.
- reshapes the two production sites that previously relied on cause for diagnostic info, using the `enrich-boom` helper from #1127:
  - `mongodb.js` dup-key: `boom.cause = error` -> `code: organisationsErrorCodes.organisationDuplicateKey` + `event.reason: \`fields=...\``
  - `fetch-json.js` network failure: `boom.cause = error` -> `code: commonErrorCodes.externalFetchFailed` + `event.reason: \`type=... code=...\``
- drops inert cause attachments (decoration that never reached the logger) from 4 non-boom paths: `inmemory.js`, `exceljs-parser.js`, `s3-uri.js`, `validate-config.js`
- flips `process-import-file.test.js` from `warnIfLogNotCdpCompliant` (advisory in #1127) to `expectLogToBeCdpCompliant` (strict)
- removes the `warnIfLogNotCdpCompliant` export from the helper — no consumers remain
- removes 5 cause-asserting tests across `logger.test.js`, `validate-config.test.js`, `exceljs-parser.test.js` per the "drop tests rather than assert negatives when removing functionality" preference

### error-code constants extraction
- per-domain enum modules with camelCase keys and lowercase snake_case wire values:
  - `src/reports/enums/error-codes.js` -> `reportsErrorCodes.{cadenceMismatch,reportIncomplete,invalidPeriod,periodNotEnded,reportAlreadyExists}`
  - `src/repositories/organisations/enums/error-codes.js` -> `organisationsErrorCodes.organisationDuplicateKey`
  - `src/common/enums/error-codes.js` -> `commonErrorCodes.externalFetchFailed`
- all 7 production throw sites + 6 test files updated to import from these constants
- aligns wire-value style with existing `LOGGING_EVENT_ACTIONS` (lowercase snake_case): `'CADENCE_MISMATCH'` -> `'cadence_mismatch'`, etc.

## breaking changes for opensearch consumers (low impact)

1. `error.cause.type` and `error.cause.code` are no longer emitted. any opensearch query or alert filtering on these will silently start matching nothing. risk is low — these only ever landed in the dropped-fields s3 sink, never indexed.
2. `error.code` values change from uppercase to lowercase snake_case (e.g. `'CADENCE_MISMATCH'` -> `'cadence_mismatch'`). risk is low — pae-1384 only landed 2026-04-24 (#1116), so unlikely any draft dashboards exist yet. anyone holding a query filtering on these uppercase values needs to update.

## test plan

- [ ] `npm test` green (5896 tests pass locally)
- [ ] `npm run lint` clean
- [ ] `npm run lint:types` clean
- [ ] strict mode active in `process-import-file.test.js`; advisory `warnIfLogNotCdpCompliant` removed from helper
- [ ] all `error.code` test assertions reference per-domain enum constants

## related

- supersedes the cleanup work that originally landed in #1125 (closed in favour of the advisory/strict split)
- closes `repos-vdy`, `repos-lrc`, `repos-5q9` beads

[PAE-1384]: https://eaflood.atlassian.net/browse/PAE-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ