### PR TITLE
PAE-1436 allow system logs to be retrieved by sub category

### DIFF
--- a/src/routes/v1/system-logs/post-search.js
+++ b/src/routes/v1/system-logs/post-search.js
@@ -23,7 +23,7 @@ import {
  */
 
 const DEFAULT_LIMIT = 50
-const MAX_LIMIT = 500
+const MAX_LIMIT = 200
 
 const systemLogsSearchPath = '/v1/system-logs/search'
 
@@ -40,7 +40,7 @@ export const systemLogsPostSearch = {
         subCategory: Joi.string().optional(),
         limit: Joi.number().integer().min(1).optional(),
         cursor: Joi.string().hex().length(24).optional()
-      }).or('organisationId', 'email')
+      }).or('organisationId', 'email', 'subCategory')
     }
   },
   /**
@@ -67,11 +67,8 @@ export const systemLogsPostSearch = {
 
       const response = {
         systemLogs: result.systemLogs,
-        hasMore: result.hasMore
-      }
-
-      if (result.nextCursor) {
-        response.nextCursor = result.nextCursor
+        hasMore: result.hasMore,
+        ...(result.nextCursor ? { nextCursor: result.nextCursor } : {})
       }
 
       logger.info({

--- a/src/routes/v1/system-logs/post-search.test.js
+++ b/src/routes/v1/system-logs/post-search.test.js
@@ -76,7 +76,7 @@ describe('POST /v1/system-logs/search', () => {
       await addSystemLog({ email, subCategory: 'summary-log', id: 1 })
       await addSystemLog({ email, subCategory: 'epr-organisations', id: 2 })
 
-      const response = await makeRequest({ email, subCategory: 'summary-log' })
+      const response = await makeRequest({ subCategory: 'summary-log' })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       const result = JSON.parse(response.payload)
@@ -191,12 +191,6 @@ describe('POST /v1/system-logs/search', () => {
       expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
     })
 
-    it('returns 422 when only subCategory is provided', async () => {
-      const response = await makeRequest({ subCategory: 'summary-log' })
-
-      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
-    })
-
     it('returns 422 when cursor is not a valid hex string', async () => {
       const response = await makeRequest({
         email: 'test@example.com',
@@ -216,7 +210,9 @@ describe('POST /v1/system-logs/search', () => {
     })
 
     it('silently caps limit at the maximum when exceeded', async () => {
-      await addSystemLog({ email: 'alice@example.com', id: 1 })
+      ;[...Array(250).keys()].forEach(async (i) => {
+        await addSystemLog({ email: 'alice@example.com', id: i + 1 })
+      })
 
       const response = await makeRequest({
         email: 'alice@example.com',
@@ -224,6 +220,9 @@ describe('POST /v1/system-logs/search', () => {
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
+      const result = JSON.parse(response.payload)
+
+      expect(result.systemLogs).toHaveLength(200)
     })
   })
 


### PR DESCRIPTION
Ticket: [PAE-1436](https://eaflood.atlassian.net/browse/PAE-1436)
## Description

Update system logs endpoint to change filtering restraint
- from: one of "org id, email" must be supplied (prevents searching by _only_ event type)
- to: one of "org id, email, event type" must be supplied

This relaxation is safe as the endpoint is paginated with an (internal) max limit of 200 (reduced from 500 and verified in tests), which limits the load calls to this endpoint can put on the service

Goes with https://github.com/DEFRA/epr-re-ex-admin-frontend/pull/379

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1436]: https://eaflood.atlassian.net/browse/PAE-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ