### PR TITLE
PAE-1339: Tighten FeatureFlags typedef and remove dead override keys

### DIFF
--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -1,4 +1,5 @@
 /**
+ * @param {import('./feature-flags.port.js').FeatureFlagOverrides} [flags]
  * @returns {import('./feature-flags.port.js').FeatureFlags}
  */
 export const createInMemoryFeatureFlags = (flags = {}) => ({

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -15,6 +15,7 @@
  * @property {boolean} [reports]
  * @property {boolean} [orsWasteBalanceValidation]
  * @property {boolean} [wasteBalanceLedger]
+ * @property {boolean} [migrateFormSubmissionLineage]
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -8,4 +8,13 @@
  * @property {() => boolean} isMigrateFormSubmissionLineageEnabled
  */
 
+/**
+ * @typedef {Object} FeatureFlagOverrides
+ * @property {boolean} [devEndpoints]
+ * @property {boolean} [copyFormFilesToS3]
+ * @property {boolean} [reports]
+ * @property {boolean} [orsWasteBalanceValidation]
+ * @property {boolean} [wasteBalanceLedger]
+ */
+
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/routes/v1/me/organisations/get.test.js
+++ b/src/routes/v1/me/organisations/get.test.js
@@ -31,9 +31,7 @@ describe('GET /v1/me/organisations', () => {
     const organisationsRepositoryFactory =
       createInMemoryOrganisationsRepository([])
     const organisationsRepository = organisationsRepositoryFactory()
-    const featureFlags = createInMemoryFeatureFlags({
-      organisations: true
-    })
+    const featureFlags = createInMemoryFeatureFlags()
 
     const server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },
@@ -126,9 +124,7 @@ describe('GET /v1/me/organisations', () => {
     const organisationsRepositoryFactory =
       createInMemoryOrganisationsRepository([])
     const organisationsRepository = organisationsRepositoryFactory()
-    const featureFlags = createInMemoryFeatureFlags({
-      organisations: true
-    })
+    const featureFlags = createInMemoryFeatureFlags()
 
     const server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },
@@ -179,9 +175,7 @@ describe('GET /v1/me/organisations', () => {
     const organisationsRepositoryFactory =
       createInMemoryOrganisationsRepository([])
     const organisationsRepository = organisationsRepositoryFactory()
-    const featureFlags = createInMemoryFeatureFlags({
-      organisations: true
-    })
+    const featureFlags = createInMemoryFeatureFlags()
 
     const server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },
@@ -228,9 +222,7 @@ describe('GET /v1/me/organisations', () => {
   it('should return empty arrays when user has no organisations', async () => {
     const organisationsRepositoryFactory =
       createInMemoryOrganisationsRepository([])
-    const featureFlags = createInMemoryFeatureFlags({
-      organisations: true
-    })
+    const featureFlags = createInMemoryFeatureFlags()
 
     const server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },
@@ -262,9 +254,7 @@ describe('GET /v1/me/organisations', () => {
     const organisationsRepositoryFactory =
       createInMemoryOrganisationsRepository([])
     const organisationsRepository = organisationsRepositoryFactory()
-    const featureFlags = createInMemoryFeatureFlags({
-      organisations: true
-    })
+    const featureFlags = createInMemoryFeatureFlags()
 
     const server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },
@@ -313,9 +303,7 @@ describe('GET /v1/me/organisations', () => {
     const organisationsRepositoryFactory =
       createInMemoryOrganisationsRepository([])
     const organisationsRepository = organisationsRepositoryFactory()
-    const featureFlags = createInMemoryFeatureFlags({
-      organisations: true
-    })
+    const featureFlags = createInMemoryFeatureFlags()
 
     const server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },
@@ -375,9 +363,7 @@ describe('GET /v1/me/organisations', () => {
     const organisationsRepositoryFactory =
       createInMemoryOrganisationsRepository([])
     const organisationsRepository = organisationsRepositoryFactory()
-    const featureFlags = createInMemoryFeatureFlags({
-      organisations: true
-    })
+    const featureFlags = createInMemoryFeatureFlags()
 
     const server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },
@@ -424,9 +410,7 @@ describe('GET /v1/me/organisations', () => {
   it('should return 403 when user has no organisation in their token', async () => {
     const organisationsRepositoryFactory =
       createInMemoryOrganisationsRepository([])
-    const featureFlags = createInMemoryFeatureFlags({
-      organisations: true
-    })
+    const featureFlags = createInMemoryFeatureFlags()
 
     const server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },
@@ -465,9 +449,7 @@ describe('GET /v1/me/organisations', () => {
   it('should return 403 and log org IDs when user has relationships but no currentRelationshipId', async () => {
     const organisationsRepositoryFactory =
       createInMemoryOrganisationsRepository([])
-    const featureFlags = createInMemoryFeatureFlags({
-      organisations: true
-    })
+    const featureFlags = createInMemoryFeatureFlags()
 
     const server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },
@@ -512,9 +494,7 @@ describe('GET /v1/me/organisations', () => {
   it('should return 403 and log org IDs when currentRelationshipId does not match any relationship', async () => {
     const organisationsRepositoryFactory =
       createInMemoryOrganisationsRepository([])
-    const featureFlags = createInMemoryFeatureFlags({
-      organisations: true
-    })
+    const featureFlags = createInMemoryFeatureFlags()
 
     const server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },
@@ -564,7 +544,7 @@ describe('GET /v1/me/organisations', () => {
       const systemLogsRepository = systemLogsRepositoryFactory()
       const organisationsRepositoryFactory =
         createInMemoryOrganisationsRepository([])
-      const featureFlags = createInMemoryFeatureFlags({ organisations: true })
+      const featureFlags = createInMemoryFeatureFlags()
       const server = await createTestServer({
         repositories: {
           organisationsRepository: organisationsRepositoryFactory,
@@ -593,7 +573,7 @@ describe('GET /v1/me/organisations', () => {
       const systemLogsRepository = systemLogsRepositoryFactory()
       const organisationsRepositoryFactory =
         createInMemoryOrganisationsRepository([])
-      const featureFlags = createInMemoryFeatureFlags({ organisations: true })
+      const featureFlags = createInMemoryFeatureFlags()
       const server = await createTestServer({
         repositories: {
           organisationsRepository: organisationsRepositoryFactory,
@@ -657,7 +637,7 @@ describe('GET /v1/me/organisations', () => {
       }
       const organisationsRepositoryFactory =
         createInMemoryOrganisationsRepository([])
-      const featureFlags = createInMemoryFeatureFlags({ organisations: true })
+      const featureFlags = createInMemoryFeatureFlags()
       const server = await createTestServer({
         repositories: {
           organisationsRepository: organisationsRepositoryFactory,
@@ -695,7 +675,7 @@ describe('GET /v1/me/organisations', () => {
       }
       const organisationsRepositoryFactory =
         createInMemoryOrganisationsRepository([])
-      const featureFlags = createInMemoryFeatureFlags({ organisations: true })
+      const featureFlags = createInMemoryFeatureFlags()
       const server = await createTestServer({
         repositories: {
           organisationsRepository: organisationsRepositoryFactory,

--- a/src/routes/v1/organisations/get-by-id.test.js
+++ b/src/routes/v1/organisations/get-by-id.test.js
@@ -20,7 +20,7 @@ describe('GET /v1/organisations/{id}', () => {
   beforeEach(async () => {
     organisationsRepositoryFactory = createInMemoryOrganisationsRepository([])
     organisationsRepository = organisationsRepositoryFactory()
-    const featureFlags = createInMemoryFeatureFlags({ organisations: true })
+    const featureFlags = createInMemoryFeatureFlags()
 
     server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },

--- a/src/routes/v1/organisations/get.test.js
+++ b/src/routes/v1/organisations/get.test.js
@@ -30,7 +30,7 @@ describe('GET /v1/organisations', () => {
   beforeEach(async () => {
     organisationsRepositoryFactory = createInMemoryOrganisationsRepository([])
     organisationsRepository = organisationsRepositoryFactory()
-    const featureFlags = createInMemoryFeatureFlags({ organisations: true })
+    const featureFlags = createInMemoryFeatureFlags()
 
     server = await createTestServer({
       repositories: { organisationsRepository: organisationsRepositoryFactory },

--- a/src/routes/v1/organisations/link.test.js
+++ b/src/routes/v1/organisations/link.test.js
@@ -57,7 +57,7 @@ describe('POST /v1/organisations/{organisationId}/link', () => {
   beforeAll(async () => {
     organisationsRepositoryFactory = createInMemoryOrganisationsRepository([])
     organisationsRepository = organisationsRepositoryFactory()
-    const featureFlags = createInMemoryFeatureFlags({ organisations: true })
+    const featureFlags = createInMemoryFeatureFlags()
 
     server = await createTestServer({
       repositories: {

--- a/src/routes/v1/organisations/put-by-id.test.js
+++ b/src/routes/v1/organisations/put-by-id.test.js
@@ -31,7 +31,7 @@ describe('PUT /v1/organisations/{id}', () => {
     const organisationsRepositoryFactory =
       createInMemoryOrganisationsRepository([])
     organisationsRepository = organisationsRepositoryFactory()
-    const featureFlags = createInMemoryFeatureFlags({ organisations: true })
+    const featureFlags = createInMemoryFeatureFlags()
 
     server = await createTestServer({
       repositories: {
@@ -431,7 +431,7 @@ describe('PUT /v1/organisations/{id}', () => {
           organisationsRepository: instance,
           systemLogsRepository: createSystemLogsRepository()
         },
-        featureFlags: createInMemoryFeatureFlags({ organisations: true })
+        featureFlags: createInMemoryFeatureFlags()
       })
 
       const fetchResponse = await testServer.inject({
@@ -506,9 +506,7 @@ describe('PUT /v1/organisations/{id} overseas sites validation', () => {
         systemLogsRepository: createSystemLogsRepository(),
         overseasSitesRepository: overseasSitesRepoFactory
       },
-      featureFlags: createInMemoryFeatureFlags({
-        organisations: true
-      })
+      featureFlags: createInMemoryFeatureFlags()
     })
   })
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -466,7 +466,7 @@ export const createTestInfrastructure = async (
     logger: mockLogger
   })
 
-  const featureFlags = createInMemoryFeatureFlags({ summaryLogs: true })
+  const featureFlags = createInMemoryFeatureFlags()
 
   const server = await createTestServer({
     repositories: {
@@ -546,10 +546,7 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
     logger: mockLogger
   })
 
-  const featureFlags = createInMemoryFeatureFlags({
-    summaryLogs: true,
-    ...featureFlagOverrides
-  })
+  const featureFlags = createInMemoryFeatureFlags(featureFlagOverrides)
 
   const overseasSitesRepository = createInMemoryOverseasSitesRepository([
     {


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
The `createInMemoryFeatureFlags` helper accepts a plain `flags` object whose properties drive each `is...Enabled()` accessor. Previously the parameter was untyped, so callsites could pass arbitrary keys that were silently ignored.

This change adds a `FeatureFlagOverrides` typedef in `feature-flags.port.js` enumerating the known override keys and annotates the `flags` parameter with it. Tightening the type surfaces 22 callsites in test code passing keys that don't exist on the type:

- 2× `summaryLogs: true` in `integration-test-helpers.js`
- 20× `organisations: true` across `me/organisations/get.test.js`, `organisations/get.test.js`, `organisations/get-by-id.test.js`, `organisations/link.test.js`, `organisations/put-by-id.test.js`

None of these keys correspond to a real feature flag — they were all dead config. They have been deleted; behaviour is unchanged because the helper ignored them anyway.

Note: `lint:types` currently excludes test files, so the typedef tightening is documentation-only until the test suite is brought under type-checking. That follow-up is tracked separately.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ