### PR TITLE
PAE-1409: Store splitFromSubmissionId lineage on GLASS_OTHER split records

### DIFF
--- a/src/forms-submission-data/accreditation/transform-accreditation.test.js
+++ b/src/forms-submission-data/accreditation/transform-accreditation.test.js
@@ -454,6 +454,8 @@ describe('parseAccreditationSubmission - Integration Tests with Fixture Data', (
       })
     )
     expect(result[1].id).not.toBe('68e6a97723d5d5454a9a193b')
+    expect(result[1].splitFromSubmissionId).toBe('68e6a97723d5d5454a9a193b')
+    expect(result[0].splitFromSubmissionId).toBeUndefined()
   })
 
   it('should apply systemReference override when accreditation id matches override config', () => {

--- a/src/forms-submission-data/integration.test.js
+++ b/src/forms-submission-data/integration.test.js
@@ -1,6 +1,9 @@
 import exporterAccreditation from '#data/fixtures/ea/accreditation/exporter.json'
 import reprocessorGlassAccreditation from '#data/fixtures/ea/accreditation/reprocessor-glass.json'
-import { MATERIAL } from '#domain/organisations/model.js'
+import {
+  GLASS_RECYCLING_PROCESS,
+  MATERIAL
+} from '#domain/organisations/model.js'
 import { createFormSubmissionsRepository } from '#repositories/form-submissions/inmemory.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
@@ -26,6 +29,19 @@ describe('Migration Integration Tests with Fixtures', () => {
       const filePath = join(fixturesDir, filename)
       return JSON.parse(readFileSync(filePath, 'utf-8'))
     })
+  }
+
+  function verifyGlassSplitLineage(submissions) {
+    const remelt = submissions.find(
+      (s) =>
+        s.glassRecyclingProcess?.[0] === GLASS_RECYCLING_PROCESS.GLASS_RE_MELT
+    )
+    const other = submissions.find(
+      (s) =>
+        s.glassRecyclingProcess?.[0] === GLASS_RECYCLING_PROCESS.GLASS_OTHER
+    )
+    expect(other.splitFromSubmissionId).toBe(remelt.id)
+    expect(remelt.splitFromSubmissionId).toBeUndefined()
   }
 
   async function verifyIncrementalMigrationAudit(
@@ -176,6 +192,11 @@ describe('Migration Integration Tests with Fixtures', () => {
       for (const reg of org503181.registrations) {
         expect(reg.accreditationId).toBe(exporterAccreditation._id.$oid)
       }
+
+      verifyGlassSplitLineage(org503181.registrations)
+
+      const org503177 = allOrgs.find((o) => o.orgId === 503177)
+      verifyGlassSplitLineage(org503177.accreditations)
 
       const org503176 = allOrgs.find((o) => o.orgId === 503176)
       expect(org503176.accreditations).toHaveLength(3)

--- a/src/forms-submission-data/parsing-common/split-glass-submissions.js
+++ b/src/forms-submission-data/parsing-common/split-glass-submissions.js
@@ -26,6 +26,7 @@ function splitIntoRemeltAndOther(registration) {
   const other = {
     ...registration,
     id: new ObjectId().toString(),
+    splitFromSubmissionId: registration.id,
     glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER]
   }
 

--- a/src/forms-submission-data/parsing-common/split-glass-submissions.test.js
+++ b/src/forms-submission-data/parsing-common/split-glass-submissions.test.js
@@ -116,6 +116,34 @@ describe('splitGlassSubmissions', () => {
     expect(result[1].id).toBeTruthy()
   })
 
+  it('should set splitFromSubmissionId on the other registration to the original id', () => {
+    const both = makeGlassRegistration(
+      [
+        GLASS_RECYCLING_PROCESS.GLASS_RE_MELT,
+        GLASS_RECYCLING_PROCESS.GLASS_OTHER
+      ],
+      { id: 'original-id' }
+    )
+
+    const result = splitGlassSubmissions([both])
+
+    expect(result[1].splitFromSubmissionId).toBe('original-id')
+  })
+
+  it('should not set splitFromSubmissionId on the remelt registration', () => {
+    const both = makeGlassRegistration(
+      [
+        GLASS_RECYCLING_PROCESS.GLASS_RE_MELT,
+        GLASS_RECYCLING_PROCESS.GLASS_OTHER
+      ],
+      { id: 'original-id' }
+    )
+
+    const result = splitGlassSubmissions([both])
+
+    expect(result[0].splitFromSubmissionId).toBeUndefined()
+  })
+
   it('should handle a mix of glass and non-glass registrations', () => {
     const plastic = makeRegistration({ id: 'plastic-1' })
     const glassBoth = makeGlassRegistration(

--- a/src/forms-submission-data/registration/transform-registration.test.js
+++ b/src/forms-submission-data/registration/transform-registration.test.js
@@ -102,6 +102,8 @@ describe('parseRegistrationSubmission - Integration Tests with Fixture Data', ()
       })
     )
     expect(result[1].id).not.toBe(exporter._id.$oid)
+    expect(result[1].splitFromSubmissionId).toBe(exporter._id.$oid)
+    expect(result[0].splitFromSubmissionId).toBeUndefined()
 
     // Regression guard: submitter and approved person must come from distinct
     // form sections. Pre-fix, both were extracted from the "App contact"

--- a/src/repositories/organisations/schema/accreditation.js
+++ b/src/repositories/organisations/schema/accreditation.js
@@ -99,6 +99,7 @@ export const accreditationSchema = Joi.object({
   wasteProcessingType: Joi.string()
     .valid(WASTE_PROCESSING_TYPE.REPROCESSOR, WASTE_PROCESSING_TYPE.EXPORTER)
     .required(),
+  splitFromSubmissionId: idSchema.optional(),
   prnIssuance: prnIssuanceSchema.required(),
   submitterContactDetails: userSchema.required(),
   samplingInspectionPlanPart2FileUploads: Joi.array()

--- a/src/repositories/organisations/schema/registration.js
+++ b/src/repositories/organisations/schema/registration.js
@@ -104,6 +104,7 @@ export const registrationSchema = Joi.object({
     .valid(WASTE_PROCESSING_TYPE.REPROCESSOR, WASTE_PROCESSING_TYPE.EXPORTER)
     .required(),
   accreditationId: idSchema.optional(),
+  splitFromSubmissionId: idSchema.optional(),
   glassRecyclingProcess: whenMaterial(
     MATERIAL.GLASS,
     Joi.array()


### PR DESCRIPTION
Ticket: [PAE-1409](https://eaflood.atlassian.net/browse/PAE-1409)
## Summary

- Adds `splitFromSubmissionId` to the `GLASS_OTHER` record produced by `splitIntoRemeltAndOther()`, set to the original form submission ID that is retained on the `GLASS_RE_MELT` record
- Adds `splitFromSubmissionId` as an optional field to both the registration and accreditation Joi schemas
- `GLASS_RE_MELT` records are unchanged — no `splitFromSubmissionId` is set on them

[PAE-1409]: https://eaflood.atlassian.net/browse/PAE-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ