### PR TITLE
PAE-1412: extract is-production-environment helper to config

### DIFF
--- a/src/common/helpers/fail-action.js
+++ b/src/common/helpers/fail-action.js
@@ -3,10 +3,8 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '../enums/index.js'
-import { getConfig } from '#root/config.js'
+import { isProductionEnvironment } from '#root/config.js'
 
-const config = getConfig()
-const isProductionEnvironment = config.get('cdpEnvironment') === 'prod'
 const MAX_LOGGED_VALIDATION_ERRORS = 5
 
 /**
@@ -65,7 +63,7 @@ export function failAction(request, _h, error) {
   if (isJoiValidationError(error)) {
     const boomError = Boom.badData(error.message)
 
-    const message = isProductionEnvironment
+    const message = isProductionEnvironment()
       ? error.message
       : formatValidationMessage(error)
 

--- a/src/common/helpers/fail-action.test.js
+++ b/src/common/helpers/fail-action.test.js
@@ -1,18 +1,15 @@
 import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
 import Joi from 'joi'
-import { failAction } from './fail-action.js'
 
-vi.mock('#root/config.js', () => ({
-  getConfig: vi.fn(() => ({
-    get: vi.fn((key) => {
-      if (key === 'cdpEnvironment') return 'dev'
-      return undefined
-    })
-  }))
-}))
+import { failAction } from './fail-action.js'
+import { config } from '#root/config.js'
 
 describe('#fail-action', () => {
+  afterEach(() => {
+    config.reset('cdpEnvironment')
+  })
+
   const createMockRequest = () => ({
     logger: {
       warn: vi.fn()
@@ -241,24 +238,14 @@ describe('#fail-action', () => {
 
 describe('#fail-action (production)', () => {
   beforeEach(() => {
-    vi.resetModules()
-    vi.doMock('#root/config.js', () => ({
-      getConfig: vi.fn(() => ({
-        get: vi.fn((key) => {
-          if (key === 'cdpEnvironment') return 'prod'
-          return undefined
-        })
-      }))
-    }))
+    config.set('cdpEnvironment', 'prod')
   })
 
   afterEach(() => {
-    vi.doUnmock('#root/config.js')
+    config.reset('cdpEnvironment')
   })
 
-  test('does NOT include Joi details in message in production', async () => {
-    const { failAction: prodFailAction } = await import('./fail-action.js')
-
+  test('does NOT include Joi details in message in production', () => {
     const mockRequest = {
       logger: { warn: vi.fn() }
     }
@@ -266,7 +253,7 @@ describe('#fail-action (production)', () => {
     joiError.isJoi = true
     joiError.details = [{ message: '"redirectUrl" is required' }]
 
-    expect(() => prodFailAction(mockRequest, {}, joiError)).toThrow()
+    expect(() => failAction(mockRequest, {}, joiError)).toThrow()
 
     const logCall = mockRequest.logger.warn.mock.calls[0][0]
     expect(logCall.message).toBe('"redirectUrl" is required')

--- a/src/common/helpers/plugins/mongo-db-plugin.js
+++ b/src/common/helpers/plugins/mongo-db-plugin.js
@@ -1,7 +1,7 @@
 import { createMongoClient } from '#common/helpers/mongo-client.js'
 import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
-import { config } from '#root/config.js'
+import { isProductionEnvironment } from '#root/config.js'
 import { LockManager } from 'mongo-locks'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -38,8 +38,6 @@ export const mongoDbPlugin = {
 
       const locker = new LockManager(db.collection('mongo-locks'))
 
-      const isProduction = () => config.get('cdpEnvironment') === 'prod'
-
       await createFormCollections(db)
       await createLockManagerIndex(db)
 
@@ -50,7 +48,7 @@ export const mongoDbPlugin = {
 
       await createSeedData(
         db,
-        isProduction,
+        isProductionEnvironment,
         organisationsRepositoryFactory(),
         wasteRecordsRepositoryFactory()
       )

--- a/src/config.js
+++ b/src/config.js
@@ -499,4 +499,6 @@ function getConfig(overrides = {}) {
   return cfg
 }
 
-export { config, getConfig }
+const isProductionEnvironment = () => config.get('cdpEnvironment') === 'prod'
+
+export { config, getConfig, isProductionEnvironment }

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it, afterEach } from 'vitest'
+
+import { config, isProductionEnvironment } from '#root/config.js'
+
+describe('#isProductionEnvironment', () => {
+  afterEach(() => {
+    config.reset('cdpEnvironment')
+  })
+
+  it('should return true when cdpEnvironment is prod', () => {
+    config.set('cdpEnvironment', 'prod')
+
+    expect(isProductionEnvironment()).toBe(true)
+  })
+
+  it.each([
+    'local',
+    'infra-dev',
+    'management',
+    'dev',
+    'test',
+    'perf-test',
+    'ext-test'
+  ])('should return false when cdpEnvironment is %s', (env) => {
+    config.set('cdpEnvironment', env)
+
+    expect(isProductionEnvironment()).toBe(false)
+  })
+})

--- a/src/non-prod-data-reset/mongodb.plugin.js
+++ b/src/non-prod-data-reset/mongodb.plugin.js
@@ -1,8 +1,6 @@
-import { config } from '#root/config.js'
+import { isProductionEnvironment } from '#root/config.js'
 import { registerRepository } from '#plugins/register-repository.js'
 import { createNonProdDataReset } from './mongodb.js'
-
-const isProduction = () => config.get('cdpEnvironment') === 'prod'
 
 /**
  * Registers request.nonProdDataReset only when FEATURE_FLAG_DEV_ENDPOINTS is
@@ -28,7 +26,7 @@ export const nonProdDataResetPlugin = {
   ) => {
     const db = options?.db ?? server.db
     const reset = createNonProdDataReset(db, {
-      isProduction: isProduction()
+      isProduction: isProductionEnvironment()
     })
     registerRepository(server, 'nonProdDataReset', () => reset)
   }


### PR DESCRIPTION
Ticket: [PAE-1412](https://eaflood.atlassian.net/browse/PAE-1412)
extract `isProductionEnvironment()` to `src/config.js` and replace the 3 inlined definitions in `fail-action.js`, `mongo-db-plugin.js`, and `non-prod-data-reset/mongodb.plugin.js`.

[PAE-1412]: https://eaflood.atlassian.net/browse/PAE-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ