### PR TITLE
PAE-250: Prune stale axios and postcss overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,10 +102,8 @@
     "unzipper": "0.10.14"
   },
   "overrides": {
-    "axios": "1.15.2",
     "fast-xml-parser": "5.7.1",
     "glob": "11.1.0",
-    "postcss": "8.5.10",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Removes two `package.json` `overrides` entries that no longer change anything because the natural dependency tree resolves to the same (or higher) versions:

- `axios` — direct dependency `notifications-node-client@8.3.0` already pulls in `axios@1.15.2`, the same version the override was pinning
- `postcss` — `vite@7.3.2` (via vitest) already pulls in `postcss@8.5.10`, the same version the override was pinning

Each override was tested in isolation by removing it from `package.json`, regenerating the lockfile, and running both `npm audit` and `snyk test`. Both reported zero issues with the override gone, confirming the override is redundant.

The remaining overrides (`fast-xml-parser`, `glob`, `uuid`) were verified as still required: removing any of them causes either `npm audit` or `snyk test` to flag a vulnerability that the override was suppressing.

## Why prune them

The shared CI `Preparation` step rejects unpinned ranges in `overrides`, which means each entry is a permanent forced version that won't update with the rest of the tree until someone removes it. Stale overrides that no longer affect resolution add maintenance noise — they're easily mistaken for active mitigations during future audits and force the reviewer to verify why each one is still there. Pruning them keeps the override list a meaningful list of active mitigations.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ