### PR TITLE
PAE-1381: remove reports feature flag

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -342,12 +342,6 @@ const baseConfig = {
       default: false,
       env: 'FEATURE_FLAG_COPY_FORM_FILES_TO_S3'
     },
-    reports: {
-      doc: 'Feature Flag: Enable reports',
-      format: Boolean,
-      default: false,
-      env: 'FEATURE_FLAG_REPORTS'
-    },
     orsWasteBalanceValidation: {
       doc: 'Feature Flag: Validate ORS approval status during exporter waste balance classification',
       format: Boolean,

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -8,9 +8,6 @@ export const createConfigFeatureFlags = (config) => ({
   isCopyFormFilesToS3Enabled() {
     return config.get('featureFlags.copyFormFilesToS3')
   },
-  isReportsEnabled() {
-    return config.get('featureFlags.reports')
-  },
   isOrsWasteBalanceValidationEnabled() {
     return config.get('featureFlags.orsWasteBalanceValidation')
   },

--- a/src/feature-flags/feature-flags.config.test.js
+++ b/src/feature-flags/feature-flags.config.test.js
@@ -23,20 +23,6 @@ describe('createConfigFeatureFlags', () => {
     expect(config.get).toHaveBeenCalledWith('featureFlags.copyFormFilesToS3')
   })
 
-  it('returns true when reports flag is enabled', () => {
-    const config = { get: vi.fn().mockReturnValue(true) }
-    const flags = createConfigFeatureFlags(config)
-    expect(flags.isReportsEnabled()).toBe(true)
-    expect(config.get).toHaveBeenCalledWith('featureFlags.reports')
-  })
-
-  it('returns false when reports flag is disabled', () => {
-    const config = { get: vi.fn().mockReturnValue(false) }
-    const flags = createConfigFeatureFlags(config)
-    expect(flags.isReportsEnabled()).toBe(false)
-    expect(config.get).toHaveBeenCalledWith('featureFlags.reports')
-  })
-
   it('returns true when orsWasteBalanceValidation flag is enabled', () => {
     const config = { get: vi.fn().mockReturnValue(true) }
     const flags = createConfigFeatureFlags(config)

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -9,9 +9,6 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   isDevEndpointsEnabled() {
     return flags.devEndpoints ?? false
   },
-  isReportsEnabled() {
-    return flags.reports ?? false
-  },
   isOrsWasteBalanceValidationEnabled() {
     return flags.orsWasteBalanceValidation ?? false
   },

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -32,21 +32,6 @@ describe('createInMemoryFeatureFlags', () => {
     expect(flags.isDevEndpointsEnabled()).toBe(false)
   })
 
-  it('returns true when reports flag is enabled', () => {
-    const flags = createInMemoryFeatureFlags({ reports: true })
-    expect(flags.isReportsEnabled()).toBe(true)
-  })
-
-  it('returns false when reports flag is disabled', () => {
-    const flags = createInMemoryFeatureFlags({ reports: false })
-    expect(flags.isReportsEnabled()).toBe(false)
-  })
-
-  it('returns false when reports flag is not provided', () => {
-    const flags = createInMemoryFeatureFlags({})
-    expect(flags.isReportsEnabled()).toBe(false)
-  })
-
   it('returns true when orsWasteBalanceValidation flag is enabled', () => {
     const flags = createInMemoryFeatureFlags({
       orsWasteBalanceValidation: true

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -2,7 +2,6 @@
  * @typedef {Object} FeatureFlags
  * @property {() => boolean} isDevEndpointsEnabled
  * @property {() => boolean} isCopyFormFilesToS3Enabled
- * @property {() => boolean} isReportsEnabled
  * @property {() => boolean} isOrsWasteBalanceValidationEnabled
  * @property {() => boolean} isWasteBalanceLedgerEnabled
  * @property {() => boolean} isRegistrationContactsMigrationEnabled
@@ -12,7 +11,6 @@
  * @typedef {Object} FeatureFlagOverrides
  * @property {boolean} [devEndpoints]
  * @property {boolean} [copyFormFilesToS3]
- * @property {boolean} [reports]
  * @property {boolean} [orsWasteBalanceValidation]
  * @property {boolean} [wasteBalanceLedger]
  * @property {boolean} [registrationContactsMigration]

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -34,10 +34,6 @@ const router = {
           ? Object.values(devRoutes)
           : []
 
-        const reportsBehindFeatureFlag = featureFlags.isReportsEnabled()
-          ? Object.values(reportsRoutes)
-          : []
-
         server.route([
           health,
           ...apply,
@@ -60,7 +56,7 @@ const router = {
           ...summaryLogUploadsReportRoutes,
           adminPackagingRecyclingNotesList,
           ...Object.values(overseasSitesRoutes),
-          ...reportsBehindFeatureFlag,
+          ...Object.values(reportsRoutes),
           dlqMessagesGet,
           dlqPurgePost
         ])

--- a/src/reports/routes/submissions.test.js
+++ b/src/reports/routes/submissions.test.js
@@ -2,7 +2,6 @@ import { StatusCodes } from 'http-status-codes'
 import { createTestServer } from '#test/create-test-server.js'
 import { asServiceMaintainer, asStandardUser } from '#test/inject-auth.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
-import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import {
@@ -14,7 +13,7 @@ import { getReportSubmissionsPath } from './submissions.js'
 describe(`GET ${getReportSubmissionsPath}`, () => {
   setupAuthContext()
 
-  const createServer = async (featureFlagOverrides = { reports: true }) => {
+  const createServer = async () => {
     const registration = buildRegistration({
       wasteProcessingType: 'reprocessor'
     })
@@ -29,74 +28,57 @@ describe(`GET ${getReportSubmissionsPath}`, () => {
       repositories: {
         organisationsRepository: organisationsRepositoryFactory,
         reportsRepository: createInMemoryReportsRepository()
-      },
-      featureFlags: createInMemoryFeatureFlags(featureFlagOverrides)
+      }
     })
 
     return server
   }
 
-  describe('when reports feature flag is enabled', () => {
-    it('returns 200 for a service maintainer', async () => {
-      const server = await createServer()
+  it('returns 200 for a service maintainer', async () => {
+    const server = await createServer()
 
-      const response = await server.inject({
-        method: 'GET',
-        url: getReportSubmissionsPath,
-        ...asServiceMaintainer()
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.OK)
+    const response = await server.inject({
+      method: 'GET',
+      url: getReportSubmissionsPath,
+      ...asServiceMaintainer()
     })
 
-    it('returns reportSubmissions array and generatedAt in the response', async () => {
-      const server = await createServer()
-
-      const response = await server.inject({
-        method: 'GET',
-        url: getReportSubmissionsPath,
-        ...asServiceMaintainer()
-      })
-
-      const payload = JSON.parse(response.payload)
-      expect(payload).toHaveProperty('reportSubmissions')
-      expect(Array.isArray(payload.reportSubmissions)).toBe(true)
-      expect(payload).toHaveProperty('generatedAt')
-      expect(typeof payload.generatedAt).toBe('string')
-    })
-
-    it('returns 403 for a standard user', async () => {
-      const registration = buildRegistration()
-      const org = buildOrganisation({ registrations: [registration] })
-
-      const organisationsRepositoryFactory =
-        createInMemoryOrganisationsRepository()
-      const organisationsRepository = organisationsRepositoryFactory()
-      await organisationsRepository.insert(org)
-
-      const server = await createServer()
-
-      const response = await server.inject({
-        method: 'GET',
-        url: getReportSubmissionsPath,
-        ...asStandardUser({ linkedOrgId: org.id })
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
-    })
+    expect(response.statusCode).toBe(StatusCodes.OK)
   })
 
-  describe('when reports feature flag is disabled', () => {
-    it('returns 404', async () => {
-      const server = await createServer({ reports: false })
+  it('returns reportSubmissions array and generatedAt in the response', async () => {
+    const server = await createServer()
 
-      const response = await server.inject({
-        method: 'GET',
-        url: getReportSubmissionsPath,
-        ...asServiceMaintainer()
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    const response = await server.inject({
+      method: 'GET',
+      url: getReportSubmissionsPath,
+      ...asServiceMaintainer()
     })
+
+    const payload = JSON.parse(response.payload)
+    expect(payload).toHaveProperty('reportSubmissions')
+    expect(Array.isArray(payload.reportSubmissions)).toBe(true)
+    expect(payload).toHaveProperty('generatedAt')
+    expect(typeof payload.generatedAt).toBe('string')
+  })
+
+  it('returns 403 for a standard user', async () => {
+    const registration = buildRegistration()
+    const org = buildOrganisation({ registrations: [registration] })
+
+    const organisationsRepositoryFactory =
+      createInMemoryOrganisationsRepository()
+    const organisationsRepository = organisationsRepositoryFactory()
+    await organisationsRepository.insert(org)
+
+    const server = await createServer()
+
+    const response = await server.inject({
+      method: 'GET',
+      url: getReportSubmissionsPath,
+      ...asStandardUser({ linkedOrgId: org.id })
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
   })
 })

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -135,10 +135,7 @@ function getProductionPlugins(config) {
     orsImportsRepositoryPlugin
   ]
 
-  /* istanbul ignore next -- gated by feature flag, tested via createTestServer */
-  if (config.get('featureFlags.reports')) {
-    plugins.push(mongoReportsRepositoryPlugin)
-  }
+  plugins.push(mongoReportsRepositoryPlugin)
 
   /* istanbul ignore next -- gated by feature flag, only loaded in non-prod envs */
   if (config.get('featureFlags.devEndpoints')) {


### PR DESCRIPTION
Ticket: [PAE-1381](https://eaflood.atlassian.net/browse/PAE-1381)
- Remove `FEATURE_FLAG_REPORTS` config and `isReportsEnabled` feature flag method
- Reports routes are now always registered in the router
- `mongoReportsRepositoryPlugin` is now always loaded in the server
- Remove feature-flag-disabled test case from submissions route tests

[PAE-1381]: https://eaflood.atlassian.net/browse/PAE-1381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ