### PR TITLE
PAE-1382: Add canonicalSource marker and per-accreditation rebuild primitives

### DIFF
--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -489,7 +489,8 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
   material = 'paper',
   organisationId = new ObjectId().toString(),
   registrationId = new ObjectId().toString(),
-  featureFlagOverrides = {}
+  featureFlagOverrides = {},
+  existingWasteBalances = []
 } = {}) => {
   const accreditationId = 'ACC-123'
   const summaryLogsRepositoryFactory = createInMemorySummaryLogsRepository()
@@ -530,7 +531,7 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
   }
 
   const wasteBalancesRepositoryFactory = createInMemoryWasteBalancesRepository(
-    [],
+    existingWasteBalances,
     {
       ledgerRepository,
       featureFlags,

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-ledger.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-ledger.test.js
@@ -100,7 +100,7 @@ describe('Waste balance ledger (Exporter, flag ON)', () => {
     await submitAndPoll(env, summaryLogId)
   }
 
-  const seedV2Balance = (organisationId) => ({
+  const seedLedgerBalance = (organisationId) => ({
     id: 'seeded-balance',
     accreditationId: 'ACC-123',
     organisationId,
@@ -109,21 +109,21 @@ describe('Waste balance ledger (Exporter, flag ON)', () => {
     amount: 0,
     availableAmount: 0,
     transactions: [],
-    canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2
+    canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
   })
 
-  const setupV2 = () => {
+  const setupLedger = () => {
     const organisationId = new ObjectId().toString()
     return setupWasteBalanceIntegrationEnvironment({
       processingType: 'exporter',
       organisationId,
       featureFlagOverrides: { wasteBalanceLedger: true },
-      existingWasteBalances: [seedV2Balance(organisationId)]
+      existingWasteBalances: [seedLedgerBalance(organisationId)]
     })
   }
 
   it('appends one ledger transaction per included row on first upload', async () => {
-    const env = await setupV2()
+    const env = await setupLedger()
     const { ledgerRepository, accreditationId, wasteBalancesRepository } = env
 
     await performSubmission(
@@ -162,13 +162,13 @@ describe('Waste balance ledger (Exporter, flag ON)', () => {
     expect(lookupCredited({ type: 'exported', rowId: '1001' })).toBe(100)
     expect(lookupCredited({ type: 'exported', rowId: '1002' })).toBe(200)
 
-    const v1Balance =
+    const embeddedBalance =
       await wasteBalancesRepository.findByAccreditationId(accreditationId)
-    expect(v1Balance?.transactions ?? []).toHaveLength(0)
+    expect(embeddedBalance?.transactions ?? []).toHaveLength(0)
   })
 
   it('appends nothing on a re-upload of identical data (idempotency invariant)', async () => {
-    const env = await setupV2()
+    const env = await setupLedger()
     const { ledgerRepository, accreditationId } = env
     const data = createUploadData([{ rowId: 2001, exportTonnage: 50 }])
 
@@ -185,7 +185,7 @@ describe('Waste balance ledger (Exporter, flag ON)', () => {
   })
 
   it('emits a single delta when one row is corrected on re-upload', async () => {
-    const env = await setupV2()
+    const env = await setupLedger()
     const { ledgerRepository, accreditationId } = env
 
     await performSubmission(
@@ -238,7 +238,7 @@ describe('Waste balance ledger (Exporter, flag ON)', () => {
   })
 
   it('audits each successful ledger append into the system-logs repository', async () => {
-    const env = await setupV2()
+    const env = await setupLedger()
     const { systemLogsForBalanceAudit } = env
 
     systemLogsForBalanceAudit.insert.mockClear()

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-ledger.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-ledger.test.js
@@ -1,3 +1,4 @@
+import { ObjectId } from 'mongodb'
 import { http, HttpResponse } from 'msw'
 
 import {
@@ -5,6 +6,7 @@ import {
   UPLOAD_STATUS
 } from '#domain/summary-logs/status.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import { LEDGER_SOURCE_KIND } from '#waste-balances/repository/ledger-schema.js'
 
 import {
@@ -98,11 +100,27 @@ describe('Waste balance ledger (Exporter, flag ON)', () => {
     await submitAndPoll(env, summaryLogId)
   }
 
-  const setupV2 = () =>
-    setupWasteBalanceIntegrationEnvironment({
+  const seedV2Balance = (organisationId) => ({
+    id: 'seeded-balance',
+    accreditationId: 'ACC-123',
+    organisationId,
+    schemaVersion: 1,
+    version: 0,
+    amount: 0,
+    availableAmount: 0,
+    transactions: [],
+    canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2
+  })
+
+  const setupV2 = () => {
+    const organisationId = new ObjectId().toString()
+    return setupWasteBalanceIntegrationEnvironment({
       processingType: 'exporter',
-      featureFlagOverrides: { wasteBalanceLedger: true }
+      organisationId,
+      featureFlagOverrides: { wasteBalanceLedger: true },
+      existingWasteBalances: [seedV2Balance(organisationId)]
     })
+  }
 
   it('appends one ledger transaction per included row on first upload', async () => {
     const env = await setupV2()

--- a/src/waste-balances/domain/model.js
+++ b/src/waste-balances/domain/model.js
@@ -7,6 +7,15 @@ export const WASTE_BALANCE_TRANSACTION_TYPE = Object.freeze({
  * @typedef {typeof WASTE_BALANCE_TRANSACTION_TYPE[keyof typeof WASTE_BALANCE_TRANSACTION_TYPE]} WasteBalanceTransactionType
  */
 
+export const WASTE_BALANCE_CANONICAL_SOURCE = Object.freeze({
+  V1: 'v1',
+  V2: 'v2'
+})
+
+/**
+ * @typedef {typeof WASTE_BALANCE_CANONICAL_SOURCE[keyof typeof WASTE_BALANCE_CANONICAL_SOURCE]} WasteBalanceCanonicalSource
+ */
+
 export const WASTE_BALANCE_TRANSACTION_ENTITY_TYPE = Object.freeze({
   WASTE_RECORD_RECEIVED: 'waste_record:received',
   WASTE_RECORD_SENT_ON: 'waste_record:sent_on',
@@ -75,4 +84,5 @@ export const WASTE_BALANCE_TRANSACTION_ENTITY_TYPE = Object.freeze({
  * @property {number} amount - Total balance (credits minus debits, stored as Decimal128)
  * @property {number} availableAmount - Available balance (amount minus pending debits, stored as Decimal128)
  * @property {WasteBalanceTransaction[]} transactions - Transaction history (append-only)
+ * @property {WasteBalanceCanonicalSource} canonicalSource - Per-accreditation marker. `'v1'` means this document is the source of truth and reads/writes target the embedded `transactions[]` array; `'v2'` means the ledger collection is the source of truth. New documents default to `'v1'`; the marker flips to `'v2'` once a per-accreditation rebuild from authoritative sources has completed.
  */

--- a/src/waste-balances/domain/model.js
+++ b/src/waste-balances/domain/model.js
@@ -8,8 +8,8 @@ export const WASTE_BALANCE_TRANSACTION_TYPE = Object.freeze({
  */
 
 export const WASTE_BALANCE_CANONICAL_SOURCE = Object.freeze({
-  V1: 'v1',
-  V2: 'v2'
+  EMBEDDED: 'embedded',
+  LEDGER: 'ledger'
 })
 
 /**
@@ -84,5 +84,5 @@ export const WASTE_BALANCE_TRANSACTION_ENTITY_TYPE = Object.freeze({
  * @property {number} amount - Total balance (credits minus debits, stored as Decimal128)
  * @property {number} availableAmount - Available balance (amount minus pending debits, stored as Decimal128)
  * @property {WasteBalanceTransaction[]} transactions - Transaction history (append-only)
- * @property {WasteBalanceCanonicalSource} canonicalSource - Per-accreditation marker. `'v1'` means this document is the source of truth and reads/writes target the embedded `transactions[]` array; `'v2'` means the ledger collection is the source of truth. New documents default to `'v1'`; the marker flips to `'v2'` once a per-accreditation rebuild from authoritative sources has completed.
+ * @property {WasteBalanceCanonicalSource} canonicalSource - Per-accreditation marker. `'embedded'` means this document is the source of truth and reads/writes target the embedded `transactions[]` array; `'ledger'` means the ledger collection is the source of truth. New documents default to `'embedded'`; the marker flips to `'ledger'` once a per-accreditation rebuild from authoritative sources has completed.
  */

--- a/src/waste-balances/domain/model.js
+++ b/src/waste-balances/domain/model.js
@@ -9,6 +9,7 @@ export const WASTE_BALANCE_TRANSACTION_TYPE = Object.freeze({
 
 export const WASTE_BALANCE_CANONICAL_SOURCE = Object.freeze({
   EMBEDDED: 'embedded',
+  MIGRATING: 'migrating',
   LEDGER: 'ledger'
 })
 
@@ -84,5 +85,20 @@ export const WASTE_BALANCE_TRANSACTION_ENTITY_TYPE = Object.freeze({
  * @property {number} amount - Total balance (credits minus debits, stored as Decimal128)
  * @property {number} availableAmount - Available balance (amount minus pending debits, stored as Decimal128)
  * @property {WasteBalanceTransaction[]} transactions - Transaction history (append-only)
- * @property {WasteBalanceCanonicalSource} canonicalSource - Per-accreditation marker. `'embedded'` means this document is the source of truth and reads/writes target the embedded `transactions[]` array; `'ledger'` means the ledger collection is the source of truth. New documents default to `'embedded'`; the marker flips to `'ledger'` once a per-accreditation rebuild from authoritative sources has completed.
+ * @property {WasteBalanceCanonicalSource} canonicalSource - Per-accreditation marker.
+ *   `'embedded'` means this document is the source of truth and reads/writes target
+ *   the embedded `transactions[]` array. `'migrating'` means a per-accreditation
+ *   rebuild from authoritative sources is in flight: writes that would otherwise
+ *   land on the embedded array still do (PRN write path treats `'migrating'` as
+ *   `'embedded'`), but summary-log submissions are 409-excluded by
+ *   `transitionToSubmittingExclusive` until the rebuild lands. `'ledger'` means
+ *   the ledger collection is the source of truth and embedded reads/writes are
+ *   bypassed. New documents default to `'embedded'`. Lifecycle:
+ *   `embedded → migrating → ledger` (forward sweep) with
+ *   `migrating → embedded` available as the stuck-marker recovery reset.
+ * @property {string} [migratingSince] - ISO8601 timestamp of when the marker
+ *   flipped to `'migrating'`. Set by `flipCanonicalSourceToMigrating` and
+ *   cleared by either `flipCanonicalSourceToLedger` (forward) or
+ *   `resetCanonicalSourceToEmbedded` (recovery). Drives the stuck-marker
+ *   recovery threshold check; absent on every other marker state.
  */

--- a/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
+++ b/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
@@ -1,6 +1,9 @@
 import { describe, beforeEach, expect } from 'vitest'
 import { buildWasteBalance } from './test-data.js'
-import { WASTE_BALANCE_TRANSACTION_ENTITY_TYPE } from '../../domain/model.js'
+import {
+  WASTE_BALANCE_CANONICAL_SOURCE,
+  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
+} from '../../domain/model.js'
 
 export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
   describe('deductTotalBalanceForPrnIssue', () => {
@@ -110,6 +113,29 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
 
       const result = await repository.findByAccreditationId('acc-nonexistent')
       expect(result).toBeNull()
+    })
+
+    it('preserves canonicalSource on update — only the flip method may mutate it', async ({
+      insertWasteBalance
+    }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-issue-marker',
+        organisationId: 'org-1',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      await repository.deductTotalBalanceForPrnIssue({
+        accreditationId: 'acc-issue-marker',
+        organisationId: 'org-1',
+        prnId: 'prn-marker',
+        tonnage: 1,
+        userId: 'user-1'
+      })
+
+      const result = await repository.findByAccreditationId('acc-issue-marker')
+      expect(result.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.LEDGER)
     })
 
     it('increments version number', async ({ insertWasteBalance }) => {

--- a/src/waste-balances/repository/contract/findByAccreditationId.contract.js
+++ b/src/waste-balances/repository/contract/findByAccreditationId.contract.js
@@ -1,4 +1,5 @@
 import { describe, beforeEach, expect } from 'vitest'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { buildWasteBalance } from './test-data.js'
 
 export const testFindByAccreditationIdBehaviour = (it) => {
@@ -75,6 +76,36 @@ export const testFindByAccreditationIdBehaviour = (it) => {
 
     it('throws error when accreditationId is empty string', async () => {
       await expect(repository.findByAccreditationId('')).rejects.toThrow()
+    })
+
+    it('returns canonicalSource v1 when stored as v1', async ({
+      insertWasteBalance
+    }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-marker-v1',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      const result = await repository.findByAccreditationId('acc-marker-v1')
+
+      expect(result.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V1)
+    })
+
+    it('returns canonicalSource v2 when stored as v2', async ({
+      insertWasteBalance
+    }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-marker-v2',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      const result = await repository.findByAccreditationId('acc-marker-v2')
+
+      expect(result.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V2)
     })
 
     it('returns waste balance with all transaction fields intact', async ({

--- a/src/waste-balances/repository/contract/findByAccreditationId.contract.js
+++ b/src/waste-balances/repository/contract/findByAccreditationId.contract.js
@@ -78,34 +78,38 @@ export const testFindByAccreditationIdBehaviour = (it) => {
       await expect(repository.findByAccreditationId('')).rejects.toThrow()
     })
 
-    it('returns canonicalSource v1 when stored as v1', async ({
+    it('returns canonicalSource embedded when stored as embedded', async ({
       insertWasteBalance
     }) => {
       const wasteBalance = buildWasteBalance({
-        accreditationId: 'acc-marker-v1',
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+        accreditationId: 'acc-marker-embedded',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
       })
 
       await insertWasteBalance(wasteBalance)
 
-      const result = await repository.findByAccreditationId('acc-marker-v1')
+      const result = await repository.findByAccreditationId(
+        'acc-marker-embedded'
+      )
 
-      expect(result.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V1)
+      expect(result.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      )
     })
 
-    it('returns canonicalSource v2 when stored as v2', async ({
+    it('returns canonicalSource ledger when stored as ledger', async ({
       insertWasteBalance
     }) => {
       const wasteBalance = buildWasteBalance({
-        accreditationId: 'acc-marker-v2',
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2
+        accreditationId: 'acc-marker-ledger',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       })
 
       await insertWasteBalance(wasteBalance)
 
-      const result = await repository.findByAccreditationId('acc-marker-v2')
+      const result = await repository.findByAccreditationId('acc-marker-ledger')
 
-      expect(result.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V2)
+      expect(result.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.LEDGER)
     })
 
     it('returns waste balance with all transaction fields intact', async ({

--- a/src/waste-balances/repository/contract/findByAccreditationIds.contract.js
+++ b/src/waste-balances/repository/contract/findByAccreditationIds.contract.js
@@ -1,4 +1,5 @@
 import { describe, beforeEach, expect } from 'vitest'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { buildWasteBalance } from './test-data.js'
 
 export const testFindByAccreditationIdsBehaviour = (it) => {
@@ -126,6 +127,34 @@ export const testFindByAccreditationIdsBehaviour = (it) => {
       const result = await repository.findByAccreditationIds([])
 
       expect(result).toEqual([])
+    })
+
+    it('preserves canonicalSource per balance across the batch', async ({
+      insertWasteBalances
+    }) => {
+      const onV1 = buildWasteBalance({
+        accreditationId: 'acc-mixed-v1',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+      })
+      const onV2 = buildWasteBalance({
+        accreditationId: 'acc-mixed-v2',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2
+      })
+
+      await insertWasteBalances([onV1, onV2])
+
+      const result = await repository.findByAccreditationIds([
+        'acc-mixed-v1',
+        'acc-mixed-v2'
+      ])
+
+      const byId = Object.fromEntries(result.map((b) => [b.accreditationId, b]))
+      expect(byId['acc-mixed-v1'].canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.V1
+      )
+      expect(byId['acc-mixed-v2'].canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.V2
+      )
     })
 
     it('returns waste balance with all fields intact', async ({

--- a/src/waste-balances/repository/contract/findByAccreditationIds.contract.js
+++ b/src/waste-balances/repository/contract/findByAccreditationIds.contract.js
@@ -132,28 +132,28 @@ export const testFindByAccreditationIdsBehaviour = (it) => {
     it('preserves canonicalSource per balance across the batch', async ({
       insertWasteBalances
     }) => {
-      const onV1 = buildWasteBalance({
-        accreditationId: 'acc-mixed-v1',
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+      const onEmbedded = buildWasteBalance({
+        accreditationId: 'acc-mixed-embedded',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
       })
-      const onV2 = buildWasteBalance({
-        accreditationId: 'acc-mixed-v2',
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2
+      const onLedger = buildWasteBalance({
+        accreditationId: 'acc-mixed-ledger',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       })
 
-      await insertWasteBalances([onV1, onV2])
+      await insertWasteBalances([onEmbedded, onLedger])
 
       const result = await repository.findByAccreditationIds([
-        'acc-mixed-v1',
-        'acc-mixed-v2'
+        'acc-mixed-embedded',
+        'acc-mixed-ledger'
       ])
 
       const byId = Object.fromEntries(result.map((b) => [b.accreditationId, b]))
-      expect(byId['acc-mixed-v1'].canonicalSource).toBe(
-        WASTE_BALANCE_CANONICAL_SOURCE.V1
+      expect(byId['acc-mixed-embedded'].canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
       )
-      expect(byId['acc-mixed-v2'].canonicalSource).toBe(
-        WASTE_BALANCE_CANONICAL_SOURCE.V2
+      expect(byId['acc-mixed-ledger'].canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       )
     })
 

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
@@ -11,13 +11,14 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
       repository = await wasteBalancesRepository()
     })
 
-    it('flips the marker to ledger when the captured version matches', async ({
+    it('flips the marker from migrating to ledger when the captured version matches and clears migratingSince', async ({
       insertWasteBalance
     }) => {
       const balance = buildWasteBalance({
         accreditationId: 'acc-flip-ok',
         version: 7,
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+        migratingSince: '2025-01-01T00:00:00.000Z'
       })
       await insertWasteBalance(balance)
 
@@ -32,15 +33,18 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
 
       const after = await repository.findByAccreditationId('acc-flip-ok')
       expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.LEDGER)
+      expect(after.migratingSince).toBeUndefined()
     })
 
-    it('returns the embedded post-state and leaves the marker alone when versions diverge', async ({
+    it('returns the migrating post-state and leaves the marker alone when versions diverge', async ({
       insertWasteBalance
     }) => {
+      const existingMigratingSince = '2025-01-01T00:00:00.000Z'
       const balance = buildWasteBalance({
         accreditationId: 'acc-flip-stale',
         version: 8,
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+        migratingSince: existingMigratingSince
       })
       await insertWasteBalance(balance)
 
@@ -50,13 +54,14 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
       })
 
       expect(result).toEqual({
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
       })
 
       const after = await repository.findByAccreditationId('acc-flip-stale')
       expect(after.canonicalSource).toBe(
-        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+        WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
       )
+      expect(after.migratingSince).toBe(existingMigratingSince)
     })
 
     it('returns null when the accreditation has no balance document', async () => {
@@ -68,7 +73,7 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
       expect(result).toBeNull()
     })
 
-    it('returns the ledger post-state when the marker is already on ledger — only promotes embedded', async ({
+    it('returns the ledger post-state when the marker is already on ledger — only promotes migrating', async ({
       insertWasteBalance
     }) => {
       const balance = buildWasteBalance({
@@ -93,17 +98,46 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
       expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.LEDGER)
     })
 
-    it('returns embedded post-state when a concurrent PRN write bumps version between capture and flip', async ({
+    it('returns the embedded post-state and leaves the marker alone when called before the migrating step — only promotes migrating', async ({
+      insertWasteBalance
+    }) => {
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-flip-still-embedded',
+        version: 2,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+      await insertWasteBalance(balance)
+
+      const result = await repository.flipCanonicalSourceToLedger({
+        accreditationId: 'acc-flip-still-embedded',
+        capturedVersion: 2
+      })
+
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+
+      const after = await repository.findByAccreditationId(
+        'acc-flip-still-embedded'
+      )
+      expect(after.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      )
+    })
+
+    it('returns migrating post-state when a concurrent PRN write bumps version between capture and flip', async ({
       insertWasteBalance
     }) => {
       const accreditationId = 'acc-concurrent-prn-write'
+      const existingMigratingSince = '2025-01-01T00:00:00.000Z'
       const balance = buildWasteBalance({
         accreditationId,
         organisationId: 'org-1',
         version: 4,
         amount: 100,
         availableAmount: 100,
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+        migratingSince: existingMigratingSince
       })
       await insertWasteBalance(balance)
 
@@ -124,14 +158,15 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
       })
 
       expect(result).toEqual({
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
       })
 
       const after = await repository.findByAccreditationId(accreditationId)
       expect(after.canonicalSource).toBe(
-        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+        WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
       )
       expect(after.version).toBe(capturedVersion + 1)
+      expect(after.migratingSince).toBe(existingMigratingSince)
     })
   })
 }

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
@@ -3,89 +3,97 @@ import { describe, beforeEach, expect } from 'vitest'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { buildWasteBalance } from './test-data.js'
 
-export const testFlipCanonicalSourceToV2Behaviour = (it) => {
-  describe('flipCanonicalSourceToV2', () => {
+export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
+  describe('flipCanonicalSourceToLedger', () => {
     let repository
 
     beforeEach(async ({ wasteBalancesRepository }) => {
       repository = await wasteBalancesRepository()
     })
 
-    it('flips the marker when the captured version matches', async ({
+    it('flips the marker to ledger when the captured version matches', async ({
       insertWasteBalance
     }) => {
       const balance = buildWasteBalance({
         accreditationId: 'acc-flip-ok',
         version: 7,
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
       })
       await insertWasteBalance(balance)
 
-      const result = await repository.flipCanonicalSourceToV2({
+      const result = await repository.flipCanonicalSourceToLedger({
         accreditationId: 'acc-flip-ok',
         capturedVersion: 7
       })
 
-      expect(result).toEqual({ flipped: true })
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
 
       const after = await repository.findByAccreditationId('acc-flip-ok')
-      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V2)
+      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.LEDGER)
     })
 
-    it('returns flipped: false and leaves the marker alone when versions diverge', async ({
+    it('returns the embedded post-state and leaves the marker alone when versions diverge', async ({
       insertWasteBalance
     }) => {
       const balance = buildWasteBalance({
         accreditationId: 'acc-flip-stale',
         version: 8,
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
       })
       await insertWasteBalance(balance)
 
-      const result = await repository.flipCanonicalSourceToV2({
+      const result = await repository.flipCanonicalSourceToLedger({
         accreditationId: 'acc-flip-stale',
         capturedVersion: 7
       })
 
-      expect(result).toEqual({ flipped: false })
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
 
       const after = await repository.findByAccreditationId('acc-flip-stale')
-      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V1)
+      expect(after.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      )
     })
 
-    it('returns flipped: false when the accreditation has no balance document', async () => {
-      const result = await repository.flipCanonicalSourceToV2({
+    it('returns null when the accreditation has no balance document', async () => {
+      const result = await repository.flipCanonicalSourceToLedger({
         accreditationId: 'acc-flip-missing',
         capturedVersion: 1
       })
 
-      expect(result).toEqual({ flipped: false })
+      expect(result).toBeNull()
     })
 
-    it('returns flipped: false when the marker is already v2 — only promotes v1', async ({
+    it('returns the ledger post-state when the marker is already on ledger — only promotes embedded', async ({
       insertWasteBalance
     }) => {
       const balance = buildWasteBalance({
-        accreditationId: 'acc-flip-already-v2',
+        accreditationId: 'acc-flip-already-ledger',
         version: 3,
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       })
       await insertWasteBalance(balance)
 
-      const result = await repository.flipCanonicalSourceToV2({
-        accreditationId: 'acc-flip-already-v2',
+      const result = await repository.flipCanonicalSourceToLedger({
+        accreditationId: 'acc-flip-already-ledger',
         capturedVersion: 3
       })
 
-      expect(result).toEqual({ flipped: false })
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
 
       const after = await repository.findByAccreditationId(
-        'acc-flip-already-v2'
+        'acc-flip-already-ledger'
       )
-      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V2)
+      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.LEDGER)
     })
 
-    it('no-ops when a concurrent PRN write bumps version between capture and flip', async ({
+    it('returns embedded post-state when a concurrent PRN write bumps version between capture and flip', async ({
       insertWasteBalance
     }) => {
       const accreditationId = 'acc-concurrent-prn-write'
@@ -95,7 +103,7 @@ export const testFlipCanonicalSourceToV2Behaviour = (it) => {
         version: 4,
         amount: 100,
         availableAmount: 100,
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
       })
       await insertWasteBalance(balance)
 
@@ -110,15 +118,19 @@ export const testFlipCanonicalSourceToV2Behaviour = (it) => {
         userId: 'user-1'
       })
 
-      const result = await repository.flipCanonicalSourceToV2({
+      const result = await repository.flipCanonicalSourceToLedger({
         accreditationId,
         capturedVersion
       })
 
-      expect(result).toEqual({ flipped: false })
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
 
       const after = await repository.findByAccreditationId(accreditationId)
-      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V1)
+      expect(after.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      )
       expect(after.version).toBe(capturedVersion + 1)
     })
   })

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToMigrating.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToMigrating.contract.js
@@ -1,0 +1,182 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
+import { buildWasteBalance } from './test-data.js'
+
+export const testFlipCanonicalSourceToMigratingBehaviour = (it) => {
+  describe('flipCanonicalSourceToMigrating', () => {
+    let repository
+
+    beforeEach(async ({ wasteBalancesRepository }) => {
+      repository = await wasteBalancesRepository()
+    })
+
+    it('flips the marker from embedded to migrating when the captured version matches and stamps migratingSince', async ({
+      insertWasteBalance
+    }) => {
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-flip-migrating-ok',
+        version: 7,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+      await insertWasteBalance(balance)
+
+      const beforeFlipAt = Date.now()
+      const result = await repository.flipCanonicalSourceToMigrating({
+        accreditationId: 'acc-flip-migrating-ok',
+        capturedVersion: 7
+      })
+      const afterFlipAt = Date.now()
+
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      })
+
+      const after = await repository.findByAccreditationId(
+        'acc-flip-migrating-ok'
+      )
+      expect(after.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      )
+      expect(after.migratingSince).toBeDefined()
+      const migratingAt = new Date(after.migratingSince).getTime()
+      expect(migratingAt).toBeGreaterThanOrEqual(beforeFlipAt)
+      expect(migratingAt).toBeLessThanOrEqual(afterFlipAt)
+    })
+
+    it('returns the embedded post-state and leaves the marker alone when versions diverge', async ({
+      insertWasteBalance
+    }) => {
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-flip-migrating-stale',
+        version: 8,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+      await insertWasteBalance(balance)
+
+      const result = await repository.flipCanonicalSourceToMigrating({
+        accreditationId: 'acc-flip-migrating-stale',
+        capturedVersion: 7
+      })
+
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+
+      const after = await repository.findByAccreditationId(
+        'acc-flip-migrating-stale'
+      )
+      expect(after.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      )
+      expect(after.migratingSince).toBeUndefined()
+    })
+
+    it('returns null when the accreditation has no balance document', async () => {
+      const result = await repository.flipCanonicalSourceToMigrating({
+        accreditationId: 'acc-flip-migrating-missing',
+        capturedVersion: 1
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('returns the migrating post-state and leaves migratingSince alone when already migrating — only promotes embedded', async ({
+      insertWasteBalance
+    }) => {
+      const existingMigratingSince = '2025-01-01T00:00:00.000Z'
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-flip-migrating-already',
+        version: 3,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+        migratingSince: existingMigratingSince
+      })
+      await insertWasteBalance(balance)
+
+      const result = await repository.flipCanonicalSourceToMigrating({
+        accreditationId: 'acc-flip-migrating-already',
+        capturedVersion: 3
+      })
+
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      })
+
+      const after = await repository.findByAccreditationId(
+        'acc-flip-migrating-already'
+      )
+      expect(after.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      )
+      expect(after.migratingSince).toBe(existingMigratingSince)
+    })
+
+    it('returns the ledger post-state and never demotes when the marker is already on ledger', async ({
+      insertWasteBalance
+    }) => {
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-flip-migrating-ledger',
+        version: 5,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
+      await insertWasteBalance(balance)
+
+      const result = await repository.flipCanonicalSourceToMigrating({
+        accreditationId: 'acc-flip-migrating-ledger',
+        capturedVersion: 5
+      })
+
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
+
+      const after = await repository.findByAccreditationId(
+        'acc-flip-migrating-ledger'
+      )
+      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.LEDGER)
+      expect(after.migratingSince).toBeUndefined()
+    })
+
+    it('returns embedded post-state when a concurrent PRN write bumps version between capture and flip', async ({
+      insertWasteBalance
+    }) => {
+      const accreditationId = 'acc-concurrent-prn-write-migrating'
+      const balance = buildWasteBalance({
+        accreditationId,
+        organisationId: 'org-1',
+        version: 4,
+        amount: 100,
+        availableAmount: 100,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+      await insertWasteBalance(balance)
+
+      const beforeFlip = await repository.findByAccreditationId(accreditationId)
+      const capturedVersion = beforeFlip.version
+
+      await repository.deductTotalBalanceForPrnIssue({
+        accreditationId,
+        organisationId: 'org-1',
+        prnId: 'prn-during-rebuild',
+        tonnage: 5,
+        userId: 'user-1'
+      })
+
+      const result = await repository.flipCanonicalSourceToMigrating({
+        accreditationId,
+        capturedVersion
+      })
+
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+
+      const after = await repository.findByAccreditationId(accreditationId)
+      expect(after.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      )
+      expect(after.version).toBe(capturedVersion + 1)
+      expect(after.migratingSince).toBeUndefined()
+    })
+  })
+}

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToV2.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToV2.contract.js
@@ -62,7 +62,7 @@ export const testFlipCanonicalSourceToV2Behaviour = (it) => {
       expect(result).toEqual({ flipped: false })
     })
 
-    it('is a no-op when the marker is already v2 (filter matches accreditationId+version)', async ({
+    it('returns flipped: false when the marker is already v2 — only promotes v1', async ({
       insertWasteBalance
     }) => {
       const balance = buildWasteBalance({
@@ -77,7 +77,7 @@ export const testFlipCanonicalSourceToV2Behaviour = (it) => {
         capturedVersion: 3
       })
 
-      expect(result).toEqual({ flipped: true })
+      expect(result).toEqual({ flipped: false })
 
       const after = await repository.findByAccreditationId(
         'acc-flip-already-v2'

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToV2.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToV2.contract.js
@@ -1,0 +1,125 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
+import { buildWasteBalance } from './test-data.js'
+
+export const testFlipCanonicalSourceToV2Behaviour = (it) => {
+  describe('flipCanonicalSourceToV2', () => {
+    let repository
+
+    beforeEach(async ({ wasteBalancesRepository }) => {
+      repository = await wasteBalancesRepository()
+    })
+
+    it('flips the marker when the captured version matches', async ({
+      insertWasteBalance
+    }) => {
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-flip-ok',
+        version: 7,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+      })
+      await insertWasteBalance(balance)
+
+      const result = await repository.flipCanonicalSourceToV2({
+        accreditationId: 'acc-flip-ok',
+        capturedVersion: 7
+      })
+
+      expect(result).toEqual({ flipped: true })
+
+      const after = await repository.findByAccreditationId('acc-flip-ok')
+      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V2)
+    })
+
+    it('returns flipped: false and leaves the marker alone when versions diverge', async ({
+      insertWasteBalance
+    }) => {
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-flip-stale',
+        version: 8,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+      })
+      await insertWasteBalance(balance)
+
+      const result = await repository.flipCanonicalSourceToV2({
+        accreditationId: 'acc-flip-stale',
+        capturedVersion: 7
+      })
+
+      expect(result).toEqual({ flipped: false })
+
+      const after = await repository.findByAccreditationId('acc-flip-stale')
+      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V1)
+    })
+
+    it('returns flipped: false when the accreditation has no balance document', async () => {
+      const result = await repository.flipCanonicalSourceToV2({
+        accreditationId: 'acc-flip-missing',
+        capturedVersion: 1
+      })
+
+      expect(result).toEqual({ flipped: false })
+    })
+
+    it('is a no-op when the marker is already v2 (filter matches accreditationId+version)', async ({
+      insertWasteBalance
+    }) => {
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-flip-already-v2',
+        version: 3,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2
+      })
+      await insertWasteBalance(balance)
+
+      const result = await repository.flipCanonicalSourceToV2({
+        accreditationId: 'acc-flip-already-v2',
+        capturedVersion: 3
+      })
+
+      expect(result).toEqual({ flipped: true })
+
+      const after = await repository.findByAccreditationId(
+        'acc-flip-already-v2'
+      )
+      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V2)
+    })
+
+    it('no-ops when a concurrent PRN write bumps version between capture and flip', async ({
+      insertWasteBalance
+    }) => {
+      const accreditationId = 'acc-concurrent-prn-write'
+      const balance = buildWasteBalance({
+        accreditationId,
+        organisationId: 'org-1',
+        version: 4,
+        amount: 100,
+        availableAmount: 100,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+      })
+      await insertWasteBalance(balance)
+
+      const beforeFlip = await repository.findByAccreditationId(accreditationId)
+      const capturedVersion = beforeFlip.version
+
+      await repository.deductTotalBalanceForPrnIssue({
+        accreditationId,
+        organisationId: 'org-1',
+        prnId: 'prn-during-rebuild',
+        tonnage: 5,
+        userId: 'user-1'
+      })
+
+      const result = await repository.flipCanonicalSourceToV2({
+        accreditationId,
+        capturedVersion
+      })
+
+      expect(result).toEqual({ flipped: false })
+
+      const after = await repository.findByAccreditationId(accreditationId)
+      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V1)
+      expect(after.version).toBe(capturedVersion + 1)
+    })
+  })
+}

--- a/src/waste-balances/repository/contract/resetCanonicalSourceToEmbedded.contract.js
+++ b/src/waste-balances/repository/contract/resetCanonicalSourceToEmbedded.contract.js
@@ -1,0 +1,95 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
+import { buildWasteBalance } from './test-data.js'
+
+export const testResetCanonicalSourceToEmbeddedBehaviour = (it) => {
+  describe('resetCanonicalSourceToEmbedded', () => {
+    let repository
+
+    beforeEach(async ({ wasteBalancesRepository }) => {
+      repository = await wasteBalancesRepository()
+    })
+
+    it('resets the marker from migrating back to embedded and clears migratingSince — unconditional, no version filter', async ({
+      insertWasteBalance
+    }) => {
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-reset-stuck',
+        version: 12,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+        migratingSince: '2025-01-01T00:00:00.000Z'
+      })
+      await insertWasteBalance(balance)
+
+      const result = await repository.resetCanonicalSourceToEmbedded({
+        accreditationId: 'acc-reset-stuck'
+      })
+
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+
+      const after = await repository.findByAccreditationId('acc-reset-stuck')
+      expect(after.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      )
+      expect(after.migratingSince).toBeUndefined()
+    })
+
+    it('returns null when the accreditation has no balance document', async () => {
+      const result = await repository.resetCanonicalSourceToEmbedded({
+        accreditationId: 'acc-reset-missing'
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('returns the embedded post-state and is a no-op when the marker is already embedded', async ({
+      insertWasteBalance
+    }) => {
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-reset-embedded',
+        version: 4,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+      await insertWasteBalance(balance)
+
+      const result = await repository.resetCanonicalSourceToEmbedded({
+        accreditationId: 'acc-reset-embedded'
+      })
+
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+
+      const after = await repository.findByAccreditationId('acc-reset-embedded')
+      expect(after.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      )
+      expect(after.migratingSince).toBeUndefined()
+    })
+
+    it('returns the ledger post-state and never demotes when the marker is already on ledger', async ({
+      insertWasteBalance
+    }) => {
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-reset-ledger',
+        version: 9,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
+      await insertWasteBalance(balance)
+
+      const result = await repository.resetCanonicalSourceToEmbedded({
+        accreditationId: 'acc-reset-ledger'
+      })
+
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
+
+      const after = await repository.findByAccreditationId('acc-reset-ledger')
+      expect(after.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.LEDGER)
+    })
+  })
+}

--- a/src/waste-balances/repository/contract/test-data.js
+++ b/src/waste-balances/repository/contract/test-data.js
@@ -22,7 +22,7 @@ export const buildWasteBalance = (overrides = {}) => {
   const amount = overrides.amount ?? 100
   const availableAmount = overrides.availableAmount ?? 100
   const canonicalSource =
-    overrides.canonicalSource ?? WASTE_BALANCE_CANONICAL_SOURCE.V1
+    overrides.canonicalSource ?? WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
 
   const transaction = {
     id: randomUUID(),

--- a/src/waste-balances/repository/contract/test-data.js
+++ b/src/waste-balances/repository/contract/test-data.js
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import {
+  WASTE_BALANCE_CANONICAL_SOURCE,
   WASTE_BALANCE_TRANSACTION_TYPE,
   WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
 } from '../../domain/model.js'
@@ -20,6 +21,8 @@ export const buildWasteBalance = (overrides = {}) => {
   const version = overrides.version ?? 1
   const amount = overrides.amount ?? 100
   const availableAmount = overrides.availableAmount ?? 100
+  const canonicalSource =
+    overrides.canonicalSource ?? WASTE_BALANCE_CANONICAL_SOURCE.V1
 
   const transaction = {
     id: randomUUID(),
@@ -53,6 +56,7 @@ export const buildWasteBalance = (overrides = {}) => {
     version,
     amount,
     availableAmount,
+    canonicalSource,
     transactions: overrides.transactions || [transaction]
   }
 }

--- a/src/waste-balances/repository/contract/updateWasteBalanceTransactions.contract.js
+++ b/src/waste-balances/repository/contract/updateWasteBalanceTransactions.contract.js
@@ -203,7 +203,7 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
       expect(balance.amount).toBe(10.5)
     })
 
-    it('marks newly created balance as canonicalSource v1', async ({
+    it('marks newly created balance as canonicalSource embedded', async ({
       wasteBalancesRepository
     }) => {
       const repository = await wasteBalancesRepository()
@@ -230,10 +230,12 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
       })
 
       const balance = await repository.findByAccreditationId(accreditation.id)
-      expect(balance.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V1)
+      expect(balance.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      )
     })
 
-    it('preserves existing canonicalSource v1 across updates', async ({
+    it('preserves existing canonicalSource embedded across updates', async ({
       wasteBalancesRepository,
       insertWasteBalance
     }) => {
@@ -247,7 +249,7 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
       const existingBalance = buildWasteBalance({
         accreditationId: accreditation.id,
         organisationId: 'org-1',
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
       })
       await insertWasteBalance(existingBalance)
 
@@ -268,7 +270,9 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
       })
 
       const balance = await repository.findByAccreditationId(accreditation.id)
-      expect(balance.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V1)
+      expect(balance.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      )
     })
 
     it('Should ignore records with outcome other than INCLUDED', async ({

--- a/src/waste-balances/repository/contract/updateWasteBalanceTransactions.contract.js
+++ b/src/waste-balances/repository/contract/updateWasteBalanceTransactions.contract.js
@@ -1,4 +1,5 @@
 import { describe, expect, vi } from 'vitest'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { buildWasteBalance, buildWasteRecord } from './test-data.js'
 import { RECEIVED_LOADS_FIELDS as FIELDS } from '#domain/summary-logs/table-schemas/exporter/fields.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
@@ -200,6 +201,74 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
       const balance = await repository.findByAccreditationId(accreditation.id)
       expect(balance.transactions).toHaveLength(1)
       expect(balance.amount).toBe(10.5)
+    })
+
+    it('marks newly created balance as canonicalSource v1', async ({
+      wasteBalancesRepository
+    }) => {
+      const repository = await wasteBalancesRepository()
+      const user = {
+        id: 'user-1',
+        email: 'user-1@example.test',
+        scope: ['standard_user']
+      }
+
+      const record = buildWasteRecord({
+        data: {
+          processingType: PROCESSING_TYPES.EXPORTER,
+          [FIELDS.WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE]: 'No',
+          [FIELDS.DATE_OF_EXPORT]: '2023-06-01',
+          [FIELDS.DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE]: 'No',
+          [FIELDS.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED]: '10.5'
+        }
+      })
+
+      await repository.updateWasteBalanceTransactions([record], {
+        user,
+        accreditation,
+        overseasSites: ORS_VALIDATION_DISABLED
+      })
+
+      const balance = await repository.findByAccreditationId(accreditation.id)
+      expect(balance.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V1)
+    })
+
+    it('preserves existing canonicalSource v1 across updates', async ({
+      wasteBalancesRepository,
+      insertWasteBalance
+    }) => {
+      const repository = await wasteBalancesRepository()
+      const user = {
+        id: 'user-1',
+        email: 'user-1@example.test',
+        scope: ['standard_user']
+      }
+
+      const existingBalance = buildWasteBalance({
+        accreditationId: accreditation.id,
+        organisationId: 'org-1',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+      })
+      await insertWasteBalance(existingBalance)
+
+      const record = buildWasteRecord({
+        data: {
+          processingType: PROCESSING_TYPES.EXPORTER,
+          [FIELDS.WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE]: 'No',
+          [FIELDS.DATE_OF_EXPORT]: '2023-06-01',
+          [FIELDS.DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE]: 'No',
+          [FIELDS.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED]: '10.5'
+        }
+      })
+
+      await repository.updateWasteBalanceTransactions([record], {
+        user,
+        accreditation,
+        overseasSites: ORS_VALIDATION_DISABLED
+      })
+
+      const balance = await repository.findByAccreditationId(accreditation.id)
+      expect(balance.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.V1)
     })
 
     it('Should ignore records with outcome other than INCLUDED', async ({

--- a/src/waste-balances/repository/helpers.js
+++ b/src/waste-balances/repository/helpers.js
@@ -152,7 +152,17 @@ const calculateAndApplyUpdates = async (
  * per-accreditation `canonicalSource` marker:
  * - flag OFF — embedded `transactions[]` array
  * - flag ON, marker `'ledger'` — ledger-append path (ADR 0031)
- * - flag ON, marker `'embedded'` or no balance yet — embedded `transactions[]` array
+ * - flag ON, marker `'embedded'`, `'migrating'`, or no balance yet — embedded
+ *   `transactions[]` array
+ *
+ * `'migrating'` deliberately routes to the embedded path: a per-accreditation
+ * rebuild that flipped the marker via `flipCanonicalSourceToMigrating` keeps
+ * the embedded write path live for PRN operations during the replay window —
+ * the version-conditional `flipCanonicalSourceToLedger` catches concurrent
+ * writes and forces a retry. Summary-log submissions are kept off this path
+ * during the migrating window by `transitionToSubmittingExclusive`'s 409
+ * exclusion, so the only writes that legitimately reach this dispatch under
+ * `'migrating'` are PRN operations.
  *
  * The marker drives per-accreditation rollout: a freshly enabled environment
  * keeps every accreditation on the embedded array until a rebuild replays

--- a/src/waste-balances/repository/helpers.js
+++ b/src/waste-balances/repository/helpers.js
@@ -54,7 +54,7 @@ export const createNewWasteBalance = (accreditationId, organisationId) => ({
   transactions: [],
   version: 0,
   schemaVersion: 1,
-  canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+  canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
 })
 
 /**
@@ -150,13 +150,14 @@ const calculateAndApplyUpdates = async (
  *
  * Dispatches on the `wasteBalanceLedger` feature flag and the
  * per-accreditation `canonicalSource` marker:
- * - flag OFF — embedded `transactions[]` array (v1)
- * - flag ON, marker `'v2'` — ledger-append path (ADR 0031)
- * - flag ON, marker `'v1'` or no balance yet — embedded `transactions[]` array (v1)
+ * - flag OFF — embedded `transactions[]` array
+ * - flag ON, marker `'ledger'` — ledger-append path (ADR 0031)
+ * - flag ON, marker `'embedded'` or no balance yet — embedded `transactions[]` array
  *
  * The marker drives per-accreditation rollout: a freshly enabled environment
- * keeps every accreditation on v1 until a rebuild migrates it to v2 and flips
- * the marker. Both paths preserve audit emission.
+ * keeps every accreditation on the embedded array until a rebuild replays
+ * authoritative history into the ledger and flips the marker. Both paths
+ * preserve audit emission.
  *
  * @param {Object} params
  * @param {import('#domain/waste-records/model.js').WasteRecord[]} params.wasteRecords
@@ -190,7 +191,7 @@ export const performUpdateWasteBalanceTransactions = async ({
   if (dependencies.featureFlags?.isWasteBalanceLedgerEnabled()) {
     const existingBalance = await findBalance(validatedAccreditationId)
     if (
-      existingBalance?.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.V2
+      existingBalance?.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
     ) {
       await performUpdateViaLedger({
         wasteRecords: annotatedRecords,

--- a/src/waste-balances/repository/helpers.js
+++ b/src/waste-balances/repository/helpers.js
@@ -12,6 +12,7 @@ import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/
 
 /** @import {OverseasSitesContext} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
 import {
+  WASTE_BALANCE_CANONICAL_SOURCE,
   WASTE_BALANCE_TRANSACTION_TYPE,
   WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
 } from '../domain/model.js'
@@ -52,7 +53,8 @@ export const createNewWasteBalance = (accreditationId, organisationId) => ({
   availableAmount: 0,
   transactions: [],
   version: 0,
-  schemaVersion: 1
+  schemaVersion: 1,
+  canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
 })
 
 /**
@@ -146,9 +148,15 @@ const calculateAndApplyUpdates = async (
 /**
  * Shared logic for updating waste balance transactions.
  *
- * Dispatches on the `wasteBalanceLedger` feature flag: ON routes through the
- * ledger-append path (ADR 0031), OFF stays on the embedded `transactions[]`
- * array. Both paths preserve audit emission.
+ * Dispatches on the `wasteBalanceLedger` feature flag and the
+ * per-accreditation `canonicalSource` marker:
+ * - flag OFF — embedded `transactions[]` array (v1)
+ * - flag ON, marker `'v2'` — ledger-append path (ADR 0031)
+ * - flag ON, marker `'v1'` or no balance yet — embedded `transactions[]` array (v1)
+ *
+ * The marker drives per-accreditation rollout: a freshly enabled environment
+ * keeps every accreditation on v1 until a rebuild migrates it to v2 and flips
+ * the marker. Both paths preserve audit emission.
  *
  * @param {Object} params
  * @param {import('#domain/waste-records/model.js').WasteRecord[]} params.wasteRecords
@@ -180,20 +188,25 @@ export const performUpdateWasteBalanceTransactions = async ({
   const validatedAccreditationId = validateAccreditationId(accreditation.id)
 
   if (dependencies.featureFlags?.isWasteBalanceLedgerEnabled()) {
-    await performUpdateViaLedger({
-      wasteRecords: annotatedRecords,
-      accreditation: { ...accreditation, id: validatedAccreditationId },
-      ledgerRepository:
-        /** @type {import('./ledger-port.js').LedgerRepository} */ (
-          dependencies.ledgerRepository
-        ),
-      dependencies: {
-        systemLogsRepository: dependencies.systemLogsRepository
-      },
-      user,
-      overseasSites
-    })
-    return
+    const existingBalance = await findBalance(validatedAccreditationId)
+    if (
+      existingBalance?.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.V2
+    ) {
+      await performUpdateViaLedger({
+        wasteRecords: annotatedRecords,
+        accreditation: { ...accreditation, id: validatedAccreditationId },
+        ledgerRepository:
+          /** @type {import('./ledger-port.js').LedgerRepository} */ (
+            dependencies.ledgerRepository
+          ),
+        dependencies: {
+          systemLogsRepository: dependencies.systemLogsRepository
+        },
+        user,
+        overseasSites
+      })
+      return
+    }
   }
 
   const result = await calculateAndApplyUpdates(

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -396,6 +396,50 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(call.user).toEqual({ id: 'user-1' })
         expect(calculateWasteBalanceUpdates).not.toHaveBeenCalled()
         expect(saveBalance).not.toHaveBeenCalled()
+        expect(findBalance).toHaveBeenCalledTimes(1)
+      })
+
+      it('uses the v1 path when flag is ON but the existing balance has no marker (legacy doc)', async () => {
+        const wasteRecords = [
+          {
+            id: 'rec-1',
+            organisationId: 'org-1',
+            data: {}
+          }
+        ]
+        const accreditation = { id: 'acc-1' }
+        const wasteBalance = {
+          id: 'bal-1',
+          accreditationId: 'acc-1',
+          amount: 0,
+          availableAmount: 0,
+          transactions: [],
+          version: 1
+        }
+        const findBalance = vi.fn().mockResolvedValue(wasteBalance)
+        const saveBalance = vi.fn().mockResolvedValue()
+        vi.mocked(performUpdateViaLedger).mockClear()
+        vi.mocked(calculateWasteBalanceUpdates).mockReturnValue({
+          newTransactions: [{ id: 't1' }],
+          newAmount: 100,
+          newAvailableAmount: 100
+        })
+
+        await performUpdateWasteBalanceTransactions({
+          wasteRecords,
+          accreditation,
+          dependencies: {
+            featureFlags: { isWasteBalanceLedgerEnabled: () => true },
+            ledgerRepository: { insertTransactions: vi.fn() }
+          },
+          findBalance,
+          saveBalance,
+          user: { id: 'user-1' },
+          overseasSites: ORS_VALIDATION_DISABLED
+        })
+
+        expect(performUpdateViaLedger).not.toHaveBeenCalled()
+        expect(saveBalance).toHaveBeenCalledTimes(1)
       })
 
       it('uses the v1 path when flag is ON but canonicalSource is still v1', async () => {

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -442,6 +442,52 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(saveBalance).toHaveBeenCalledTimes(1)
       })
 
+      it('uses the embedded path when flag is ON and canonicalSource is migrating — PRN writes during a rebuild treat migrating as embedded', async () => {
+        const wasteRecords = [
+          {
+            id: 'rec-1',
+            organisationId: 'org-1',
+            data: {}
+          }
+        ]
+        const accreditation = { id: 'acc-1' }
+        const wasteBalance = {
+          id: 'bal-1',
+          accreditationId: 'acc-1',
+          amount: 0,
+          availableAmount: 0,
+          transactions: [],
+          version: 1,
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+          migratingSince: '2025-01-01T00:00:00.000Z'
+        }
+        const findBalance = vi.fn().mockResolvedValue(wasteBalance)
+        const saveBalance = vi.fn().mockResolvedValue()
+        vi.mocked(performUpdateViaLedger).mockClear()
+        vi.mocked(calculateWasteBalanceUpdates).mockReturnValue({
+          newTransactions: [{ id: 't1' }],
+          newAmount: 100,
+          newAvailableAmount: 100
+        })
+
+        await performUpdateWasteBalanceTransactions({
+          wasteRecords,
+          accreditation,
+          dependencies: {
+            featureFlags: { isWasteBalanceLedgerEnabled: () => true },
+            ledgerRepository: { insertTransactions: vi.fn() }
+          },
+          findBalance,
+          saveBalance,
+          user: { id: 'user-1' },
+          overseasSites: ORS_VALIDATION_DISABLED
+        })
+
+        expect(performUpdateViaLedger).not.toHaveBeenCalled()
+        expect(calculateWasteBalanceUpdates).toHaveBeenCalledTimes(1)
+        expect(saveBalance).toHaveBeenCalledTimes(1)
+      })
+
       it('uses the embedded path when flag is ON but canonicalSource is still embedded', async () => {
         const wasteRecords = [
           {

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -17,6 +17,7 @@ import { calculateWasteBalanceUpdates } from '../application/calculator.js'
 import { performUpdateViaLedger } from '../application/update-via-ledger.js'
 import { audit } from '@defra/cdp-auditing'
 import {
+  WASTE_BALANCE_CANONICAL_SOURCE,
   WASTE_BALANCE_TRANSACTION_TYPE,
   WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
 } from '../domain/model.js'
@@ -351,7 +352,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
     })
 
     describe('feature flag dispatch', () => {
-      it('routes to the ledger path when wasteBalanceLedger flag is ON', async () => {
+      it('routes to the ledger path when flag is ON and canonicalSource is v2', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -362,7 +363,15 @@ describe('src/waste-balances/repository/helpers.js', () => {
         ]
         const accreditation = { id: 'acc-1' }
         const ledgerRepository = { insertTransactions: vi.fn() }
-        const findBalance = vi.fn()
+        const findBalance = vi.fn().mockResolvedValue({
+          id: 'bal-1',
+          accreditationId: 'acc-1',
+          amount: 0,
+          availableAmount: 0,
+          transactions: [],
+          version: 1,
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2
+        })
         const saveBalance = vi.fn()
         vi.mocked(performUpdateViaLedger).mockClear()
         vi.mocked(calculateWasteBalanceUpdates).mockClear()
@@ -386,8 +395,91 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(call.accreditation.id).toBe('acc-1')
         expect(call.user).toEqual({ id: 'user-1' })
         expect(calculateWasteBalanceUpdates).not.toHaveBeenCalled()
-        expect(findBalance).not.toHaveBeenCalled()
         expect(saveBalance).not.toHaveBeenCalled()
+      })
+
+      it('uses the v1 path when flag is ON but canonicalSource is still v1', async () => {
+        const wasteRecords = [
+          {
+            id: 'rec-1',
+            organisationId: 'org-1',
+            data: {}
+          }
+        ]
+        const accreditation = { id: 'acc-1' }
+        const wasteBalance = {
+          id: 'bal-1',
+          accreditationId: 'acc-1',
+          amount: 0,
+          availableAmount: 0,
+          transactions: [],
+          version: 1,
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+        }
+        const findBalance = vi.fn().mockResolvedValue(wasteBalance)
+        const saveBalance = vi.fn().mockResolvedValue()
+        vi.mocked(performUpdateViaLedger).mockClear()
+        vi.mocked(calculateWasteBalanceUpdates).mockReturnValue({
+          newTransactions: [{ id: 't1' }],
+          newAmount: 100,
+          newAvailableAmount: 100
+        })
+
+        await performUpdateWasteBalanceTransactions({
+          wasteRecords,
+          accreditation,
+          dependencies: {
+            featureFlags: { isWasteBalanceLedgerEnabled: () => true },
+            ledgerRepository: { insertTransactions: vi.fn() }
+          },
+          findBalance,
+          saveBalance,
+          user: { id: 'user-1' },
+          overseasSites: ORS_VALIDATION_DISABLED
+        })
+
+        expect(performUpdateViaLedger).not.toHaveBeenCalled()
+        expect(calculateWasteBalanceUpdates).toHaveBeenCalledTimes(1)
+        expect(saveBalance).toHaveBeenCalledTimes(1)
+      })
+
+      it('uses the v1 path when flag is ON and no balance exists yet', async () => {
+        const wasteRecords = [
+          {
+            id: 'rec-1',
+            organisationId: 'org-1',
+            data: {}
+          }
+        ]
+        const accreditation = { id: 'acc-1' }
+        const findBalance = vi.fn().mockResolvedValue(null)
+        const saveBalance = vi.fn().mockResolvedValue()
+        vi.mocked(performUpdateViaLedger).mockClear()
+        vi.mocked(calculateWasteBalanceUpdates).mockReturnValue({
+          newTransactions: [{ id: 't1' }],
+          newAmount: 100,
+          newAvailableAmount: 100
+        })
+
+        await performUpdateWasteBalanceTransactions({
+          wasteRecords,
+          accreditation,
+          dependencies: {
+            featureFlags: { isWasteBalanceLedgerEnabled: () => true },
+            ledgerRepository: { insertTransactions: vi.fn() }
+          },
+          findBalance,
+          saveBalance,
+          user: { id: 'user-1' },
+          overseasSites: ORS_VALIDATION_DISABLED
+        })
+
+        expect(performUpdateViaLedger).not.toHaveBeenCalled()
+        expect(saveBalance).toHaveBeenCalledTimes(1)
+        const savedBalance = vi.mocked(saveBalance).mock.calls[0][0]
+        expect(savedBalance.canonicalSource).toBe(
+          WASTE_BALANCE_CANONICAL_SOURCE.V1
+        )
       })
 
       it('uses the v1 embedded-array path when flag is OFF', async () => {

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -352,7 +352,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
     })
 
     describe('feature flag dispatch', () => {
-      it('routes to the ledger path when flag is ON and canonicalSource is v2', async () => {
+      it('routes to the ledger path when flag is ON and canonicalSource is ledger', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -370,7 +370,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           availableAmount: 0,
           transactions: [],
           version: 1,
-          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
         })
         const saveBalance = vi.fn()
         vi.mocked(performUpdateViaLedger).mockClear()
@@ -399,7 +399,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(findBalance).toHaveBeenCalledTimes(1)
       })
 
-      it('uses the v1 path when flag is ON but the existing balance has no marker (legacy doc)', async () => {
+      it('uses the embedded path when flag is ON but the existing balance has no marker (legacy doc)', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -442,7 +442,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(saveBalance).toHaveBeenCalledTimes(1)
       })
 
-      it('uses the v1 path when flag is ON but canonicalSource is still v1', async () => {
+      it('uses the embedded path when flag is ON but canonicalSource is still embedded', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -458,7 +458,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           availableAmount: 0,
           transactions: [],
           version: 1,
-          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
         }
         const findBalance = vi.fn().mockResolvedValue(wasteBalance)
         const saveBalance = vi.fn().mockResolvedValue()
@@ -487,7 +487,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(saveBalance).toHaveBeenCalledTimes(1)
       })
 
-      it('uses the v1 path when flag is ON and no balance exists yet', async () => {
+      it('uses the embedded path when flag is ON and no balance exists yet', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -522,11 +522,11 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(saveBalance).toHaveBeenCalledTimes(1)
         const savedBalance = vi.mocked(saveBalance).mock.calls[0][0]
         expect(savedBalance.canonicalSource).toBe(
-          WASTE_BALANCE_CANONICAL_SOURCE.V1
+          WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
         )
       })
 
-      it('uses the v1 embedded-array path when flag is OFF', async () => {
+      it('uses the embedded-array path when flag is OFF', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -22,11 +22,13 @@ export const findBalance = (wasteBalanceStorage) => async (id) => {
 /**
  * Save a waste balance.
  *
- * The persisted `canonicalSource` is the existing document's value, ignoring
- * whatever the caller supplies. Only `flipCanonicalSourceToLedger` is allowed
- * to mutate the marker; every other write path is `canonicalSource`-blind.
- * Inserts take the caller's value verbatim so the initial marker (`'embedded'`
- * for fresh balances) lands on the new doc.
+ * On update, both `canonicalSource` and `migratingSince` are taken from the
+ * existing document, ignoring whatever the caller supplies. The marker
+ * lifecycle is mutated solely by `flipCanonicalSourceToMigrating`,
+ * `flipCanonicalSourceToLedger`, and `resetCanonicalSourceToEmbedded`; every
+ * other write path is marker-blind. Inserts take the caller's
+ * `canonicalSource` verbatim so the initial marker (`'embedded'` for fresh
+ * balances) lands on the new doc.
  *
  * @param {import('../domain/model.js').WasteBalance[]} wasteBalanceStorage
  * @returns {(updatedBalance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>}
@@ -43,10 +45,16 @@ export const saveBalance =
     }
 
     const existing = wasteBalanceStorage[existingIndex]
-    wasteBalanceStorage[existingIndex] = {
+    const preserved = {
       ...updatedBalance,
       canonicalSource: existing.canonicalSource
     }
+    if (existing.migratingSince !== undefined) {
+      preserved.migratingSince = existing.migratingSince
+    } else {
+      delete preserved.migratingSince
+    }
+    wasteBalanceStorage[existingIndex] = preserved
   }
 
 /**
@@ -137,7 +145,7 @@ export const createInMemoryWasteBalancesRepository = (
         saveBalance: saveBalance(wasteBalanceStorage)
       })
     },
-    flipCanonicalSourceToLedger: async ({
+    flipCanonicalSourceToMigrating: async ({
       accreditationId,
       capturedVersion
     }) => {
@@ -152,7 +160,44 @@ export const createInMemoryWasteBalancesRepository = (
         current.version === capturedVersion &&
         current.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
       ) {
+        current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+        current.migratingSince = new Date().toISOString()
+      }
+      return { canonicalSource: current.canonicalSource }
+    },
+    flipCanonicalSourceToLedger: async ({
+      accreditationId,
+      capturedVersion
+    }) => {
+      const validatedAccreditationId = validateAccreditationId(accreditationId)
+      const current = wasteBalanceStorage.find(
+        (b) => b.accreditationId === validatedAccreditationId
+      )
+      if (!current) {
+        return null
+      }
+      if (
+        current.version === capturedVersion &&
+        current.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      ) {
         current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+        delete current.migratingSince
+      }
+      return { canonicalSource: current.canonicalSource }
+    },
+    resetCanonicalSourceToEmbedded: async ({ accreditationId }) => {
+      const validatedAccreditationId = validateAccreditationId(accreditationId)
+      const current = wasteBalanceStorage.find(
+        (b) => b.accreditationId === validatedAccreditationId
+      )
+      if (!current) {
+        return null
+      }
+      if (
+        current.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      ) {
+        current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+        delete current.migratingSince
       }
       return { canonicalSource: current.canonicalSource }
     },

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -49,10 +49,10 @@ export const saveBalance =
       ...updatedBalance,
       canonicalSource: existing.canonicalSource
     }
-    if (existing.migratingSince !== undefined) {
-      preserved.migratingSince = existing.migratingSince
-    } else {
+    if (existing.migratingSince === undefined) {
       delete preserved.migratingSince
+    } else {
+      preserved.migratingSince = existing.migratingSince
     }
     wasteBalanceStorage[existingIndex] = preserved
   }
@@ -81,6 +81,63 @@ const performFindByAccreditationIds =
     )
 
     return balances.map((balance) => structuredClone(balance))
+  }
+
+const performFlipCanonicalSourceToMigrating =
+  (wasteBalanceStorage) =>
+  async ({ accreditationId, capturedVersion }) => {
+    const validatedAccreditationId = validateAccreditationId(accreditationId)
+    const current = wasteBalanceStorage.find(
+      (b) => b.accreditationId === validatedAccreditationId
+    )
+    if (!current) {
+      return null
+    }
+    if (
+      current.version === capturedVersion &&
+      current.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+    ) {
+      current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      current.migratingSince = new Date().toISOString()
+    }
+    return { canonicalSource: current.canonicalSource }
+  }
+
+const performFlipCanonicalSourceToLedger =
+  (wasteBalanceStorage) =>
+  async ({ accreditationId, capturedVersion }) => {
+    const validatedAccreditationId = validateAccreditationId(accreditationId)
+    const current = wasteBalanceStorage.find(
+      (b) => b.accreditationId === validatedAccreditationId
+    )
+    if (!current) {
+      return null
+    }
+    if (
+      current.version === capturedVersion &&
+      current.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+    ) {
+      current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      delete current.migratingSince
+    }
+    return { canonicalSource: current.canonicalSource }
+  }
+
+const performResetCanonicalSourceToEmbedded =
+  (wasteBalanceStorage) =>
+  async ({ accreditationId }) => {
+    const validatedAccreditationId = validateAccreditationId(accreditationId)
+    const current = wasteBalanceStorage.find(
+      (b) => b.accreditationId === validatedAccreditationId
+    )
+    if (!current) {
+      return null
+    }
+    if (current.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING) {
+      current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      delete current.migratingSince
+    }
+    return { canonicalSource: current.canonicalSource }
   }
 
 /**
@@ -145,62 +202,12 @@ export const createInMemoryWasteBalancesRepository = (
         saveBalance: saveBalance(wasteBalanceStorage)
       })
     },
-    flipCanonicalSourceToMigrating: async ({
-      accreditationId,
-      capturedVersion
-    }) => {
-      const validatedAccreditationId = validateAccreditationId(accreditationId)
-      const current = wasteBalanceStorage.find(
-        (b) => b.accreditationId === validatedAccreditationId
-      )
-      if (!current) {
-        return null
-      }
-      if (
-        current.version === capturedVersion &&
-        current.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
-      ) {
-        current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
-        current.migratingSince = new Date().toISOString()
-      }
-      return { canonicalSource: current.canonicalSource }
-    },
-    flipCanonicalSourceToLedger: async ({
-      accreditationId,
-      capturedVersion
-    }) => {
-      const validatedAccreditationId = validateAccreditationId(accreditationId)
-      const current = wasteBalanceStorage.find(
-        (b) => b.accreditationId === validatedAccreditationId
-      )
-      if (!current) {
-        return null
-      }
-      if (
-        current.version === capturedVersion &&
-        current.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
-      ) {
-        current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
-        delete current.migratingSince
-      }
-      return { canonicalSource: current.canonicalSource }
-    },
-    resetCanonicalSourceToEmbedded: async ({ accreditationId }) => {
-      const validatedAccreditationId = validateAccreditationId(accreditationId)
-      const current = wasteBalanceStorage.find(
-        (b) => b.accreditationId === validatedAccreditationId
-      )
-      if (!current) {
-        return null
-      }
-      if (
-        current.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
-      ) {
-        current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
-        delete current.migratingSince
-      }
-      return { canonicalSource: current.canonicalSource }
-    },
+    flipCanonicalSourceToMigrating:
+      performFlipCanonicalSourceToMigrating(wasteBalanceStorage),
+    flipCanonicalSourceToLedger:
+      performFlipCanonicalSourceToLedger(wasteBalanceStorage),
+    resetCanonicalSourceToEmbedded:
+      performResetCanonicalSourceToEmbedded(wasteBalanceStorage),
     // Test-only method to access internal storage
     _getStorageForTesting: () => wasteBalanceStorage
   })

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -33,8 +33,13 @@ export const saveBalance =
 
     if (existingIndex === -1) {
       wasteBalanceStorage.push(updatedBalance)
-    } else {
-      wasteBalanceStorage[existingIndex] = updatedBalance
+      return
+    }
+
+    const existing = wasteBalanceStorage[existingIndex]
+    wasteBalanceStorage[existingIndex] = {
+      ...updatedBalance,
+      canonicalSource: existing.canonicalSource
     }
   }
 
@@ -129,7 +134,9 @@ export const createInMemoryWasteBalancesRepository = (
     flipCanonicalSourceToV2: async ({ accreditationId, capturedVersion }) => {
       const balance = wasteBalanceStorage.find(
         (b) =>
-          b.accreditationId === accreditationId && b.version === capturedVersion
+          b.accreditationId === accreditationId &&
+          b.version === capturedVersion &&
+          b.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.V1
       )
       if (!balance) {
         return { flipped: false }

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -1,4 +1,5 @@
 import { validateAccreditationId } from './validation.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
 import {
   performUpdateWasteBalanceTransactions,
   performDeductAvailableBalanceForPrnCreation,
@@ -124,6 +125,17 @@ export const createInMemoryWasteBalancesRepository = (
         findBalance: findBalance(wasteBalanceStorage),
         saveBalance: saveBalance(wasteBalanceStorage)
       })
+    },
+    flipCanonicalSourceToV2: async ({ accreditationId, capturedVersion }) => {
+      const balance = wasteBalanceStorage.find(
+        (b) =>
+          b.accreditationId === accreditationId && b.version === capturedVersion
+      )
+      if (!balance) {
+        return { flipped: false }
+      }
+      balance.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.V2
+      return { flipped: true }
     },
     // Test-only method to access internal storage
     _getStorageForTesting: () => wasteBalanceStorage

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -22,6 +22,12 @@ export const findBalance = (wasteBalanceStorage) => async (id) => {
 /**
  * Save a waste balance.
  *
+ * The persisted `canonicalSource` is the existing document's value, ignoring
+ * whatever the caller supplies. Only `flipCanonicalSourceToLedger` is allowed
+ * to mutate the marker; every other write path is `canonicalSource`-blind.
+ * Inserts take the caller's value verbatim so the initial marker (`'embedded'`
+ * for fresh balances) lands on the new doc.
+ *
  * @param {import('../domain/model.js').WasteBalance[]} wasteBalanceStorage
  * @returns {(updatedBalance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>}
  */
@@ -131,18 +137,24 @@ export const createInMemoryWasteBalancesRepository = (
         saveBalance: saveBalance(wasteBalanceStorage)
       })
     },
-    flipCanonicalSourceToV2: async ({ accreditationId, capturedVersion }) => {
-      const balance = wasteBalanceStorage.find(
-        (b) =>
-          b.accreditationId === accreditationId &&
-          b.version === capturedVersion &&
-          b.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.V1
+    flipCanonicalSourceToLedger: async ({
+      accreditationId,
+      capturedVersion
+    }) => {
+      const validatedAccreditationId = validateAccreditationId(accreditationId)
+      const current = wasteBalanceStorage.find(
+        (b) => b.accreditationId === validatedAccreditationId
       )
-      if (!balance) {
-        return { flipped: false }
+      if (!current) {
+        return null
       }
-      balance.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.V2
-      return { flipped: true }
+      if (
+        current.version === capturedVersion &&
+        current.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      ) {
+        current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      }
+      return { canonicalSource: current.canonicalSource }
     },
     // Test-only method to access internal storage
     _getStorageForTesting: () => wasteBalanceStorage

--- a/src/waste-balances/repository/ledger-contract/deleteAllForAccreditationId.contract.js
+++ b/src/waste-balances/repository/ledger-contract/deleteAllForAccreditationId.contract.js
@@ -1,0 +1,77 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { buildLedgerTransaction } from '../ledger-test-data.js'
+
+export const testDeleteAllForAccreditationIdBehaviour = (it) => {
+  describe('deleteAllForAccreditationId', () => {
+    let repository
+
+    beforeEach(async ({ ledgerRepository }) => {
+      repository = await ledgerRepository()
+    })
+
+    it('removes every transaction belonging to the given accreditation', async () => {
+      await repository.insertTransactions([
+        buildLedgerTransaction({ accreditationId: 'acc-target', number: 1 }),
+        buildLedgerTransaction({ accreditationId: 'acc-target', number: 2 }),
+        buildLedgerTransaction({ accreditationId: 'acc-target', number: 3 })
+      ])
+
+      await repository.deleteAllForAccreditationId('acc-target')
+
+      const remaining =
+        await repository.findLatestByAccreditationId('acc-target')
+      expect(remaining).toBeNull()
+    })
+
+    it('leaves transactions for other accreditations untouched', async () => {
+      await repository.insertTransactions([
+        buildLedgerTransaction({ accreditationId: 'acc-target', number: 1 }),
+        buildLedgerTransaction({ accreditationId: 'acc-other', number: 1 }),
+        buildLedgerTransaction({ accreditationId: 'acc-other', number: 2 })
+      ])
+
+      await repository.deleteAllForAccreditationId('acc-target')
+
+      const survivor = await repository.findLatestByAccreditationId('acc-other')
+      expect(survivor).not.toBeNull()
+      expect(survivor.number).toBe(2)
+    })
+
+    it('is a no-op when no transactions exist for the accreditation', async () => {
+      await expect(
+        repository.deleteAllForAccreditationId('acc-empty')
+      ).resolves.toBeUndefined()
+    })
+
+    it('is idempotent — repeated calls are safe and remain a no-op', async () => {
+      await repository.insertTransactions([
+        buildLedgerTransaction({ accreditationId: 'acc-twice', number: 1 })
+      ])
+
+      await repository.deleteAllForAccreditationId('acc-twice')
+      await expect(
+        repository.deleteAllForAccreditationId('acc-twice')
+      ).resolves.toBeUndefined()
+
+      const remaining =
+        await repository.findLatestByAccreditationId('acc-twice')
+      expect(remaining).toBeNull()
+    })
+
+    it('clears the slot so subsequent inserts can reuse low numbers', async () => {
+      await repository.insertTransactions([
+        buildLedgerTransaction({ accreditationId: 'acc-reuse', number: 1 }),
+        buildLedgerTransaction({ accreditationId: 'acc-reuse', number: 2 })
+      ])
+
+      await repository.deleteAllForAccreditationId('acc-reuse')
+
+      await expect(
+        repository.insertTransactions([
+          buildLedgerTransaction({ accreditationId: 'acc-reuse', number: 1 })
+        ])
+      ).resolves.toBeDefined()
+    })
+  })
+}

--- a/src/waste-balances/repository/ledger-inmemory.js
+++ b/src/waste-balances/repository/ledger-inmemory.js
@@ -89,11 +89,6 @@ export const createInMemoryLedgerRepository = (initialTransactions = []) => {
 
       return structuredClone(latest)
     },
-    /**
-     * @param {string} accreditationId
-     * @param {Array<{ type: string, rowId: string }>} wasteRecords
-     * @returns {Promise<import('./ledger-port.js').CreditedAmountLookup>}
-     */
     /** @param {string} accreditationId */
     deleteAllForAccreditationId: async (accreditationId) => {
       for (let index = storage.length - 1; index >= 0; index -= 1) {
@@ -102,6 +97,11 @@ export const createInMemoryLedgerRepository = (initialTransactions = []) => {
         }
       }
     },
+    /**
+     * @param {string} accreditationId
+     * @param {Array<{ type: string, rowId: string }>} wasteRecords
+     * @returns {Promise<import('./ledger-port.js').CreditedAmountLookup>}
+     */
     findLatestCreditedAmountsByWasteRecords: async (
       accreditationId,
       wasteRecords

--- a/src/waste-balances/repository/ledger-inmemory.js
+++ b/src/waste-balances/repository/ledger-inmemory.js
@@ -94,6 +94,14 @@ export const createInMemoryLedgerRepository = (initialTransactions = []) => {
      * @param {Array<{ type: string, rowId: string }>} wasteRecords
      * @returns {Promise<import('./ledger-port.js').CreditedAmountLookup>}
      */
+    /** @param {string} accreditationId */
+    deleteAllForAccreditationId: async (accreditationId) => {
+      for (let index = storage.length - 1; index >= 0; index -= 1) {
+        if (storage[index].accreditationId === accreditationId) {
+          storage.splice(index, 1)
+        }
+      }
+    },
     findLatestCreditedAmountsByWasteRecords: async (
       accreditationId,
       wasteRecords

--- a/src/waste-balances/repository/ledger-mongodb.js
+++ b/src/waste-balances/repository/ledger-mongodb.js
@@ -189,6 +189,15 @@ const performFindLatestCreditedAmountsByWasteRecords =
   }
 
 /**
+ * @param {Collection} collection
+ * @returns {(accreditationId: string) => Promise<void>}
+ */
+const performDeleteAllForAccreditationId =
+  (collection) => async (accreditationId) => {
+    await collection.deleteMany({ accreditationId })
+  }
+
+/**
  * Creates a MongoDB-backed ledger repository.
  *
  * @param {Db} db
@@ -201,6 +210,7 @@ export const createMongoLedgerRepository = async (db) => {
     insertTransactions: performInsertTransactions(collection),
     findLatestByAccreditationId: performFindLatestByAccreditationId(collection),
     findLatestCreditedAmountsByWasteRecords:
-      performFindLatestCreditedAmountsByWasteRecords(collection)
+      performFindLatestCreditedAmountsByWasteRecords(collection),
+    deleteAllForAccreditationId: performDeleteAllForAccreditationId(collection)
   })
 }

--- a/src/waste-balances/repository/ledger-port.contract.js
+++ b/src/waste-balances/repository/ledger-port.contract.js
@@ -1,9 +1,11 @@
 import { testInsertTransactionsBehaviour } from './ledger-contract/insertTransactions.contract.js'
 import { testFindLatestByAccreditationIdBehaviour } from './ledger-contract/findLatestByAccreditationId.contract.js'
 import { testFindLatestCreditedAmountsByWasteRecordsBehaviour } from './ledger-contract/findLatestCreditedAmountsByWasteRecords.contract.js'
+import { testDeleteAllForAccreditationIdBehaviour } from './ledger-contract/deleteAllForAccreditationId.contract.js'
 
 export const testLedgerRepositoryContract = (it) => {
   testInsertTransactionsBehaviour(it)
   testFindLatestByAccreditationIdBehaviour(it)
   testFindLatestCreditedAmountsByWasteRecordsBehaviour(it)
+  testDeleteAllForAccreditationIdBehaviour(it)
 }

--- a/src/waste-balances/repository/ledger-port.js
+++ b/src/waste-balances/repository/ledger-port.js
@@ -90,6 +90,11 @@ export class LedgerSlotConflictError extends Error {
  *   reconciliation invariant on the ledger write path: a re-upload of
  *   identical data converges to zero new transactions because every row's
  *   target amount equals its already-credited amount.
+ * @property {(accreditationId: string) => Promise<void>} deleteAllForAccreditationId
+ *   Remove every ledger transaction belonging to the accreditation. Idempotent
+ *   — resolves cleanly when no transactions exist. Used as the first step of a
+ *   per-accreditation rebuild to clear residue from any prior interrupted
+ *   attempt before replaying authoritative history.
  */
 
 /**

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -55,7 +55,7 @@ const performFindByAccreditationIds = (db) => async (accreditationIds) => {
   })
 }
 
-const performFlipCanonicalSourceToLedger =
+const performFlipCanonicalSourceToMigrating =
   (db) =>
   async ({ accreditationId, capturedVersion }) => {
     const validatedAccreditationId = validateAccreditationId(accreditationId)
@@ -66,7 +66,71 @@ const performFlipCanonicalSourceToLedger =
         version: capturedVersion,
         canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
       },
-      { $set: { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER } },
+      {
+        $set: {
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+          migratingSince: new Date().toISOString()
+        }
+      },
+      { returnDocument: 'after' }
+    )
+    if (updated) {
+      return { canonicalSource: updated.canonicalSource }
+    }
+    const current = await collection.findOne(
+      { accreditationId: validatedAccreditationId },
+      { projection: { canonicalSource: 1 } }
+    )
+    if (!current) {
+      return null
+    }
+    return { canonicalSource: current.canonicalSource }
+  }
+
+const performFlipCanonicalSourceToLedger =
+  (db) =>
+  async ({ accreditationId, capturedVersion }) => {
+    const validatedAccreditationId = validateAccreditationId(accreditationId)
+    const collection = db.collection(WASTE_BALANCE_COLLECTION_NAME)
+    const updated = await collection.findOneAndUpdate(
+      {
+        accreditationId: validatedAccreditationId,
+        version: capturedVersion,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      },
+      {
+        $set: { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER },
+        $unset: { migratingSince: '' }
+      },
+      { returnDocument: 'after' }
+    )
+    if (updated) {
+      return { canonicalSource: updated.canonicalSource }
+    }
+    const current = await collection.findOne(
+      { accreditationId: validatedAccreditationId },
+      { projection: { canonicalSource: 1 } }
+    )
+    if (!current) {
+      return null
+    }
+    return { canonicalSource: current.canonicalSource }
+  }
+
+const performResetCanonicalSourceToEmbedded =
+  (db) =>
+  async ({ accreditationId }) => {
+    const validatedAccreditationId = validateAccreditationId(accreditationId)
+    const collection = db.collection(WASTE_BALANCE_COLLECTION_NAME)
+    const updated = await collection.findOneAndUpdate(
+      {
+        accreditationId: validatedAccreditationId,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      },
+      {
+        $set: { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED },
+        $unset: { migratingSince: '' }
+      },
       { returnDocument: 'after' }
     )
     if (updated) {
@@ -107,8 +171,11 @@ export const findBalance = (db) => async (id) => {
  * Save a waste balance.
  *
  * The persisted `canonicalSource` is set only on insert via `$setOnInsert` and
- * never on update. Only `flipCanonicalSourceToLedger` is allowed to mutate the
- * marker; every other write path is `canonicalSource`-blind.
+ * never on update. The marker is mutated solely by the dedicated lifecycle
+ * primitives — `flipCanonicalSourceToMigrating`, `flipCanonicalSourceToLedger`,
+ * and `resetCanonicalSourceToEmbedded` — which also own `migratingSince`. Every
+ * other write path is `canonicalSource`-blind and never touches
+ * `migratingSince`.
  *
  * @param {import('mongodb').Db} db
  * @returns {(updatedBalance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>}
@@ -194,6 +261,8 @@ export const createWasteBalancesRepository = async (db, dependencies = {}) => {
         saveBalance: saveBalance(db)
       })
     },
-    flipCanonicalSourceToLedger: performFlipCanonicalSourceToLedger(db)
+    flipCanonicalSourceToMigrating: performFlipCanonicalSourceToMigrating(db),
+    flipCanonicalSourceToLedger: performFlipCanonicalSourceToLedger(db),
+    resetCanonicalSourceToEmbedded: performResetCanonicalSourceToEmbedded(db)
   })
 }

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -79,6 +79,10 @@ export const findBalance = (db) => async (id) => {
 /**
  * Save a waste balance.
  *
+ * The persisted `canonicalSource` is set only on insert via `$setOnInsert` and
+ * never on update. Only `flipCanonicalSourceToLedger` is allowed to mutate the
+ * marker; every other write path is `canonicalSource`-blind.
+ *
  * @param {import('mongodb').Db} db
  * @returns {(updatedBalance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>}
  */
@@ -163,18 +167,32 @@ export const createWasteBalancesRepository = async (db, dependencies = {}) => {
         saveBalance: saveBalance(db)
       })
     },
-    flipCanonicalSourceToV2: async ({ accreditationId, capturedVersion }) => {
-      const result = await db
-        .collection(WASTE_BALANCE_COLLECTION_NAME)
-        .updateOne(
-          {
-            accreditationId,
-            version: capturedVersion,
-            canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
-          },
-          { $set: { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2 } }
-        )
-      return { flipped: result.matchedCount === 1 }
+    flipCanonicalSourceToLedger: async ({
+      accreditationId,
+      capturedVersion
+    }) => {
+      const validatedAccreditationId = validateAccreditationId(accreditationId)
+      const collection = db.collection(WASTE_BALANCE_COLLECTION_NAME)
+      const updated = await collection.findOneAndUpdate(
+        {
+          accreditationId: validatedAccreditationId,
+          version: capturedVersion,
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+        },
+        { $set: { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER } },
+        { returnDocument: 'after' }
+      )
+      if (updated) {
+        return { canonicalSource: updated.canonicalSource }
+      }
+      const current = await collection.findOne(
+        { accreditationId: validatedAccreditationId },
+        { projection: { canonicalSource: 1 } }
+      )
+      if (!current) {
+        return null
+      }
+      return { canonicalSource: current.canonicalSource }
     }
   })
 }

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -167,7 +167,11 @@ export const createWasteBalancesRepository = async (db, dependencies = {}) => {
       const result = await db
         .collection(WASTE_BALANCE_COLLECTION_NAME)
         .updateOne(
-          { accreditationId, version: capturedVersion },
+          {
+            accreditationId,
+            version: capturedVersion,
+            canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V1
+          },
           { $set: { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2 } }
         )
       return { flipped: result.matchedCount === 1 }

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -55,6 +55,33 @@ const performFindByAccreditationIds = (db) => async (accreditationIds) => {
   })
 }
 
+const performFlipCanonicalSourceToLedger =
+  (db) =>
+  async ({ accreditationId, capturedVersion }) => {
+    const validatedAccreditationId = validateAccreditationId(accreditationId)
+    const collection = db.collection(WASTE_BALANCE_COLLECTION_NAME)
+    const updated = await collection.findOneAndUpdate(
+      {
+        accreditationId: validatedAccreditationId,
+        version: capturedVersion,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      },
+      { $set: { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER } },
+      { returnDocument: 'after' }
+    )
+    if (updated) {
+      return { canonicalSource: updated.canonicalSource }
+    }
+    const current = await collection.findOne(
+      { accreditationId: validatedAccreditationId },
+      { projection: { canonicalSource: 1 } }
+    )
+    if (!current) {
+      return null
+    }
+    return { canonicalSource: current.canonicalSource }
+  }
+
 /**
  * Find a waste balance by accreditation ID.
  *
@@ -167,32 +194,6 @@ export const createWasteBalancesRepository = async (db, dependencies = {}) => {
         saveBalance: saveBalance(db)
       })
     },
-    flipCanonicalSourceToLedger: async ({
-      accreditationId,
-      capturedVersion
-    }) => {
-      const validatedAccreditationId = validateAccreditationId(accreditationId)
-      const collection = db.collection(WASTE_BALANCE_COLLECTION_NAME)
-      const updated = await collection.findOneAndUpdate(
-        {
-          accreditationId: validatedAccreditationId,
-          version: capturedVersion,
-          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
-        },
-        { $set: { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER } },
-        { returnDocument: 'after' }
-      )
-      if (updated) {
-        return { canonicalSource: updated.canonicalSource }
-      }
-      const current = await collection.findOne(
-        { accreditationId: validatedAccreditationId },
-        { projection: { canonicalSource: 1 } }
-      )
-      if (!current) {
-        return null
-      }
-      return { canonicalSource: current.canonicalSource }
-    }
+    flipCanonicalSourceToLedger: performFlipCanonicalSourceToLedger(db)
   })
 }

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -1,4 +1,5 @@
 import { validateAccreditationId } from './validation.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
 import {
   performUpdateWasteBalanceTransactions,
   performDeductAvailableBalanceForPrnCreation,
@@ -96,7 +97,8 @@ export const saveBalance = (db) => async (updatedBalance, newTransactions) => {
       },
       $setOnInsert: {
         _id: updatedBalance.id,
-        organisationId: updatedBalance.organisationId
+        organisationId: updatedBalance.organisationId,
+        canonicalSource: updatedBalance.canonicalSource
       }
     }),
     { upsert: true }
@@ -160,6 +162,15 @@ export const createWasteBalancesRepository = async (db, dependencies = {}) => {
         findBalance: findBalance(db),
         saveBalance: saveBalance(db)
       })
+    },
+    flipCanonicalSourceToV2: async ({ accreditationId, capturedVersion }) => {
+      const result = await db
+        .collection(WASTE_BALANCE_COLLECTION_NAME)
+        .updateOne(
+          { accreditationId, version: capturedVersion },
+          { $set: { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.V2 } }
+        )
+      return { flipped: result.matchedCount === 1 }
     }
   })
 }

--- a/src/waste-balances/repository/port.contract.js
+++ b/src/waste-balances/repository/port.contract.js
@@ -5,7 +5,7 @@ import { testDeductAvailableBalanceForPrnCreationBehaviour } from './contract/de
 import { testDeductTotalBalanceForPrnIssueBehaviour } from './contract/deductTotalBalanceForPrnIssue.contract.js'
 import { testCreditAvailableBalanceForPrnCancellationBehaviour } from './contract/creditAvailableBalanceForPrnCancellation.contract.js'
 import { testCreditFullBalanceForIssuedPrnCancellationBehaviour } from './contract/creditFullBalanceForIssuedPrnCancellation.contract.js'
-import { testFlipCanonicalSourceToV2Behaviour } from './contract/flipCanonicalSourceToV2.contract.js'
+import { testFlipCanonicalSourceToLedgerBehaviour } from './contract/flipCanonicalSourceToLedger.contract.js'
 
 export const testWasteBalancesRepositoryContract = (repositoryFactory) => {
   testFindByAccreditationIdBehaviour(repositoryFactory)
@@ -15,5 +15,5 @@ export const testWasteBalancesRepositoryContract = (repositoryFactory) => {
   testDeductTotalBalanceForPrnIssueBehaviour(repositoryFactory)
   testCreditAvailableBalanceForPrnCancellationBehaviour(repositoryFactory)
   testCreditFullBalanceForIssuedPrnCancellationBehaviour(repositoryFactory)
-  testFlipCanonicalSourceToV2Behaviour(repositoryFactory)
+  testFlipCanonicalSourceToLedgerBehaviour(repositoryFactory)
 }

--- a/src/waste-balances/repository/port.contract.js
+++ b/src/waste-balances/repository/port.contract.js
@@ -5,6 +5,7 @@ import { testDeductAvailableBalanceForPrnCreationBehaviour } from './contract/de
 import { testDeductTotalBalanceForPrnIssueBehaviour } from './contract/deductTotalBalanceForPrnIssue.contract.js'
 import { testCreditAvailableBalanceForPrnCancellationBehaviour } from './contract/creditAvailableBalanceForPrnCancellation.contract.js'
 import { testCreditFullBalanceForIssuedPrnCancellationBehaviour } from './contract/creditFullBalanceForIssuedPrnCancellation.contract.js'
+import { testFlipCanonicalSourceToV2Behaviour } from './contract/flipCanonicalSourceToV2.contract.js'
 
 export const testWasteBalancesRepositoryContract = (repositoryFactory) => {
   testFindByAccreditationIdBehaviour(repositoryFactory)
@@ -14,4 +15,5 @@ export const testWasteBalancesRepositoryContract = (repositoryFactory) => {
   testDeductTotalBalanceForPrnIssueBehaviour(repositoryFactory)
   testCreditAvailableBalanceForPrnCancellationBehaviour(repositoryFactory)
   testCreditFullBalanceForIssuedPrnCancellationBehaviour(repositoryFactory)
+  testFlipCanonicalSourceToV2Behaviour(repositoryFactory)
 }

--- a/src/waste-balances/repository/port.contract.js
+++ b/src/waste-balances/repository/port.contract.js
@@ -5,7 +5,9 @@ import { testDeductAvailableBalanceForPrnCreationBehaviour } from './contract/de
 import { testDeductTotalBalanceForPrnIssueBehaviour } from './contract/deductTotalBalanceForPrnIssue.contract.js'
 import { testCreditAvailableBalanceForPrnCancellationBehaviour } from './contract/creditAvailableBalanceForPrnCancellation.contract.js'
 import { testCreditFullBalanceForIssuedPrnCancellationBehaviour } from './contract/creditFullBalanceForIssuedPrnCancellation.contract.js'
+import { testFlipCanonicalSourceToMigratingBehaviour } from './contract/flipCanonicalSourceToMigrating.contract.js'
 import { testFlipCanonicalSourceToLedgerBehaviour } from './contract/flipCanonicalSourceToLedger.contract.js'
+import { testResetCanonicalSourceToEmbeddedBehaviour } from './contract/resetCanonicalSourceToEmbedded.contract.js'
 
 export const testWasteBalancesRepositoryContract = (repositoryFactory) => {
   testFindByAccreditationIdBehaviour(repositoryFactory)
@@ -15,5 +17,7 @@ export const testWasteBalancesRepositoryContract = (repositoryFactory) => {
   testDeductTotalBalanceForPrnIssueBehaviour(repositoryFactory)
   testCreditAvailableBalanceForPrnCancellationBehaviour(repositoryFactory)
   testCreditFullBalanceForIssuedPrnCancellationBehaviour(repositoryFactory)
+  testFlipCanonicalSourceToMigratingBehaviour(repositoryFactory)
   testFlipCanonicalSourceToLedgerBehaviour(repositoryFactory)
+  testResetCanonicalSourceToEmbeddedBehaviour(repositoryFactory)
 }

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -35,7 +35,7 @@
  */
 
 /**
- * @typedef {Object} FlipCanonicalSourceToLedgerParams
+ * @typedef {Object} FlipCanonicalSourceToMigratingParams
  * @property {string} accreditationId
  * @property {number} capturedVersion - The `version` observed on the embedded
  *   doc at the start of a per-accreditation rebuild. The flip only succeeds
@@ -45,13 +45,58 @@
  */
 
 /**
+ * @typedef {{ canonicalSource: import('../domain/model.js').WasteBalanceCanonicalSource } | null} FlipCanonicalSourceToMigratingResult
+ *   Post-state of the accreditation's balance document. The result mirrors the
+ *   persisted vocabulary so callers can distinguish:
+ *
+ *   - `{ canonicalSource: 'migrating' }` — either this call promoted an
+ *     `'embedded'` doc to `'migrating'`, or the doc was already `'migrating'`.
+ *   - `{ canonicalSource: 'embedded' }` — the flip did not land; a concurrent
+ *     write bumped `version` between capture and flip and the marker stays put.
+ *   - `{ canonicalSource: 'ledger' }` — the doc is already on the ledger and
+ *     never demotes; the flip is a no-op.
+ *   - `null` — no balance document exists for this accreditation.
+ */
+
+/**
+ * @typedef {Object} FlipCanonicalSourceToLedgerParams
+ * @property {string} accreditationId
+ * @property {number} capturedVersion - The `version` observed on the
+ *   `'migrating'` doc at the start of step 3 of a per-accreditation rebuild
+ *   (after authoritative history has been replayed into the ledger). The flip
+ *   only succeeds when the live document's `version` still matches; any
+ *   concurrent PRN write that landed during the replay bumps `version`, the
+ *   filter no-ops, and the marker stays `'migrating'` so the rebuild can retry.
+ */
+
+/**
  * @typedef {{ canonicalSource: import('../domain/model.js').WasteBalanceCanonicalSource } | null} FlipCanonicalSourceToLedgerResult
  *   Post-state of the accreditation's balance document.
  *
  *   - `{ canonicalSource: 'ledger' }` — the doc is on the ledger now (this call
  *     promoted it, or a prior call already did).
- *   - `{ canonicalSource: 'embedded' }` — the flip did not land; a concurrent
+ *   - `{ canonicalSource: 'migrating' }` — the flip did not land; a concurrent
  *     write bumped `version` between capture and flip and the marker stays put.
+ *   - `{ canonicalSource: 'embedded' }` — caller invoked the flip before the
+ *     embedded → migrating step, or after a stuck-marker reset; embedded never
+ *     promotes directly to ledger.
+ *   - `null` — no balance document exists for this accreditation.
+ */
+
+/**
+ * @typedef {Object} ResetCanonicalSourceToEmbeddedParams
+ * @property {string} accreditationId
+ */
+
+/**
+ * @typedef {{ canonicalSource: import('../domain/model.js').WasteBalanceCanonicalSource } | null} ResetCanonicalSourceToEmbeddedResult
+ *   Post-state of the accreditation's balance document.
+ *
+ *   - `{ canonicalSource: 'embedded' }` — either this call reset a stuck
+ *     `'migrating'` doc, or the doc was already `'embedded'`. `migratingSince`
+ *     is cleared.
+ *   - `{ canonicalSource: 'ledger' }` — the doc is on the ledger and never
+ *     demotes; the reset is a no-op.
  *   - `null` — no balance document exists for this accreditation.
  */
 
@@ -64,20 +109,31 @@
  * @property {(params: DeductTotalBalanceParams) => Promise<void>} deductTotalBalanceForPrnIssue
  * @property {(params: CreditAvailableBalanceParams) => Promise<void>} creditAvailableBalanceForPrnCancellation
  * @property {(params: CreditFullBalanceParams) => Promise<void>} creditFullBalanceForIssuedPrnCancellation
+ * @property {(params: FlipCanonicalSourceToMigratingParams) => Promise<FlipCanonicalSourceToMigratingResult>} flipCanonicalSourceToMigrating
+ *   Promote an `'embedded'` accreditation to `'migrating'` and stamp
+ *   `migratingSince`, gated on `version` matching the captured value. The
+ *   filter is `{ accreditationId, version: capturedVersion, canonicalSource:
+ *   'embedded' }` so the call strictly promotes — `'migrating'` and `'ledger'`
+ *   are never demoted. Used as step 1 of a per-accreditation rebuild: while the
+ *   marker is `'migrating'`, summary-log submissions for the registration are
+ *   409-excluded by `transitionToSubmittingExclusive` so the rebuild has a
+ *   stable cross-collection window to replay authoritative history into the
+ *   ledger.
  * @property {(params: FlipCanonicalSourceToLedgerParams) => Promise<FlipCanonicalSourceToLedgerResult>} flipCanonicalSourceToLedger
- *   Promote an `'embedded'` accreditation to `'ledger'`, gated on `version`
- *   matching the captured value. The filter is `{ accreditationId, version:
- *   capturedVersion, canonicalSource: 'embedded' }` so the call strictly
- *   promotes — never demotes. Returns the post-state, mirroring the persisted
- *   marker vocabulary, so callers can distinguish the four outcomes:
- *
- *   - filter matched and the marker just flipped → `{ canonicalSource: 'ledger' }`
- *   - already on the ledger when called → `{ canonicalSource: 'ledger' }`
- *   - concurrent embedded write bumped `version` → `{ canonicalSource: 'embedded' }`
- *   - no balance document for this accreditation → `null`
- *
- *   Used as the final step of a per-accreditation rebuild after authoritative
- *   history has been replayed into the ledger.
+ *   Promote a `'migrating'` accreditation to `'ledger'` and clear
+ *   `migratingSince`, gated on `version` matching the captured value. The
+ *   filter is `{ accreditationId, version: capturedVersion, canonicalSource:
+ *   'migrating' }` so the call strictly promotes — `'embedded'` is never
+ *   short-circuited and `'ledger'` never demotes. Used as the final step of a
+ *   per-accreditation rebuild after authoritative history has been replayed
+ *   into the ledger.
+ * @property {(params: ResetCanonicalSourceToEmbeddedParams) => Promise<ResetCanonicalSourceToEmbeddedResult>} resetCanonicalSourceToEmbedded
+ *   Unconditionally reset a `'migrating'` accreditation back to `'embedded'`
+ *   and clear `migratingSince`. Used by the sweep runner's startup pass to
+ *   recover documents stuck in `'migrating'` past the recovery threshold —
+ *   the rebuild process died between the two flips and submissions for the
+ *   registration are blocked until the marker is reset. Strictly demotes:
+ *   `'embedded'` is left as-is and `'ledger'` is never demoted.
  */
 
 /**

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -35,6 +35,23 @@
  */
 
 /**
+ * @typedef {Object} FlipCanonicalSourceToV2Params
+ * @property {string} accreditationId
+ * @property {number} capturedVersion - The `version` observed on the v1 doc at
+ *   the start of a per-accreditation rebuild. The flip only succeeds when the
+ *   live document's `version` still matches; any concurrent v1 write between
+ *   capture and flip bumps `version`, the filter no-ops, and the marker stays
+ *   `'v1'`.
+ */
+
+/**
+ * @typedef {Object} FlipCanonicalSourceToV2Result
+ * @property {boolean} flipped - `true` when the document was updated; `false`
+ *   when no document matched (either no balance exists or the captured version
+ *   is stale).
+ */
+
+/**
  * @typedef {Object} WasteBalancesRepository
  * @property {(accreditationId: string) => Promise<import('../domain/model.js').WasteBalance | null>} findByAccreditationId
  * @property {(accreditationIds: string[]) => Promise<import('../domain/model.js').WasteBalance[]>} findByAccreditationIds
@@ -43,6 +60,12 @@
  * @property {(params: DeductTotalBalanceParams) => Promise<void>} deductTotalBalanceForPrnIssue
  * @property {(params: CreditAvailableBalanceParams) => Promise<void>} creditAvailableBalanceForPrnCancellation
  * @property {(params: CreditFullBalanceParams) => Promise<void>} creditFullBalanceForIssuedPrnCancellation
+ * @property {(params: FlipCanonicalSourceToV2Params) => Promise<FlipCanonicalSourceToV2Result>} flipCanonicalSourceToV2
+ *   Atomically set `canonicalSource` to `'v2'` for an accreditation, gated on
+ *   `version` matching the captured value. Used as the final step of a
+ *   per-accreditation rebuild after authoritative history has been replayed
+ *   into the ledger; the version filter ensures concurrent v1 writes abort
+ *   the flip rather than corrupting the marker.
  */
 
 /**

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -61,11 +61,13 @@
  * @property {(params: CreditAvailableBalanceParams) => Promise<void>} creditAvailableBalanceForPrnCancellation
  * @property {(params: CreditFullBalanceParams) => Promise<void>} creditFullBalanceForIssuedPrnCancellation
  * @property {(params: FlipCanonicalSourceToV2Params) => Promise<FlipCanonicalSourceToV2Result>} flipCanonicalSourceToV2
- *   Atomically set `canonicalSource` to `'v2'` for an accreditation, gated on
- *   `version` matching the captured value. Used as the final step of a
- *   per-accreditation rebuild after authoritative history has been replayed
- *   into the ledger; the version filter ensures concurrent v1 writes abort
- *   the flip rather than corrupting the marker.
+ *   Promote a `'v1'` accreditation to `'v2'`, gated on `version` matching the
+ *   captured value. The filter is `{ accreditationId, version: capturedVersion,
+ *   canonicalSource: 'v1' }` so the call strictly promotes — already-`'v2'`
+ *   documents return `{ flipped: false }` and a concurrent v1 write that
+ *   bumped `version` between capture and flip also returns `{ flipped: false }`.
+ *   Used as the final step of a per-accreditation rebuild after authoritative
+ *   history has been replayed into the ledger.
  */
 
 /**

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -35,20 +35,24 @@
  */
 
 /**
- * @typedef {Object} FlipCanonicalSourceToV2Params
+ * @typedef {Object} FlipCanonicalSourceToLedgerParams
  * @property {string} accreditationId
- * @property {number} capturedVersion - The `version` observed on the v1 doc at
- *   the start of a per-accreditation rebuild. The flip only succeeds when the
- *   live document's `version` still matches; any concurrent v1 write between
- *   capture and flip bumps `version`, the filter no-ops, and the marker stays
- *   `'v1'`.
+ * @property {number} capturedVersion - The `version` observed on the embedded
+ *   doc at the start of a per-accreditation rebuild. The flip only succeeds
+ *   when the live document's `version` still matches; any concurrent embedded
+ *   write between capture and flip bumps `version`, the filter no-ops, and the
+ *   marker stays `'embedded'`.
  */
 
 /**
- * @typedef {Object} FlipCanonicalSourceToV2Result
- * @property {boolean} flipped - `true` when the document was updated; `false`
- *   when no document matched (either no balance exists or the captured version
- *   is stale).
+ * @typedef {{ canonicalSource: import('../domain/model.js').WasteBalanceCanonicalSource } | null} FlipCanonicalSourceToLedgerResult
+ *   Post-state of the accreditation's balance document.
+ *
+ *   - `{ canonicalSource: 'ledger' }` — the doc is on the ledger now (this call
+ *     promoted it, or a prior call already did).
+ *   - `{ canonicalSource: 'embedded' }` — the flip did not land; a concurrent
+ *     write bumped `version` between capture and flip and the marker stays put.
+ *   - `null` — no balance document exists for this accreditation.
  */
 
 /**
@@ -60,12 +64,18 @@
  * @property {(params: DeductTotalBalanceParams) => Promise<void>} deductTotalBalanceForPrnIssue
  * @property {(params: CreditAvailableBalanceParams) => Promise<void>} creditAvailableBalanceForPrnCancellation
  * @property {(params: CreditFullBalanceParams) => Promise<void>} creditFullBalanceForIssuedPrnCancellation
- * @property {(params: FlipCanonicalSourceToV2Params) => Promise<FlipCanonicalSourceToV2Result>} flipCanonicalSourceToV2
- *   Promote a `'v1'` accreditation to `'v2'`, gated on `version` matching the
- *   captured value. The filter is `{ accreditationId, version: capturedVersion,
- *   canonicalSource: 'v1' }` so the call strictly promotes — already-`'v2'`
- *   documents return `{ flipped: false }` and a concurrent v1 write that
- *   bumped `version` between capture and flip also returns `{ flipped: false }`.
+ * @property {(params: FlipCanonicalSourceToLedgerParams) => Promise<FlipCanonicalSourceToLedgerResult>} flipCanonicalSourceToLedger
+ *   Promote an `'embedded'` accreditation to `'ledger'`, gated on `version`
+ *   matching the captured value. The filter is `{ accreditationId, version:
+ *   capturedVersion, canonicalSource: 'embedded' }` so the call strictly
+ *   promotes — never demotes. Returns the post-state, mirroring the persisted
+ *   marker vocabulary, so callers can distinguish the four outcomes:
+ *
+ *   - filter matched and the marker just flipped → `{ canonicalSource: 'ledger' }`
+ *   - already on the ledger when called → `{ canonicalSource: 'ledger' }`
+ *   - concurrent embedded write bumped `version` → `{ canonicalSource: 'embedded' }`
+ *   - no balance document for this accreditation → `null`
+ *
  *   Used as the final step of a per-accreditation rebuild after authoritative
  *   history has been replayed into the ledger.
  */


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

Adds the per-accreditation `canonicalSource` marker on the waste-balance document plus the repository primitives a per-accreditation rebuild needs. Together these unblock the per-accreditation rollout shape from the [waste-balance ledger rollout design](https://github.com/DEFRA/epr-re-ex-service/pull/202): each accreditation moves through `'embedded' → 'migrating' → 'ledger'` independently, gated on real authoritative-source replay rather than a global flag flip, with `'migrating'` reserved as the cross-collection-write exclusion window the upfront sweep needs to serialise the rebuild against in-flight summary-log submissions.

## Why

The summary-log write path landed flag-gated routing in [#1139](https://github.com/DEFRA/epr-backend/pull/1139), but flag-only routing forces an all-or-nothing migration: either every accreditation switches at once, or none do. Without a per-accreditation marker the rollout design has nowhere to record "this accreditation is mid-rebuild" or "this accreditation is now on the ledger". This PR adds that marker plus the rebuild lifecycle primitives, leaving the sweep runner, dry-run mode, stuck-marker recovery scheduler, and the `transitionToSubmittingExclusive` extension as separate follow-up work tracked under PAE-1382.

## What changes

### Domain

`WasteBalance` gains `canonicalSource: 'embedded' | 'migrating' | 'ledger'` and an optional `migratingSince: string` (ISO8601) timestamp. New documents default to `'embedded'`; `migratingSince` is set on the `embedded → migrating` flip and cleared on every exit (`migrating → ledger` and the recovery `migrating → embedded` reset). The `WASTE_BALANCE_CANONICAL_SOURCE` constant follows the existing `WASTE_BALANCE_TRANSACTION_TYPE` enum pattern.

### Dispatch

`performUpdateWasteBalanceTransactions` consults the marker as well as the global flag. Routing table:

- flag OFF — embedded `transactions[]` array
- flag ON, marker `'ledger'` — ledger-append path (ADR 0031)
- flag ON, marker `'embedded'`, `'migrating'`, or no balance yet — embedded `transactions[]` array

`'migrating'` deliberately routes to the embedded path: a per-accreditation rebuild that flipped the marker keeps the embedded write path live for PRN operations during the replay, and the version-conditional `flipCanonicalSourceToLedger` catches concurrent writes and forces a retry. Summary-log submissions are kept off this path during the migrating window by the (separately tracked) `transitionToSubmittingExclusive` 409 exclusion, so the only writes that legitimately reach this dispatch under `'migrating'` are PRN operations.

### Repository surface

`LedgerRepository.deleteAllForAccreditationId(accreditationId)` — idempotent removal of every ledger transaction for an accreditation. Used as step 2 of a rebuild to clear residue from any prior interrupted attempt.

`WasteBalancesRepository.flipCanonicalSourceToMigrating({ accreditationId, capturedVersion })` — promotes `'embedded' → 'migrating'` and stamps `migratingSince`, gated on `{ accreditationId, version: capturedVersion, canonicalSource: 'embedded' }`. Strictly promotes — `'migrating'` and `'ledger'` are never demoted. Step 1 of a rebuild.

`WasteBalancesRepository.flipCanonicalSourceToLedger({ accreditationId, capturedVersion })` — promotes `'migrating' → 'ledger'` and clears `migratingSince`, gated on `{ accreditationId, version: capturedVersion, canonicalSource: 'migrating' }`. Strictly promotes — `'embedded'` is not short-circuited and `'ledger'` never demotes. Final step of a rebuild after authoritative history has been replayed into the ledger; concurrent-write detection during the replay window relies on the `version` filter here.

`WasteBalancesRepository.resetCanonicalSourceToEmbedded({ accreditationId })` — unconditional `'migrating' → 'embedded'` reset that clears `migratingSince`. No version filter. The sweep runner's startup-pass primitive for documents stuck in `'migrating'` past the recovery threshold; `'embedded'` and `'ledger'` are left alone.

All three primitives return the post-state, mirroring the persisted vocabulary so callers can distinguish each outcome — including `null` when the accreditation has no balance document. The MongoDB adapter uses `findOneAndUpdate({ returnDocument: 'after' })` so the happy path is one round-trip; on no-match it follows up with a projection-only `findOne` to read the current marker. Both adapters run `validateAccreditationId` at the boundary, matching every other single-ID port method.

### Persistence invariant

The MongoDB `saveBalance` upsert sets `canonicalSource` only via `$setOnInsert` and never touches `migratingSince`, so concurrent flips are not clobbered by in-flight embedded writes whose snapshot pre-dated the flip. The in-memory `saveBalance` mirrors this — on update it preserves the existing document's marker and `migratingSince` rather than replacing the whole object. JSDoc on both adapters spells out the load-bearing rule: the marker lifecycle is owned exclusively by the three lifecycle primitives; every other write path is marker-blind and never touches `migratingSince`.

### Coverage

Every primitive is exercised through the existing in-memory and MongoDB contract harnesses. The contract suite covers strict-promotion (each flip refuses the wrong precondition), idempotency on the post-state, the simultaneous-PRN-write race against `flipCanonicalSourceToLedger` from the rollout design doc, and an end-to-end check that non-flip writes leave existing `'ledger'` markers untouched. `helpers.test.js` adds a regression test pinning the `'migrating'` routing on the dispatch path so the upfront-sweep model can't quietly regress to short-circuiting migrating documents.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
