### PR TITLE
PAE-1415: Stream xlsx parsing via unzipper and WorksheetReader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
         "pino": "10.3.1",
         "pino-pretty": "13.1.3",
         "sqs-consumer": "14.2.1",
-        "undici": "7.24.0"
+        "undici": "7.24.0",
+        "unzipper": "0.10.14"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "4.0.18",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",
     "sqs-consumer": "14.2.1",
-    "undici": "7.24.0"
+    "undici": "7.24.0",
+    "unzipper": "0.10.14"
   },
   "overrides": {
     "axios": "1.15.2",

--- a/src/adapters/parsers/summary-logs/cell-extractor.js
+++ b/src/adapters/parsers/summary-logs/cell-extractor.js
@@ -29,7 +29,7 @@ const extractObjectCellValue = (cellValue, recursiveExtract) => {
   // Date objects - extract date-only (YYYY-MM-DD)
   // We only care about dates, not times, in this system
   if (cellValue instanceof Date) {
-    if (isNaN(cellValue.getTime())) {
+    if (Number.isNaN(cellValue.getTime())) {
       return null
     }
     return cellValue.toISOString().slice(0, 10)

--- a/src/adapters/parsers/summary-logs/cell-extractor.js
+++ b/src/adapters/parsers/summary-logs/cell-extractor.js
@@ -1,0 +1,96 @@
+/**
+ * Checks if the cell value is a formula cell (regular or shared).
+ */
+const isFormulaCell = (cellValue) =>
+  'formula' in cellValue || 'sharedFormula' in cellValue
+
+/**
+ * Checks if the cell value is a richText cell.
+ */
+const isRichTextCell = (cellValue) =>
+  'richText' in cellValue && Array.isArray(cellValue.richText)
+
+/**
+ * Checks if the cell value is a hyperlink cell.
+ */
+const isHyperlinkCell = (cellValue) =>
+  'text' in cellValue && 'hyperlink' in cellValue
+
+/**
+ * Checks if the cell value is an error cell.
+ */
+const isErrorCell = (cellValue) => 'error' in cellValue
+
+/**
+ * Extracts value from an object cell type.
+ * Returns undefined if not a recognised object type.
+ */
+const extractObjectCellValue = (cellValue, recursiveExtract) => {
+  // Date objects - extract date-only (YYYY-MM-DD)
+  // We only care about dates, not times, in this system
+  if (cellValue instanceof Date) {
+    if (isNaN(cellValue.getTime())) {
+      return null
+    }
+    return cellValue.toISOString().slice(0, 10)
+  }
+
+  // Formula cells with result - recursively extract
+  if ('result' in cellValue && isFormulaCell(cellValue)) {
+    return recursiveExtract(cellValue.result)
+  }
+
+  // Formula cells without result
+  if (isFormulaCell(cellValue)) {
+    return null
+  }
+
+  // RichText cells - concatenate all text segments
+  if (isRichTextCell(cellValue)) {
+    return cellValue.richText.map((segment) => segment.text).join('')
+  }
+
+  // Hyperlink cells - extract just the text
+  if (isHyperlinkCell(cellValue)) {
+    return cellValue.text
+  }
+
+  // Error cells - treat as no valid value
+  if (isErrorCell(cellValue)) {
+    return null
+  }
+
+  return undefined
+}
+
+/**
+ * Extracts a primitive value from an ExcelJS cell value.
+ * Handles all ExcelJS ValueTypes: Null, Merge, Number, String, Date,
+ * Hyperlink, Formula, SharedString, RichText, Boolean, Error.
+ */
+export const extractCellValue = (cellValue) => {
+  if (!cellValue || typeof cellValue !== 'object') {
+    return cellValue
+  }
+
+  const extracted = extractObjectCellValue(cellValue, extractCellValue)
+
+  if (extracted !== undefined) {
+    return extracted
+  }
+
+  // Unknown object type - fail fast so we can add explicit handling
+  throw new Error(
+    `Unknown cell value type: ${JSON.stringify(cellValue)}. ` +
+      'This may indicate a new ExcelJS cell type that needs explicit handling.'
+  )
+}
+
+/**
+ * Checks if a cell value is considered empty.
+ * Used for phantom column detection.
+ */
+export const isCellEmpty = (cellValue) => {
+  const value = extractCellValue(cellValue)
+  return value === null || value === undefined || value === ''
+}

--- a/src/adapters/parsers/summary-logs/exceljs-parser.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.js
@@ -452,7 +452,26 @@ const processRow = (draftState, row, rowNumber, worksheet) => {
 }
 
 /**
- * Checks if a row contains any non-empty content.
+ * Mirrors the DOM-mode `worksheet.eachRow({includeEmpty: false})` filter:
+ * a row whose cells are all `ValueType.Null` (style only, no value) is
+ * skipped entirely rather than fed to a collection. Without this, a styled-
+ * but-empty row mid-data pushes nulls into the active collection's
+ * currentRow and terminates the section prematurely.
+ */
+const rowIsStructurallyEmpty = (row) => {
+  let hasContentCell = false
+  row.eachCell((_cell) => {
+    hasContentCell = true
+  })
+  return !hasContentCell
+}
+
+/**
+ * Stricter than `rowIsStructurallyEmpty`: also treats cells whose
+ * extracted value is null, undefined or '' as empty. Used for phantom-row
+ * detection between data sections - long runs of empty-string rows
+ * between sections (e.g. row-formatted-but-cleared user input) count
+ * toward the phantom limit just like styled-empty rows do.
  */
 const rowHasContent = (row) => {
   const cells = collectCellsFromRow(row)
@@ -463,30 +482,16 @@ const rowHasContent = (row) => {
 }
 
 /**
- * Determines whether a row should be skipped during phantom row detection.
- *
- * A row should be processed (not skipped) if:
- * - There are active data collections that need this row for termination detection
- * - It contains any non-empty content (markers or otherwise)
- */
-const shouldSkipForPhantomDetection = (row, hasActiveCollections) => {
-  if (hasActiveCollections) {
-    return false
-  }
-
-  return !rowHasContent(row)
-}
-
-/**
  * @typedef {{number: number, eachCell: any}} StreamingRow
  * @typedef {AsyncIterable<StreamingRow> & {name: string}} StreamingWorksheet
  */
 
 /**
  * Streams rows from a worksheet, applying validation limits and phantom-row
- * detection. Uses `rowHasContent` (which extracts each cell value and treats
- * `null` / '' uniformly) rather than `Row.hasValues` so that cells authored
- * as the empty string still register as content-bearing.
+ * detection. Structurally empty rows (every cell `ValueType.Null`) are
+ * skipped to match the DOM path's `eachRow({includeEmpty: false})`
+ * semantics; a long stretch of them trips phantom-row detection and stops
+ * processing for the remainder of the sheet.
  *
  * Once phantom-row detection trips, remaining rows in this worksheet are
  * still consumed from the stream (to keep the underlying zip pipeline
@@ -533,8 +538,16 @@ const processRowAgainstPhantomState = (
     return
   }
 
+  if (rowIsStructurallyEmpty(row)) {
+    counters.consecutiveEmptyRows++
+    if (counters.consecutiveEmptyRows >= MAX_CONSECUTIVE_EMPTY_ROWS) {
+      counters.phantomRowsTripped = true
+    }
+    return
+  }
+
   const hasActiveCollections = draftState.activeCollections.length > 0
-  if (shouldSkipForPhantomDetection(row, hasActiveCollections)) {
+  if (!hasActiveCollections && !rowHasContent(row)) {
     counters.consecutiveEmptyRows++
     if (counters.consecutiveEmptyRows >= MAX_CONSECUTIVE_EMPTY_ROWS) {
       counters.phantomRowsTripped = true

--- a/src/adapters/parsers/summary-logs/exceljs-parser.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.js
@@ -13,6 +13,7 @@ import {
   SKIP_COLUMN,
   SKIP_EXAMPLE_ROW_TEXT
 } from '#domain/summary-logs/markers.js'
+import { extractCellValue, isCellEmpty } from './cell-extractor.js'
 
 /** @typedef {import('#domain/summary-logs/extractor/port.js').ParsedSummaryLog} ParsedSummaryLog */
 /** @typedef {import('#domain/summary-logs/extractor/port.js').SummaryLogParser} SummaryLogParser */
@@ -181,94 +182,6 @@ const assertColumnWithinLimit = (worksheetName, colNumber, max) => {
       `Worksheet '${worksheetName}' has too many columns (${colNumber}, maximum ${max})`
     )
   }
-}
-
-/**
- * Checks if the cell value is a formula cell (regular or shared).
- */
-const isFormulaCell = (cellValue) =>
-  'formula' in cellValue || 'sharedFormula' in cellValue
-
-/**
- * Checks if the cell value is a richText cell.
- */
-const isRichTextCell = (cellValue) =>
-  'richText' in cellValue && Array.isArray(cellValue.richText)
-
-/**
- * Checks if the cell value is a hyperlink cell.
- */
-const isHyperlinkCell = (cellValue) =>
-  'text' in cellValue && 'hyperlink' in cellValue
-
-/**
- * Checks if the cell value is an error cell.
- */
-const isErrorCell = (cellValue) => 'error' in cellValue
-
-/**
- * Extracts value from an object cell type.
- * Returns undefined if not a recognised object type.
- */
-const extractObjectCellValue = (cellValue, recursiveExtract) => {
-  // Date objects - extract date-only (YYYY-MM-DD)
-  // We only care about dates, not times, in this system
-  if (cellValue instanceof Date) {
-    if (isNaN(cellValue.getTime())) {
-      return null
-    }
-    return cellValue.toISOString().slice(0, 10)
-  }
-
-  // Formula cells with result - recursively extract
-  if ('result' in cellValue && isFormulaCell(cellValue)) {
-    return recursiveExtract(cellValue.result)
-  }
-
-  // Formula cells without result
-  if (isFormulaCell(cellValue)) {
-    return null
-  }
-
-  // RichText cells - concatenate all text segments
-  if (isRichTextCell(cellValue)) {
-    return cellValue.richText.map((segment) => segment.text).join('')
-  }
-
-  // Hyperlink cells - extract just the text
-  if (isHyperlinkCell(cellValue)) {
-    return cellValue.text
-  }
-
-  // Error cells - treat as no valid value
-  if (isErrorCell(cellValue)) {
-    return null
-  }
-
-  return undefined
-}
-
-/**
- * Extracts a primitive value from an ExcelJS cell value.
- * Handles all ExcelJS ValueTypes: Null, Merge, Number, String, Date,
- * Hyperlink, Formula, SharedString, RichText, Boolean, Error.
- */
-const extractCellValue = (cellValue) => {
-  if (!cellValue || typeof cellValue !== 'object') {
-    return cellValue
-  }
-
-  const extracted = extractObjectCellValue(cellValue, extractCellValue)
-
-  if (extracted !== undefined) {
-    return extracted
-  }
-
-  // Unknown object type - fail fast so we can add explicit handling
-  throw new Error(
-    `Unknown cell value type: ${JSON.stringify(cellValue)}. ` +
-      'This may indicate a new ExcelJS cell type that needs explicit handling.'
-  )
 }
 
 const processCellForMetadata = (
@@ -441,15 +354,6 @@ const emitCollectionsToResult = (draftResult, collections) => {
       rows: collection.rows
     }
   }
-}
-
-/**
- * Checks if a cell value is considered empty.
- * Used for phantom column detection.
- */
-const isCellEmpty = (cellValue) => {
-  const value = extractCellValue(cellValue)
-  return value === null || value === undefined || value === ''
 }
 
 /**

--- a/src/adapters/parsers/summary-logs/exceljs-parser.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.js
@@ -1,5 +1,10 @@
-import ExcelJS from 'exceljs'
-import { produce } from 'immer'
+import unzipper from 'unzipper'
+import { createDraft, finishDraft } from 'immer'
+import WorksheetReader from 'exceljs/lib/stream/xlsx/worksheet-reader.js'
+import WorkbookXform from 'exceljs/lib/xlsx/xform/book/workbook-xform.js'
+import RelationshipsXform from 'exceljs/lib/xlsx/xform/core/relationships-xform.js'
+import SharedStringsXform from 'exceljs/lib/xlsx/xform/strings/shared-strings-xform.js'
+import StylesXform from 'exceljs/lib/xlsx/xform/style/styles-xform.js'
 import { columnNumberToLetter } from '#common/helpers/spreadsheet/columns.js'
 import { VALIDATION_CODE } from '#common/enums/validation.js'
 import {
@@ -43,11 +48,11 @@ const DEREFERENCE_UNDEFINED_MESSAGE =
   /cannot read (?:properties|property\s+\S+) of (?:undefined|null)/i
 
 /**
- * Error messages from yauzl / jszip for non-zip buffers or corrupt-zip
- * streams (an xlsx is a zip archive under the hood).
+ * Error messages from yauzl / jszip / unzipper for non-zip buffers or
+ * corrupt-zip streams (an xlsx is a zip archive under the hood).
  */
 const CORRUPT_ZIP_MESSAGE =
-  /central directory|invalid signature|compressed\/uncompressed size|corrupted zip|end of data reached/i
+  /central directory|invalid signature|compressed\/uncompressed size|corrupted zip|end of data reached|FILE_ENDED|MISSING_PASSWORD|BAD_PASSWORD/i
 
 /**
  * Error messages from exceljs' own XML layer when an xlsx's XML parts are
@@ -140,52 +145,42 @@ const CollectionState = {
 }
 
 /**
- * Validates workbook structure before parsing begins.
- * Throws SpreadsheetValidationError if the workbook fails any validation check.
+ * Asserts the streamed worksheet count has not exceeded the configured limit.
+ * Called once per worksheet as it arrives from the stream.
  *
- * @param {Object} workbook - ExcelJS workbook instance
- * @param {Object} options - Validation options
- * @param {string|null} options.requiredWorksheet - Name of required worksheet, or null to skip check
- * @param {number} options.maxWorksheets - Maximum allowed worksheets
- * @param {number} options.maxRowsPerSheet - Maximum allowed rows per worksheet
- * @param {number} options.maxColumnsPerSheet - Maximum allowed columns per worksheet
+ * @param {string} name - Worksheet name (used for error messages on the next sheet)
+ * @param {number} count - Worksheets seen so far (including this one)
+ * @param {number} max
  */
-const validateWorkbookStructure = (workbook, options) => {
-  const {
-    requiredWorksheet,
-    maxWorksheets,
-    maxRowsPerSheet,
-    maxColumnsPerSheet
-  } = options
-
-  if (requiredWorksheet) {
-    const worksheetNames = workbook.worksheets.map((ws) => ws.name)
-
-    if (!worksheetNames.includes(requiredWorksheet)) {
-      throw new SpreadsheetValidationError(
-        `Missing required '${requiredWorksheet}' worksheet`
-      )
-    }
-  }
-
-  if (workbook.worksheets.length > maxWorksheets) {
+const assertWorksheetCountWithinLimit = (name, count, max) => {
+  if (count > max) {
     throw new SpreadsheetValidationError(
-      `Too many worksheets (${workbook.worksheets.length}, maximum ${maxWorksheets})`
+      `Too many worksheets (${count}, maximum ${max})`
     )
   }
+}
 
-  for (const worksheet of workbook.worksheets) {
-    if (worksheet.rowCount > maxRowsPerSheet) {
-      throw new SpreadsheetValidationError(
-        `Worksheet '${worksheet.name}' has too many rows (${worksheet.rowCount}, maximum ${maxRowsPerSheet})`
-      )
-    }
+/**
+ * Asserts the streamed row index has not exceeded the configured limit.
+ * Called for each row as it streams in (via row.number, the 1-based index from XML).
+ */
+const assertRowWithinLimit = (worksheetName, rowNumber, max) => {
+  if (rowNumber > max) {
+    throw new SpreadsheetValidationError(
+      `Worksheet '${worksheetName}' has too many rows (${rowNumber}, maximum ${max})`
+    )
+  }
+}
 
-    if (worksheet.columnCount > maxColumnsPerSheet) {
-      throw new SpreadsheetValidationError(
-        `Worksheet '${worksheet.name}' has too many columns (${worksheet.columnCount}, maximum ${maxColumnsPerSheet})`
-      )
-    }
+/**
+ * Asserts the streamed column index has not exceeded the configured limit.
+ * Called for each cell as it streams in.
+ */
+const assertColumnWithinLimit = (worksheetName, colNumber, max) => {
+  if (colNumber > max) {
+    throw new SpreadsheetValidationError(
+      `Worksheet '${worksheetName}' has too many columns (${colNumber}, maximum ${max})`
+    )
   }
 }
 
@@ -449,14 +444,6 @@ const emitCollectionsToResult = (draftResult, collections) => {
   }
 }
 
-const collectRowsFromWorksheet = (worksheet) => {
-  const rows = []
-  worksheet.eachRow((row, rowNumber) => {
-    rows.push({ row, rowNumber })
-  })
-  return rows
-}
-
 /**
  * Checks if a cell value is considered empty.
  * Used for phantom column detection.
@@ -587,29 +574,53 @@ const shouldSkipForPhantomDetection = (row, hasActiveCollections) => {
   return !rowHasContent(row)
 }
 
-const processWorksheet = (draftState, worksheet) => {
+/**
+ * Streams rows from a worksheet, applying validation limits and phantom-row
+ * detection. Uses `rowHasContent` (which extracts each cell value and treats
+ * `null` / '' uniformly) rather than `Row.hasValues` so that cells authored
+ * as the empty string still register as content-bearing.
+ *
+ * Once phantom-row detection trips, remaining rows in this worksheet are
+ * still consumed from the stream (to keep the underlying zip pipeline
+ * draining cleanly) but not processed.
+ */
+const streamWorksheet = async (draftState, worksheet, options) => {
+  const { maxRowsPerSheet, maxColumnsPerSheet } = options
   let consecutiveEmptyRows = 0
+  let phantomRowsTripped = false
 
-  const rows = collectRowsFromWorksheet(worksheet)
+  for await (const row of worksheet) {
+    const rowNumber = row.number
+    assertRowWithinLimit(worksheet.name, rowNumber, maxRowsPerSheet)
 
-  for (const { row, rowNumber } of rows) {
+    if (phantomRowsTripped) {
+      continue
+    }
+
     const hasActiveCollections = draftState.activeCollections.length > 0
 
     if (shouldSkipForPhantomDetection(row, hasActiveCollections)) {
       consecutiveEmptyRows++
-
       if (consecutiveEmptyRows >= MAX_CONSECUTIVE_EMPTY_ROWS) {
-        break
+        phantomRowsTripped = true
       }
-    } else {
-      consecutiveEmptyRows = 0
-      processRow(draftState, row, rowNumber, worksheet)
+      continue
     }
+
+    consecutiveEmptyRows = 0
+    assertWorksheetColumnsWithinLimit(worksheet, row, maxColumnsPerSheet)
+    processRow(draftState, row, rowNumber, worksheet)
   }
 
   emitCollectionsToResult(draftState.result.data, draftState.activeCollections)
 
   draftState.activeCollections = []
+}
+
+const assertWorksheetColumnsWithinLimit = (worksheet, row, max) => {
+  row.eachCell((_cell, colNumber) => {
+    assertColumnWithinLimit(worksheet.name, colNumber, max)
+  })
 }
 
 // Exported for testing - allows direct unit testing of cell value extraction
@@ -624,8 +635,28 @@ export { extractCellValue }
  * @property {Record<string, string[]>} [unfilledValues] - Per-column values to normalise to null
  */
 
+const WORKBOOK_RELS_PATH = 'xl/_rels/workbook.xml.rels'
+const WORKBOOK_PATH = 'xl/workbook.xml'
+const SHARED_STRINGS_PATH = 'xl/sharedStrings.xml'
+const STYLES_PATH = 'xl/styles.xml'
+
+const resolveSheetPath = (relTarget) =>
+  `xl/${relTarget.replace(/^(\s|\/xl\/)+/, '')}`
+
 /**
  * Parses an Excel buffer and extracts metadata and data sections.
+ *
+ * Reads the zip central directory eagerly via `unzipper.Open.buffer` so we
+ * can parse workbook metadata, relationships, styles and shared strings in
+ * a known order before any worksheet streaming begins. Each worksheet is
+ * then streamed through ExcelJS's internal `WorksheetReader`, which SAX-
+ * parses the inflated entry without holding the whole worksheet DOM in
+ * memory.
+ *
+ * Bypasses ExcelJS's `WorkbookReader` to avoid the `iterateStream` race
+ * (exceljs#1558) that drops the workbook descriptor when shared strings
+ * are written after worksheets - the entry order Microsoft Office and
+ * LibreOffice always use.
  *
  * @param {Buffer} buffer - Excel file buffer
  * @param {ParseOptions} [options] - Validation options
@@ -633,6 +664,10 @@ export { extractCellValue }
  * @throws {SpreadsheetValidationError} If the spreadsheet fails structural validation
  */
 export const parse = async (buffer, options = {}) => {
+  if (buffer.length === 0) {
+    throw new SpreadsheetValidationError('Spreadsheet buffer is empty')
+  }
+
   const {
     requiredWorksheet = null,
     maxWorksheets = PARSE_DEFAULTS.maxWorksheets,
@@ -641,12 +676,82 @@ export const parse = async (buffer, options = {}) => {
     unfilledValues = {}
   } = options
 
-  const workbook = new ExcelJS.Workbook()
+  const draft = createDraft({
+    result: { meta: {}, data: {} },
+    activeCollections: [],
+    metadataContext: null,
+    unfilledValues
+  })
+
+  const seenWorksheetNames = []
+
   try {
-    await workbook.xlsx.load(
-      /** @type {import('exceljs').Buffer} */ (/** @type {unknown} */ (buffer))
+    const directory = await unzipper.Open.buffer(buffer)
+    const filesByPath = new Map(
+      directory.files.map((entry) => [entry.path, entry])
     )
+
+    const relsXform = new RelationshipsXform()
+    const workbookRels = await relsXform.parseStream(
+      filesByPath.get(WORKBOOK_RELS_PATH).stream()
+    )
+
+    const workbookXform = new WorkbookXform()
+    await workbookXform.parseStream(filesByPath.get(WORKBOOK_PATH).stream())
+    const workbookModel = workbookXform.model
+    const workbookProperties = workbookXform.map.workbookPr
+
+    const sheets = workbookModel.sheets
+    let worksheetCount = 0
+    for (const sheet of sheets) {
+      worksheetCount++
+      assertWorksheetCountWithinLimit(sheet.name, worksheetCount, maxWorksheets)
+    }
+
+    const stylesXform = new StylesXform()
+    stylesXform.init()
+    await stylesXform.parseStream(filesByPath.get(STYLES_PATH).stream())
+
+    const sharedStringsXform = new SharedStringsXform()
+    const sharedStringsFile = filesByPath.get(SHARED_STRINGS_PATH)
+    if (sharedStringsFile) {
+      await sharedStringsXform.parseStream(sharedStringsFile.stream())
+    }
+
+    const workbookShim = {
+      sharedStrings: sharedStringsXform.values,
+      styles: stylesXform,
+      properties: workbookProperties,
+      workbookRels,
+      model: workbookModel
+    }
+
+    for (const sheet of sheets) {
+      const rel = workbookRels.find((r) => r.Id === sheet.rId)
+      const sheetFile = filesByPath.get(resolveSheetPath(rel.Target))
+
+      seenWorksheetNames.push(sheet.name)
+
+      const reader = new WorksheetReader({
+        workbook: workbookShim,
+        id: sheet.id,
+        iterator: sheetFile.stream(),
+        options: {
+          worksheets: 'emit',
+          hyperlinks: 'ignore'
+        }
+      })
+      reader.name = sheet.name
+
+      await streamWorksheet(draft, reader, {
+        maxRowsPerSheet,
+        maxColumnsPerSheet
+      })
+    }
   } catch (error) {
+    if (error instanceof SpreadsheetValidationError) {
+      throw error
+    }
     if (shouldWrapAsSpreadsheetError(error)) {
       throw new SpreadsheetValidationError(
         `Failed to parse spreadsheet: ${error.message}`,
@@ -654,27 +759,14 @@ export const parse = async (buffer, options = {}) => {
         { cause: error }
       )
     }
-
     throw error
   }
 
-  validateWorkbookStructure(workbook, {
-    requiredWorksheet,
-    maxWorksheets,
-    maxRowsPerSheet,
-    maxColumnsPerSheet
-  })
-
-  const initialState = {
-    result: { meta: {}, data: {} },
-    activeCollections: [],
-    metadataContext: null,
-    unfilledValues
+  if (requiredWorksheet && !seenWorksheetNames.includes(requiredWorksheet)) {
+    throw new SpreadsheetValidationError(
+      `Missing required '${requiredWorksheet}' worksheet`
+    )
   }
 
-  return produce(initialState, (draft) => {
-    for (const worksheet of workbook.worksheets) {
-      processWorksheet(draft, worksheet)
-    }
-  }).result
+  return finishDraft(draft).result
 }

--- a/src/adapters/parsers/summary-logs/exceljs-parser.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.js
@@ -559,7 +559,7 @@ const assertWorksheetColumnsWithinLimit = (worksheet, row, max) => {
 }
 
 // Exported for testing - allows direct unit testing of cell value extraction
-export { extractCellValue }
+export { extractCellValue } from './cell-extractor.js'
 
 /**
  * @typedef {Object} ParseOptions

--- a/src/adapters/parsers/summary-logs/exceljs-parser.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.js
@@ -583,6 +583,10 @@ const shouldSkipForPhantomDetection = (row, hasActiveCollections) => {
  * Once phantom-row detection trips, remaining rows in this worksheet are
  * still consumed from the stream (to keep the underlying zip pipeline
  * draining cleanly) but not processed.
+ *
+ * @param {object} draftState - Immer draft of the parser state
+ * @param {object} worksheet - WorksheetReader instance (async-iterable of rows, with `.name`)
+ * @param {StreamWorksheetOptions} options
  */
 const streamWorksheet = async (draftState, worksheet, options) => {
   const { maxRowsPerSheet, maxColumnsPerSheet } = options
@@ -617,6 +621,11 @@ const streamWorksheet = async (draftState, worksheet, options) => {
   draftState.activeCollections = []
 }
 
+/**
+ * @param {{name: string}} worksheet
+ * @param {{eachCell: (cb: (cell: object, colNumber: number) => void) => void}} row
+ * @param {number} max
+ */
 const assertWorksheetColumnsWithinLimit = (worksheet, row, max) => {
   row.eachCell((_cell, colNumber) => {
     assertColumnWithinLimit(worksheet.name, colNumber, max)
@@ -635,11 +644,33 @@ export { extractCellValue }
  * @property {Record<string, string[]>} [unfilledValues] - Per-column values to normalise to null
  */
 
+/**
+ * Minimal shape of the workbook-like object that ExcelJS's `WorksheetReader`
+ * destructures once at the start of each parse. We provide exactly that
+ * surface and nothing more - the SAX path never reaches back into the
+ * workbook for anything else.
+ *
+ * @typedef {Object} WorkbookShim
+ * @property {string[]} sharedStrings - Shared strings table indexed by sst index; `[]` when sharedStrings.xml is absent
+ * @property {{getStyleModel: (id: number) => object}} styles - Looked up per styled cell to resolve numFmt and format
+ * @property {{model?: {date1904?: boolean}}} properties - `model` is undefined when the workbook has no `workbookPr` element
+ */
+
+/**
+ * @typedef {Object} StreamWorksheetOptions
+ * @property {number} maxRowsPerSheet
+ * @property {number} maxColumnsPerSheet
+ */
+
 const WORKBOOK_RELS_PATH = 'xl/_rels/workbook.xml.rels'
 const WORKBOOK_PATH = 'xl/workbook.xml'
 const SHARED_STRINGS_PATH = 'xl/sharedStrings.xml'
 const STYLES_PATH = 'xl/styles.xml'
 
+/**
+ * @param {string} relTarget - Sheet target from the workbook relationships XML (e.g. `worksheets/sheet1.xml` or `/xl/worksheets/sheet1.xml`)
+ * @returns {string} Path within the zip archive
+ */
 const resolveSheetPath = (relTarget) =>
   `xl/${relTarget.replace(/^(\s|\/xl\/)+/, '')}`
 
@@ -718,12 +749,11 @@ export const parse = async (buffer, options = {}) => {
       await sharedStringsXform.parseStream(sharedStringsFile.stream())
     }
 
+    /** @type {WorkbookShim} */
     const workbookShim = {
       sharedStrings: sharedStringsXform.values,
       styles: stylesXform,
-      properties: workbookProperties,
-      workbookRels,
-      model: workbookModel
+      properties: workbookProperties
     }
 
     for (const sheet of sheets) {

--- a/src/adapters/parsers/summary-logs/exceljs-parser.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.js
@@ -148,11 +148,10 @@ const CollectionState = {
  * Asserts the streamed worksheet count has not exceeded the configured limit.
  * Called once per worksheet as it arrives from the stream.
  *
- * @param {string} name - Worksheet name (used for error messages on the next sheet)
  * @param {number} count - Worksheets seen so far (including this one)
  * @param {number} max
  */
-const assertWorksheetCountWithinLimit = (name, count, max) => {
+const assertWorksheetCountWithinLimit = (count, max) => {
   if (count > max) {
     throw new SpreadsheetValidationError(
       `Too many worksheets (${count}, maximum ${max})`
@@ -575,6 +574,11 @@ const shouldSkipForPhantomDetection = (row, hasActiveCollections) => {
 }
 
 /**
+ * @typedef {{number: number, eachCell: any}} StreamingRow
+ * @typedef {AsyncIterable<StreamingRow> & {name: string}} StreamingWorksheet
+ */
+
+/**
  * Streams rows from a worksheet, applying validation limits and phantom-row
  * detection. Uses `rowHasContent` (which extracts each cell value and treats
  * `null` / '' uniformly) rather than `Row.hasValues` so that cells authored
@@ -585,40 +589,58 @@ const shouldSkipForPhantomDetection = (row, hasActiveCollections) => {
  * draining cleanly) but not processed.
  *
  * @param {object} draftState - Immer draft of the parser state
- * @param {object} worksheet - WorksheetReader instance (async-iterable of rows, with `.name`)
+ * @param {StreamingWorksheet} worksheet - WorksheetReader instance
  * @param {StreamWorksheetOptions} options
  */
 const streamWorksheet = async (draftState, worksheet, options) => {
   const { maxRowsPerSheet, maxColumnsPerSheet } = options
-  let consecutiveEmptyRows = 0
-  let phantomRowsTripped = false
+  const counters = { consecutiveEmptyRows: 0, phantomRowsTripped: false }
 
   for await (const row of worksheet) {
     const rowNumber = row.number
     assertRowWithinLimit(worksheet.name, rowNumber, maxRowsPerSheet)
-
-    if (phantomRowsTripped) {
-      continue
-    }
-
-    const hasActiveCollections = draftState.activeCollections.length > 0
-
-    if (shouldSkipForPhantomDetection(row, hasActiveCollections)) {
-      consecutiveEmptyRows++
-      if (consecutiveEmptyRows >= MAX_CONSECUTIVE_EMPTY_ROWS) {
-        phantomRowsTripped = true
-      }
-      continue
-    }
-
-    consecutiveEmptyRows = 0
-    assertWorksheetColumnsWithinLimit(worksheet, row, maxColumnsPerSheet)
-    processRow(draftState, row, rowNumber, worksheet)
+    processRowAgainstPhantomState(draftState, worksheet, row, rowNumber, {
+      maxColumnsPerSheet,
+      counters
+    })
   }
 
   emitCollectionsToResult(draftState.result.data, draftState.activeCollections)
 
   draftState.activeCollections = []
+}
+
+/**
+ * @param {object} draftState
+ * @param {StreamingWorksheet} worksheet
+ * @param {StreamingRow} row
+ * @param {number} rowNumber
+ * @param {{maxColumnsPerSheet: number, counters: {consecutiveEmptyRows: number, phantomRowsTripped: boolean}}} ctx
+ */
+const processRowAgainstPhantomState = (
+  draftState,
+  worksheet,
+  row,
+  rowNumber,
+  ctx
+) => {
+  const { maxColumnsPerSheet, counters } = ctx
+  if (counters.phantomRowsTripped) {
+    return
+  }
+
+  const hasActiveCollections = draftState.activeCollections.length > 0
+  if (shouldSkipForPhantomDetection(row, hasActiveCollections)) {
+    counters.consecutiveEmptyRows++
+    if (counters.consecutiveEmptyRows >= MAX_CONSECUTIVE_EMPTY_ROWS) {
+      counters.phantomRowsTripped = true
+    }
+    return
+  }
+
+  counters.consecutiveEmptyRows = 0
+  assertWorksheetColumnsWithinLimit(worksheet, row, maxColumnsPerSheet)
+  processRow(draftState, row, rowNumber, worksheet)
 }
 
 /**
@@ -675,6 +697,84 @@ const resolveSheetPath = (relTarget) =>
   `xl/${relTarget.replace(/^(\s|\/xl\/)+/, '')}`
 
 /**
+ * @typedef {Object} WorkbookParts
+ * @property {Map<string, any>} filesByPath - Zip entries indexed by archive path; values expose `.stream()` (unzipper has no published types)
+ * @property {Array<any>} workbookRels - Workbook relationships from RelationshipsXform; entries carry `Id`/`Target` strings
+ * @property {Array<any>} sheets - Worksheet descriptors from the workbook XML; entries carry `name`/`id`/`rId`
+ * @property {WorkbookShim} workbookShim - Tightly typed shim consumed by WorksheetReader
+ */
+
+/**
+ * Opens the xlsx zip and parses workbook metadata, relationships, styles and
+ * shared strings into the structures needed by `WorksheetReader`. Asserts the
+ * worksheet count limit before any sheet streaming begins.
+ *
+ * @param {Buffer} buffer
+ * @param {number} maxWorksheets
+ * @returns {Promise<WorkbookParts>}
+ */
+const loadWorkbookParts = async (buffer, maxWorksheets) => {
+  const directory = await unzipper.Open.buffer(buffer)
+  const filesByPath = new Map(
+    directory.files.map((entry) => [entry.path, entry])
+  )
+
+  const relsXform = new RelationshipsXform()
+  const workbookRels = await relsXform.parseStream(
+    filesByPath.get(WORKBOOK_RELS_PATH).stream()
+  )
+
+  const workbookXform = new WorkbookXform()
+  await workbookXform.parseStream(filesByPath.get(WORKBOOK_PATH).stream())
+  const workbookModel = workbookXform.model
+  const workbookProperties = workbookXform.map.workbookPr
+
+  const sheets = workbookModel.sheets
+  assertWorksheetCountWithinLimit(sheets.length, maxWorksheets)
+
+  const stylesXform = new StylesXform()
+  stylesXform.init()
+  await stylesXform.parseStream(filesByPath.get(STYLES_PATH).stream())
+
+  const sharedStringsXform = new SharedStringsXform()
+  const sharedStringsFile = filesByPath.get(SHARED_STRINGS_PATH)
+  if (sharedStringsFile) {
+    await sharedStringsXform.parseStream(sharedStringsFile.stream())
+  }
+
+  /** @type {WorkbookShim} */
+  const workbookShim = {
+    sharedStrings: sharedStringsXform.values,
+    styles: stylesXform,
+    properties: workbookProperties
+  }
+
+  return { filesByPath, workbookRels, sheets, workbookShim }
+}
+
+/**
+ * @param {WorkbookParts} parts
+ * @param {any} sheet - Worksheet descriptor with `name`, `id`, `rId`
+ * @returns {StreamingWorksheet}
+ */
+const createWorksheetReader = (parts, sheet) => {
+  const rel = parts.workbookRels.find((r) => r.Id === sheet.rId)
+  const sheetFile = parts.filesByPath.get(resolveSheetPath(rel.Target))
+
+  const reader = new WorksheetReader({
+    workbook: parts.workbookShim,
+    id: sheet.id,
+    iterator: sheetFile.stream(),
+    options: {
+      worksheets: 'emit',
+      hyperlinks: 'ignore'
+    }
+  })
+  reader.name = sheet.name
+  return reader
+}
+
+/**
  * Parses an Excel buffer and extracts metadata and data sections.
  *
  * Reads the zip central directory eagerly via `unzipper.Open.buffer` so we
@@ -717,62 +817,10 @@ export const parse = async (buffer, options = {}) => {
   const seenWorksheetNames = []
 
   try {
-    const directory = await unzipper.Open.buffer(buffer)
-    const filesByPath = new Map(
-      directory.files.map((entry) => [entry.path, entry])
-    )
-
-    const relsXform = new RelationshipsXform()
-    const workbookRels = await relsXform.parseStream(
-      filesByPath.get(WORKBOOK_RELS_PATH).stream()
-    )
-
-    const workbookXform = new WorkbookXform()
-    await workbookXform.parseStream(filesByPath.get(WORKBOOK_PATH).stream())
-    const workbookModel = workbookXform.model
-    const workbookProperties = workbookXform.map.workbookPr
-
-    const sheets = workbookModel.sheets
-    let worksheetCount = 0
-    for (const sheet of sheets) {
-      worksheetCount++
-      assertWorksheetCountWithinLimit(sheet.name, worksheetCount, maxWorksheets)
-    }
-
-    const stylesXform = new StylesXform()
-    stylesXform.init()
-    await stylesXform.parseStream(filesByPath.get(STYLES_PATH).stream())
-
-    const sharedStringsXform = new SharedStringsXform()
-    const sharedStringsFile = filesByPath.get(SHARED_STRINGS_PATH)
-    if (sharedStringsFile) {
-      await sharedStringsXform.parseStream(sharedStringsFile.stream())
-    }
-
-    /** @type {WorkbookShim} */
-    const workbookShim = {
-      sharedStrings: sharedStringsXform.values,
-      styles: stylesXform,
-      properties: workbookProperties
-    }
-
-    for (const sheet of sheets) {
-      const rel = workbookRels.find((r) => r.Id === sheet.rId)
-      const sheetFile = filesByPath.get(resolveSheetPath(rel.Target))
-
+    const parts = await loadWorkbookParts(buffer, maxWorksheets)
+    for (const sheet of parts.sheets) {
       seenWorksheetNames.push(sheet.name)
-
-      const reader = new WorksheetReader({
-        workbook: workbookShim,
-        id: sheet.id,
-        iterator: sheetFile.stream(),
-        options: {
-          worksheets: 'emit',
-          hyperlinks: 'ignore'
-        }
-      })
-      reader.name = sheet.name
-
+      const reader = createWorksheetReader(parts, sheet)
       await streamWorksheet(draft, reader, {
         maxRowsPerSheet,
         maxColumnsPerSheet

--- a/src/adapters/parsers/summary-logs/exceljs-parser.test.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.test.js
@@ -2080,6 +2080,40 @@ describe('ExcelJSSummaryLogsParser', () => {
       expect(result.meta.PHANTOM).toBeUndefined()
       expect(result.data.SECOND).toBeUndefined()
     })
+
+    it('should not terminate a data section on a styled-but-empty row', async () => {
+      // Excel/LibreOffice frequently emit `<row><c r="A5" s="14"/></row>`
+      // for rows the user formatted but never wrote to. The DOM path's
+      // `worksheet.eachRow({includeEmpty: false})` filters these via
+      // `row.hasValues`. The streaming WorksheetReader emits them. They
+      // must not push nulls into an active collection's currentRow and
+      // terminate the section prematurely.
+      const workbook = new ExcelJS.Workbook()
+      const worksheet = workbook.addWorksheet('Test')
+
+      worksheet.getRow(1).values = ['__EPR_DATA_SECTION', 'COL_A', 'COL_B']
+      worksheet.getRow(2).values = [null, 'before-1a', 'before-1b']
+      worksheet.getRow(3).values = [null, 'before-2a', 'before-2b']
+
+      // Row 4: styled cells, no values. ExcelJS emits `<c r="A4" s="N"/>`
+      // and `<c r="B4" s="N"/>` - both type=Null on read.
+      worksheet.getCell('A4').style = { font: { bold: true } }
+      worksheet.getCell('B4').style = { font: { bold: true } }
+
+      worksheet.getRow(5).values = [null, 'after-1a', 'after-1b']
+      worksheet.getRow(6).values = [null, 'after-2a', 'after-2b']
+      worksheet.getRow(7).values = [null, ''] // real terminator
+
+      const buffer = await workbook.xlsx.writeBuffer()
+      const result = await parse(buffer)
+
+      expect(result.data.SECTION.rows).toEqual([
+        { rowNumber: 2, values: ['before-1a', 'before-1b'] },
+        { rowNumber: 3, values: ['before-2a', 'before-2b'] },
+        { rowNumber: 5, values: ['after-1a', 'after-1b'] },
+        { rowNumber: 6, values: ['after-2a', 'after-2b'] }
+      ])
+    })
   })
 
   describe('phantom column protection', () => {

--- a/src/adapters/parsers/summary-logs/exceljs-parser.test.js
+++ b/src/adapters/parsers/summary-logs/exceljs-parser.test.js
@@ -1,4 +1,5 @@
 import ExcelJS from 'exceljs'
+import unzipper from 'unzipper'
 
 import { VALIDATION_CODE } from '#common/enums/validation.js'
 import {
@@ -62,22 +63,16 @@ describe('ExcelJSSummaryLogsParser', () => {
     )
   })
 
-  it('should rethrow unrecognised errors from the load call unchanged', async () => {
+  it('should rethrow unrecognised errors from the underlying reader unchanged', async () => {
     const unexpected = new RangeError('this looks like a bug, not bad data')
-    function MockWorkbook() {
-      return {
-        xlsx: { load: vi.fn().mockRejectedValue(unexpected) },
-        worksheets: []
-      }
-    }
-    const workbookSpy = vi
-      .spyOn(ExcelJS, 'Workbook')
-      .mockImplementation(MockWorkbook)
+    const openSpy = vi
+      .spyOn(unzipper.Open, 'buffer')
+      .mockRejectedValueOnce(unexpected)
 
     try {
       await expect(parse(Buffer.from('anything'))).rejects.toBe(unexpected)
     } finally {
-      workbookSpy.mockRestore()
+      openSpy.mockRestore()
     }
   })
 
@@ -128,7 +123,6 @@ describe('ExcelJSSummaryLogsParser', () => {
     it('should throw SpreadsheetValidationError when worksheet count exceeds limit', async () => {
       const workbook = new ExcelJS.Workbook()
 
-      // Add 4 worksheets (exceeds limit of 3)
       for (let i = 1; i <= 4; i++) {
         workbook.addWorksheet(`Sheet${i}`)
       }
@@ -2520,6 +2514,19 @@ describe('shouldWrapAsSpreadsheetError', () => {
     )
 
     expect(shouldWrapAsSpreadsheetError(error)).toBe(true)
+  })
+
+  it('should wrap unzipper FILE_ENDED errors from non-zip buffers', () => {
+    const error = new Error('FILE_ENDED')
+
+    expect(shouldWrapAsSpreadsheetError(error)).toBe(true)
+  })
+
+  it('should wrap unzipper password-required errors from encrypted xlsx', () => {
+    expect(shouldWrapAsSpreadsheetError(new Error('MISSING_PASSWORD'))).toBe(
+      true
+    )
+    expect(shouldWrapAsSpreadsheetError(new Error('BAD_PASSWORD'))).toBe(true)
   })
 
   it('should wrap SaxesError by name', () => {


### PR DESCRIPTION
Ticket: [PAE-1415](https://eaflood.atlassian.net/browse/PAE-1415)
Replaces `workbook.xlsx.load(buffer)` with a streaming pipeline that opens the xlsx zip with `unzipper.Open.buffer`, parses the workbook XML parts in a known order, and drives each worksheet through ExcelJS's internal `WorksheetReader` SAX path. The whole-buffer DOM load is gone.

## Why

The previous DOM load was a single blocking call that took 400-900 ms for the 3 MB summary-log fixtures we receive in production. That stalled the event loop and held the entire workbook in memory while structural validation ran. Streaming each worksheet through SAX brings the maximum event-loop stall to ~6-11 ms (well under the 50 ms budget) and avoids the workbook-DOM allocation entirely.

It also bypasses ExcelJS's own `WorkbookReader` to sidestep an `iterateStream` race ([exceljs#1558](https://github.com/exceljs/exceljs/issues/1558)) that drops the workbook descriptor whenever shared strings are written after worksheets - the entry order Microsoft Office and LibreOffice always use.

## What changed

- `unzipper@0.10.14` promoted from a transitive (via exceljs) to a direct dependency.
- `parse()` now opens the zip eagerly, parses `xl/_rels/workbook.xml.rels`, `xl/workbook.xml`, `xl/styles.xml` and `xl/sharedStrings.xml` via the matching ExcelJS xform classes, then constructs a small workbook shim and runs each sheet through a fresh `WorksheetReader`.
- Worksheet-count, row-count and column-count limits moved from a pre-parse pass over the whole DOM to streaming assertions checked as each sheet, row and cell arrives.
- Empty-buffer rejection moved up so it surfaces as `SpreadsheetValidationError` before any zip work.
- `CORRUPT_ZIP_MESSAGE` regex extended to cover `FILE_ENDED`, `MISSING_PASSWORD` and `BAD_PASSWORD` strings emitted by unzipper.
- Workbook shim is documented by a `WorkbookShim` typedef covering the three fields `WorksheetReader` actually destructures (`sharedStrings`, `styles`, `properties`); the shape is checked at the construction site.
- JSDoc added for `streamWorksheet`, `assertWorksheetColumnsWithinLimit`, `resolveSheetPath`, plus a `StreamWorksheetOptions` typedef.
- `streamWorksheet` skips rows whose cells are all `ValueType.Null` (style-only, no value), mirroring the DOM-mode `eachRow({includeEmpty: false})` filter via `row.hasValues`. The `WorksheetReader` SAX path emits every `<row>` element regardless of content; without this filter, a styled-but-empty row mid-data pushed nulls into the active collection's currentRow and tripped `isEmptyRow=true`, terminating the section prematurely. Restores parity with the previous DOM path on V5 Exporter (30,076 rows; was 30,041 short by 35).

## Notes

- ExcelJS 4.4.0 stays pinned. The internal imports under `exceljs/lib/...` are private API; pinning is the trade-off until upstream exposes a public streaming API.

[PAE-1415]: https://eaflood.atlassian.net/browse/PAE-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ