### PR TITLE
PAE-1295: Add pagination and search to GET /v1/organisations

### DIFF
--- a/src/repositories/organisations/contract/find-page.contract.js
+++ b/src/repositories/organisations/contract/find-page.contract.js
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect } from 'vitest'
+import { buildOrganisation } from './test-data.js'
+
+const buildOrgWithName = (name) => {
+  const base = buildOrganisation()
+  return {
+    ...base,
+    companyDetails: { ...base.companyDetails, name }
+  }
+}
+
+const insertNamed = async (repository, names) => {
+  for (const name of names) {
+    await repository.insert(buildOrgWithName(name))
+  }
+}
+
+export const testFindPageBehaviour = (it) => {
+  describe('findPage', () => {
+    let repository
+
+    beforeEach(async ({ organisationsRepository }) => {
+      repository = await organisationsRepository()
+    })
+
+    describe('empty collection', () => {
+      it('returns items=[], totalItems=0, totalPages=0', async () => {
+        const result = await repository.findPage({ page: 1, pageSize: 50 })
+
+        expect(result).toEqual({
+          items: [],
+          page: 1,
+          pageSize: 50,
+          totalItems: 0,
+          totalPages: 0
+        })
+      })
+    })
+
+    describe('pagination', () => {
+      it('sorts results alphabetically by companyDetails.name ascending', async () => {
+        await insertNamed(repository, ['Charlie Ltd', 'Alpha Co', 'Bravo Inc'])
+
+        const result = await repository.findPage({ page: 1, pageSize: 10 })
+
+        expect(result.items.map((o) => o.companyDetails.name)).toEqual([
+          'Alpha Co',
+          'Bravo Inc',
+          'Charlie Ltd'
+        ])
+        expect(result.totalItems).toBe(3)
+        expect(result.totalPages).toBe(1)
+      })
+
+      it('returns the requested page slice', async () => {
+        await insertNamed(repository, ['A', 'B', 'C', 'D', 'E'])
+
+        const result = await repository.findPage({ page: 2, pageSize: 2 })
+
+        expect(result.items.map((o) => o.companyDetails.name)).toEqual([
+          'C',
+          'D'
+        ])
+        expect(result.page).toBe(2)
+        expect(result.pageSize).toBe(2)
+        expect(result.totalItems).toBe(5)
+        expect(result.totalPages).toBe(3)
+      })
+
+      it('returns a partially filled last page', async () => {
+        await insertNamed(repository, ['A', 'B', 'C', 'D', 'E'])
+
+        const result = await repository.findPage({ page: 3, pageSize: 2 })
+
+        expect(result.items.map((o) => o.companyDetails.name)).toEqual(['E'])
+        expect(result.totalItems).toBe(5)
+        expect(result.totalPages).toBe(3)
+      })
+
+      it('returns empty items when page is beyond end (no 404)', async () => {
+        await insertNamed(repository, ['Only Org'])
+
+        const result = await repository.findPage({ page: 99, pageSize: 10 })
+
+        expect(result.items).toEqual([])
+        expect(result.page).toBe(99)
+        expect(result.pageSize).toBe(10)
+        expect(result.totalItems).toBe(1)
+        expect(result.totalPages).toBe(1)
+      })
+
+      it('computes totalPages correctly when totalItems is exactly divisible by pageSize', async () => {
+        await insertNamed(repository, ['A', 'B', 'C', 'D'])
+
+        const result = await repository.findPage({ page: 1, pageSize: 2 })
+
+        expect(result.totalItems).toBe(4)
+        expect(result.totalPages).toBe(2)
+      })
+
+      it('returns both organisations when two share the same name', async () => {
+        await insertNamed(repository, ['Same Name Ltd', 'Same Name Ltd'])
+
+        const result = await repository.findPage({ page: 1, pageSize: 10 })
+
+        expect(result.totalItems).toBe(2)
+        expect(result.items).toHaveLength(2)
+        expect(
+          result.items.every((o) => o.companyDetails.name === 'Same Name Ltd')
+        ).toBe(true)
+      })
+    })
+
+    describe('search', () => {
+      it('filters case-insensitively by substring on companyDetails.name', async () => {
+        await insertNamed(repository, ['Acme Ltd', 'ACME Corp', 'Globex Inc'])
+
+        const result = await repository.findPage({
+          search: 'acme',
+          page: 1,
+          pageSize: 50
+        })
+
+        expect(result.totalItems).toBe(2)
+        expect(result.items.map((o) => o.companyDetails.name).sort()).toEqual([
+          'ACME Corp',
+          'Acme Ltd'
+        ])
+      })
+
+      it('matches partial substrings (not just prefix)', async () => {
+        await insertNamed(repository, ['Acme Holdings Ltd', 'Globex Inc'])
+
+        const result = await repository.findPage({
+          search: 'holdings',
+          page: 1,
+          pageSize: 50
+        })
+
+        expect(result.totalItems).toBe(1)
+        expect(result.items[0].companyDetails.name).toBe('Acme Holdings Ltd')
+      })
+
+      it('returns empty items and zero totals when no matches', async () => {
+        await insertNamed(repository, ['Acme Ltd'])
+
+        const result = await repository.findPage({
+          search: 'nonexistent',
+          page: 1,
+          pageSize: 50
+        })
+
+        expect(result.items).toEqual([])
+        expect(result.totalItems).toBe(0)
+        expect(result.totalPages).toBe(0)
+      })
+
+      it('treats empty string search as no filter', async () => {
+        await insertNamed(repository, ['Acme Ltd', 'Globex Inc'])
+
+        const result = await repository.findPage({
+          search: '',
+          page: 1,
+          pageSize: 50
+        })
+
+        expect(result.totalItems).toBe(2)
+      })
+
+      it('treats undefined search as no filter', async () => {
+        await insertNamed(repository, ['Acme Ltd', 'Globex Inc'])
+
+        const result = await repository.findPage({
+          page: 1,
+          pageSize: 50
+        })
+
+        expect(result.totalItems).toBe(2)
+      })
+
+      it('escapes regex special characters in the search term', async () => {
+        await insertNamed(repository, ['A.B.C Ltd', 'AXBXC Ltd'])
+
+        const result = await repository.findPage({
+          search: 'A.B.C',
+          page: 1,
+          pageSize: 50
+        })
+
+        expect(result.totalItems).toBe(1)
+        expect(result.items[0].companyDetails.name).toBe('A.B.C Ltd')
+      })
+
+      it('counts only matching documents in totalItems when paginating a search', async () => {
+        await insertNamed(repository, [
+          'Acme A',
+          'Acme B',
+          'Acme C',
+          'Acme D',
+          'Acme E',
+          'Globex A',
+          'Globex B'
+        ])
+
+        const result = await repository.findPage({
+          search: 'acme',
+          page: 2,
+          pageSize: 2
+        })
+
+        expect(result.items.map((o) => o.companyDetails.name)).toEqual([
+          'Acme C',
+          'Acme D'
+        ])
+        expect(result.totalItems).toBe(5)
+        expect(result.totalPages).toBe(3)
+      })
+    })
+
+    describe('returned organisation shape', () => {
+      it('returns the full Organisation shape with computed status field', async () => {
+        const org = buildOrgWithName('Acme Ltd')
+        await repository.insert(org)
+
+        const result = await repository.findPage({ page: 1, pageSize: 10 })
+
+        const found = result.items[0]
+        expect(found.id).toBe(org.id)
+        expect(found.orgId).toBe(org.orgId)
+        expect(found.companyDetails.name).toBe('Acme Ltd')
+        expect(found.status).toBeDefined()
+      })
+    })
+  })
+}

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -154,7 +154,7 @@ const ORS_ADMIN_LIST_PROJECTION = {
   'accreditations.accreditationNumber': 1
 }
 
-const escapeRegex = (string) =>
+export const escapeRegex = (string) =>
   string.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 
 const buildOrsAdminListBasePipeline = ({ registrationNumber }) => [

--- a/src/repositories/organisations/inmemory.js
+++ b/src/repositories/organisations/inmemory.js
@@ -160,9 +160,7 @@ const performFindPage =
 
     if (trimmedSearch !== '') {
       const pattern = new RegExp(escapeRegex(trimmedSearch), 'i')
-      matches = matches.filter((org) =>
-        pattern.test(org.companyDetails.name)
-      )
+      matches = matches.filter((org) => pattern.test(org.companyDetails.name))
     }
 
     matches.sort((a, b) => {

--- a/src/repositories/organisations/inmemory.js
+++ b/src/repositories/organisations/inmemory.js
@@ -166,8 +166,12 @@ const performFindPage =
     matches.sort((a, b) => {
       const aName = a.companyDetails.name
       const bName = b.companyDetails.name
-      if (aName < bName) return -1
-      if (aName > bName) return 1
+      if (aName < bName) {
+        return -1
+      }
+      if (aName > bName) {
+        return 1
+      }
       return 0
     })
 

--- a/src/repositories/organisations/inmemory.js
+++ b/src/repositories/organisations/inmemory.js
@@ -5,6 +5,7 @@ import { REG_ACC_STATUS, USER_ROLES } from '#domain/organisations/model.js'
 import { validateId, validateOrganisationInsert } from './schema/index.js'
 import {
   createInitialStatusHistory,
+  escapeRegex,
   mapDocumentWithCurrentStatuses,
   prepareForReplace,
   SCHEMA_VERSION
@@ -149,6 +150,38 @@ const performFindAll = (staleCache) => async () => {
     mapDocumentWithCurrentStatuses({ ...org })
   )
 }
+
+const performFindPage =
+  (staleCache) =>
+  async ({ search, page, pageSize }) => {
+    const trimmedSearch = (search ?? '').trim()
+
+    let matches = structuredClone(staleCache)
+
+    if (trimmedSearch !== '') {
+      const pattern = new RegExp(escapeRegex(trimmedSearch), 'i')
+      matches = matches.filter((org) =>
+        pattern.test(org.companyDetails.name)
+      )
+    }
+
+    matches.sort((a, b) => {
+      const aName = a.companyDetails.name
+      const bName = b.companyDetails.name
+      if (aName < bName) return -1
+      if (aName > bName) return 1
+      return 0
+    })
+
+    const totalItems = matches.length
+    const totalPages = Math.ceil(totalItems / pageSize)
+    const start = (page - 1) * pageSize
+    const items = matches
+      .slice(start, start + pageSize)
+      .map((org) => mapDocumentWithCurrentStatuses({ ...org }))
+
+    return { items, page, pageSize, totalItems, totalPages }
+  }
 
 const performFindAllForOverseasSitesAdminList = (staleCache) => async () => {
   return structuredClone(staleCache).map(
@@ -386,6 +419,7 @@ export const createInMemoryOrganisationsRepository = (
       replace: replaceFn,
       replaceRaw: replaceRawFn,
       findAll: performFindAll(staleCache),
+      findPage: performFindPage(staleCache),
       findAllForOverseasSitesAdminList:
         performFindAllForOverseasSitesAdminList(staleCache),
       findAllLinked: performFindAllLinked(staleCache),

--- a/src/repositories/organisations/mongodb.js
+++ b/src/repositories/organisations/mongodb.js
@@ -3,6 +3,7 @@ import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 import {
   createInitialStatusHistory,
+  escapeRegex,
   mapDocumentWithCurrentStatuses,
   performFindAllForOverseasSitesAdminList,
   performFindPageForOrsAdminList,
@@ -210,6 +211,35 @@ const performFindAll = (db) => async () => {
   return docs.map((doc) => mapDocumentWithCurrentStatuses(doc))
 }
 
+const performFindPage =
+  (db) =>
+  async ({ search, page, pageSize }) => {
+    const trimmedSearch = (search ?? '').trim()
+    const filter =
+      trimmedSearch === ''
+        ? {}
+        : {
+            'companyDetails.name': {
+              $regex: escapeRegex(trimmedSearch),
+              $options: 'i'
+            }
+          }
+
+    const collection = db.collection(COLLECTION_NAME)
+    const totalItems = await collection.countDocuments(filter)
+    const docs = await collection
+      .find(filter)
+      .sort({ 'companyDetails.name': 1 })
+      .skip((page - 1) * pageSize)
+      .limit(pageSize)
+      .toArray()
+
+    const items = docs.map((doc) => mapDocumentWithCurrentStatuses(doc))
+    const totalPages = Math.ceil(totalItems / pageSize)
+
+    return { items, page, pageSize, totalItems, totalPages }
+  }
+
 const LINKED_ORG_PROJECTION = {
   orgId: 1,
   'companyDetails.name': 1,
@@ -276,9 +306,6 @@ const performFindByLinkedDefraOrgId = (db) => async (defraOrgId) => {
 
   return mapDocumentWithCurrentStatuses(doc)
 }
-
-const escapeRegex = (string) =>
-  string.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 
 const performFindAllLinkableForUser = (db) => async (email) => {
   const docs = await db
@@ -428,6 +455,7 @@ export const createOrganisationsRepository = async (
       replaceRaw: performReplaceRaw(db),
       findById,
       findAll: performFindAll(db),
+      findPage: performFindPage(db),
       findAllForOverseasSitesAdminList:
         performFindAllForOverseasSitesAdminList(db),
       findPageForOverseasSitesAdminList: performFindPageForOrsAdminList(db),

--- a/src/repositories/organisations/port.contract.js
+++ b/src/repositories/organisations/port.contract.js
@@ -3,6 +3,7 @@ import { testFindByIdsBehaviour } from './contract/find-by-ids.contract.js'
 import { testFindAllIdsBehaviour } from './contract/find-all-ids.contract.js'
 import { testFindAllLinkedBehaviour } from './contract/find-all-linked.contract.js'
 import { testFindByLinkedDefraOrgIdBehaviour } from './contract/find-by-linked-defra-org-id.contract.js'
+import { testFindPageBehaviour } from './contract/find-page.contract.js'
 import { testInsertBehaviour } from './contract/insert.contract.js'
 import { testReplaceBehaviour } from './contract/replace.contract.js'
 import { testReplaceRawBehaviour } from './contract/replace-raw.contract.js'
@@ -22,6 +23,7 @@ export const testOrganisationsRepositoryContract = (repositoryFactory) => {
   testFindAllIdsBehaviour(repositoryFactory)
   testFindAllLinkedBehaviour(repositoryFactory)
   testFindByLinkedDefraOrgIdBehaviour(repositoryFactory)
+  testFindPageBehaviour(repositoryFactory)
   testFindRegistrationByIdBehaviour(repositoryFactory)
   testFindAccreditationByIdBehaviour(repositoryFactory)
   testDataIsolationBehaviour(repositoryFactory)

--- a/src/repositories/organisations/port.js
+++ b/src/repositories/organisations/port.js
@@ -61,6 +61,7 @@
  * @property {(id: string, version: number, replacement: OrganisationReplacement) => Promise<void>} replace
  * @property {(id: string, version: number, document: Organisation) => Promise<void>} replaceRaw - Direct write bypassing status history management (dev/test only)
  * @property {() => Promise<Organisation[]>} findAll
+ * @property {(params: { search?: string, page: number, pageSize: number }) => Promise<{ items: Organisation[], page: number, pageSize: number, totalItems: number, totalPages: number }>} findPage - Paginated organisations query with optional case-insensitive substring search on companyDetails.name; results sorted alphabetically by name
  * @property {() => Promise<OrganisationsOverseasSitesAdminListItem[]>} [findAllForOverseasSitesAdminList] - Lightweight projection for ORS admin list endpoint
  * @property {(params: { page: number, pageSize: number, registrationNumber?: string }) => Promise<OrganisationsOverseasSitesAdminListPage>} [findPageForOverseasSitesAdminList] - Paginated ORS admin list query optimized for MongoDB-backed reads
  * @property {(ids: string[]) => Promise<Organisation[]>} findByIds - Find organisations by array of IDs

--- a/src/routes/v1/organisations/get.js
+++ b/src/routes/v1/organisations/get.js
@@ -33,7 +33,10 @@ export const organisationsGetAll = {
     }
   },
   /**
-   * @param {import('#common/hapi-types.js').HapiRequest & {organisationsRepository: OrganisationsRepository}} request
+   * @param {import('#common/hapi-types.js').HapiRequest & {
+   *   organisationsRepository: OrganisationsRepository,
+   *   query: { search?: string, page?: number, pageSize?: number }
+   * }} request
    * @param {Object} h - Hapi response toolkit
    */
   handler: async ({ organisationsRepository, query }, h) => {

--- a/src/routes/v1/organisations/get.js
+++ b/src/routes/v1/organisations/get.js
@@ -1,9 +1,24 @@
+import Joi from 'joi'
 import { StatusCodes } from 'http-status-codes'
 import { ROLES } from '#common/helpers/auth/constants.js'
 
 /** @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository */
 
 export const organisationsGetAllPath = '/v1/organisations'
+
+const DEFAULT_PAGE = 1
+const DEFAULT_PAGE_SIZE = 50
+const MAX_PAGE_SIZE = 200
+const MAX_SEARCH_LENGTH = 200
+
+const querySchema = Joi.object({
+  search: Joi.string().trim().allow('').max(MAX_SEARCH_LENGTH).optional(),
+  page: Joi.number().integer().min(1).optional(),
+  pageSize: Joi.number().integer().min(1).max(MAX_PAGE_SIZE).optional()
+}).unknown(false)
+
+const isPaginatedRequest = (query) =>
+  'search' in query || 'page' in query || 'pageSize' in query
 
 export const organisationsGetAll = {
   method: 'GET',
@@ -12,15 +27,27 @@ export const organisationsGetAll = {
     auth: {
       scope: [ROLES.serviceMaintainer]
     },
-    tags: ['api', 'admin']
+    tags: ['api', 'admin'],
+    validate: {
+      query: querySchema
+    }
   },
   /**
    * @param {import('#common/hapi-types.js').HapiRequest & {organisationsRepository: OrganisationsRepository}} request
    * @param {Object} h - Hapi response toolkit
    */
-  handler: async ({ organisationsRepository }, h) => {
-    const organisations = await organisationsRepository.findAll()
+  handler: async ({ organisationsRepository, query }, h) => {
+    if (!isPaginatedRequest(query)) {
+      const organisations = await organisationsRepository.findAll()
+      return h.response(organisations).code(StatusCodes.OK)
+    }
 
-    return h.response(organisations).code(StatusCodes.OK)
+    const result = await organisationsRepository.findPage({
+      search: query.search,
+      page: query.page ?? DEFAULT_PAGE,
+      pageSize: query.pageSize ?? DEFAULT_PAGE_SIZE
+    })
+
+    return h.response(result).code(StatusCodes.OK)
   }
 }

--- a/src/routes/v1/organisations/get.test.js
+++ b/src/routes/v1/organisations/get.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { StatusCodes } from 'http-status-codes'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
@@ -10,6 +10,16 @@ import { testInvalidTokenScenarios } from '#vite/helpers/test-invalid-token-scen
 import { testOnlyServiceMaintainerCanAccess } from '#vite/helpers/test-invalid-roles-scenarios.js'
 
 const { validToken } = entraIdMockAuthTokens
+
+const buildOrgWithName = (name) => {
+  const base = buildOrganisation()
+  return {
+    ...base,
+    companyDetails: { ...base.companyDetails, name }
+  }
+}
+
+const authHeaders = { Authorization: `Bearer ${validToken}` }
 
 describe('GET /v1/organisations', () => {
   setupAuthContext()
@@ -28,33 +38,225 @@ describe('GET /v1/organisations', () => {
     })
   })
 
-  it('returns 200 and all organisations', async () => {
-    const featureFlags = createInMemoryFeatureFlags({ organisations: true })
+  describe('Mode A — legacy (no recognised query params)', () => {
+    it('returns 200 and a top-level array of all organisations', async () => {
+      const org1 = buildOrganisation()
+      const org2 = buildOrganisation()
 
-    const server = await createTestServer({
-      repositories: { organisationsRepository: organisationsRepositoryFactory },
-      featureFlags
+      await organisationsRepository.insert(org1)
+      await organisationsRepository.insert(org2)
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/v1/organisations',
+        headers: authHeaders
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const result = JSON.parse(response.payload)
+      expect(Array.isArray(result)).toBe(true)
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe(org1.id)
+      expect(result[1].id).toBe(org2.id)
     })
 
-    const org1 = buildOrganisation()
-    const org2 = buildOrganisation()
+    it('returns an empty array when no organisations exist', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/v1/organisations',
+        headers: authHeaders
+      })
 
-    await organisationsRepository.insert(org1)
-    await organisationsRepository.insert(org2)
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(response.payload)).toEqual([])
+    })
+  })
 
-    const response = await server.inject({
-      method: 'GET',
-      url: '/v1/organisations',
-      headers: {
-        Authorization: `Bearer ${validToken}`
-      }
+  describe('Mode B — paginated (any of search, page, pageSize present)', () => {
+    describe('mode trigger', () => {
+      it('returns envelope shape when only page is provided', async () => {
+        await organisationsRepository.insert(buildOrganisation())
+
+        const response = await server.inject({
+          method: 'GET',
+          url: '/v1/organisations?page=1',
+          headers: authHeaders
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const result = JSON.parse(response.payload)
+        expect(Array.isArray(result)).toBe(false)
+        expect(result).toHaveProperty('items')
+        expect(result).toHaveProperty('totalItems')
+      })
+
+      it('returns envelope shape when only pageSize is provided', async () => {
+        await organisationsRepository.insert(buildOrganisation())
+
+        const response = await server.inject({
+          method: 'GET',
+          url: '/v1/organisations?pageSize=10',
+          headers: authHeaders
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const result = JSON.parse(response.payload)
+        expect(Array.isArray(result)).toBe(false)
+        expect(result).toHaveProperty('items')
+      })
+
+      it('returns envelope shape when only search is provided', async () => {
+        await organisationsRepository.insert(buildOrgWithName('Acme Ltd'))
+        await organisationsRepository.insert(buildOrgWithName('Globex Inc'))
+
+        const response = await server.inject({
+          method: 'GET',
+          url: '/v1/organisations?search=acme',
+          headers: authHeaders
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const result = JSON.parse(response.payload)
+        expect(Array.isArray(result)).toBe(false)
+        expect(result.totalItems).toBe(1)
+        expect(result.items[0].companyDetails.name).toBe('Acme Ltd')
+      })
     })
 
-    expect(response.statusCode).toBe(StatusCodes.OK)
-    const result = JSON.parse(response.payload)
-    expect(result).toHaveLength(2)
-    expect(result[0].id).toBe(org1.id)
-    expect(result[1].id).toBe(org2.id)
+    describe('response shape', () => {
+      it('returns envelope with items, page, pageSize, totalItems, totalPages', async () => {
+        await organisationsRepository.insert(buildOrgWithName('Alpha'))
+        await organisationsRepository.insert(buildOrgWithName('Bravo'))
+        await organisationsRepository.insert(buildOrgWithName('Charlie'))
+
+        const response = await server.inject({
+          method: 'GET',
+          url: '/v1/organisations?page=1&pageSize=10',
+          headers: authHeaders
+        })
+
+        const result = JSON.parse(response.payload)
+        expect(result).toMatchObject({
+          page: 1,
+          pageSize: 10,
+          totalItems: 3,
+          totalPages: 1
+        })
+        expect(result.items).toHaveLength(3)
+      })
+    })
+
+    describe('defaults', () => {
+      it('applies default pageSize=50 when only search is provided', async () => {
+        const response = await server.inject({
+          method: 'GET',
+          url: '/v1/organisations?search=anything',
+          headers: authHeaders
+        })
+
+        expect(JSON.parse(response.payload).pageSize).toBe(50)
+      })
+
+      it('applies default page=1 when only pageSize is provided', async () => {
+        const response = await server.inject({
+          method: 'GET',
+          url: '/v1/organisations?pageSize=10',
+          headers: authHeaders
+        })
+
+        expect(JSON.parse(response.payload).page).toBe(1)
+      })
+    })
+
+    describe('search and pagination semantics', () => {
+      it('filters by case-insensitive substring on company name', async () => {
+        await organisationsRepository.insert(buildOrgWithName('Acme Ltd'))
+        await organisationsRepository.insert(buildOrgWithName('ACME Corp'))
+        await organisationsRepository.insert(buildOrgWithName('Globex Inc'))
+
+        const response = await server.inject({
+          method: 'GET',
+          url: '/v1/organisations?search=acme&page=1&pageSize=50',
+          headers: authHeaders
+        })
+
+        const result = JSON.parse(response.payload)
+        expect(result.totalItems).toBe(2)
+      })
+
+      it('sorts items alphabetically by company name', async () => {
+        await organisationsRepository.insert(buildOrgWithName('Charlie Ltd'))
+        await organisationsRepository.insert(buildOrgWithName('Alpha Co'))
+        await organisationsRepository.insert(buildOrgWithName('Bravo Inc'))
+
+        const response = await server.inject({
+          method: 'GET',
+          url: '/v1/organisations?page=1&pageSize=50',
+          headers: authHeaders
+        })
+
+        const result = JSON.parse(response.payload)
+        expect(result.items.map((o) => o.companyDetails.name)).toEqual([
+          'Alpha Co',
+          'Bravo Inc',
+          'Charlie Ltd'
+        ])
+      })
+
+      it('returns empty items but valid totals when page is beyond the end', async () => {
+        await organisationsRepository.insert(buildOrganisation())
+
+        const response = await server.inject({
+          method: 'GET',
+          url: '/v1/organisations?page=99&pageSize=10',
+          headers: authHeaders
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const result = JSON.parse(response.payload)
+        expect(result.items).toEqual([])
+        expect(result.totalItems).toBe(1)
+        expect(result.totalPages).toBe(1)
+      })
+
+      it('treats whitespace-only search as no filter', async () => {
+        await organisationsRepository.insert(buildOrgWithName('Acme Ltd'))
+        await organisationsRepository.insert(buildOrgWithName('Globex Inc'))
+
+        const response = await server.inject({
+          method: 'GET',
+          url: '/v1/organisations?search=%20%20',
+          headers: authHeaders
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(JSON.parse(response.payload).totalItems).toBe(2)
+      })
+    })
+  })
+
+  describe('validation', () => {
+    it.each([
+      ['page=0', '/v1/organisations?page=0'],
+      ['page negative', '/v1/organisations?page=-1'],
+      ['page non-integer', '/v1/organisations?page=abc'],
+      ['pageSize=0', '/v1/organisations?pageSize=0'],
+      ['pageSize over max', '/v1/organisations?pageSize=201'],
+      ['pageSize negative', '/v1/organisations?pageSize=-5'],
+      ['unknown query param', '/v1/organisations?unknownParam=x'],
+      [
+        'search exceeds max length',
+        `/v1/organisations?search=${'a'.repeat(201)}`
+      ]
+    ])('returns 422 for %s', async (_desc, url) => {
+      const response = await server.inject({
+        method: 'GET',
+        url,
+        headers: authHeaders
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+    })
   })
 
   testInvalidTokenScenarios({


### PR DESCRIPTION
Ticket: [PAE-1295](https://eaflood.atlassian.net/browse/PAE-1295)
## Summary
The `GET /v1/organisations` endpoint previously returned the entire collection unfiltered. With over 5,000 organisations in TEST, this caused a backend journey test timeout and forced the admin UI to fetch the full dataset on every page load. This change adds server-side pagination and case-insensitive name search, while preserving the existing top-level array response when no query parameters are supplied so the backend can be deployed independently of the Admin UI.

## What Changed
- Added `?search=`, `?page=`, and `?pageSize=` query parameters to `GET /v1/organisations`
- Added `findPage` to the organisations repository, implemented in both the MongoDB and in-memory adapters
- Results are sorted alphabetically by company name; search is a case-insensitive substring match on the name field
- Preserved the legacy array response shape when no recognised query parameters are present, so the as-yet-unmigrated admin UI keeps working
- Added a contract test exercising both adapters plus route integration tests covering both response modes and validation

## Why
The endpoint is consumed only by the Admin UI, which currently fetches everything and filters client-side. Moving the work server-side fixes the journey test timeout and removes the Admin UI's bandwidth and rendering pressure once it adopts the new shape. The dual-mode response keeps backend and frontend deploys independent, matching the project's deployment policy.

[PAE-1295]: https://eaflood.atlassian.net/browse/PAE-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ