### PR TITLE
PAE-1382: Store ledger amounts as Decimal128

### DIFF
--- a/src/waste-balances/repository/ledger-contract/findLatestByAccreditationId.contract.js
+++ b/src/waste-balances/repository/ledger-contract/findLatestByAccreditationId.contract.js
@@ -69,5 +69,24 @@ export const testFindLatestByAccreditationIdBehaviour = (it) => {
       expect(x.number).toBe(1)
       expect(y.number).toBe(5)
     })
+
+    it('round-trips high-precision amounts exactly', async () => {
+      await repository.insertTransactions([
+        buildLedgerTransaction({
+          accreditationId: 'acc-precision',
+          number: 1,
+          amount: 200.005,
+          openingBalance: { amount: 0, availableAmount: 0 },
+          closingBalance: { amount: 200.005, availableAmount: 200.005 }
+        })
+      ])
+
+      const result =
+        await repository.findLatestByAccreditationId('acc-precision')
+
+      expect(result.amount).toBe(200.005)
+      expect(result.closingBalance.amount).toBe(200.005)
+      expect(result.closingBalance.availableAmount).toBe(200.005)
+    })
   })
 }

--- a/src/waste-balances/repository/ledger-decimal.js
+++ b/src/waste-balances/repository/ledger-decimal.js
@@ -1,0 +1,67 @@
+import { Decimal128 } from 'mongodb'
+
+import { toDecimalString, toNumber } from '#common/helpers/decimal-utils.js'
+
+/**
+ * Storage encoding for ledger amount fields.
+ *
+ * The schema accepts amounts as JS numbers (the application boundary). The
+ * MongoDB adapter persists every amount as `Decimal128` so accumulated
+ * balances do not suffer the IEEE 754 drift a BSON Double would silently
+ * introduce — at 73,000 transactions per accreditation per year (ADR 0031),
+ * the drift would be material. Reads convert back to JS numbers via
+ * `toNumber` so callers stay in the same shape they handed in.
+ *
+ * Only the amount fields need conversion — the slot `number`, identifiers,
+ * and dates pass through unchanged.
+ */
+
+/**
+ * @param {number} value
+ * @returns {import('mongodb').Decimal128}
+ */
+const toDecimal128 = (value) => Decimal128.fromString(toDecimalString(value))
+
+/**
+ * @param {import('./ledger-schema.js').LedgerBalanceSnapshot} snapshot
+ */
+const snapshotToMongo = (snapshot) => ({
+  amount: toDecimal128(snapshot.amount),
+  availableAmount: toDecimal128(snapshot.availableAmount)
+})
+
+/**
+ * @param {{ amount: unknown, availableAmount: unknown }} snapshot
+ * @returns {import('./ledger-schema.js').LedgerBalanceSnapshot}
+ */
+const snapshotFromMongo = (snapshot) => ({
+  amount: toNumber(/** @type {*} */ (snapshot.amount)),
+  availableAmount: toNumber(/** @type {*} */ (snapshot.availableAmount))
+})
+
+/**
+ * Convert the amount fields of a ledger transaction insert document to BSON
+ * Decimal128. Other fields pass through unchanged.
+ *
+ * @param {import('./ledger-schema.js').LedgerTransactionInsert} transaction
+ */
+export const ledgerInsertToMongo = (transaction) => ({
+  ...transaction,
+  amount: toDecimal128(transaction.amount),
+  openingBalance: snapshotToMongo(transaction.openingBalance),
+  closingBalance: snapshotToMongo(transaction.closingBalance)
+})
+
+/**
+ * Convert the amount fields of a ledger transaction MongoDB document back to
+ * JS numbers. `toNumber` accepts both Decimal128 and plain numbers, so legacy
+ * Double-typed rows round-trip without a separate read path.
+ *
+ * @param {Record<string, unknown> & { amount: unknown, openingBalance: { amount: unknown, availableAmount: unknown }, closingBalance: { amount: unknown, availableAmount: unknown } }} doc
+ */
+export const ledgerDocumentFromMongo = (doc) => ({
+  ...doc,
+  amount: toNumber(/** @type {*} */ (doc.amount)),
+  openingBalance: snapshotFromMongo(doc.openingBalance),
+  closingBalance: snapshotFromMongo(doc.closingBalance)
+})

--- a/src/waste-balances/repository/ledger-decimal.test.js
+++ b/src/waste-balances/repository/ledger-decimal.test.js
@@ -1,0 +1,91 @@
+import { Decimal128 } from 'mongodb'
+import { describe, it, expect } from 'vitest'
+
+import {
+  ledgerDocumentFromMongo,
+  ledgerInsertToMongo
+} from './ledger-decimal.js'
+import { buildLedgerTransaction } from './ledger-test-data.js'
+
+describe('ledgerInsertToMongo', () => {
+  it('converts the top-level amount to BSON Decimal128', () => {
+    const persistable = ledgerInsertToMongo(
+      buildLedgerTransaction({ amount: 1.5 })
+    )
+    expect(persistable.amount).toBeInstanceOf(Decimal128)
+    expect(persistable.amount.toString()).toBe('1.5')
+  })
+
+  it('converts opening and closing snapshot amounts to BSON Decimal128', () => {
+    const persistable = ledgerInsertToMongo(
+      buildLedgerTransaction({
+        openingBalance: { amount: 0, availableAmount: 0 },
+        closingBalance: { amount: 1.5, availableAmount: 1.5 }
+      })
+    )
+    expect(persistable.openingBalance.amount).toBeInstanceOf(Decimal128)
+    expect(persistable.openingBalance.availableAmount).toBeInstanceOf(
+      Decimal128
+    )
+    expect(persistable.closingBalance.amount).toBeInstanceOf(Decimal128)
+    expect(persistable.closingBalance.availableAmount).toBeInstanceOf(
+      Decimal128
+    )
+    expect(persistable.closingBalance.amount.toString()).toBe('1.5')
+  })
+
+  it('preserves non-amount fields verbatim', () => {
+    const transaction = buildLedgerTransaction({
+      accreditationId: 'acc-x',
+      number: 7
+    })
+    const persistable = ledgerInsertToMongo(transaction)
+    expect(persistable.accreditationId).toBe('acc-x')
+    expect(persistable.number).toBe(7)
+    expect(persistable.source).toEqual(transaction.source)
+  })
+})
+
+describe('ledgerDocumentFromMongo', () => {
+  it('converts BSON Decimal128 amounts back to JS numbers', () => {
+    const fromMongo = ledgerDocumentFromMongo({
+      ...buildLedgerTransaction(),
+      amount: Decimal128.fromString('1.5'),
+      openingBalance: {
+        amount: Decimal128.fromString('0'),
+        availableAmount: Decimal128.fromString('0')
+      },
+      closingBalance: {
+        amount: Decimal128.fromString('1.5'),
+        availableAmount: Decimal128.fromString('1.5')
+      }
+    })
+    expect(fromMongo.amount).toBe(1.5)
+    expect(fromMongo.closingBalance.amount).toBe(1.5)
+    expect(fromMongo.closingBalance.availableAmount).toBe(1.5)
+  })
+
+  it('round-trips finite-precision values exactly', () => {
+    const original = buildLedgerTransaction({
+      amount: 200.005,
+      closingBalance: { amount: 200.005, availableAmount: 200.005 }
+    })
+    const decoded = ledgerDocumentFromMongo(ledgerInsertToMongo(original))
+    expect(decoded.amount).toBe(200.005)
+    expect(decoded.closingBalance.amount).toBe(200.005)
+    expect(decoded.closingBalance.availableAmount).toBe(200.005)
+  })
+
+  it('round-trips negative amounts', () => {
+    const decoded = ledgerDocumentFromMongo(
+      ledgerInsertToMongo(
+        buildLedgerTransaction({
+          amount: -42.5,
+          closingBalance: { amount: -42.5, availableAmount: -42.5 }
+        })
+      )
+    )
+    expect(decoded.amount).toBe(-42.5)
+    expect(decoded.closingBalance.amount).toBe(-42.5)
+  })
+})

--- a/src/waste-balances/repository/ledger-mongodb.js
+++ b/src/waste-balances/repository/ledger-mongodb.js
@@ -8,6 +8,10 @@
  * @typedef {import('./ledger-schema.js').LedgerTransaction} LedgerTransaction
  */
 
+import {
+  ledgerDocumentFromMongo,
+  ledgerInsertToMongo
+} from './ledger-decimal.js'
 import { LedgerSlotConflictError } from './ledger-port.js'
 import {
   validateLedgerTransactionInsert,
@@ -63,7 +67,10 @@ export async function ensureLedgerCollection(db) {
 
 const toLedgerTransaction = (doc) => {
   const { _id, ...rest } = doc
-  return validateLedgerTransactionRead({ id: _id.toString(), ...rest })
+  return validateLedgerTransactionRead({
+    id: _id.toString(),
+    ...ledgerDocumentFromMongo(rest)
+  })
 }
 
 /**
@@ -104,10 +111,11 @@ const performInsertTransactions = (collection) => async (transactions) => {
   }
 
   const validated = transactions.map(validateLedgerTransactionInsert)
+  const persistable = validated.map(ledgerInsertToMongo)
 
   try {
-    const result = await collection.insertMany(validated, { ordered: true })
-    return validated.map((transaction, index) =>
+    const result = await collection.insertMany(persistable, { ordered: true })
+    return persistable.map((transaction, index) =>
       toLedgerTransaction({ _id: result.insertedIds[index], ...transaction })
     )
   } catch (error) {

--- a/src/waste-balances/repository/ledger-mongodb.test.js
+++ b/src/waste-balances/repository/ledger-mongodb.test.js
@@ -1,6 +1,6 @@
 import { describe, beforeEach, expect } from 'vitest'
 import { it as mongoIt } from '#vite/fixtures/mongo.js'
-import { MongoClient } from 'mongodb'
+import { Decimal128, MongoClient } from 'mongodb'
 
 import {
   createMongoLedgerRepository,
@@ -147,6 +147,35 @@ describe('MongoDB ledger repository', () => {
 
   describe('ledger repository contract', () => {
     testLedgerRepositoryContract(it)
+  })
+
+  describe('amount field BSON typing', () => {
+    it('persists amount and snapshot fields as Decimal128', async ({
+      ledgerCollection,
+      ledgerRepository
+    }) => {
+      const repository = await ledgerRepository()
+      await repository.insertTransactions([
+        buildLedgerTransaction({
+          accreditationId: 'acc-decimal',
+          number: 1,
+          amount: 1.5,
+          openingBalance: { amount: 0, availableAmount: 0 },
+          closingBalance: { amount: 1.5, availableAmount: 1.5 }
+        })
+      ])
+
+      const raw = await ledgerCollection.findOne({
+        accreditationId: 'acc-decimal'
+      })
+
+      expect(raw.amount).toBeInstanceOf(Decimal128)
+      expect(raw.openingBalance.amount).toBeInstanceOf(Decimal128)
+      expect(raw.openingBalance.availableAmount).toBeInstanceOf(Decimal128)
+      expect(raw.closingBalance.amount).toBeInstanceOf(Decimal128)
+      expect(raw.closingBalance.availableAmount).toBeInstanceOf(Decimal128)
+      expect(raw.amount.toString()).toBe('1.5')
+    })
   })
 
   describe('insertTransactions error translation', () => {


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)

## Summary

The new waste balance ledger collection (added under ADR 0031 / PAE-1382) was persisting `amount` and the opening / closing balance snapshots as BSON Double. The schema declared them as `Joi.number()` and the MongoDB adapter `insertMany`d the validated transactions unchanged.

ADR 0031 cites ~73,000 transactions per accreditation per year as the motivating scale for the migration. At that scale, cumulative IEEE 754 drift would silently move balances away from operator-entered tonnages — a regression versus the existing waste-balance code, which already runs on `decimal.js` arithmetic and is structurally compatible with Decimal128 storage. The drift would also undermine the delta-zero-skip and ledger-derived balance invariants the remaining migration work depends on.

## What changed

A new module, `src/waste-balances/repository/ledger-decimal.js`, owns the BSON encoding for amount fields. The MongoDB adapter calls it on the way in (`Decimal128.fromString(toDecimalString(value))`) and on the way out (existing `toNumber` helper, which already handles BSON Decimal128 + plain Numbers).

- Top-level `amount` and the `openingBalance` / `closingBalance` snapshots are persisted as `Decimal128`. Slot `number`, identifiers, and dates are unchanged.
- Schema and contract tests stay in JS-number shape — encoding is contained inside the MongoDB adapter where the BSON typing matters. Callers see no API change.
- The in-memory adapter is unchanged: it does no arithmetic over amounts and round-trips JS numbers via `structuredClone`.
- A raw-document `instanceof Decimal128` assertion in `ledger-mongodb.test.js` guards the BSON shape so that any future regression that drops the encoding step fails loudly.
- A high-precision round-trip fixture (`200.005`) lives in the contract suite so both adapters are checked for parity on values that would expose drift if anyone broke the storage shape.

## Notes

- No migration is needed. The `FEATURE_FLAG_WASTE_BALANCE_LEDGER` default is `false` and there are no environment overrides in `cdp-app-config`. `appendToLedger` has no production callers yet, so no rows exist to convert.
- No aggregation pipelines touch amount fields today — the only ledger ops are `insertMany`, `findOne`, and `createIndex`. Aggregation primitives land alongside the migration of the write and read paths; literal numeric operands inside those will need `$toDecimal` coercion at that point.
- Schema acceptance was deliberately narrowed to JS numbers only. No caller produces a Decimal128 at the schema boundary, so accepting it would have been dead-code accommodation. The decimal arithmetic discipline is upheld by where the encoding lives (the MongoDB adapter), not by what the schema additionally accepts.
- The corresponding "Decimal arithmetic" amendment to ADR 0031 lands in a separate epr-re-ex-service PR.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ