### PR TITLE
PAE-1421: Add regulator column to report submissions API

### DIFF
--- a/src/domain/organisations/model.js
+++ b/src/domain/organisations/model.js
@@ -31,6 +31,13 @@ export const REGULATOR = Object.freeze({
   NIEA: 'niea'
 })
 
+export const REGULATOR_DISPLAY = Object.freeze({
+  ea: 'EA',
+  nrw: 'NRW',
+  sepa: 'SEPA',
+  niea: 'NIEA'
+})
+
 /**
  * @typedef {typeof MATERIAL[keyof typeof MATERIAL]} Material
  */

--- a/src/domain/organisations/model.js
+++ b/src/domain/organisations/model.js
@@ -203,6 +203,10 @@ export const USER_ROLES = Object.freeze({
  */
 
 /**
+ * @typedef {typeof REGULATOR_DISPLAY[keyof typeof REGULATOR_DISPLAY]} RegulatorDisplay
+ */
+
+/**
  * @typedef {typeof BUSINESS_TYPE[keyof typeof BUSINESS_TYPE]} BusinessTypeValue
  */
 

--- a/src/reports/application/report-submissions.js
+++ b/src/reports/application/report-submissions.js
@@ -36,7 +36,7 @@ const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
 /**
  * @typedef {Object} SubmissionBaseFields
- * @property {string} regulator
+ * @property {import('#domain/organisations/model.js').RegulatorDisplay} regulator
  * @property {string} organisationName
  * @property {string} submitterPhone
  * @property {string} approvedPersonsPhone
@@ -184,7 +184,7 @@ function buildRow(
   submittedBy
 ) {
   return {
-    regulator: REGULATOR_DISPLAY[registration.submittedToRegulator] ?? '',
+    regulator: REGULATOR_DISPLAY[registration.submittedToRegulator],
     organisationName: org.companyDetails.name,
     submitterPhone: registration.submitterContactDetails.phone,
     approvedPersonsPhone: registration.approvedPersons

--- a/src/reports/application/report-submissions.js
+++ b/src/reports/application/report-submissions.js
@@ -4,13 +4,12 @@
 import { CADENCE } from '#reports/domain/cadence.js'
 import { generateReportingPeriods } from '#reports/domain/generate-reporting-periods.js'
 import { mergeReportingPeriods } from '#reports/domain/merge-reporting-periods.js'
-import {
-  formatMaterial,
-  capitalize,
-  uppercaseString
-} from '#common/helpers/formatters.js'
+import { formatMaterial, capitalize } from '#common/helpers/formatters.js'
 import { formatPeriodLabel } from '#reports/domain/period-labels.js'
-import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+import {
+  REG_ACC_STATUS,
+  REGULATOR_DISPLAY
+} from '#domain/organisations/model.js'
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
 
 const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
@@ -185,7 +184,7 @@ function buildRow(
   submittedBy
 ) {
   return {
-    regulator: uppercaseString(registration.submittedToRegulator),
+    regulator: REGULATOR_DISPLAY[registration.submittedToRegulator] ?? '',
     organisationName: org.companyDetails.name,
     submitterPhone: registration.submitterContactDetails.phone,
     approvedPersonsPhone: registration.approvedPersons

--- a/src/reports/application/report-submissions.js
+++ b/src/reports/application/report-submissions.js
@@ -4,7 +4,11 @@
 import { CADENCE } from '#reports/domain/cadence.js'
 import { generateReportingPeriods } from '#reports/domain/generate-reporting-periods.js'
 import { mergeReportingPeriods } from '#reports/domain/merge-reporting-periods.js'
-import { formatMaterial, capitalize } from '#common/helpers/formatters.js'
+import {
+  formatMaterial,
+  capitalize,
+  uppercaseString
+} from '#common/helpers/formatters.js'
 import { formatPeriodLabel } from '#reports/domain/period-labels.js'
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
@@ -33,6 +37,7 @@ const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
 /**
  * @typedef {Object} SubmissionBaseFields
+ * @property {string} regulator
  * @property {string} organisationName
  * @property {string} submitterPhone
  * @property {string} approvedPersonsPhone
@@ -180,6 +185,7 @@ function buildRow(
   submittedBy
 ) {
   return {
+    regulator: uppercaseString(registration.submittedToRegulator),
     organisationName: org.companyDetails.name,
     submitterPhone: registration.submitterContactDetails.phone,
     approvedPersonsPhone: registration.approvedPersons

--- a/src/reports/application/report-submissions.test.js
+++ b/src/reports/application/report-submissions.test.js
@@ -44,6 +44,7 @@ describe('generateReportSubmissions (integration)', () => {
     const result = await generateReportSubmissions(orgRepo, reportsRepo)
 
     const baseRow = {
+      regulator: 'EA',
       organisationName: 'ACME ltd',
       submitterPhone: '1234567890',
       approvedPersonsPhone: '1234567890',
@@ -391,6 +392,45 @@ describe('generateReportSubmissions (edge cases)', () => {
     const row = result.reportSubmissions[0]
     expect(row.registrationNumber).toBe('REG-001')
     expect(row.accreditationNumber).toBe('')
+  })
+
+  it.each([
+    ['ea', 'EA'],
+    ['niea', 'NIEA'],
+    ['sepa', 'SEPA'],
+    ['nrw', 'NRW']
+  ])(
+    'uppercases regulator %s to %s',
+    async (submittedToRegulator, expected) => {
+      const org = buildOrg({
+        registrations: [
+          buildRegistrationMock({
+            status: 'approved',
+            submittedToRegulator
+          })
+        ]
+      })
+
+      const result = await generateReportSubmissions(
+        makeOrgsRepo([org]),
+        makeReportsRepo()
+      )
+
+      expect(result.reportSubmissions[0].regulator).toBe(expected)
+    }
+  )
+
+  it('returns empty regulator when submittedToRegulator is missing', async () => {
+    const org = buildOrg({
+      registrations: [buildRegistrationMock({ status: 'approved' })]
+    })
+
+    const result = await generateReportSubmissions(
+      makeOrgsRepo([org]),
+      makeReportsRepo()
+    )
+
+    expect(result.reportSubmissions[0].regulator).toBe('')
   })
 
   it('excludes test organisations from report submissions', async () => {

--- a/src/reports/application/report-submissions.test.js
+++ b/src/reports/application/report-submissions.test.js
@@ -433,6 +433,24 @@ describe('generateReportSubmissions (edge cases)', () => {
     expect(result.reportSubmissions[0].regulator).toBe('')
   })
 
+  it('returns empty regulator for an unknown submittedToRegulator value', async () => {
+    const org = buildOrg({
+      registrations: [
+        buildRegistrationMock({
+          status: 'approved',
+          submittedToRegulator: 'foo'
+        })
+      ]
+    })
+
+    const result = await generateReportSubmissions(
+      makeOrgsRepo([org]),
+      makeReportsRepo()
+    )
+
+    expect(result.reportSubmissions[0].regulator).toBe('')
+  })
+
   it('excludes test organisations from report submissions', async () => {
     const testOrg = buildOrg({
       orgId: 999999,

--- a/src/reports/application/report-submissions.test.js
+++ b/src/reports/application/report-submissions.test.js
@@ -220,6 +220,7 @@ const buildRegistrationMock = (overrides = {}) => ({
   accreditationId: null,
   glassRecyclingProcess: null,
   registrationNumber: 'REG-001',
+  submittedToRegulator: 'ea',
   submitterContactDetails: {
     phone: '01234567890',
     email: 'submitter@example.com'
@@ -419,37 +420,6 @@ describe('generateReportSubmissions (edge cases)', () => {
       expect(result.reportSubmissions[0].regulator).toBe(expected)
     }
   )
-
-  it('returns empty regulator when submittedToRegulator is missing', async () => {
-    const org = buildOrg({
-      registrations: [buildRegistrationMock({ status: 'approved' })]
-    })
-
-    const result = await generateReportSubmissions(
-      makeOrgsRepo([org]),
-      makeReportsRepo()
-    )
-
-    expect(result.reportSubmissions[0].regulator).toBe('')
-  })
-
-  it('returns empty regulator for an unknown submittedToRegulator value', async () => {
-    const org = buildOrg({
-      registrations: [
-        buildRegistrationMock({
-          status: 'approved',
-          submittedToRegulator: 'foo'
-        })
-      ]
-    })
-
-    const result = await generateReportSubmissions(
-      makeOrgsRepo([org]),
-      makeReportsRepo()
-    )
-
-    expect(result.reportSubmissions[0].regulator).toBe('')
-  })
 
   it('excludes test organisations from report submissions', async () => {
     const testOrg = buildOrg({

--- a/src/reports/routes/submissions.js
+++ b/src/reports/routes/submissions.js
@@ -20,7 +20,7 @@ export const getReportSubmissions = {
           .items(
             Joi.object({
               regulator: Joi.string()
-                .valid(...Object.values(REGULATOR_DISPLAY), '')
+                .valid(...Object.values(REGULATOR_DISPLAY))
                 .required(),
               organisationName: Joi.string().required(),
               submitterPhone: Joi.string().required(),

--- a/src/reports/routes/submissions.js
+++ b/src/reports/routes/submissions.js
@@ -18,6 +18,7 @@ export const getReportSubmissions = {
         reportSubmissions: Joi.array()
           .items(
             Joi.object({
+              regulator: Joi.string().allow('').required(),
               organisationName: Joi.string().required(),
               submitterPhone: Joi.string().required(),
               approvedPersonsPhone: Joi.string().required(),

--- a/src/reports/routes/submissions.js
+++ b/src/reports/routes/submissions.js
@@ -2,6 +2,7 @@ import Joi from 'joi'
 
 import { ROLES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
+import { REGULATOR_DISPLAY } from '#domain/organisations/model.js'
 import { generateReportSubmissions } from '#reports/application/report-submissions.js'
 
 export const getReportSubmissionsPath = '/v1/organisations/reports/submissions'
@@ -18,7 +19,9 @@ export const getReportSubmissions = {
         reportSubmissions: Joi.array()
           .items(
             Joi.object({
-              regulator: Joi.string().allow('').required(),
+              regulator: Joi.string()
+                .valid(...Object.values(REGULATOR_DISPLAY), '')
+                .required(),
               organisationName: Joi.string().required(),
               submitterPhone: Joi.string().required(),
               approvedPersonsPhone: Joi.string().required(),


### PR DESCRIPTION
## Summary

- Adds a `regulator` field to every row of the `GET /v1/organisations/reports/submissions` response
- Sourced from `registration.submittedToRegulator` (lowercase, required) and converted via a `REGULATOR_DISPLAY` lookup map
- Joi response schema enforces `.valid('EA','NIEA','SEPA','NRW')` — typos or unexpected values from the producer are rejected at the boundary
- Unblocks the admin FE work that adds "Regulator" as the first CSV column ([epr-re-ex-admin-frontend#375](https://github.com/DEFRA/epr-re-ex-admin-frontend/pull/375))

## Changes

- `src/domain/organisations/model.js` — adds `REGULATOR_DISPLAY` constant alongside `REGULATOR`, mapping each lowercase code to its display form; adds `RegulatorDisplay` typedef
- `src/reports/application/report-submissions.js` — extends `ReportSubmissionsRow` typedef using `RegulatorDisplay`; imports `REGULATOR_DISPLAY`; populates `regulator` in `buildRow` via lookup
- `src/reports/routes/submissions.js` — adds `regulator: Joi.string().valid(...Object.values(REGULATOR_DISPLAY)).required()` as the first field of the response schema
- `src/reports/application/report-submissions.test.js` — extends integration fixture's `baseRow`; adds parameterised `it.each` covering all four regulators (`ea`/`niea`/`sepa`/`nrw`); adds `submittedToRegulator: 'ea'` to mock helper default
