### PR TITLE
PAE-1409: Store original form submission id during migration

### DIFF
--- a/src/application/public-register/public-register-transformer.test.js
+++ b/src/application/public-register/public-register-transformer.test.js
@@ -50,14 +50,16 @@ describe('transform', () => {
   }
 
   const createTestAccreditation = (overrides = {}) => {
+    const id = new ObjectId().toString()
     const status = overrides.status || REG_ACC_STATUS.APPROVED
     return buildAccreditation({
+      id,
       status,
       material: MATERIAL.PLASTIC,
       wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
       validFrom: VALID_FROM,
       validTo: VALID_TO,
-      formSubmissionTime: new Date('2025-12-15'),
+      formSubmission: { id, time: new Date('2025-12-15') },
       prnIssuance: { tonnageBand: 'up_to_10000' },
       statusHistory: [
         { status: REG_ACC_STATUS.CREATED, updatedAt: CREATED_DATE },

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -30,14 +30,15 @@ describe('SummaryLogsValidator integration', () => {
   ) => {
     const registrationId = randomUUID()
 
+    const accreditationId = randomUUID()
     const accreditation = accreditationNumber
       ? {
-          id: randomUUID(),
+          id: accreditationId,
           accreditationNumber,
           material: 'paper',
           wasteProcessingType,
           ...(wasteProcessingType === 'reprocessor' && { reprocessingType }),
-          formSubmissionTime: new Date(),
+          formSubmission: { id: accreditationId, time: new Date() },
           submittedToRegulator: 'ea'
         }
       : undefined
@@ -48,7 +49,7 @@ describe('SummaryLogsValidator integration', () => {
       material: 'paper',
       wasteProcessingType,
       ...(wasteProcessingType === 'reprocessor' && { reprocessingType }),
-      formSubmissionTime: new Date(),
+      formSubmission: { id: registrationId, time: new Date() },
       submittedToRegulator: 'ea',
       ...(accreditation && { accreditationId: accreditation.id })
     }

--- a/src/auditing/form-submission-lineage-migration.js
+++ b/src/auditing/form-submission-lineage-migration.js
@@ -1,0 +1,60 @@
+import { isPayloadSmallEnoughToAudit, safeAudit } from './helpers.js'
+
+/**
+ * @import {SystemLogsRepository} from '#repositories/system-logs/port.js'
+ */
+
+const SYSTEM_USER = { id: 'system', email: 'system', scope: [] }
+
+const EVENT = {
+  category: 'entity',
+  subCategory: 'epr-organisations',
+  action: 'migrate-form-submission-lineage'
+}
+
+/**
+ * Audit a form submission lineage migration for an organisation.
+ * This is a system-initiated action (no user request context).
+ * Logs the full organisation state before and after migration.
+ *
+ * @param {SystemLogsRepository} systemLogsRepository
+ * @param {string} organisationId
+ * @param {Object} previous - Organisation state before migration
+ * @param {Object} next - Organisation state after migration
+ */
+async function auditFormSubmissionLineageMigration(
+  systemLogsRepository,
+  organisationId,
+  previous,
+  next
+) {
+  const payload = {
+    event: EVENT,
+    context: {
+      organisationId,
+      previous,
+      next
+    },
+    user: SYSTEM_USER
+  }
+
+  // CDP audit has size limits - send reduced context if too big
+  const safeAuditingPayload = isPayloadSmallEnoughToAudit(payload)
+    ? payload
+    : {
+        ...payload,
+        context: { organisationId }
+      }
+
+  safeAudit(safeAuditingPayload)
+
+  // System logs have no size limit - always store full state
+  await systemLogsRepository.insert({
+    createdAt: new Date(),
+    createdBy: SYSTEM_USER,
+    event: EVENT,
+    context: payload.context
+  })
+}
+
+export { auditFormSubmissionLineageMigration }

--- a/src/auditing/form-submission-lineage-migration.test.js
+++ b/src/auditing/form-submission-lineage-migration.test.js
@@ -1,0 +1,166 @@
+import { auditFormSubmissionLineageMigration } from './form-submission-lineage-migration.js'
+import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest'
+import { ObjectId } from 'mongodb'
+
+const mockAudit = vi.fn()
+const mockInsert = vi.fn()
+
+vi.mock('@defra/cdp-auditing', () => ({
+  audit: (...args) => mockAudit(...args)
+}))
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    warn: vi.fn()
+  }
+}))
+
+vi.mock('#root/config.js', () => ({
+  config: {
+    get: vi.fn((key) => {
+      if (key === 'audit.maxPayloadSizeBytes') {
+        return 10000
+      }
+      return undefined
+    })
+  }
+}))
+
+describe('auditFormSubmissionLineageMigration', () => {
+  const now = new Date('2026-02-11T12:00:00.000Z')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  const organisationId = new ObjectId().toString()
+  const systemUser = { id: 'system', email: 'system', scope: [] }
+
+  const createMockSystemLogsRepository = () => ({
+    insert: mockInsert
+  })
+
+  it('logs full previous/next state to both CDP audit and system log', async () => {
+    const previous = {
+      registrations: [
+        { id: new ObjectId().toString(), registrationNumber: 'REG-2025-01' }
+      ],
+      accreditations: [
+        { id: new ObjectId().toString(), accreditationNumber: 'ACC-2025-01' }
+      ]
+    }
+    const next = {
+      registrations: [
+        { id: new ObjectId().toString(), registrationNumber: 'REG-2025-01' },
+        { id: new ObjectId().toString(), registrationNumber: 'REG-2025-02' }
+      ],
+      accreditations: [
+        { id: new ObjectId().toString(), accreditationNumber: 'ACC-2025-01' },
+        { id: new ObjectId().toString(), accreditationNumber: 'ACC-2025-02' }
+      ]
+    }
+
+    await auditFormSubmissionLineageMigration(
+      createMockSystemLogsRepository(),
+      organisationId,
+      previous,
+      next
+    )
+
+    expect(mockAudit).toHaveBeenCalledWith({
+      event: {
+        category: 'entity',
+        subCategory: 'epr-organisations',
+        action: 'migrate-form-submission-lineage'
+      },
+      context: {
+        organisationId,
+        previous,
+        next
+      },
+      user: systemUser
+    })
+
+    expect(mockInsert).toHaveBeenCalledWith({
+      createdAt: now,
+      createdBy: systemUser,
+      event: {
+        category: 'entity',
+        subCategory: 'epr-organisations',
+        action: 'migrate-form-submission-lineage'
+      },
+      context: {
+        organisationId,
+        previous,
+        next
+      }
+    })
+  })
+
+  it('sends reduced context to CDP audit but full state to system log when payload is too large', async () => {
+    const largeData = 'x'.repeat(15000)
+    const previous = {
+      registrations: [
+        {
+          id: new ObjectId().toString(),
+          registrationNumber: 'REG-2025-01',
+          data: largeData
+        }
+      ],
+      accreditations: []
+    }
+    const next = {
+      registrations: [
+        {
+          id: new ObjectId().toString(),
+          registrationNumber: 'REG-2025-01',
+          data: largeData
+        },
+        {
+          id: new ObjectId().toString(),
+          registrationNumber: 'REG-2025-02',
+          data: largeData
+        }
+      ],
+      accreditations: []
+    }
+
+    await auditFormSubmissionLineageMigration(
+      createMockSystemLogsRepository(),
+      organisationId,
+      previous,
+      next
+    )
+
+    expect(mockAudit).toHaveBeenCalledWith({
+      event: {
+        category: 'entity',
+        subCategory: 'epr-organisations',
+        action: 'migrate-form-submission-lineage'
+      },
+      context: { organisationId },
+      user: systemUser
+    })
+
+    expect(mockInsert).toHaveBeenCalledWith({
+      createdAt: now,
+      createdBy: systemUser,
+      event: {
+        category: 'entity',
+        subCategory: 'epr-organisations',
+        action: 'migrate-form-submission-lineage'
+      },
+      context: {
+        organisationId,
+        previous,
+        next
+      }
+    })
+  })
+})

--- a/src/config.js
+++ b/src/config.js
@@ -365,6 +365,12 @@ const baseConfig = {
       format: Boolean,
       default: false,
       env: 'FEATURE_FLAG_WASTE_BALANCE_LEDGER'
+    },
+    migrateFormSubmissionLineage: {
+      doc: 'Feature Flag: Backfill formSubmission lineage on existing orgs/reg/acc',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_FLAG_MIGRATE_FORM_SUBMISSION_LINEAGE'
     }
   },
   formSubmissionOverrides: {

--- a/src/data/fixtures/common/epr-organisations/sample-organisation-1.json
+++ b/src/data/fixtures/common/epr-organisations/sample-organisation-1.json
@@ -1,7 +1,7 @@
 {
   "id": "6507f1f77bcf86cd79943901",
   "orgId": 50002,
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "version": 1,
   "statusHistory": [
     {
@@ -26,7 +26,10 @@
     ]
   },
   "submittedToRegulator": "ea",
-  "formSubmissionTime": "2025-08-22T19:34:44.944Z",
+  "formSubmission": {
+    "time": "2025-08-22T19:34:44.944Z",
+    "id": "6507f1f77bcf86cd79943901"
+  },
   "submitterContactDetails": {
     "fullName": "Anakin Skywalker",
     "email": "anakin.skywalker@starwars.com",
@@ -48,7 +51,10 @@
       ],
       "submittedToRegulator": "ea",
       "orgName": "ACME ltd",
-      "formSubmissionTime": "2025-08-20T19:34:44.944Z",
+      "formSubmission": {
+        "time": "2025-08-20T19:34:44.944Z",
+        "id": "6507f1f77bcf86cd79943902"
+      },
       "site": {
         "address": {
           "line1": "7 Glass processing site",
@@ -152,7 +158,10 @@
       ],
       "submittedToRegulator": "ea",
       "orgName": "ACME ltd",
-      "formSubmissionTime": "2025-08-21T19:34:44.944Z",
+      "formSubmission": {
+        "time": "2025-08-21T19:34:44.944Z",
+        "id": "68f6a147c117aec8a1ab7494"
+      },
       "material": "plastic",
       "wasteProcessingType": "exporter",
       "glassRecyclingProcess": null,
@@ -198,7 +207,10 @@
       "accreditationNumber": null,
       "validFrom": null,
       "validTo": null,
-      "formSubmissionTime": "2025-08-20T21:34:44.944Z",
+      "formSubmission": {
+        "time": "2025-08-20T21:34:44.944Z",
+        "id": "68f6a147c117aec8a1ab7495"
+      },
       "statusHistory": [
         {
           "status": "created",
@@ -282,7 +294,10 @@
       "accreditationNumber": null,
       "validFrom": null,
       "validTo": null,
-      "formSubmissionTime": "2025-08-21T21:34:44.944Z",
+      "formSubmission": {
+        "time": "2025-08-21T21:34:44.944Z",
+        "id": "68f6a147c117aec8a1ab7496"
+      },
       "statusHistory": [
         {
           "status": "created",
@@ -366,7 +381,10 @@
       "accreditationNumber": null,
       "validFrom": null,
       "validTo": null,
-      "formSubmissionTime": "2025-08-22T21:34:44.944Z",
+      "formSubmission": {
+        "time": "2025-08-22T21:34:44.944Z",
+        "id": "68f6a147c117aec8a1ab7494"
+      },
       "statusHistory": [
         {
           "status": "created",

--- a/src/data/fixtures/common/epr-organisations/sample-organisation-2.json
+++ b/src/data/fixtures/common/epr-organisations/sample-organisation-2.json
@@ -1,7 +1,7 @@
 {
   "id": "6507f1f77bcf86cd79943921",
   "orgId": 50004,
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "version": 1,
   "statusHistory": [
     {
@@ -13,7 +13,10 @@
   "reprocessingNations": ["wales"],
   "businessType": "individual",
   "submittedToRegulator": "nrw",
-  "formSubmissionTime": "2025-10-01T08:30:00.000Z",
+  "formSubmission": {
+    "time": "2025-10-01T08:30:00.000Z",
+    "id": "6507f1f77bcf86cd79943921"
+  },
   "submitterContactDetails": {
     "fullName": "Carol White",
     "email": "carol.white@export.com",
@@ -32,7 +35,10 @@
       ],
       "submittedToRegulator": "nrw",
       "orgName": "Plastic Exporters",
-      "formSubmissionTime": "2025-10-01T08:00:00.000Z",
+      "formSubmission": {
+        "time": "2025-10-01T08:00:00.000Z",
+        "id": "6507f1f77bcf86cd79943922"
+      },
       "material": "plastic",
       "wasteProcessingType": "exporter",
       "glassRecyclingProcess": null,
@@ -78,7 +84,10 @@
   "accreditations": [
     {
       "id": "68f6a147c117aec8a1ab7499",
-      "formSubmissionTime": "2025-10-01T09:00:00.000Z",
+      "formSubmission": {
+        "time": "2025-10-01T09:00:00.000Z",
+        "id": "68f6a147c117aec8a1ab7499"
+      },
       "statusHistory": [
         {
           "status": "created",

--- a/src/data/fixtures/common/epr-organisations/sample-organisation-3.json
+++ b/src/data/fixtures/common/epr-organisations/sample-organisation-3.json
@@ -1,7 +1,7 @@
 {
   "id": "6507f1f77bcf86cd79943931",
   "orgId": 50005,
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "version": 1,
   "statusHistory": [
     {
@@ -13,7 +13,10 @@
   "reprocessingNations": ["northern_ireland", "england"],
   "businessType": "unincorporated",
   "submittedToRegulator": "niea",
-  "formSubmissionTime": "2025-11-01T12:00:00.000Z",
+  "formSubmission": {
+    "time": "2025-11-01T12:00:00.000Z",
+    "id": "6507f1f77bcf86cd79943931"
+  },
   "submitterContactDetails": {
     "fullName": "Eve Black",
     "email": "eve.black@charity.org",
@@ -32,7 +35,10 @@
       ],
       "submittedToRegulator": "niea",
       "orgName": "Green Future Trust",
-      "formSubmissionTime": "2025-11-01T11:00:00.000Z",
+      "formSubmission": {
+        "time": "2025-11-01T11:00:00.000Z",
+        "id": "6507f1f77bcf86cd79943932"
+      },
       "site": {
         "address": {
           "line1": "100 Trust Road",
@@ -131,7 +137,10 @@
       ],
       "submittedToRegulator": "niea",
       "orgName": "Green Future Trust",
-      "formSubmissionTime": "2025-11-01T11:30:00.000Z",
+      "formSubmission": {
+        "time": "2025-11-01T11:30:00.000Z",
+        "id": "6507f1f77bcf86cd79943933"
+      },
       "material": "aluminium",
       "wasteProcessingType": "exporter",
       "glassRecyclingProcess": null,
@@ -177,7 +186,10 @@
   "accreditations": [
     {
       "id": "68f6a147c117aec8a1ab749a",
-      "formSubmissionTime": "2025-11-01T13:00:00.000Z",
+      "formSubmission": {
+        "time": "2025-11-01T13:00:00.000Z",
+        "id": "68f6a147c117aec8a1ab749a"
+      },
       "statusHistory": [
         {
           "status": "created",

--- a/src/data/fixtures/common/epr-organisations/sample-organisation-4.json
+++ b/src/data/fixtures/common/epr-organisations/sample-organisation-4.json
@@ -1,7 +1,7 @@
 {
   "id": "6507f1f77bcf86cd79943911",
   "orgId": 50003,
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "version": 1,
   "statusHistory": [
     {
@@ -13,7 +13,10 @@
   "reprocessingNations": ["scotland", "northern_ireland"],
   "businessType": "partnership",
   "submittedToRegulator": "sepa",
-  "formSubmissionTime": "2025-09-10T10:00:00.000Z",
+  "formSubmission": {
+    "time": "2025-09-10T10:00:00.000Z",
+    "id": "6507f1f77bcf86cd79943911"
+  },
   "submitterContactDetails": {
     "fullName": "Alice Smith",
     "email": "alice.smith@ecorecycle.com",
@@ -32,7 +35,10 @@
       ],
       "submittedToRegulator": "sepa",
       "orgName": "Eco Recycle Ltd",
-      "formSubmissionTime": "2025-09-09T09:00:00.000Z",
+      "formSubmission": {
+        "time": "2025-09-09T09:00:00.000Z",
+        "id": "6507f1f77bcf86cd79943912"
+      },
       "site": {
         "address": {
           "line1": "1 Green Park",
@@ -131,7 +137,10 @@
       ],
       "submittedToRegulator": "sepa",
       "orgName": "Eco Recycle Ltd",
-      "formSubmissionTime": "2025-09-09T10:00:00.000Z",
+      "formSubmission": {
+        "time": "2025-09-09T10:00:00.000Z",
+        "id": "6507f1f77bcf86cd79943913"
+      },
       "material": "paper",
       "wasteProcessingType": "exporter",
       "glassRecyclingProcess": null,
@@ -177,7 +186,10 @@
   "accreditations": [
     {
       "id": "68f6a147c117aec8a1ab7497",
-      "formSubmissionTime": "2025-09-09T11:00:00.000Z",
+      "formSubmission": {
+        "time": "2025-09-09T11:00:00.000Z",
+        "id": "68f6a147c117aec8a1ab7497"
+      },
       "statusHistory": [
         {
           "status": "created",
@@ -261,7 +273,10 @@
     },
     {
       "id": "68f6a147c117aec8a1ab7498",
-      "formSubmissionTime": "2025-09-09T12:00:00.000Z",
+      "formSubmission": {
+        "time": "2025-09-09T12:00:00.000Z",
+        "id": "68f6a147c117aec8a1ab7498"
+      },
       "statusHistory": [
         {
           "status": "created",

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -16,5 +16,8 @@ export const createConfigFeatureFlags = (config) => ({
   },
   isWasteBalanceLedgerEnabled() {
     return config.get('featureFlags.wasteBalanceLedger')
+  },
+  isMigrateFormSubmissionLineageEnabled() {
+    return config.get('featureFlags.migrateFormSubmissionLineage')
   }
 })

--- a/src/feature-flags/feature-flags.config.test.js
+++ b/src/feature-flags/feature-flags.config.test.js
@@ -64,4 +64,19 @@ describe('createConfigFeatureFlags', () => {
     const flags = createConfigFeatureFlags(config)
     expect(flags.isWasteBalanceLedgerEnabled()).toBe(false)
   })
+
+  it('returns true when migrateFormSubmissionLineage flag is enabled', () => {
+    const config = { get: vi.fn().mockReturnValue(true) }
+    const flags = createConfigFeatureFlags(config)
+    expect(flags.isMigrateFormSubmissionLineageEnabled()).toBe(true)
+    expect(config.get).toHaveBeenCalledWith(
+      'featureFlags.migrateFormSubmissionLineage'
+    )
+  })
+
+  it('returns false when migrateFormSubmissionLineage flag is disabled', () => {
+    const config = { get: vi.fn().mockReturnValue(false) }
+    const flags = createConfigFeatureFlags(config)
+    expect(flags.isMigrateFormSubmissionLineageEnabled()).toBe(false)
+  })
 })

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -16,5 +16,8 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   },
   isWasteBalanceLedgerEnabled() {
     return flags.wasteBalanceLedger ?? false
+  },
+  isMigrateFormSubmissionLineageEnabled() {
+    return flags.migrateFormSubmissionLineage ?? false
   }
 })

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -80,4 +80,23 @@ describe('createInMemoryFeatureFlags', () => {
     const flags = createInMemoryFeatureFlags({})
     expect(flags.isWasteBalanceLedgerEnabled()).toBe(false)
   })
+
+  it('returns true when migrateFormSubmissionLineage flag is enabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      migrateFormSubmissionLineage: true
+    })
+    expect(flags.isMigrateFormSubmissionLineageEnabled()).toBe(true)
+  })
+
+  it('returns false when migrateFormSubmissionLineage flag is disabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      migrateFormSubmissionLineage: false
+    })
+    expect(flags.isMigrateFormSubmissionLineageEnabled()).toBe(false)
+  })
+
+  it('returns false when migrateFormSubmissionLineage flag is not provided', () => {
+    const flags = createInMemoryFeatureFlags({})
+    expect(flags.isMigrateFormSubmissionLineageEnabled()).toBe(false)
+  })
 })

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -5,6 +5,7 @@
  * @property {() => boolean} isReportsEnabled
  * @property {() => boolean} isOrsWasteBalanceValidationEnabled
  * @property {() => boolean} isWasteBalanceLedgerEnabled
+ * @property {() => boolean} isMigrateFormSubmissionLineageEnabled
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/forms-submission-data/accreditation/transform-accreditation.js
+++ b/src/forms-submission-data/accreditation/transform-accreditation.js
@@ -55,6 +55,7 @@ function buildParsedAccreditation(id, rawSubmissionData) {
 
   return {
     id,
+    formSubmission: { id, time: extractTimestamp(rawSubmissionData) },
     formSubmissionTime: extractTimestamp(rawSubmissionData),
     submittedToRegulator: extractAgencyFromDefinitionName(rawSubmissionData),
     wasteProcessingType,

--- a/src/forms-submission-data/accreditation/transform-accreditation.js
+++ b/src/forms-submission-data/accreditation/transform-accreditation.js
@@ -56,7 +56,6 @@ function buildParsedAccreditation(id, rawSubmissionData) {
   return {
     id,
     formSubmission: { id, time: extractTimestamp(rawSubmissionData) },
-    formSubmissionTime: extractTimestamp(rawSubmissionData),
     submittedToRegulator: extractAgencyFromDefinitionName(rawSubmissionData),
     wasteProcessingType,
     orgId: convertToNumber(

--- a/src/forms-submission-data/accreditation/transform-accreditation.test.js
+++ b/src/forms-submission-data/accreditation/transform-accreditation.test.js
@@ -31,7 +31,6 @@ describe('parseAccreditationSubmission - Integration Tests with Fixture Data', (
         id: '68e6aa2423d5d5454a9a193c',
         time: new Date('2025-10-08T18:15:00.199Z')
       },
-      formSubmissionTime: new Date('2025-10-08T18:15:00.199Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
       orgId: 503181,
@@ -146,7 +145,6 @@ describe('parseAccreditationSubmission - Integration Tests with Fixture Data', (
         id: '68e6a62723d5d5454a9a193a',
         time: new Date('2025-10-08T17:57:59.709Z')
       },
-      formSubmissionTime: new Date('2025-10-08T17:57:59.709Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
       orgId: 503176,
@@ -254,7 +252,6 @@ describe('parseAccreditationSubmission - Integration Tests with Fixture Data', (
         id: '68e6a50423d5d5454a9a1939',
         time: new Date('2025-10-08T17:53:08.213Z')
       },
-      formSubmissionTime: new Date('2025-10-08T17:53:08.213Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
       orgId: 503176,
@@ -367,7 +364,6 @@ describe('parseAccreditationSubmission - Integration Tests with Fixture Data', (
         id: '68e6a97723d5d5454a9a193b',
         time: new Date('2025-10-08T18:12:07.326Z')
       },
-      formSubmissionTime: new Date('2025-10-08T18:12:07.326Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
       orgId: 503177,

--- a/src/forms-submission-data/accreditation/transform-accreditation.test.js
+++ b/src/forms-submission-data/accreditation/transform-accreditation.test.js
@@ -27,6 +27,10 @@ describe('parseAccreditationSubmission - Integration Tests with Fixture Data', (
 
     expect(result[0]).toStrictEqual({
       id: '68e6aa2423d5d5454a9a193c',
+      formSubmission: {
+        id: '68e6aa2423d5d5454a9a193c',
+        time: new Date('2025-10-08T18:15:00.199Z')
+      },
       formSubmissionTime: new Date('2025-10-08T18:15:00.199Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
@@ -138,6 +142,10 @@ describe('parseAccreditationSubmission - Integration Tests with Fixture Data', (
 
     expect(result[0]).toStrictEqual({
       id: '68e6a62723d5d5454a9a193a',
+      formSubmission: {
+        id: '68e6a62723d5d5454a9a193a',
+        time: new Date('2025-10-08T17:57:59.709Z')
+      },
       formSubmissionTime: new Date('2025-10-08T17:57:59.709Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
@@ -242,6 +250,10 @@ describe('parseAccreditationSubmission - Integration Tests with Fixture Data', (
 
     expect(result[0]).toStrictEqual({
       id: '68e6a50423d5d5454a9a1939',
+      formSubmission: {
+        id: '68e6a50423d5d5454a9a1939',
+        time: new Date('2025-10-08T17:53:08.213Z')
+      },
       formSubmissionTime: new Date('2025-10-08T17:53:08.213Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
@@ -351,6 +363,10 @@ describe('parseAccreditationSubmission - Integration Tests with Fixture Data', (
     )
 
     const commonFields = {
+      formSubmission: {
+        id: '68e6a97723d5d5454a9a193b',
+        time: new Date('2025-10-08T18:12:07.326Z')
+      },
       formSubmissionTime: new Date('2025-10-08T18:12:07.326Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,

--- a/src/forms-submission-data/link-form-submissions.js
+++ b/src/forms-submission-data/link-form-submissions.js
@@ -153,11 +153,11 @@ function findEligibleAccreditations(registration, accreditations) {
 }
 
 /**
- * Selects the latest accreditation from a list by formSubmissionTime
+ * Selects the latest accreditation from a list by formSubmission.time
  */
 function selectLatestAccreditation(accreditations) {
   return accreditations.sort(
-    (a, b) => b.formSubmissionTime - a.formSubmissionTime
+    (a, b) => b.formSubmission.time - a.formSubmission.time
   )[0]
 }
 

--- a/src/forms-submission-data/link-form-submissions.test.js
+++ b/src/forms-submission-data/link-form-submissions.test.js
@@ -316,7 +316,7 @@ describe('linkRegistrationToAccreditations', () => {
             id: reg1Id,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg1Id, time: oneDayAgo }
           }
         ],
         accreditations: [
@@ -324,7 +324,7 @@ describe('linkRegistrationToAccreditations', () => {
             id: accId1,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: accId1, time: oneDayAgo }
           }
         ]
       }
@@ -359,7 +359,7 @@ describe('linkRegistrationToAccreditations', () => {
             site: {
               address: { line1: '78 Portland Place', postcode: '   W1b 1NT' }
             },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg1Id, time: oneDayAgo }
           }
         ],
         accreditations: [
@@ -370,7 +370,7 @@ describe('linkRegistrationToAccreditations', () => {
             site: {
               address: { line1: '78 Portland Place', postcode: 'W1B1NT ' }
             },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: accId1, time: oneDayAgo }
           }
         ]
       }
@@ -404,7 +404,7 @@ describe('linkRegistrationToAccreditations', () => {
             id: reg1Id,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg1Id, time: oneDayAgo }
           },
           {
             id: reg2Id,
@@ -413,7 +413,7 @@ describe('linkRegistrationToAccreditations', () => {
             site: {
               address: { line1: '78 Portland Place', postcode: 'W1C 1NT' }
             },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg2Id, time: oneDayAgo }
           }
         ],
         accreditations: [
@@ -422,13 +422,13 @@ describe('linkRegistrationToAccreditations', () => {
             wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
             material: MATERIAL.ALUMINIUM,
             site: { address: { line1: '78', postcode: 'W1B 1NT' } },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: acc1Id, time: oneDayAgo }
           },
           {
             id: acc2Id,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.PAPER,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: acc2Id, time: oneDayAgo }
           }
         ]
       }
@@ -458,18 +458,24 @@ describe('linkRegistrationToAccreditations', () => {
 
   it('caps unlinked accreditations log at 10 items', () => {
     const org1Id = new ObjectId().toString()
-    const accreditations = Array.from({ length: 12 }, () => ({
-      id: new ObjectId().toString(),
-      wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
-      material: MATERIAL.WOOD,
-      formSubmissionTime: oneDayAgo
-    }))
-    const registrations = Array.from({ length: 12 }, () => ({
-      id: new ObjectId().toString(),
-      wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
-      material: MATERIAL.PAPER,
-      formSubmissionTime: oneDayAgo
-    }))
+    const accreditations = Array.from({ length: 12 }, () => {
+      const id = new ObjectId().toString()
+      return {
+        id,
+        wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+        material: MATERIAL.WOOD,
+        formSubmission: { id, time: oneDayAgo }
+      }
+    })
+    const registrations = Array.from({ length: 12 }, () => {
+      const id = new ObjectId().toString()
+      return {
+        id,
+        wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+        material: MATERIAL.PAPER,
+        formSubmission: { id, time: oneDayAgo }
+      }
+    })
     const organisations = [
       {
         id: org1Id,
@@ -508,7 +514,7 @@ describe('linkRegistrationToAccreditations', () => {
             id: reg1Id,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg1Id, time: oneDayAgo }
           }
         ],
         accreditations: [
@@ -516,7 +522,7 @@ describe('linkRegistrationToAccreditations', () => {
             id: acc1Id,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: acc1Id, time: oneDayAgo }
           }
         ]
       },
@@ -532,7 +538,7 @@ describe('linkRegistrationToAccreditations', () => {
             site: {
               address: { line1: '78 Portland Place', postcode: 'W1B 1NT' }
             },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg2Id, time: oneDayAgo }
           }
         ],
         accreditations: [
@@ -543,7 +549,7 @@ describe('linkRegistrationToAccreditations', () => {
             site: {
               address: { line1: '78 Portland Place', postcode: 'W1B 1NT' }
             },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: acc2Id, time: oneDayAgo }
           }
         ]
       }
@@ -580,7 +586,7 @@ describe('linkRegistrationToAccreditations', () => {
             site: {
               address: { line1: '78 Portland Place', postcode: 'W1B 1NT' }
             },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg1Id, time: oneDayAgo }
           },
           {
             id: reg2Id,
@@ -589,7 +595,7 @@ describe('linkRegistrationToAccreditations', () => {
             site: {
               address: { line1: '78 Portland Place', postcode: 'W1B 1NT' }
             },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg2Id, time: oneDayAgo }
           }
         ],
         accreditations: [
@@ -600,7 +606,7 @@ describe('linkRegistrationToAccreditations', () => {
             site: {
               address: { line1: '78 Portland Place', postcode: 'W1B 1NT' }
             },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: accId1, time: oneDayAgo }
           }
         ]
       }
@@ -643,7 +649,7 @@ describe('linkRegistrationToAccreditations', () => {
             site: {
               address: { line1: '78 Portland Place', postcode: 'W1B 1NT' }
             },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg1Id, time: oneDayAgo }
           }
         ],
         accreditations: [
@@ -654,7 +660,7 @@ describe('linkRegistrationToAccreditations', () => {
             site: {
               address: { line1: '78 Portland Place', postcode: 'W1B 1NT' }
             },
-            formSubmissionTime: twoDaysAgo
+            formSubmission: { id: accId1, time: twoDaysAgo }
           },
           {
             id: accId2,
@@ -663,7 +669,7 @@ describe('linkRegistrationToAccreditations', () => {
             site: {
               address: { line1: '78 Portland Place', postcode: 'W1B 1NT' }
             },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: accId2, time: oneDayAgo }
           }
         ]
       }
@@ -717,7 +723,7 @@ describe('linkRegistrationToAccreditations', () => {
             wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
             material: MATERIAL.ALUMINIUM,
             site: { address: {} },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg1Id, time: oneDayAgo }
           }
         ],
         accreditations: [
@@ -726,7 +732,7 @@ describe('linkRegistrationToAccreditations', () => {
             wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
             material: MATERIAL.ALUMINIUM,
             site: { address: {} },
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: acc1Id, time: oneDayAgo }
           }
         ]
       }
@@ -752,7 +758,7 @@ describe('linkRegistrationToAccreditations', () => {
             status: ORGANISATION_STATUS.APPROVED,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo,
+            formSubmission: { id: reg1Id, time: oneDayAgo },
             accreditationId: accId1
           }
         ],
@@ -762,14 +768,14 @@ describe('linkRegistrationToAccreditations', () => {
             status: ORGANISATION_STATUS.APPROVED,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: accId1, time: oneDayAgo }
           },
           {
             id: accId2,
             status: ORGANISATION_STATUS.CREATED,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: new Date()
+            formSubmission: { id: accId2, time: new Date() }
           }
         ]
       }
@@ -798,7 +804,7 @@ describe('linkRegistrationToAccreditations', () => {
             status: ORGANISATION_STATUS.APPROVED,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg1Id, time: oneDayAgo }
           }
         ],
         accreditations: [
@@ -807,7 +813,7 @@ describe('linkRegistrationToAccreditations', () => {
             status: ORGANISATION_STATUS.CREATED,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: new Date()
+            formSubmission: { id: accId1, time: new Date() }
           }
         ]
       }
@@ -834,7 +840,7 @@ describe('linkRegistrationToAccreditations', () => {
             status: ORGANISATION_STATUS.APPROVED,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo,
+            formSubmission: { id: reg1Id, time: oneDayAgo },
             accreditationId: accId1
           }
         ],
@@ -844,14 +850,14 @@ describe('linkRegistrationToAccreditations', () => {
             status: ORGANISATION_STATUS.CREATED,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: accId1, time: oneDayAgo }
           },
           {
             id: accId2,
             status: ORGANISATION_STATUS.CREATED,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: new Date()
+            formSubmission: { id: accId2, time: new Date() }
           }
         ]
       }
@@ -879,14 +885,14 @@ describe('linkRegistrationToAccreditations', () => {
             accreditationId: accId1,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg1Id, time: oneDayAgo }
           },
           {
             id: reg2Id,
             status: ORGANISATION_STATUS.CREATED,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: reg2Id, time: oneDayAgo }
           }
         ],
         accreditations: [
@@ -895,7 +901,7 @@ describe('linkRegistrationToAccreditations', () => {
             status: ORGANISATION_STATUS.APPROVED,
             wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
             material: MATERIAL.WOOD,
-            formSubmissionTime: oneDayAgo
+            formSubmission: { id: accId1, time: oneDayAgo }
           }
         ]
       }

--- a/src/forms-submission-data/migration/migrate-form-submission-lineage.js
+++ b/src/forms-submission-data/migration/migrate-form-submission-lineage.js
@@ -79,12 +79,14 @@ async function resolveFormSubmission(
  * @param {FormSubmissionsRepository} formSubmissionsRepository
  * @param {OrganisationsRepository} organisationsRepository
  * @param {SystemLogsRepository} systemLogsRepository
+ * @param {boolean} isMigrationEnabled
  */
 async function migrateOrganisation(
   org,
   formSubmissionsRepository,
   organisationsRepository,
-  systemLogsRepository
+  systemLogsRepository,
+  isMigrationEnabled
 ) {
   const orgFormSubmission = {
     id: org.id,
@@ -95,37 +97,53 @@ async function migrateOrganisation(
   const accreditations = org.accreditations
 
   const updatedRegistrations = await Promise.all(
-    registrations.map(async (reg) => ({
-      ...reg,
-      formSubmission: await resolveFormSubmission(
-        reg,
-        org.id,
-        registrations,
-        (regFormSubmissionId) =>
-          formSubmissionsRepository.findRegistrationById(regFormSubmissionId),
-        'registration'
-      )
-    }))
+    registrations.map(async (reg) => {
+      const { formSubmissionTime: _regTime, ...regWithoutFormSubmissionTime } =
+        reg
+      return {
+        ...regWithoutFormSubmissionTime,
+        formSubmission: await resolveFormSubmission(
+          reg,
+          org.id,
+          registrations,
+          (registrationId) =>
+            formSubmissionsRepository.findRegistrationById(registrationId),
+          'registration'
+        )
+      }
+    })
   )
 
   const updatedAccreditations = await Promise.all(
-    accreditations.map(async (acc) => ({
-      ...acc,
-      formSubmission: await resolveFormSubmission(
-        acc,
-        org.id,
-        accreditations,
-        (accFormSubmissionId) =>
-          formSubmissionsRepository.findAccreditationById(accFormSubmissionId),
-        'accreditation'
-      )
-    }))
+    accreditations.map(async (acc) => {
+      const { formSubmissionTime: _accTime, ...accWithoutFormSubmissionTime } =
+        acc
+      return {
+        ...accWithoutFormSubmissionTime,
+        formSubmission: await resolveFormSubmission(
+          acc,
+          org.id,
+          accreditations,
+          (accreditationId) =>
+            formSubmissionsRepository.findAccreditationById(accreditationId),
+          'accreditation'
+        )
+      }
+    })
   )
 
-  const { id, version, ...orgWithoutIdAndVersion } = org
+  const {
+    id,
+    version,
+    formSubmissionTime: _orgTime,
+    ...orgWithoutIdAndVersionTime
+  } = org
+  if (!isMigrationEnabled) {
+    return
+  }
 
   await organisationsRepository.replace(id, version, {
-    ...orgWithoutIdAndVersion,
+    ...orgWithoutIdAndVersionTime,
     formSubmission: orgFormSubmission,
     registrations: updatedRegistrations,
     accreditations: updatedAccreditations,
@@ -148,12 +166,14 @@ async function migrateOrganisation(
  * @param {FormSubmissionsRepository} formSubmissionsRepository
  * @param {OrganisationsRepository} organisationsRepository
  * @param {SystemLogsRepository} systemLogsRepository
+ * @param {boolean} isMigrationEnabled
  * @returns {Promise<void>}
  */
 export async function migrateFormSubmissionLineage(
   formSubmissionsRepository,
   organisationsRepository,
-  systemLogsRepository
+  systemLogsRepository,
+  isMigrationEnabled
 ) {
   const orgs = await organisationsRepository.findAllBySchemaVersion(1)
 
@@ -162,6 +182,13 @@ export async function migrateFormSubmissionLineage(
       message: 'migrate-form-submission-lineage: no organisations to migrate'
     })
     return
+  }
+
+  if (!isMigrationEnabled) {
+    logger.info({
+      message:
+        'migrate-form-submission-lineage: running in dry-run mode — no changes will be written'
+    })
   }
 
   logger.info({
@@ -177,7 +204,8 @@ export async function migrateFormSubmissionLineage(
         org,
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        isMigrationEnabled
       )
       succeeded++
     } catch (error) {

--- a/src/forms-submission-data/migration/migrate-form-submission-lineage.js
+++ b/src/forms-submission-data/migration/migrate-form-submission-lineage.js
@@ -1,0 +1,195 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import {
+  GLASS_RECYCLING_PROCESS,
+  MATERIAL
+} from '#domain/organisations/model.js'
+import { auditFormSubmissionLineageMigration } from '#root/auditing/form-submission-lineage-migration.js'
+
+/**
+ * @import {FormSubmissionsRepository} from '#repositories/form-submissions/port.js'
+ * @import {OrganisationsRepository} from '#repositories/organisations/port.js'
+ * @import {SystemLogsRepository} from '#repositories/system-logs/port.js'
+ */
+
+const MIGRATION_SCHEMA_VERSION = 2
+
+function isGlassOther(item) {
+  return (
+    item.material === MATERIAL.GLASS &&
+    item.glassRecyclingProcess?.length === 1 &&
+    item.glassRecyclingProcess[0] === GLASS_RECYCLING_PROCESS.GLASS_OTHER
+  )
+}
+
+/**
+ * Resolve formSubmission for a registration or accreditation.
+ *
+ * @param {object} item
+ * @param {object[]} siblings - All items of the same type in the same org
+ * @param {string} orgId - org Id
+ * @param {(id: string) => Promise<object|null>} findById
+ * @param {string} itemType - 'registration' or 'accreditation' (used in log messages)
+ * @returns {Promise<{id: string, time: Date}>}
+ */
+async function resolveFormSubmission(
+  item,
+  orgId,
+  siblings,
+  findById,
+  itemType
+) {
+  const found = await findById(item.id)
+
+  if (found) {
+    return { id: item.id, time: item.formSubmissionTime }
+  }
+
+  if (isGlassOther(item)) {
+    const sibling = siblings.find(
+      (s) =>
+        s.id !== item.id &&
+        s.material === MATERIAL.GLASS &&
+        s.glassRecyclingProcess?.includes(
+          GLASS_RECYCLING_PROCESS.GLASS_RE_MELT
+        ) &&
+        s.formSubmissionTime?.getTime() === item.formSubmissionTime?.getTime()
+    )
+
+    if (sibling) {
+      return { id: sibling.id, time: item.formSubmissionTime }
+    }
+
+    logger.error({
+      message: `migrate-form-submission-lineage: no sibling remelt found for glass-other ${itemType} ${item.id} , org id: ${orgId}`
+    })
+  } else {
+    logger.error({
+      message: `migrate-form-submission-lineage: no form submission found for ${itemType} ${item.id}, org id :${orgId}`
+    })
+  }
+
+  return { id: item.id, time: item.formSubmissionTime }
+}
+
+/**
+ * Migrate a single organisation: backfill formSubmission on org, registrations and accreditations,
+ * then replace with schemaVersion 2.
+ *
+ * @param {object} org
+ * @param {FormSubmissionsRepository} formSubmissionsRepository
+ * @param {OrganisationsRepository} organisationsRepository
+ * @param {SystemLogsRepository} systemLogsRepository
+ */
+async function migrateOrganisation(
+  org,
+  formSubmissionsRepository,
+  organisationsRepository,
+  systemLogsRepository
+) {
+  const orgFormSubmission = {
+    id: org.id,
+    time: org.formSubmissionTime
+  }
+
+  const registrations = org.registrations
+  const accreditations = org.accreditations
+
+  const updatedRegistrations = await Promise.all(
+    registrations.map(async (reg) => ({
+      ...reg,
+      formSubmission: await resolveFormSubmission(
+        reg,
+        org.id,
+        registrations,
+        (regFormSubmissionId) =>
+          formSubmissionsRepository.findRegistrationById(regFormSubmissionId),
+        'registration'
+      )
+    }))
+  )
+
+  const updatedAccreditations = await Promise.all(
+    accreditations.map(async (acc) => ({
+      ...acc,
+      formSubmission: await resolveFormSubmission(
+        acc,
+        org.id,
+        accreditations,
+        (accFormSubmissionId) =>
+          formSubmissionsRepository.findAccreditationById(accFormSubmissionId),
+        'accreditation'
+      )
+    }))
+  )
+
+  const { id, version, ...orgWithoutIdAndVersion } = org
+
+  await organisationsRepository.replace(id, version, {
+    ...orgWithoutIdAndVersion,
+    formSubmission: orgFormSubmission,
+    registrations: updatedRegistrations,
+    accreditations: updatedAccreditations,
+    schemaVersion: MIGRATION_SCHEMA_VERSION
+  })
+
+  const next = await organisationsRepository.findById(id, version + 1)
+
+  await auditFormSubmissionLineageMigration(
+    systemLogsRepository,
+    org.id,
+    org,
+    next
+  )
+}
+
+/**
+ * Backfill formSubmission lineage on all organisations at schemaVersion 1.
+ *
+ * @param {FormSubmissionsRepository} formSubmissionsRepository
+ * @param {OrganisationsRepository} organisationsRepository
+ * @param {SystemLogsRepository} systemLogsRepository
+ * @returns {Promise<void>}
+ */
+export async function migrateFormSubmissionLineage(
+  formSubmissionsRepository,
+  organisationsRepository,
+  systemLogsRepository
+) {
+  const orgs = await organisationsRepository.findAllBySchemaVersion(1)
+
+  if (orgs.length === 0) {
+    logger.info({
+      message: 'migrate-form-submission-lineage: no organisations to migrate'
+    })
+    return
+  }
+
+  logger.info({
+    message: `migrate-form-submission-lineage: migrating ${orgs.length} organisation(s)`
+  })
+
+  let succeeded = 0
+  let failed = 0
+
+  for (const org of orgs) {
+    try {
+      await migrateOrganisation(
+        org,
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+      succeeded++
+    } catch (error) {
+      failed++
+      logger.error({
+        err: error,
+        message: `migrate-form-submission-lineage: failed to migrate organisation ${org.id}`
+      })
+    }
+  }
+
+  logger.info({
+    message: `migrate-form-submission-lineage: completed — ${succeeded} succeeded, ${failed} failed`
+  })
+}

--- a/src/forms-submission-data/migration/migrate-form-submission-lineage.test.js
+++ b/src/forms-submission-data/migration/migrate-form-submission-lineage.test.js
@@ -1,0 +1,425 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { migrateFormSubmissionLineage } from './migrate-form-submission-lineage.js'
+import {
+  GLASS_RECYCLING_PROCESS,
+  MATERIAL
+} from '#domain/organisations/model.js'
+
+import { logger } from '#common/helpers/logging/logger.js'
+import { auditFormSubmissionLineageMigration } from '#root/auditing/form-submission-lineage-migration.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('#auditing/form-submission-lineage-migration.js', () => ({
+  auditFormSubmissionLineageMigration: vi.fn().mockResolvedValue(undefined)
+}))
+
+const SUBMISSION_TIME = new Date('2025-01-15T10:00:00.000Z')
+
+function makeOrg(overrides = {}) {
+  return {
+    id: 'org-id-1',
+    version: 1,
+    schemaVersion: 1,
+    orgId: 500001,
+    formSubmissionTime: SUBMISSION_TIME,
+    registrations: [],
+    accreditations: [],
+    ...overrides
+  }
+}
+
+function makeRegistration(overrides = {}) {
+  return {
+    id: 'reg-id-1',
+    formSubmissionTime: SUBMISSION_TIME,
+    material: MATERIAL.PLASTIC,
+    ...overrides
+  }
+}
+
+function makeAccreditation(overrides = {}) {
+  return {
+    id: 'acc-id-1',
+    formSubmissionTime: SUBMISSION_TIME,
+    material: MATERIAL.PLASTIC,
+    ...overrides
+  }
+}
+
+function makeFormSubmissionsRepository(overrides = {}) {
+  return {
+    findRegistrationById: vi.fn().mockResolvedValue(null),
+    findAccreditationById: vi.fn().mockResolvedValue(null),
+    ...overrides
+  }
+}
+
+function makeOrganisationsRepository(orgs = [], overrides = {}) {
+  return {
+    findAllBySchemaVersion: vi.fn().mockResolvedValue(orgs),
+    findById: vi
+      .fn()
+      .mockImplementation((id) => orgs.find((o) => o.id === id) ?? null),
+    replace: vi.fn().mockResolvedValue(undefined),
+    ...overrides
+  }
+}
+
+function makeSystemLogsRepository() {
+  return {
+    insert: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+describe('migrateFormSubmissionLineage', () => {
+  let formSubmissionsRepository
+  let organisationsRepository
+  let systemLogsRepository
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    formSubmissionsRepository = makeFormSubmissionsRepository()
+    systemLogsRepository = makeSystemLogsRepository()
+  })
+
+  describe('when there are no organisations to migrate', () => {
+    it('exits without making any changes', async () => {
+      organisationsRepository = makeOrganisationsRepository([])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      expect(organisationsRepository.replace).not.toHaveBeenCalled()
+      expect(systemLogsRepository.insert).not.toHaveBeenCalled()
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('no organisations to migrate')
+        })
+      )
+    })
+  })
+
+  describe('form submission lineage for organisations', () => {
+    it('links the organisation to its own form submission', async () => {
+      const org = makeOrg({
+        id: 'org-123',
+        formSubmissionTime: SUBMISSION_TIME
+      })
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      expect(updates.formSubmission).toEqual({
+        id: 'org-123',
+        time: SUBMISSION_TIME
+      })
+    })
+  })
+
+  describe('form submission lineage for registrations', () => {
+    it('links a registration to its own form submission', async () => {
+      const reg = makeRegistration({ id: 'reg-found' })
+      const org = makeOrg({ registrations: [reg] })
+
+      formSubmissionsRepository.findRegistrationById.mockImplementation((id) =>
+        id === 'reg-found' ? { id } : null
+      )
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      expect(updates.registrations[0].formSubmission).toEqual({
+        id: 'reg-found',
+        time: SUBMISSION_TIME
+      })
+    })
+
+    it('links a glass-other registration to the same submission as its remelt sibling', async () => {
+      const remelt = makeRegistration({
+        id: 'remelt-id',
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_RE_MELT],
+        formSubmissionTime: SUBMISSION_TIME
+      })
+      const other = makeRegistration({
+        id: 'other-id',
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER],
+        formSubmissionTime: SUBMISSION_TIME
+      })
+      const org = makeOrg({ registrations: [remelt, other] })
+
+      // remelt found in the forms repo, other is not (it was a synthetic split)
+      formSubmissionsRepository.findRegistrationById.mockImplementation((id) =>
+        id === 'remelt-id' ? { id } : null
+      )
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      const otherResult = updates.registrations.find((r) => r.id === 'other-id')
+      expect(otherResult.formSubmission).toEqual({
+        id: 'remelt-id',
+        time: SUBMISSION_TIME
+      })
+    })
+
+    it('falls back to the own id when no remelt sibling exists for a glass-other registration', async () => {
+      const other = makeRegistration({
+        id: 'other-id',
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER]
+      })
+      const org = makeOrg({ registrations: [other] })
+
+      formSubmissionsRepository.findRegistrationById.mockResolvedValue(null)
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('no sibling remelt found')
+        })
+      )
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      expect(updates.registrations[0].formSubmission).toEqual({
+        id: 'other-id',
+        time: SUBMISSION_TIME
+      })
+    })
+
+    it('falls back to the own id when no form submission exists in the repository', async () => {
+      const reg = makeRegistration({
+        id: 'reg-not-found',
+        material: MATERIAL.PLASTIC
+      })
+      const org = makeOrg({ registrations: [reg] })
+
+      formSubmissionsRepository.findRegistrationById.mockResolvedValue(null)
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'no form submission found for registration reg-not-found'
+          )
+        })
+      )
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      expect(updates.registrations[0].formSubmission).toEqual({
+        id: 'reg-not-found',
+        time: SUBMISSION_TIME
+      })
+    })
+  })
+
+  describe('form submission lineage for accreditations', () => {
+    it('links an accreditation to its own form submission', async () => {
+      const acc = makeAccreditation({ id: 'acc-found' })
+      const org = makeOrg({ accreditations: [acc] })
+
+      formSubmissionsRepository.findAccreditationById.mockImplementation(
+        (id) => (id === 'acc-found' ? { id } : null)
+      )
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      expect(updates.accreditations[0].formSubmission).toEqual({
+        id: 'acc-found',
+        time: SUBMISSION_TIME
+      })
+    })
+
+    it('links a glass-other accreditation to the same submission as its remelt sibling', async () => {
+      const remelt = makeAccreditation({
+        id: 'acc-remelt-id',
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_RE_MELT],
+        formSubmissionTime: SUBMISSION_TIME
+      })
+      const other = makeAccreditation({
+        id: 'acc-other-id',
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER],
+        formSubmissionTime: SUBMISSION_TIME
+      })
+      const org = makeOrg({ accreditations: [remelt, other] })
+
+      formSubmissionsRepository.findAccreditationById.mockImplementation(
+        (id) => (id === 'acc-remelt-id' ? { id } : null)
+      )
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      const otherResult = updates.accreditations.find(
+        (a) => a.id === 'acc-other-id'
+      )
+      expect(otherResult.formSubmission).toEqual({
+        id: 'acc-remelt-id',
+        time: SUBMISSION_TIME
+      })
+    })
+
+    it('falls back to the own id when no remelt sibling exists for a glass-other accreditation', async () => {
+      const other = makeAccreditation({
+        id: 'acc-other-id',
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER]
+      })
+      const org = makeOrg({ accreditations: [other] })
+
+      formSubmissionsRepository.findAccreditationById.mockResolvedValue(null)
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('no sibling remelt found')
+        })
+      )
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      expect(updates.accreditations[0].formSubmission).toEqual({
+        id: 'acc-other-id',
+        time: SUBMISSION_TIME
+      })
+    })
+  })
+
+  describe('schema version upgrade', () => {
+    it('upgrades each organisation to schemaVersion 2 without including id or version in the saved document', async () => {
+      const org = makeOrg({ id: 'org-abc', version: 3 })
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      expect(organisationsRepository.replace).toHaveBeenCalledWith(
+        'org-abc',
+        3,
+        expect.objectContaining({ schemaVersion: 2 })
+      )
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      expect(updates.id).toBeUndefined()
+      expect(updates.version).toBeUndefined()
+    })
+  })
+
+  describe('audit trail', () => {
+    it('records a migration log entry for each organisation processed', async () => {
+      const org1 = makeOrg({ id: 'org-1' })
+      const org2 = makeOrg({ id: 'org-2' })
+      organisationsRepository = makeOrganisationsRepository([org1, org2])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      expect(auditFormSubmissionLineageMigration).toHaveBeenCalledWith(
+        systemLogsRepository,
+        org1.id,
+        org1,
+        org1
+      )
+    })
+  })
+
+  describe('scope of migration', () => {
+    it('only targets organisations at schemaVersion 1', async () => {
+      organisationsRepository = makeOrganisationsRepository([])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      expect(
+        organisationsRepository.findAllBySchemaVersion
+      ).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('error resilience', () => {
+    it('continues processing remaining organisations when one fails', async () => {
+      const org1 = makeOrg({ id: 'org-fail' })
+      const org2 = makeOrg({ id: 'org-ok' })
+      organisationsRepository = makeOrganisationsRepository([org1, org2], {
+        replace: vi
+          .fn()
+          .mockRejectedValueOnce(new Error('version conflict'))
+          .mockResolvedValueOnce(undefined)
+      })
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'failed to migrate organisation org-fail'
+          )
+        })
+      )
+    })
+  })
+})

--- a/src/forms-submission-data/migration/migrate-form-submission-lineage.test.js
+++ b/src/forms-submission-data/migration/migrate-form-submission-lineage.test.js
@@ -95,7 +95,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       expect(organisationsRepository.replace).not.toHaveBeenCalled()
@@ -119,7 +120,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       const updates = organisationsRepository.replace.mock.calls[0][2]
@@ -127,6 +129,7 @@ describe('migrateFormSubmissionLineage', () => {
         id: 'org-123',
         time: SUBMISSION_TIME
       })
+      expect(updates.formSubmissionTime).toBeUndefined()
     })
   })
 
@@ -143,7 +146,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       const updates = organisationsRepository.replace.mock.calls[0][2]
@@ -151,6 +155,7 @@ describe('migrateFormSubmissionLineage', () => {
         id: 'reg-found',
         time: SUBMISSION_TIME
       })
+      expect(updates.registrations[0].formSubmissionTime).toBeUndefined()
     })
 
     it('links a glass-other registration to the same submission as its remelt sibling', async () => {
@@ -177,7 +182,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       const updates = organisationsRepository.replace.mock.calls[0][2]
@@ -202,7 +208,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       expect(logger.error).toHaveBeenCalledWith(
@@ -230,7 +237,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       expect(logger.error).toHaveBeenCalledWith(
@@ -261,7 +269,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       const updates = organisationsRepository.replace.mock.calls[0][2]
@@ -294,7 +303,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       const updates = organisationsRepository.replace.mock.calls[0][2]
@@ -321,7 +331,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       expect(logger.error).toHaveBeenCalledWith(
@@ -337,6 +348,64 @@ describe('migrateFormSubmissionLineage', () => {
     })
   })
 
+  describe('formSubmissionTime removal', () => {
+    it('removes formSubmissionTime from the organisation', async () => {
+      const org = makeOrg({
+        id: 'org-123',
+        formSubmissionTime: SUBMISSION_TIME
+      })
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository,
+        true
+      )
+
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      expect(updates.formSubmissionTime).toBeUndefined()
+    })
+
+    it('removes formSubmissionTime from each registration', async () => {
+      const reg = makeRegistration({
+        id: 'reg-1',
+        formSubmissionTime: SUBMISSION_TIME
+      })
+      const org = makeOrg({ registrations: [reg] })
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository,
+        true
+      )
+
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      expect(updates.registrations[0].formSubmissionTime).toBeUndefined()
+    })
+
+    it('removes formSubmissionTime from each accreditation', async () => {
+      const acc = makeAccreditation({
+        id: 'acc-1',
+        formSubmissionTime: SUBMISSION_TIME
+      })
+      const org = makeOrg({ accreditations: [acc] })
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository,
+        true
+      )
+
+      const updates = organisationsRepository.replace.mock.calls[0][2]
+      expect(updates.accreditations[0].formSubmissionTime).toBeUndefined()
+    })
+  })
+
   describe('schema version upgrade', () => {
     it('upgrades each organisation to schemaVersion 2 without including id or version in the saved document', async () => {
       const org = makeOrg({ id: 'org-abc', version: 3 })
@@ -345,7 +414,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       expect(organisationsRepository.replace).toHaveBeenCalledWith(
@@ -368,7 +438,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       expect(auditFormSubmissionLineageMigration).toHaveBeenCalledWith(
@@ -387,7 +458,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       expect(
@@ -410,7 +482,8 @@ describe('migrateFormSubmissionLineage', () => {
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        true
       )
 
       expect(logger.error).toHaveBeenCalledWith(
@@ -420,6 +493,28 @@ describe('migrateFormSubmissionLineage', () => {
           )
         })
       )
+    })
+  })
+
+  describe('dry-run mode (isMigrationEnabled = false)', () => {
+    it('logs a dry-run message and skips db update and audit', async () => {
+      const org = makeOrg({ id: 'org-dry' })
+      organisationsRepository = makeOrganisationsRepository([org])
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository,
+        false
+      )
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('dry-run mode')
+        })
+      )
+      expect(organisationsRepository.replace).not.toHaveBeenCalled()
+      expect(auditFormSubmissionLineageMigration).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/forms-submission-data/organisation/transform-organisation.js
+++ b/src/forms-submission-data/organisation/transform-organisation.js
@@ -196,6 +196,7 @@ export function parseOrgSubmission(id, orgId, rawSubmissionData) {
   const parsed = {
     id,
     orgId,
+    formSubmission: { id, time: extractTimestamp(rawSubmissionData) },
     wasteProcessingTypes: extractWasteProcessingTypes(
       answersByShortDescription
     ),

--- a/src/forms-submission-data/organisation/transform-organisation.js
+++ b/src/forms-submission-data/organisation/transform-organisation.js
@@ -209,7 +209,6 @@ export function parseOrgSubmission(id, orgId, rawSubmissionData) {
     managementContactDetails: getManagementContactDetails(
       answersByShortDescription
     ),
-    formSubmissionTime: extractTimestamp(rawSubmissionData),
     submittedToRegulator: extractAgencyFromDefinitionName(rawSubmissionData),
     partnership: getPartnershipDetails(
       answersByShortDescription,

--- a/src/forms-submission-data/organisation/transform-organisation.test.js
+++ b/src/forms-submission-data/organisation/transform-organisation.test.js
@@ -56,7 +56,6 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
         jobTitle: 'Sustainability Director'
       },
       managementContactDetails: undefined,
-      formSubmissionTime: new Date('2025-10-08T16:14:15.390Z'),
       submittedToRegulator: 'ea',
       partnership: {
         type: PARTNERSHIP_TYPE.LTD,
@@ -118,7 +117,6 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
         jobTitle: 'Sustainability Director'
       },
       managementContactDetails: undefined,
-      formSubmissionTime: new Date('2025-10-08T16:13:16.313Z'),
       submittedToRegulator: 'ea',
       partnership: {
         type: PARTNERSHIP_TYPE.LTD_LIABILITY,
@@ -176,7 +174,6 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
         jobTitle: 'Director'
       },
       managementContactDetails: undefined,
-      formSubmissionTime: new Date('2025-10-08T16:19:54.601Z'),
       submittedToRegulator: 'ea',
       partnership: undefined
     })
@@ -227,7 +224,6 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
         phone: '0123456789',
         jobTitle: 'Director'
       },
-      formSubmissionTime: new Date('2025-10-08T16:25:35.824Z'),
       submittedToRegulator: 'ea',
       partnership: undefined
     })
@@ -278,7 +274,6 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
         jobTitle: 'Sustainability Director'
       },
       managementContactDetails: undefined,
-      formSubmissionTime: new Date('2025-10-08T16:28:18.572Z'),
       submittedToRegulator: 'ea',
       partnership: undefined
     })
@@ -329,7 +324,6 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
         phone: '0123456789',
         jobTitle: 'Sustainability master'
       },
-      formSubmissionTime: new Date('2025-10-23T13:35:37.874Z'),
       submittedToRegulator: 'ea',
       partnership: undefined
     })
@@ -380,7 +374,6 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
         phone: '0123456789',
         jobTitle: 'Director'
       },
-      formSubmissionTime: new Date('2025-10-23T13:39:07.408Z'),
       submittedToRegulator: 'ea',
       partnership: undefined
     })
@@ -436,7 +429,6 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
         phone: '0123456789',
         jobTitle: 'Director'
       },
-      formSubmissionTime: new Date('2025-10-23T13:42:35.918Z'),
       submittedToRegulator: 'ea',
       partnership: undefined
     })

--- a/src/forms-submission-data/organisation/transform-organisation.test.js
+++ b/src/forms-submission-data/organisation/transform-organisation.test.js
@@ -30,6 +30,10 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
     expect(result[0]).toStrictEqual({
       id: registeredLtdPartnership._id.$oid,
       orgId: registeredLtdPartnership.orgId,
+      formSubmission: {
+        id: registeredLtdPartnership._id.$oid,
+        time: new Date('2025-10-08T16:14:15.390Z')
+      },
       wasteProcessingTypes: [WASTE_PROCESSING_TYPE.EXPORTER],
       reprocessingNations: [],
       businessType: undefined,
@@ -84,6 +88,10 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
     expect(result[0]).toStrictEqual({
       id: registeredLtdLiability._id.$oid,
       orgId: registeredLtdLiability.orgId,
+      formSubmission: {
+        id: registeredLtdLiability._id.$oid,
+        time: new Date('2025-10-08T16:13:16.313Z')
+      },
       wasteProcessingTypes: [
         WASTE_PROCESSING_TYPE.REPROCESSOR,
         WASTE_PROCESSING_TYPE.EXPORTER
@@ -133,6 +141,10 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
     expect(result[0]).toStrictEqual({
       id: registeredNoPartnership._id.$oid,
       orgId: registeredNoPartnership.orgId,
+      formSubmission: {
+        id: registeredNoPartnership._id.$oid,
+        time: new Date('2025-10-08T16:19:54.601Z')
+      },
       wasteProcessingTypes: [
         WASTE_PROCESSING_TYPE.REPROCESSOR,
         WASTE_PROCESSING_TYPE.EXPORTER
@@ -184,6 +196,10 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
     expect(result[0]).toStrictEqual({
       id: nonRegisteredUkSoleTrader._id.$oid,
       orgId: nonRegisteredUkSoleTrader.orgId,
+      formSubmission: {
+        id: nonRegisteredUkSoleTrader._id.$oid,
+        time: new Date('2025-10-08T16:25:35.824Z')
+      },
       wasteProcessingTypes: [WASTE_PROCESSING_TYPE.REPROCESSOR],
       reprocessingNations: [NATION.ENGLAND, NATION.SCOTLAND],
       businessType: BUSINESS_TYPE.INDIVIDUAL,
@@ -231,6 +247,10 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
     expect(result[0]).toStrictEqual({
       id: nonRegisteredOutsideUk._id.$oid,
       orgId: nonRegisteredOutsideUk.orgId,
+      formSubmission: {
+        id: nonRegisteredOutsideUk._id.$oid,
+        time: new Date('2025-10-08T16:28:18.572Z')
+      },
       wasteProcessingTypes: [
         WASTE_PROCESSING_TYPE.REPROCESSOR,
         WASTE_PROCESSING_TYPE.EXPORTER
@@ -278,6 +298,10 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
     expect(result[0]).toStrictEqual({
       id: unincorporatedSeparateControl._id.$oid,
       orgId: unincorporatedSeparateControl.orgId,
+      formSubmission: {
+        id: unincorporatedSeparateControl._id.$oid,
+        time: new Date('2025-10-23T13:35:37.874Z')
+      },
       wasteProcessingTypes: [WASTE_PROCESSING_TYPE.EXPORTER],
       reprocessingNations: [],
       businessType: BUSINESS_TYPE.UNINCORPORATED,
@@ -325,6 +349,10 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
     expect(result[0]).toStrictEqual({
       id: soleTraderSeparateControl._id.$oid,
       orgId: soleTraderSeparateControl.orgId,
+      formSubmission: {
+        id: soleTraderSeparateControl._id.$oid,
+        time: new Date('2025-10-23T13:39:07.408Z')
+      },
       wasteProcessingTypes: [WASTE_PROCESSING_TYPE.EXPORTER],
       reprocessingNations: [],
       businessType: BUSINESS_TYPE.INDIVIDUAL,
@@ -375,6 +403,10 @@ describe('parseOrgSubmission - Integration Tests with Fixture Data', () => {
     expect(result[0]).toStrictEqual({
       id: nonUkSeparateControl._id.$oid,
       orgId: nonUkSeparateControl.orgId,
+      formSubmission: {
+        id: nonUkSeparateControl._id.$oid,
+        time: new Date('2025-10-23T13:42:35.918Z')
+      },
       wasteProcessingTypes: [WASTE_PROCESSING_TYPE.REPROCESSOR],
       reprocessingNations: [NATION.ENGLAND],
       businessType: undefined,

--- a/src/forms-submission-data/parsing-common/split-glass-submissions.js
+++ b/src/forms-submission-data/parsing-common/split-glass-submissions.js
@@ -17,14 +17,14 @@ function hasBothGlassProcesses(registration) {
   )
 }
 
-function splitIntoRemeltAndOther(registration) {
+function splitIntoRemeltAndOther(submission) {
   const remelt = {
-    ...registration,
+    ...submission,
     glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_RE_MELT]
   }
 
   const other = {
-    ...registration,
+    ...submission,
     id: new ObjectId().toString(),
     glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER]
   }

--- a/src/forms-submission-data/parsing-common/split-glass-submissions.test.js
+++ b/src/forms-submission-data/parsing-common/split-glass-submissions.test.js
@@ -15,6 +15,7 @@ vi.mock('#common/helpers/logging/logger.js', () => ({
 function makeRegistration(overrides = {}) {
   return {
     id: 'reg-1',
+    formSubmission: { id: 'reg-1', time: new Date('2025-01-01T00:00:00.000Z') },
     material: MATERIAL.PLASTIC,
     glassRecyclingProcess: undefined,
     orgId: 123,
@@ -114,6 +115,25 @@ describe('splitGlassSubmissions', () => {
 
     expect(result[1].id).not.toBe('original-id')
     expect(result[1].id).toBeTruthy()
+  })
+
+  it('should carry formSubmission.id from the original submission onto both split registrations', () => {
+    const submissionTime = new Date('2025-01-01T00:00:00.000Z')
+    const both = makeGlassRegistration(
+      [
+        GLASS_RECYCLING_PROCESS.GLASS_RE_MELT,
+        GLASS_RECYCLING_PROCESS.GLASS_OTHER
+      ],
+      {
+        id: 'original-id',
+        formSubmission: { id: 'original-id', time: submissionTime }
+      }
+    )
+
+    const result = splitGlassSubmissions([both])
+
+    expect(result[0].formSubmission.id).toBe('original-id')
+    expect(result[1].formSubmission.id).toBe('original-id')
   })
 
   it('should handle a mix of glass and non-glass registrations', () => {

--- a/src/forms-submission-data/registration/transform-registration.js
+++ b/src/forms-submission-data/registration/transform-registration.js
@@ -53,7 +53,6 @@ function buildParsedRegistration(id, rawSubmissionData) {
   return {
     id,
     formSubmission: { id, time: extractTimestamp(rawSubmissionData) },
-    formSubmissionTime: extractTimestamp(rawSubmissionData),
     submittedToRegulator: extractAgencyFromDefinitionName(rawSubmissionData),
     orgId: convertToNumber(
       answersByShortDescription[

--- a/src/forms-submission-data/registration/transform-registration.js
+++ b/src/forms-submission-data/registration/transform-registration.js
@@ -52,6 +52,7 @@ function buildParsedRegistration(id, rawSubmissionData) {
 
   return {
     id,
+    formSubmission: { id, time: extractTimestamp(rawSubmissionData) },
     formSubmissionTime: extractTimestamp(rawSubmissionData),
     submittedToRegulator: extractAgencyFromDefinitionName(rawSubmissionData),
     orgId: convertToNumber(

--- a/src/forms-submission-data/registration/transform-registration.test.js
+++ b/src/forms-submission-data/registration/transform-registration.test.js
@@ -30,6 +30,10 @@ describe('parseRegistrationSubmission - Integration Tests with Fixture Data', ()
     const commonFields = {
       orgId: 503181,
       systemReference: '68e6912278f83083f0f17a7b',
+      formSubmission: {
+        id: exporter._id.$oid,
+        time: new Date('2025-10-08T17:48:22.220Z')
+      },
       formSubmissionTime: new Date('2025-10-08T17:48:22.220Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
@@ -129,6 +133,10 @@ describe('parseRegistrationSubmission - Integration Tests with Fixture Data', ()
       id: reprocessorAllMaterials._id.$oid,
       orgId: 503176,
       systemReference: '68e68d9c78f83083f0f17a76',
+      formSubmission: {
+        id: reprocessorAllMaterials._id.$oid,
+        time: new Date('2025-10-08T17:40:07.373Z')
+      },
       formSubmissionTime: new Date('2025-10-08T17:40:07.373Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,

--- a/src/forms-submission-data/registration/transform-registration.test.js
+++ b/src/forms-submission-data/registration/transform-registration.test.js
@@ -34,7 +34,6 @@ describe('parseRegistrationSubmission - Integration Tests with Fixture Data', ()
         id: exporter._id.$oid,
         time: new Date('2025-10-08T17:48:22.220Z')
       },
-      formSubmissionTime: new Date('2025-10-08T17:48:22.220Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
       orgName: 'EuroPack GmbH',
@@ -137,7 +136,6 @@ describe('parseRegistrationSubmission - Integration Tests with Fixture Data', ()
         id: reprocessorAllMaterials._id.$oid,
         time: new Date('2025-10-08T17:40:07.373Z')
       },
-      formSubmissionTime: new Date('2025-10-08T17:40:07.373Z'),
       submittedToRegulator: REGULATOR.EA,
       wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
       orgName: 'Green Recycling Solutions Ltd',

--- a/src/forms-submission-data/types.js
+++ b/src/forms-submission-data/types.js
@@ -38,6 +38,7 @@
  *   businessType?: string
  *   companyDetails: object
  *   defraId?: DefraId
+ *   formSubmission?: { id: string, time: Date }
  *   formSubmissionTime: Date
  *   id: string
  *   managementContactDetails?: User
@@ -56,6 +57,7 @@
  *   approvedPersons: User[]
  *   cbduNumber: string
  *   exportPorts?: string[]
+ *   formSubmission?: { id: string, time: Date }
  *   formSubmissionTime: Date
  *   glassRecyclingProcess?: string
  *   id: string
@@ -80,6 +82,7 @@
 
 /**
  * @typedef {{
+ *   formSubmission?: { id: string, time: Date }
  *   formSubmissionTime: Date
  *   glassRecyclingProcess?: string
  *   id: string

--- a/src/repositories/organisations/contract/find-accreditation-by-id.contract.js
+++ b/src/repositories/organisations/contract/find-accreditation-by-id.contract.js
@@ -38,7 +38,7 @@ export const testFindAccreditationByIdBehaviour = (it) => {
       )
 
       const {
-        formSubmissionTime: _formSubmissionTime,
+        formSubmission: _formSubmission,
         statusHistory: _statusHistory,
         ...expected
       } = accreditation1

--- a/src/repositories/organisations/contract/find-all-by-schema-version.contract.js
+++ b/src/repositories/organisations/contract/find-all-by-schema-version.contract.js
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect } from 'vitest'
+import { buildOrganisation } from './test-data.js'
+
+export const testFindAllBySchemaVersionBehaviour = (it) => {
+  describe('findAllBySchemaVersion', () => {
+    let repository
+
+    beforeEach(async ({ organisationsRepository }) => {
+      repository = await organisationsRepository()
+    })
+
+    it('returns empty array when no organisations match the schema version', async () => {
+      const org = buildOrganisation()
+      await repository.insert(org)
+
+      const result = await repository.findAllBySchemaVersion(99)
+
+      expect(result).toEqual([])
+    })
+
+    it('returns all organisations matching the given schema version', async () => {
+      const org1 = buildOrganisation()
+      const org2 = buildOrganisation()
+      const org3 = buildOrganisation()
+
+      await Promise.all([org1, org2, org3].map((o) => repository.insert(o)))
+
+      const result = await repository.findAllBySchemaVersion(2)
+
+      expect(result).toHaveLength(3)
+      expect(result.map((o) => o.id)).toEqual(
+        expect.arrayContaining([org1.id, org2.id, org3.id])
+      )
+
+      expect(await repository.findAllBySchemaVersion(1)).toHaveLength(0)
+    })
+
+    it('returns empty array when no organisations exist', async () => {
+      const result = await repository.findAllBySchemaVersion(2)
+
+      expect(result).toEqual([])
+    })
+  })
+}

--- a/src/repositories/organisations/contract/find-registration-by-id.contract.js
+++ b/src/repositories/organisations/contract/find-registration-by-id.contract.js
@@ -24,8 +24,7 @@ export const testFindRegistrationByIdBehaviour = (it) => {
         orgName: 'Test Org 2',
         material: 'plastic',
         wasteProcessingType: 'exporter',
-        cbduNumber: 'CBDU222222',
-        formSubmissionTime: '2025-08-21T19:34:44.944Z'
+        cbduNumber: 'CBDU222222'
       })
 
       const org = buildOrganisation({

--- a/src/repositories/organisations/contract/insert.contract.js
+++ b/src/repositories/organisations/contract/insert.contract.js
@@ -22,19 +22,16 @@ export const testInsertBehaviour = (it) => {
 
         const expectedData = {
           ...orgWithoutStatusHistory,
-          formSubmissionTime: new Date(orgData.formSubmissionTime),
           registrations: orgData.registrations.map((reg) => {
             const { statusHistory: _, ...regWithoutStatusHistory } = reg
             return {
-              ...regWithoutStatusHistory,
-              formSubmissionTime: new Date(reg.formSubmissionTime)
+              ...regWithoutStatusHistory
             }
           }),
           accreditations: orgData.accreditations.map((acc) => {
             const { statusHistory: _, ...accWithoutStatusHistory } = acc
             return {
-              ...accWithoutStatusHistory,
-              formSubmissionTime: new Date(acc.formSubmissionTime)
+              ...accWithoutStatusHistory
             }
           }),
           users: []
@@ -119,12 +116,12 @@ export const testInsertBehaviour = (it) => {
           )
         })
 
-        it('rejects insert with missing formSubmissionTime', async () => {
+        it('rejects insert with missing formSubmission', async () => {
           const orgWithoutTime = buildOrganisation({
-            formSubmissionTime: undefined
+            formSubmission: undefined
           })
           await expect(repository.insert(orgWithoutTime)).rejects.toThrow(
-            'Invalid organisation data: formSubmissionTime: "formSubmissionTime" is required'
+            'Invalid organisation data: formSubmission: "formSubmission" is required'
           )
         })
 

--- a/src/repositories/organisations/contract/reg-acc-approval.contract.js
+++ b/src/repositories/organisations/contract/reg-acc-approval.contract.js
@@ -17,10 +17,6 @@ import {
 } from '#domain/organisations/model.js'
 
 export const testRegAccApprovalValidation = (it) => {
-  const DAY = 24 * 60 * 60 * 1000
-  const oneDayAgo = new Date(Date.now() - DAY)
-  const twoDaysAgo = new Date(Date.now() - 2 * DAY)
-
   // Date strings for validFrom/validTo
   const { VALID_FROM, VALID_TO } = getValidDateRange()
 
@@ -382,8 +378,7 @@ export const testRegAccApprovalValidation = (it) => {
                     defraFormUploadedFileId: 'file-1',
                     defraFormUserDownloadLink: 'https://example.com/file-1'
                   }
-                ],
-                formSubmissionTime: twoDaysAgo
+                ]
               }),
               buildAccreditation({
                 id: acc2Id,
@@ -396,8 +391,7 @@ export const testRegAccApprovalValidation = (it) => {
                     defraFormUploadedFileId: 'file-2',
                     defraFormUserDownloadLink: 'https://example.com/file-2'
                   }
-                ],
-                formSubmissionTime: oneDayAgo
+                ]
               })
             ]
           }

--- a/src/repositories/organisations/contract/replace.contract.js
+++ b/src/repositories/organisations/contract/replace.contract.js
@@ -165,7 +165,10 @@ export const testReplaceBehaviour = (it) => {
 
         const { statusHistory: _, ...expectedReg } = {
           ...newRegistration,
-          formSubmissionTime: new Date(newRegistration.formSubmissionTime)
+          formSubmission: {
+            id: newRegistration.formSubmission.id,
+            time: new Date(newRegistration.formSubmission.time)
+          }
         }
         const { statusHistory: actualStatusHistory, ...actualReg } = addedReg
 
@@ -202,8 +205,7 @@ export const testReplaceBehaviour = (it) => {
         expect(addedAcc).toBeDefined()
 
         const { statusHistory: _, ...expectedAcc } = {
-          ...newAccreditation,
-          formSubmissionTime: new Date(newAccreditation.formSubmissionTime)
+          ...newAccreditation
         }
         const { statusHistory: actualStatusHistory, ...actualAcc } = addedAcc
         expect(actualAcc).toMatchObject(expectedAcc)

--- a/src/repositories/organisations/contract/test-data.js
+++ b/src/repositories/organisations/contract/test-data.js
@@ -94,7 +94,10 @@ export const buildOrganisation = (overrides = {}) => {
   const accreditations = org1.accreditations.map((acc) => ({
     ...acc,
     id: accreditationIdMap.get(acc.id),
-    formSubmissionTime: new Date(acc.formSubmissionTime),
+    formSubmission: {
+      id: accreditationIdMap.get(acc.id),
+      time: new Date(acc.formSubmission.time)
+    },
     statusHistory: createInitialStatusHistory()
   }))
 
@@ -102,7 +105,10 @@ export const buildOrganisation = (overrides = {}) => {
   const registrations = org1.registrations.map((reg) => ({
     ...reg,
     id: new ObjectId().toString(),
-    formSubmissionTime: new Date(reg.formSubmissionTime),
+    formSubmission: {
+      id: reg.formSubmission.id,
+      time: new Date(reg.formSubmission.time)
+    },
     statusHistory: createInitialStatusHistory(),
     // Update accreditationId to point to the new accreditation ID
     ...(reg.accreditationId && {
@@ -114,7 +120,10 @@ export const buildOrganisation = (overrides = {}) => {
     ...org1,
     orgId: generateOrgId(),
     id: new ObjectId().toString(),
-    formSubmissionTime: new Date(org1.formSubmissionTime),
+    formSubmission: {
+      id: org1.formSubmission.id,
+      time: new Date(org1.formSubmission.time)
+    },
     partnership: org1.partnership,
     statusHistory: createInitialStatusHistory(),
     registrations,

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -12,8 +12,6 @@ import { validateApprovals } from './schema/helpers.js'
 import { collateUsers } from './collate-users.js'
 import { getCurrentStatus } from './status.js'
 
-export const SCHEMA_VERSION = 2
-
 export const createStatusHistoryEntry = (status) => ({
   status,
   updatedAt: new Date()

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -12,7 +12,7 @@ import { validateApprovals } from './schema/helpers.js'
 import { collateUsers } from './collate-users.js'
 import { getCurrentStatus } from './status.js'
 
-export const SCHEMA_VERSION = 1
+export const SCHEMA_VERSION = 2
 
 export const createStatusHistoryEntry = (status) => ({
   status,

--- a/src/repositories/organisations/inmemory.js
+++ b/src/repositories/organisations/inmemory.js
@@ -7,10 +7,10 @@ import {
   createInitialStatusHistory,
   escapeRegex,
   mapDocumentWithCurrentStatuses,
-  prepareForReplace,
-  SCHEMA_VERSION
+  prepareForReplace
 } from './helpers.js'
 import { getCurrentStatus } from './status.js'
+import { CURRENT_SCHEMA_VERSION } from '#repositories/organisations/schema/helpers.js'
 
 // Aggressive retry settings for in-memory testing (setImmediate() is microseconds)
 const MAX_CONSISTENCY_RETRIES = 5
@@ -51,7 +51,7 @@ const performInsert = (storage, staleCache) => async (organisation) => {
   const newOrg = structuredClone({
     _id: id,
     version: 1,
-    schemaVersion: SCHEMA_VERSION,
+    schemaVersion: CURRENT_SCHEMA_VERSION,
     statusHistory: createInitialStatusHistory(),
     users: [],
     ...orgFields,

--- a/src/repositories/organisations/inmemory.js
+++ b/src/repositories/organisations/inmemory.js
@@ -19,7 +19,6 @@ const CONSISTENCY_RETRY_DELAY_MS = 5
 const initializeItems = (items) =>
   items?.map((item) => ({
     ...item,
-    formSubmissionTime: new Date(item.formSubmissionTime),
     statusHistory: createInitialStatusHistory()
   })) || []
 
@@ -56,7 +55,6 @@ const performInsert = (storage, staleCache) => async (organisation) => {
     statusHistory: createInitialStatusHistory(),
     users: [],
     ...orgFields,
-    formSubmissionTime: new Date(orgFields.formSubmissionTime),
     registrations,
     accreditations
   })
@@ -149,6 +147,12 @@ const performFindAll = (staleCache) => async () => {
   return structuredClone(staleCache).map((org) =>
     mapDocumentWithCurrentStatuses({ ...org })
   )
+}
+
+const performFindAllBySchemaVersion = (staleCache) => async (schemaVersion) => {
+  return structuredClone(staleCache)
+    .filter((org) => org.schemaVersion === schemaVersion)
+    .map((org) => mapDocumentWithCurrentStatuses({ ...org }))
 }
 
 const performFindPage =
@@ -421,6 +425,7 @@ export const createInMemoryOrganisationsRepository = (
       replace: replaceFn,
       replaceRaw: replaceRawFn,
       findAll: performFindAll(staleCache),
+      findAllBySchemaVersion: performFindAllBySchemaVersion(staleCache),
       findPage: performFindPage(staleCache),
       findAllForOverseasSitesAdminList:
         performFindAllForOverseasSitesAdminList(staleCache),

--- a/src/repositories/organisations/mongodb.js
+++ b/src/repositories/organisations/mongodb.js
@@ -211,6 +211,14 @@ const performFindAll = (db) => async () => {
   return docs.map((doc) => mapDocumentWithCurrentStatuses(doc))
 }
 
+const performFindAllBySchemaVersion = (db) => async (schemaVersion) => {
+  const docs = await db
+    .collection(COLLECTION_NAME)
+    .find({ schemaVersion })
+    .toArray()
+  return docs.map((doc) => mapDocumentWithCurrentStatuses(doc))
+}
+
 const performFindPage =
   (db) =>
   async ({ search, page, pageSize }) => {
@@ -455,6 +463,7 @@ export const createOrganisationsRepository = async (
       replaceRaw: performReplaceRaw(db),
       findById,
       findAll: performFindAll(db),
+      findAllBySchemaVersion: performFindAllBySchemaVersion(db),
       findPage: performFindPage(db),
       findAllForOverseasSitesAdminList:
         performFindAllForOverseasSitesAdminList(db),

--- a/src/repositories/organisations/mongodb.js
+++ b/src/repositories/organisations/mongodb.js
@@ -7,11 +7,11 @@ import {
   mapDocumentWithCurrentStatuses,
   performFindAllForOverseasSitesAdminList,
   performFindPageForOrsAdminList,
-  prepareForReplace,
-  SCHEMA_VERSION
+  prepareForReplace
 } from './helpers.js'
 import { getCurrentStatus } from './status.js'
 import { validateId, validateOrganisationInsert } from './schema/index.js'
+import { CURRENT_SCHEMA_VERSION } from '#repositories/organisations/schema/helpers.js'
 
 const COLLECTION_NAME = 'epr-organisations'
 const MONGODB_DUPLICATE_KEY_ERROR_CODE = 11000
@@ -64,7 +64,7 @@ const performInsert = (db) => async (organisation) => {
     await db.collection(COLLECTION_NAME).insertOne({
       _id: ObjectId.createFromHexString(id),
       version: 1,
-      schemaVersion: SCHEMA_VERSION,
+      schemaVersion: CURRENT_SCHEMA_VERSION,
       statusHistory: createInitialStatusHistory(),
       ...orgFields,
       registrations,

--- a/src/repositories/organisations/mongodb.ors.test.js
+++ b/src/repositories/organisations/mongodb.ors.test.js
@@ -35,7 +35,7 @@ const buildOrganisation = (overrides = {}) => {
     version: 1,
     schemaVersion: 1,
     companyDetails: { name: 'Test Org' },
-    formSubmissionTime: new Date().toISOString(),
+    formSubmission: { id, time: new Date() },
     submittedToRegulator: 'EA',
     submitterContactDetails: {
       fullName: 'Test User',
@@ -50,7 +50,7 @@ const buildOrganisation = (overrides = {}) => {
         wasteProcessingType: 'exporter',
         material: 'Plastic',
         orgName: 'Test Org',
-        formSubmissionTime: new Date().toISOString(),
+        formSubmission: { id: 'reg-001', time: new Date() },
         submittedToRegulator: 'EA',
         reprocessingType: null,
         submitterContactDetails: {

--- a/src/repositories/organisations/port.contract.js
+++ b/src/repositories/organisations/port.contract.js
@@ -1,6 +1,7 @@
 import { testFindBehaviour } from './contract/find.contract.js'
 import { testFindByIdsBehaviour } from './contract/find-by-ids.contract.js'
 import { testFindAllIdsBehaviour } from './contract/find-all-ids.contract.js'
+import { testFindAllBySchemaVersionBehaviour } from './contract/find-all-by-schema-version.contract.js'
 import { testFindAllLinkedBehaviour } from './contract/find-all-linked.contract.js'
 import { testFindByLinkedDefraOrgIdBehaviour } from './contract/find-by-linked-defra-org-id.contract.js'
 import { testFindPageBehaviour } from './contract/find-page.contract.js'
@@ -21,6 +22,7 @@ export const testOrganisationsRepositoryContract = (repositoryFactory) => {
   testFindBehaviour(repositoryFactory)
   testFindByIdsBehaviour(repositoryFactory)
   testFindAllIdsBehaviour(repositoryFactory)
+  testFindAllBySchemaVersionBehaviour(repositoryFactory)
   testFindAllLinkedBehaviour(repositoryFactory)
   testFindByLinkedDefraOrgIdBehaviour(repositoryFactory)
   testFindPageBehaviour(repositoryFactory)

--- a/src/repositories/organisations/port.js
+++ b/src/repositories/organisations/port.js
@@ -61,6 +61,7 @@
  * @property {(id: string, version: number, replacement: OrganisationReplacement) => Promise<void>} replace
  * @property {(id: string, version: number, document: Organisation) => Promise<void>} replaceRaw - Direct write bypassing status history management (dev/test only)
  * @property {() => Promise<Organisation[]>} findAll
+ * @property {(schemaVersion: number) => Promise<Organisation[]>} findAllBySchemaVersion - Find all organisations with a specific schema version
  * @property {(params: { search?: string, page: number, pageSize: number }) => Promise<{ items: Organisation[], page: number, pageSize: number, totalItems: number, totalPages: number }>} findPage - Paginated organisations query with optional case-insensitive substring search on companyDetails.name; results sorted alphabetically by name
  * @property {() => Promise<OrganisationsOverseasSitesAdminListItem[]>} [findAllForOverseasSitesAdminList] - Lightweight projection for ORS admin list endpoint
  * @property {(params: { page: number, pageSize: number, registrationNumber?: string }) => Promise<OrganisationsOverseasSitesAdminListPage>} [findPageForOverseasSitesAdminList] - Paginated ORS admin list query optimized for MongoDB-backed reads

--- a/src/repositories/organisations/schema/accreditation.js
+++ b/src/repositories/organisations/schema/accreditation.js
@@ -68,7 +68,6 @@ export const accreditationSchema = Joi.object({
     .when('status', requiredWhenApprovedOrSuspended)
     .default(null),
   reprocessingType: reprocessingTypeSchema,
-  formSubmissionTime: Joi.date().iso().required(),
   submittedToRegulator: Joi.string()
     .valid(REGULATOR.EA, REGULATOR.NRW, REGULATOR.SEPA, REGULATOR.NIEA)
     .required(),
@@ -99,6 +98,10 @@ export const accreditationSchema = Joi.object({
   wasteProcessingType: Joi.string()
     .valid(WASTE_PROCESSING_TYPE.REPROCESSOR, WASTE_PROCESSING_TYPE.EXPORTER)
     .required(),
+  formSubmission: Joi.object({
+    id: idSchema.required(),
+    time: Joi.date().iso().required()
+  }).required(),
   prnIssuance: prnIssuanceSchema.required(),
   submitterContactDetails: userSchema.required(),
   samplingInspectionPlanPart2FileUploads: Joi.array()

--- a/src/repositories/organisations/schema/accreditation.js
+++ b/src/repositories/organisations/schema/accreditation.js
@@ -9,6 +9,8 @@ import {
 } from '#domain/organisations/model.js'
 import {
   formFileUploadSchema,
+  formSubmissionSchema,
+  formSubmissionTimeSchema,
   idSchema,
   reprocessingTypeSchema,
   userSchema
@@ -98,10 +100,17 @@ export const accreditationSchema = Joi.object({
   wasteProcessingType: Joi.string()
     .valid(WASTE_PROCESSING_TYPE.REPROCESSOR, WASTE_PROCESSING_TYPE.EXPORTER)
     .required(),
-  formSubmission: Joi.object({
-    id: idSchema.required(),
-    time: Joi.date().iso().required()
-  }).required(),
+  formSubmissionTime: Joi.when('/schemaVersion', {
+    is: 1,
+    then: formSubmissionTimeSchema.required(),
+    otherwise: formSubmissionTimeSchema.forbidden()
+  }),
+
+  formSubmission: Joi.when('/schemaVersion', {
+    is: 2,
+    then: formSubmissionSchema.required(),
+    otherwise: formSubmissionSchema.forbidden()
+  }),
   prnIssuance: prnIssuanceSchema.required(),
   submitterContactDetails: userSchema.required(),
   samplingInspectionPlanPart2FileUploads: Joi.array()

--- a/src/repositories/organisations/schema/base.js
+++ b/src/repositories/organisations/schema/base.js
@@ -122,3 +122,10 @@ export const reprocessingTypeSchema = Joi.when('wasteProcessingType', {
     .default(null),
   otherwise: Joi.forbidden()
 })
+
+export const formSubmissionTimeSchema = Joi.date().iso()
+
+export const formSubmissionSchema = Joi.object({
+  id: idSchema.required(),
+  time: Joi.date().iso().required()
+})

--- a/src/repositories/organisations/schema/helpers.js
+++ b/src/repositories/organisations/schema/helpers.js
@@ -11,6 +11,8 @@ import {
 } from '#formsubmission/submission-keys.js'
 import Boom from '@hapi/boom'
 
+export const CURRENT_SCHEMA_VERSION = 2
+
 export const whenReprocessor = (schema) =>
   Joi.when('wasteProcessingType', {
     is: WASTE_PROCESSING_TYPE.REPROCESSOR,

--- a/src/repositories/organisations/schema/organisation.js
+++ b/src/repositories/organisations/schema/organisation.js
@@ -13,6 +13,8 @@ import {
 import {
   collatedUserSchema,
   companyDetailsSchema,
+  formSubmissionSchema,
+  formSubmissionTimeSchema,
   idSchema,
   linkedDefraOrganisationSchema,
   partnershipSchema,
@@ -34,10 +36,17 @@ export const organisationInsertSchema = Joi.object({
     )
     .optional(),
   companyDetails: companyDetailsSchema.required(),
-  formSubmission: Joi.object({
-    id: idSchema.required(),
-    time: Joi.date().iso().required()
-  }).required(),
+  formSubmissionTime: Joi.when('schemaVersion', {
+    is: 1,
+    then: formSubmissionTimeSchema.required(),
+    otherwise: formSubmissionTimeSchema.forbidden()
+  }),
+
+  formSubmission: Joi.when('schemaVersion', {
+    is: 2,
+    then: formSubmissionSchema.required(),
+    otherwise: formSubmissionSchema.forbidden()
+  }),
   id: idSchema,
   linkedDefraOrganisation: linkedDefraOrganisationSchema.optional(),
   managementContactDetails: userSchema.optional(),

--- a/src/repositories/organisations/schema/organisation.js
+++ b/src/repositories/organisations/schema/organisation.js
@@ -34,7 +34,10 @@ export const organisationInsertSchema = Joi.object({
     )
     .optional(),
   companyDetails: companyDetailsSchema.required(),
-  formSubmissionTime: Joi.date().iso().required(),
+  formSubmission: Joi.object({
+    id: idSchema.required(),
+    time: Joi.date().iso().required()
+  }).required(),
   id: idSchema,
   linkedDefraOrganisation: linkedDefraOrganisationSchema.optional(),
   managementContactDetails: userSchema.optional(),
@@ -79,7 +82,7 @@ export const organisationReplaceSchema = organisationInsertSchema
   .fork(NON_UPDATABLE_FIELDS, (schema) => schema.forbidden())
   .fork(['status'], (schema) => schema.optional())
   .keys({
-    schemaVersion: Joi.number().required().valid(1),
+    schemaVersion: Joi.number().required().valid(1, 2),
     registrations: Joi.array()
       .items(registrationUpdateSchema)
       .default([])

--- a/src/repositories/organisations/schema/registration.js
+++ b/src/repositories/organisations/schema/registration.js
@@ -10,6 +10,8 @@ import {
 import {
   addressSchema,
   formFileUploadSchema,
+  formSubmissionSchema,
+  formSubmissionTimeSchema,
   idSchema,
   reprocessingTypeSchema,
   userSchema
@@ -103,10 +105,17 @@ export const registrationSchema = Joi.object({
     .valid(WASTE_PROCESSING_TYPE.REPROCESSOR, WASTE_PROCESSING_TYPE.EXPORTER)
     .required(),
   accreditationId: idSchema.optional(),
-  formSubmission: Joi.object({
-    id: idSchema.required(),
-    time: Joi.date().iso().required()
-  }).required(),
+  formSubmissionTime: Joi.when('/schemaVersion', {
+    is: 1,
+    then: formSubmissionTimeSchema.required(),
+    otherwise: formSubmissionTimeSchema.forbidden()
+  }),
+
+  formSubmission: Joi.when('/schemaVersion', {
+    is: 2,
+    then: formSubmissionSchema.required(),
+    otherwise: formSubmissionSchema.forbidden()
+  }),
   glassRecyclingProcess: whenMaterial(
     MATERIAL.GLASS,
     Joi.array()

--- a/src/repositories/organisations/schema/registration.js
+++ b/src/repositories/organisations/schema/registration.js
@@ -83,7 +83,6 @@ export const registrationSchema = Joi.object({
   reprocessingType: reprocessingTypeSchema,
   validFrom: dateRequiredWhenApprovedOrSuspended(),
   validTo: dateRequiredWhenApprovedOrSuspended(),
-  formSubmissionTime: Joi.date().iso().required(),
   submittedToRegulator: Joi.string()
     .valid(REGULATOR.EA, REGULATOR.NRW, REGULATOR.SEPA, REGULATOR.NIEA)
     .required(),
@@ -104,6 +103,10 @@ export const registrationSchema = Joi.object({
     .valid(WASTE_PROCESSING_TYPE.REPROCESSOR, WASTE_PROCESSING_TYPE.EXPORTER)
     .required(),
   accreditationId: idSchema.optional(),
+  formSubmission: Joi.object({
+    id: idSchema.required(),
+    time: Joi.date().iso().required()
+  }).required(),
   glassRecyclingProcess: whenMaterial(
     MATERIAL.GLASS,
     Joi.array()

--- a/src/repositories/organisations/schema/validation.js
+++ b/src/repositories/organisations/schema/validation.js
@@ -9,6 +9,7 @@ import {
   statusHistoryItemSchema
 } from './organisation.js'
 import { accreditationSchema } from './accreditation.js'
+import { CURRENT_SCHEMA_VERSION } from '#repositories/organisations/schema/helpers.js'
 
 const formatValidationErrorDetails = (error) => {
   return error.details
@@ -41,10 +42,13 @@ export const validateId = (id) => {
   return value
 }
 
-export const validateOrganisationInsert = (data) => {
+export const validateOrganisationInsert = (
+  data,
+  schemaVersion = CURRENT_SCHEMA_VERSION
+) => {
   return validateWithSchema(
     organisationInsertSchema,
-    data,
+    { ...data, schemaVersion },
     'Invalid organisation data'
   )
 }
@@ -73,18 +77,24 @@ export const validateStatusHistory = (statusHistory) => {
   return value
 }
 
-export const validateRegistration = (data) => {
+export const validateRegistration = (
+  data,
+  schemaVersion = CURRENT_SCHEMA_VERSION
+) => {
   return validateWithSchema(
     registrationSchema,
-    data,
+    { ...data, schemaVersion },
     'Invalid registration data'
   )
 }
 
-export const validateAccreditation = (data) => {
+export const validateAccreditation = (
+  data,
+  schemaVersion = CURRENT_SCHEMA_VERSION
+) => {
   return validateWithSchema(
     accreditationSchema,
-    data,
+    { ...data, schemaVersion },
     'Invalid accreditation data'
   )
 }

--- a/src/repositories/organisations/schema/validation.test.js
+++ b/src/repositories/organisations/schema/validation.test.js
@@ -627,7 +627,7 @@ describe('organisationJSONSchemaOverrides', () => {
     delete accreditation.glassRecyclingProcess
 
     const organisation = buildOrganisation({
-      schemaVersion: 1,
+      schemaVersion: 2,
       registrations: [registration],
       accreditations: [accreditation]
     })
@@ -647,7 +647,7 @@ describe('organisationJSONSchemaOverrides', () => {
       })
       delete registration.glassRecyclingProcess
       const organisation = buildOrganisation({
-        schemaVersion: 1,
+        schemaVersion: 2,
         registrations: [registration],
         accreditations: []
       })
@@ -666,7 +666,7 @@ describe('organisationJSONSchemaOverrides', () => {
       })
       delete registration.glassRecyclingProcess
       const organisation = buildOrganisation({
-        schemaVersion: 1,
+        schemaVersion: 2,
         registrations: [registration],
         accreditations: []
       })
@@ -687,7 +687,7 @@ describe('organisationJSONSchemaOverrides', () => {
       delete registration.plantEquipmentDetails
 
       const organisation = buildOrganisation({
-        schemaVersion: 1,
+        schemaVersion: 2,
         registrations: [registration],
         accreditations: []
       })
@@ -707,7 +707,7 @@ describe('organisationJSONSchemaOverrides', () => {
       delete registration.orsFileUploads
 
       const organisation = buildOrganisation({
-        schemaVersion: 1,
+        schemaVersion: 2,
         registrations: [registration],
         accreditations: []
       })
@@ -724,7 +724,7 @@ describe('organisationJSONSchemaOverrides', () => {
       delete registration.glassRecyclingProcess
 
       const organisation = buildOrganisation({
-        schemaVersion: 1,
+        schemaVersion: 2,
         registrations: [registration],
         accreditations: []
       })
@@ -745,7 +745,7 @@ describe('organisationJSONSchemaOverrides', () => {
       })
       delete accreditation.glassRecyclingProcess
       const organisation = buildOrganisation({
-        schemaVersion: 1,
+        schemaVersion: 2,
         registrations: [],
         accreditations: [accreditation]
       })
@@ -764,7 +764,7 @@ describe('organisationJSONSchemaOverrides', () => {
       delete accreditation.glassRecyclingProcess
 
       const organisation = buildOrganisation({
-        schemaVersion: 1,
+        schemaVersion: 2,
         registrations: [],
         accreditations: [accreditation]
       })

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
@@ -80,7 +80,7 @@ describe('Repeated uploads of identical data', () => {
             glassRecyclingProcess: ['glass_re_melt'],
             wasteProcessingType: 'reprocessor',
             reprocessingType: 'input',
-            formSubmissionTime: new Date(),
+            formSubmission: { id: registrationId, time: new Date() },
             submittedToRegulator: 'ea',
             validFrom: VALID_FROM,
             validTo: VALID_TO,

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -87,7 +87,6 @@ describe('Submission and placeholder tests', () => {
             material: 'paper',
             wasteProcessingType: 'reprocessor',
             reprocessingType: 'input',
-            formSubmissionTime: new Date(),
             submittedToRegulator: 'ea',
             validFrom: VALID_FROM,
             validTo: VALID_TO,
@@ -754,7 +753,6 @@ describe('Submission and placeholder tests', () => {
             material: 'paper',
             wasteProcessingType: 'reprocessor',
             reprocessingType: 'input',
-            formSubmissionTime: new Date(),
             submittedToRegulator: 'ea',
             accreditationId
           }
@@ -766,7 +764,6 @@ describe('Submission and placeholder tests', () => {
             material: 'paper',
             wasteProcessingType: 'reprocessor',
             reprocessingType: 'input',
-            formSubmissionTime: new Date(),
             submittedToRegulator: 'ea'
           }
         ]

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
@@ -307,7 +307,7 @@ describe('Advanced validation scenarios', () => {
             registrationNumber: 'REG-123',
             material: 'paper',
             wasteProcessingType: 'reprocessor',
-            formSubmissionTime: new Date(),
+            formSubmission: { id: registrationId, time: new Date() },
             submittedToRegulator: 'ea'
           }
         ]

--- a/src/server/run-form-submission-lineage-migration.js
+++ b/src/server/run-form-submission-lineage-migration.js
@@ -19,14 +19,6 @@ export const runFormSubmissionLineageMigration = async (
   try {
     const featureFlagsInstance = options.featureFlags || server.featureFlags
 
-    if (!featureFlagsInstance.isMigrateFormSubmissionLineageEnabled()) {
-      logger.info({
-        message:
-          'Feature flag disabled, skipping form submission lineage migration'
-      })
-      return
-    }
-
     const lock = await server.locker.lock('migrate-form-submission-lineage')
     if (!lock) {
       logger.info({
@@ -50,7 +42,8 @@ export const runFormSubmissionLineageMigration = async (
       await migrateFormSubmissionLineage(
         formSubmissionsRepository,
         organisationsRepository,
-        systemLogsRepository
+        systemLogsRepository,
+        featureFlagsInstance.isMigrateFormSubmissionLineageEnabled()
       )
 
       logger.info({

--- a/src/server/run-form-submission-lineage-migration.js
+++ b/src/server/run-form-submission-lineage-migration.js
@@ -1,0 +1,68 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import { migrateFormSubmissionLineage } from '#formsubmission/migration/migrate-form-submission-lineage.js'
+import { createFormSubmissionsRepository } from '#repositories/form-submissions/mongodb.js'
+import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
+
+/**
+ * Run the formSubmission lineage backfill migration on startup.
+ *
+ * @param {Object} server - Hapi server instance
+ * @param {Object} [options] - Optional configuration
+ * @param {Object} [options.featureFlags] - Feature flags instance (for testing)
+ * @returns {Promise<void>}
+ */
+export const runFormSubmissionLineageMigration = async (
+  server,
+  options = {}
+) => {
+  try {
+    const featureFlagsInstance = options.featureFlags || server.featureFlags
+
+    if (!featureFlagsInstance.isMigrateFormSubmissionLineageEnabled()) {
+      logger.info({
+        message:
+          'Feature flag disabled, skipping form submission lineage migration'
+      })
+      return
+    }
+
+    const lock = await server.locker.lock('migrate-form-submission-lineage')
+    if (!lock) {
+      logger.info({
+        message:
+          'Unable to obtain lock, skipping form submission lineage migration'
+      })
+      return
+    }
+
+    try {
+      const formSubmissionsRepository = (
+        await createFormSubmissionsRepository(server.db, logger)
+      )()
+      const organisationsRepository = (
+        await createOrganisationsRepository(server.db)
+      )()
+      const systemLogsRepository = (
+        await createSystemLogsRepository(server.db)
+      )(logger)
+
+      await migrateFormSubmissionLineage(
+        formSubmissionsRepository,
+        organisationsRepository,
+        systemLogsRepository
+      )
+
+      logger.info({
+        message: 'Form submission lineage migration completed successfully'
+      })
+    } finally {
+      await lock.free()
+    }
+  } catch (error) {
+    logger.error({
+      err: error,
+      message: 'Failed to run form submission lineage migration'
+    })
+  }
+}

--- a/src/server/run-form-submission-lineage-migration.test.js
+++ b/src/server/run-form-submission-lineage-migration.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { runFormSubmissionLineageMigration } from './run-form-submission-lineage-migration.js'
+
+import { logger } from '#common/helpers/logging/logger.js'
+import { migrateFormSubmissionLineage } from '#formsubmission/migration/migrate-form-submission-lineage.js'
+import { createFormSubmissionsRepository } from '#repositories/form-submissions/mongodb.js'
+import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+vi.mock('#formsubmission/migration/migrate-form-submission-lineage.js', () => ({
+  migrateFormSubmissionLineage: vi.fn()
+}))
+vi.mock('#repositories/form-submissions/mongodb.js', () => ({
+  createFormSubmissionsRepository: vi.fn()
+}))
+vi.mock('#repositories/organisations/mongodb.js', () => ({
+  createOrganisationsRepository: vi.fn()
+}))
+vi.mock('#repositories/system-logs/mongodb.js', () => ({
+  createSystemLogsRepository: vi.fn()
+}))
+
+describe('runFormSubmissionLineageMigration', () => {
+  let mockServer
+  let mockLock
+  let mockFeatureFlags
+  let mockFormSubmissionsRepository
+  let mockOrganisationsRepository
+  let mockSystemLogsRepository
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockFormSubmissionsRepository = {}
+    mockOrganisationsRepository = {}
+    mockSystemLogsRepository = {}
+
+    mockLock = {
+      free: vi.fn().mockResolvedValue(undefined)
+    }
+
+    mockFeatureFlags = {
+      isMigrateFormSubmissionLineageEnabled: vi.fn().mockReturnValue(true)
+    }
+
+    mockServer = {
+      db: {},
+      featureFlags: mockFeatureFlags,
+      locker: {
+        lock: vi.fn().mockResolvedValue(mockLock)
+      }
+    }
+
+    createFormSubmissionsRepository.mockResolvedValue(
+      () => mockFormSubmissionsRepository
+    )
+    createOrganisationsRepository.mockResolvedValue(
+      () => mockOrganisationsRepository
+    )
+    createSystemLogsRepository.mockResolvedValue(() => mockSystemLogsRepository)
+    migrateFormSubmissionLineage.mockResolvedValue(undefined)
+  })
+
+  it('runs the migration when the feature flag is enabled', async () => {
+    await runFormSubmissionLineageMigration(mockServer)
+
+    expect(mockServer.locker.lock).toHaveBeenCalledWith(
+      'migrate-form-submission-lineage'
+    )
+    expect(migrateFormSubmissionLineage).toHaveBeenCalledWith(
+      mockFormSubmissionsRepository,
+      mockOrganisationsRepository,
+      mockSystemLogsRepository
+    )
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Form submission lineage migration completed successfully'
+    })
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('skips the migration when the feature flag is disabled', async () => {
+    mockFeatureFlags.isMigrateFormSubmissionLineageEnabled.mockReturnValue(
+      false
+    )
+
+    await runFormSubmissionLineageMigration(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Feature flag disabled, skipping form submission lineage migration'
+    })
+    expect(mockServer.locker.lock).not.toHaveBeenCalled()
+    expect(migrateFormSubmissionLineage).not.toHaveBeenCalled()
+  })
+
+  it('skips the migration when the distributed lock cannot be obtained', async () => {
+    mockServer.locker.lock.mockResolvedValue(null)
+
+    await runFormSubmissionLineageMigration(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Unable to obtain lock, skipping form submission lineage migration'
+    })
+    expect(migrateFormSubmissionLineage).not.toHaveBeenCalled()
+  })
+
+  it('releases the lock after the migration succeeds', async () => {
+    await runFormSubmissionLineageMigration(mockServer)
+
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('releases the lock and logs an error when the migration fails', async () => {
+    const error = new Error('migration failed')
+    migrateFormSubmissionLineage.mockRejectedValue(error)
+
+    await runFormSubmissionLineageMigration(mockServer)
+
+    expect(mockLock.free).toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run form submission lineage migration'
+    })
+  })
+
+  it('uses options.featureFlags when provided instead of server.featureFlags', async () => {
+    const overrideFlags = {
+      isMigrateFormSubmissionLineageEnabled: vi.fn().mockReturnValue(false)
+    }
+
+    await runFormSubmissionLineageMigration(mockServer, {
+      featureFlags: overrideFlags
+    })
+
+    expect(
+      overrideFlags.isMigrateFormSubmissionLineageEnabled
+    ).toHaveBeenCalled()
+    expect(
+      mockFeatureFlags.isMigrateFormSubmissionLineageEnabled
+    ).not.toHaveBeenCalled()
+    expect(migrateFormSubmissionLineage).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/run-form-submission-lineage-migration.test.js
+++ b/src/server/run-form-submission-lineage-migration.test.js
@@ -76,7 +76,8 @@ describe('runFormSubmissionLineageMigration', () => {
     expect(migrateFormSubmissionLineage).toHaveBeenCalledWith(
       mockFormSubmissionsRepository,
       mockOrganisationsRepository,
-      mockSystemLogsRepository
+      mockSystemLogsRepository,
+      true
     )
     expect(logger.info).toHaveBeenCalledWith({
       message: 'Form submission lineage migration completed successfully'
@@ -84,19 +85,22 @@ describe('runFormSubmissionLineageMigration', () => {
     expect(mockLock.free).toHaveBeenCalled()
   })
 
-  it('skips the migration when the feature flag is disabled', async () => {
+  it('passes the flag as false to migrateFormSubmissionLineage when the feature flag is disabled', async () => {
     mockFeatureFlags.isMigrateFormSubmissionLineageEnabled.mockReturnValue(
       false
     )
 
     await runFormSubmissionLineageMigration(mockServer)
 
-    expect(logger.info).toHaveBeenCalledWith({
-      message:
-        'Feature flag disabled, skipping form submission lineage migration'
-    })
-    expect(mockServer.locker.lock).not.toHaveBeenCalled()
-    expect(migrateFormSubmissionLineage).not.toHaveBeenCalled()
+    expect(mockServer.locker.lock).toHaveBeenCalledWith(
+      'migrate-form-submission-lineage'
+    )
+    expect(migrateFormSubmissionLineage).toHaveBeenCalledWith(
+      mockFormSubmissionsRepository,
+      mockOrganisationsRepository,
+      mockSystemLogsRepository,
+      false
+    )
   })
 
   it('skips the migration when the distributed lock cannot be obtained', async () => {
@@ -145,6 +149,11 @@ describe('runFormSubmissionLineageMigration', () => {
     expect(
       mockFeatureFlags.isMigrateFormSubmissionLineageEnabled
     ).not.toHaveBeenCalled()
-    expect(migrateFormSubmissionLineage).not.toHaveBeenCalled()
+    expect(migrateFormSubmissionLineage).toHaveBeenCalledWith(
+      mockFormSubmissionsRepository,
+      mockOrganisationsRepository,
+      mockSystemLogsRepository,
+      false
+    )
   })
 })

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -42,6 +42,7 @@ import { commandQueueConsumerPlugin } from '#server/queue-consumer/queue-consume
 import { runFormsDataMigration } from '#server/run-forms-data-migration.js'
 import { copyFormFilesToS3 } from '#server/copy-form-files-to-s3.js'
 import { runRowIdCollisionDiagnostic } from '#server/run-row-id-collision-diagnostic.js'
+import { runFormSubmissionLineageMigration } from '#server/run-form-submission-lineage-migration.js'
 
 function getServerConfig(config) {
   return {
@@ -215,6 +216,7 @@ async function createServer(options = {}) {
     runFormsDataMigration(server)
     copyFormFilesToS3(server)
     runRowIdCollisionDiagnostic(server)
+    runFormSubmissionLineageMigration(server)
   })
 
   return server


### PR DESCRIPTION
Ticket: [PAE-1409](https://eaflood.atlassian.net/browse/PAE-1409)
## [PAE-1409: Store original form submission id during migration](https://github.com/DEFRA/epr-backend/commit/77a97260c011f9ee5ac38d2fdfb90491bea36935)

<!-- Describe your changes -->

- Store original form submission id as a field inside epr-organisations at org/registration/accreditation level
- Create a one off migration process to back populate form submission id's for existing organisations. This will be disabled by default via feature flag. Increment schemaVersion to 2 during migration 
- All new organisations will default to schemaVersion 2
- Schema changes are backward  compatible, so should not break anything until migration completes. At that point can remove all checks in schema specific to version 1 and default to version 2
- For cases where glass other registration/accreditation has been synthetically created, use formSubmission time to find original form submission id within an org

<img width="2761" height="1111" alt="image" src="https://github.com/user-attachments/assets/5df43511-8f3d-4a02-9460-fec4e1fc59e1" />


<img width="2761" height="1111" alt="image" src="https://github.com/user-attachments/assets/a6396052-3ada-4267-ad2a-ccece6484c66" />

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1409]: https://eaflood.atlassian.net/browse/PAE-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ