### PR TITLE
PAE-1382: Route waste-balance reads through canonicalSource marker

### DIFF
--- a/src/non-prod-data-reset/mongodb.test.js
+++ b/src/non-prod-data-reset/mongodb.test.js
@@ -20,6 +20,7 @@ import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.
 import { buildSystemLog } from '#repositories/system-logs/contract/test-data.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
 import { buildWasteBalance } from '#waste-balances/repository/contract/test-data.js'
+import { createMongoLedgerRepository } from '#waste-balances/repository/ledger-mongodb.js'
 import {
   createWasteBalancesRepository,
   saveBalance
@@ -93,7 +94,10 @@ const it = mongoIt.extend({
       database,
       []
     )
-    const wasteBalancesFactory = await createWasteBalancesRepository(database)
+    const ledgerFactory = await createMongoLedgerRepository(database)
+    const wasteBalancesFactory = await createWasteBalancesRepository(database, {
+      ledgerRepository: ledgerFactory()
+    })
     const reportsFactory = await createReportsRepository(database)
     const wasteRecordsFactory = await createWasteRecordsRepository(database)
     const summaryLogsFactory = await createSummaryLogsRepository(

--- a/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
+++ b/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
@@ -1,5 +1,6 @@
 import { describe, beforeEach, expect } from 'vitest'
 import { buildWasteBalance } from './test-data.js'
+import { buildLedgerTransaction } from '../ledger-test-data.js'
 import {
   WASTE_BALANCE_CANONICAL_SOURCE,
   WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
@@ -116,7 +117,8 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
     })
 
     it('preserves canonicalSource on update — only the flip method may mutate it', async ({
-      insertWasteBalance
+      insertWasteBalance,
+      ledgerRepository
     }) => {
       const wasteBalance = buildWasteBalance({
         accreditationId: 'acc-issue-marker',
@@ -125,6 +127,13 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
       })
 
       await insertWasteBalance(wasteBalance)
+      await ledgerRepository.insertTransactions([
+        buildLedgerTransaction({
+          accreditationId: 'acc-issue-marker',
+          number: 1,
+          closingBalance: { amount: 0, availableAmount: 0 }
+        })
+      ])
 
       await repository.deductTotalBalanceForPrnIssue({
         accreditationId: 'acc-issue-marker',

--- a/src/waste-balances/repository/contract/findByAccreditationId.contract.js
+++ b/src/waste-balances/repository/contract/findByAccreditationId.contract.js
@@ -1,6 +1,7 @@
 import { describe, beforeEach, expect } from 'vitest'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { buildWasteBalance } from './test-data.js'
+import { buildLedgerTransaction } from '../ledger-test-data.js'
 
 export const testFindByAccreditationIdBehaviour = (it) => {
   describe('findByAccreditationId', () => {
@@ -110,6 +111,148 @@ export const testFindByAccreditationIdBehaviour = (it) => {
       const result = await repository.findByAccreditationId('acc-marker-ledger')
 
       expect(result.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.LEDGER)
+    })
+
+    describe('marker-aware amount resolution', () => {
+      it('returns embedded amount and availableAmount when marker is embedded', async ({
+        insertWasteBalance,
+        ledgerRepository
+      }) => {
+        await insertWasteBalance(
+          buildWasteBalance({
+            accreditationId: 'acc-marker-embedded-amounts',
+            canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED,
+            amount: 250,
+            availableAmount: 200
+          })
+        )
+
+        await ledgerRepository.insertTransactions([
+          buildLedgerTransaction({
+            accreditationId: 'acc-marker-embedded-amounts',
+            number: 1,
+            closingBalance: { amount: 999, availableAmount: 999 }
+          })
+        ])
+
+        const result = await repository.findByAccreditationId(
+          'acc-marker-embedded-amounts'
+        )
+
+        expect(result.amount).toBe(250)
+        expect(result.availableAmount).toBe(200)
+      })
+
+      it('returns embedded amount and availableAmount when marker is migrating', async ({
+        insertWasteBalance,
+        ledgerRepository
+      }) => {
+        await insertWasteBalance(
+          buildWasteBalance({
+            accreditationId: 'acc-marker-migrating-amounts',
+            canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+            amount: 75,
+            availableAmount: 50
+          })
+        )
+
+        await ledgerRepository.insertTransactions([
+          buildLedgerTransaction({
+            accreditationId: 'acc-marker-migrating-amounts',
+            number: 1,
+            closingBalance: { amount: 999, availableAmount: 999 }
+          })
+        ])
+
+        const result = await repository.findByAccreditationId(
+          'acc-marker-migrating-amounts'
+        )
+
+        expect(result.amount).toBe(75)
+        expect(result.availableAmount).toBe(50)
+      })
+
+      it('substitutes amount and availableAmount from the latest ledger transaction when marker is ledger', async ({
+        insertWasteBalance,
+        ledgerRepository
+      }) => {
+        await insertWasteBalance(
+          buildWasteBalance({
+            accreditationId: 'acc-marker-ledger-amounts',
+            canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+            amount: 999,
+            availableAmount: 999
+          })
+        )
+
+        await ledgerRepository.insertTransactions([
+          buildLedgerTransaction({
+            accreditationId: 'acc-marker-ledger-amounts',
+            number: 1,
+            closingBalance: { amount: 100, availableAmount: 90 }
+          }),
+          buildLedgerTransaction({
+            accreditationId: 'acc-marker-ledger-amounts',
+            number: 2,
+            closingBalance: { amount: 175, availableAmount: 150 }
+          })
+        ])
+
+        const result = await repository.findByAccreditationId(
+          'acc-marker-ledger-amounts'
+        )
+
+        expect(result.amount).toBe(175)
+        expect(result.availableAmount).toBe(150)
+      })
+
+      it('returns zero amounts when marker is ledger and no ledger transactions exist', async ({
+        insertWasteBalance
+      }) => {
+        await insertWasteBalance(
+          buildWasteBalance({
+            accreditationId: 'acc-marker-ledger-empty',
+            canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+            amount: 999,
+            availableAmount: 999
+          })
+        )
+
+        const result = await repository.findByAccreditationId(
+          'acc-marker-ledger-empty'
+        )
+
+        expect(result.amount).toBe(0)
+        expect(result.availableAmount).toBe(0)
+      })
+
+      it('preserves the canonicalSource marker on the returned document', async ({
+        insertWasteBalance,
+        ledgerRepository
+      }) => {
+        await insertWasteBalance(
+          buildWasteBalance({
+            accreditationId: 'acc-marker-ledger-preserved',
+            canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+          })
+        )
+
+        await ledgerRepository.insertTransactions([
+          buildLedgerTransaction({
+            accreditationId: 'acc-marker-ledger-preserved',
+            number: 1,
+            closingBalance: { amount: 10, availableAmount: 10 }
+          })
+        ])
+
+        const result = await repository.findByAccreditationId(
+          'acc-marker-ledger-preserved'
+        )
+
+        expect(result.canonicalSource).toBe(
+          WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+        )
+      })
     })
 
     it('returns waste balance with all transaction fields intact', async ({

--- a/src/waste-balances/repository/contract/findByAccreditationId.contract.js
+++ b/src/waste-balances/repository/contract/findByAccreditationId.contract.js
@@ -99,7 +99,8 @@ export const testFindByAccreditationIdBehaviour = (it) => {
     })
 
     it('returns canonicalSource ledger when stored as ledger', async ({
-      insertWasteBalance
+      insertWasteBalance,
+      ledgerRepository
     }) => {
       const wasteBalance = buildWasteBalance({
         accreditationId: 'acc-marker-ledger',
@@ -107,6 +108,13 @@ export const testFindByAccreditationIdBehaviour = (it) => {
       })
 
       await insertWasteBalance(wasteBalance)
+      await ledgerRepository.insertTransactions([
+        buildLedgerTransaction({
+          accreditationId: 'acc-marker-ledger',
+          number: 1,
+          closingBalance: { amount: 0, availableAmount: 0 }
+        })
+      ])
 
       const result = await repository.findByAccreditationId('acc-marker-ledger')
 
@@ -206,7 +214,7 @@ export const testFindByAccreditationIdBehaviour = (it) => {
         expect(result.availableAmount).toBe(150)
       })
 
-      it('returns zero amounts when marker is ledger and no ledger transactions exist', async ({
+      it('throws when marker is ledger and no ledger transactions exist', async ({
         insertWasteBalance
       }) => {
         await insertWasteBalance(
@@ -218,12 +226,11 @@ export const testFindByAccreditationIdBehaviour = (it) => {
           })
         )
 
-        const result = await repository.findByAccreditationId(
-          'acc-marker-ledger-empty'
+        await expect(
+          repository.findByAccreditationId('acc-marker-ledger-empty')
+        ).rejects.toThrow(
+          /acc-marker-ledger-empty.*canonicalSource 'ledger' but no ledger transactions/
         )
-
-        expect(result.amount).toBe(0)
-        expect(result.availableAmount).toBe(0)
       })
 
       it('preserves the canonicalSource marker on the returned document', async ({

--- a/src/waste-balances/repository/contract/findByAccreditationIds.contract.js
+++ b/src/waste-balances/repository/contract/findByAccreditationIds.contract.js
@@ -131,7 +131,8 @@ export const testFindByAccreditationIdsBehaviour = (it) => {
     })
 
     it('preserves canonicalSource per balance across the batch', async ({
-      insertWasteBalances
+      insertWasteBalances,
+      ledgerRepository
     }) => {
       const onEmbedded = buildWasteBalance({
         accreditationId: 'acc-mixed-embedded',
@@ -143,6 +144,13 @@ export const testFindByAccreditationIdsBehaviour = (it) => {
       })
 
       await insertWasteBalances([onEmbedded, onLedger])
+      await ledgerRepository.insertTransactions([
+        buildLedgerTransaction({
+          accreditationId: 'acc-mixed-ledger',
+          number: 1,
+          closingBalance: { amount: 0, availableAmount: 0 }
+        })
+      ])
 
       const result = await repository.findByAccreditationIds([
         'acc-mixed-embedded',

--- a/src/waste-balances/repository/contract/findByAccreditationIds.contract.js
+++ b/src/waste-balances/repository/contract/findByAccreditationIds.contract.js
@@ -1,6 +1,7 @@
 import { describe, beforeEach, expect } from 'vitest'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { buildWasteBalance } from './test-data.js'
+import { buildLedgerTransaction } from '../ledger-test-data.js'
 
 export const testFindByAccreditationIdsBehaviour = (it) => {
   describe('findByAccreditationIds', () => {
@@ -155,6 +156,73 @@ export const testFindByAccreditationIdsBehaviour = (it) => {
       expect(byId['acc-mixed-ledger'].canonicalSource).toBe(
         WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       )
+    })
+
+    describe('marker-aware amount resolution per balance', () => {
+      it('substitutes amounts only for balances whose marker is ledger', async ({
+        insertWasteBalances,
+        ledgerRepository
+      }) => {
+        await insertWasteBalances([
+          buildWasteBalance({
+            accreditationId: 'acc-batch-embedded',
+            canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED,
+            amount: 100,
+            availableAmount: 80
+          }),
+          buildWasteBalance({
+            accreditationId: 'acc-batch-migrating',
+            canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+            amount: 200,
+            availableAmount: 150
+          }),
+          buildWasteBalance({
+            accreditationId: 'acc-batch-ledger',
+            canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+            amount: 999,
+            availableAmount: 999
+          })
+        ])
+
+        await ledgerRepository.insertTransactions([
+          buildLedgerTransaction({
+            accreditationId: 'acc-batch-embedded',
+            number: 1,
+            closingBalance: { amount: 999, availableAmount: 999 }
+          }),
+          buildLedgerTransaction({
+            accreditationId: 'acc-batch-migrating',
+            number: 1,
+            closingBalance: { amount: 999, availableAmount: 999 }
+          }),
+          buildLedgerTransaction({
+            accreditationId: 'acc-batch-ledger',
+            number: 1,
+            closingBalance: { amount: 50, availableAmount: 40 }
+          }),
+          buildLedgerTransaction({
+            accreditationId: 'acc-batch-ledger',
+            number: 2,
+            closingBalance: { amount: 75, availableAmount: 60 }
+          })
+        ])
+
+        const result = await repository.findByAccreditationIds([
+          'acc-batch-embedded',
+          'acc-batch-migrating',
+          'acc-batch-ledger'
+        ])
+
+        const byId = Object.fromEntries(
+          result.map((b) => [b.accreditationId, b])
+        )
+        expect(byId['acc-batch-embedded'].amount).toBe(100)
+        expect(byId['acc-batch-embedded'].availableAmount).toBe(80)
+        expect(byId['acc-batch-migrating'].amount).toBe(200)
+        expect(byId['acc-batch-migrating'].availableAmount).toBe(150)
+        expect(byId['acc-batch-ledger'].amount).toBe(75)
+        expect(byId['acc-batch-ledger'].availableAmount).toBe(60)
+      })
     })
 
     it('returns waste balance with all fields intact', async ({

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
@@ -2,6 +2,7 @@ import { describe, beforeEach, expect } from 'vitest'
 
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { buildWasteBalance } from './test-data.js'
+import { buildLedgerTransaction } from '../ledger-test-data.js'
 
 export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
   describe('flipCanonicalSourceToLedger', () => {
@@ -12,7 +13,8 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
     })
 
     it('flips the marker from migrating to ledger when the captured version matches and clears migratingSince', async ({
-      insertWasteBalance
+      insertWasteBalance,
+      ledgerRepository
     }) => {
       const balance = buildWasteBalance({
         accreditationId: 'acc-flip-ok',
@@ -21,6 +23,13 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
         migratingSince: '2025-01-01T00:00:00.000Z'
       })
       await insertWasteBalance(balance)
+      await ledgerRepository.insertTransactions([
+        buildLedgerTransaction({
+          accreditationId: 'acc-flip-ok',
+          number: 1,
+          closingBalance: { amount: 0, availableAmount: 0 }
+        })
+      ])
 
       const result = await repository.flipCanonicalSourceToLedger({
         accreditationId: 'acc-flip-ok',
@@ -74,7 +83,8 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
     })
 
     it('returns the ledger post-state when the marker is already on ledger — only promotes migrating', async ({
-      insertWasteBalance
+      insertWasteBalance,
+      ledgerRepository
     }) => {
       const balance = buildWasteBalance({
         accreditationId: 'acc-flip-already-ledger',
@@ -82,6 +92,13 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
         canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       })
       await insertWasteBalance(balance)
+      await ledgerRepository.insertTransactions([
+        buildLedgerTransaction({
+          accreditationId: 'acc-flip-already-ledger',
+          number: 1,
+          closingBalance: { amount: 0, availableAmount: 0 }
+        })
+      ])
 
       const result = await repository.flipCanonicalSourceToLedger({
         accreditationId: 'acc-flip-already-ledger',

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToMigrating.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToMigrating.contract.js
@@ -2,6 +2,7 @@ import { describe, beforeEach, expect } from 'vitest'
 
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { buildWasteBalance } from './test-data.js'
+import { buildLedgerTransaction } from '../ledger-test-data.js'
 
 export const testFlipCanonicalSourceToMigratingBehaviour = (it) => {
   describe('flipCanonicalSourceToMigrating', () => {
@@ -112,7 +113,8 @@ export const testFlipCanonicalSourceToMigratingBehaviour = (it) => {
     })
 
     it('returns the ledger post-state and never demotes when the marker is already on ledger', async ({
-      insertWasteBalance
+      insertWasteBalance,
+      ledgerRepository
     }) => {
       const balance = buildWasteBalance({
         accreditationId: 'acc-flip-migrating-ledger',
@@ -120,6 +122,13 @@ export const testFlipCanonicalSourceToMigratingBehaviour = (it) => {
         canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       })
       await insertWasteBalance(balance)
+      await ledgerRepository.insertTransactions([
+        buildLedgerTransaction({
+          accreditationId: 'acc-flip-migrating-ledger',
+          number: 1,
+          closingBalance: { amount: 0, availableAmount: 0 }
+        })
+      ])
 
       const result = await repository.flipCanonicalSourceToMigrating({
         accreditationId: 'acc-flip-migrating-ledger',

--- a/src/waste-balances/repository/contract/resetCanonicalSourceToEmbedded.contract.js
+++ b/src/waste-balances/repository/contract/resetCanonicalSourceToEmbedded.contract.js
@@ -2,6 +2,7 @@ import { describe, beforeEach, expect } from 'vitest'
 
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { buildWasteBalance } from './test-data.js'
+import { buildLedgerTransaction } from '../ledger-test-data.js'
 
 export const testResetCanonicalSourceToEmbeddedBehaviour = (it) => {
   describe('resetCanonicalSourceToEmbedded', () => {
@@ -71,7 +72,8 @@ export const testResetCanonicalSourceToEmbeddedBehaviour = (it) => {
     })
 
     it('returns the ledger post-state and never demotes when the marker is already on ledger', async ({
-      insertWasteBalance
+      insertWasteBalance,
+      ledgerRepository
     }) => {
       const balance = buildWasteBalance({
         accreditationId: 'acc-reset-ledger',
@@ -79,6 +81,13 @@ export const testResetCanonicalSourceToEmbeddedBehaviour = (it) => {
         canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       })
       await insertWasteBalance(balance)
+      await ledgerRepository.insertTransactions([
+        buildLedgerTransaction({
+          accreditationId: 'acc-reset-ledger',
+          number: 1,
+          closingBalance: { amount: 0, availableAmount: 0 }
+        })
+      ])
 
       const result = await repository.resetCanonicalSourceToEmbedded({
         accreditationId: 'acc-reset-ledger'

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -62,7 +62,7 @@ export const saveBalance =
  * Find a waste balance by accreditation ID.
  *
  * @param {import('../domain/model.js').WasteBalance[]} wasteBalanceStorage
- * @param {import('./ledger-port.js').LedgerRepository | undefined} ledgerRepository
+ * @param {import('./ledger-port.js').LedgerRepository} ledgerRepository
  * @returns {(accreditationId: string) => Promise<import('../domain/model.js').WasteBalance | null>}
  */
 export const performFindByAccreditationId =
@@ -154,16 +154,16 @@ const performResetCanonicalSourceToEmbedded =
  * Create an in-memory waste balances repository.
  * Ensures data isolation by deep-cloning on read.
  *
- * @param {Array} [initialWasteBalances=[]]
- * @param {Object} [dependencies]
+ * @param {Array} initialWasteBalances
+ * @param {Object} dependencies
+ * @param {import('./ledger-port.js').LedgerRepository} dependencies.ledgerRepository
  * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [dependencies.systemLogsRepository]
- * @param {import('./ledger-port.js').LedgerRepository} [dependencies.ledgerRepository]
  * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [dependencies.featureFlags]
  * @returns {import('./port.js').WasteBalancesRepositoryFactory}
  */
 export const createInMemoryWasteBalancesRepository = (
-  initialWasteBalances = [],
-  dependencies = {}
+  initialWasteBalances,
+  dependencies
 ) => {
   const wasteBalanceStorage = initialWasteBalances
 

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -7,6 +7,7 @@ import {
   performCreditAvailableBalanceForPrnCancellation,
   performCreditFullBalanceForIssuedPrnCancellation
 } from './helpers.js'
+import { resolveBalanceAmounts } from './marker-aware-read.js'
 
 /**
  * Find a waste balance by accreditation ID.
@@ -61,26 +62,35 @@ export const saveBalance =
  * Find a waste balance by accreditation ID.
  *
  * @param {import('../domain/model.js').WasteBalance[]} wasteBalanceStorage
+ * @param {import('./ledger-port.js').LedgerRepository | undefined} ledgerRepository
  * @returns {(accreditationId: string) => Promise<import('../domain/model.js').WasteBalance | null>}
  */
 export const performFindByAccreditationId =
-  (wasteBalanceStorage) => async (accreditationId) => {
+  (wasteBalanceStorage, ledgerRepository) => async (accreditationId) => {
     const validatedAccreditationId = validateAccreditationId(accreditationId)
 
     const balance = wasteBalanceStorage.find(
       (b) => b.accreditationId === validatedAccreditationId
     )
 
-    return balance ? structuredClone(balance) : null
+    if (!balance) {
+      return null
+    }
+
+    return resolveBalanceAmounts(structuredClone(balance), ledgerRepository)
   }
 
 const performFindByAccreditationIds =
-  (wasteBalanceStorage) => async (accreditationIds) => {
+  (wasteBalanceStorage, ledgerRepository) => async (accreditationIds) => {
     const balances = wasteBalanceStorage.filter((b) =>
       accreditationIds.includes(b.accreditationId)
     )
 
-    return balances.map((balance) => structuredClone(balance))
+    return Promise.all(
+      balances.map((balance) =>
+        resolveBalanceAmounts(structuredClone(balance), ledgerRepository)
+      )
+    )
   }
 
 const performFlipCanonicalSourceToMigrating =
@@ -157,9 +167,17 @@ export const createInMemoryWasteBalancesRepository = (
 ) => {
   const wasteBalanceStorage = initialWasteBalances
 
+  const { ledgerRepository } = dependencies
+
   return () => ({
-    findByAccreditationId: performFindByAccreditationId(wasteBalanceStorage),
-    findByAccreditationIds: performFindByAccreditationIds(wasteBalanceStorage),
+    findByAccreditationId: performFindByAccreditationId(
+      wasteBalanceStorage,
+      ledgerRepository
+    ),
+    findByAccreditationIds: performFindByAccreditationIds(
+      wasteBalanceStorage,
+      ledgerRepository
+    ),
     updateWasteBalanceTransactions: async (
       wasteRecords,
       { user, accreditation, overseasSites }

--- a/src/waste-balances/repository/inmemory.plugin.js
+++ b/src/waste-balances/repository/inmemory.plugin.js
@@ -14,7 +14,7 @@ export function createInMemoryWasteBalancesRepositoryPlugin(
     register: (server) => {
       const ledgerRepository = createInMemoryLedgerRepository()()
       const factory = createInMemoryWasteBalancesRepository(
-        initialWasteBalances,
+        initialWasteBalances ?? [],
         {
           ledgerRepository,
           featureFlags: server.featureFlags

--- a/src/waste-balances/repository/inmemory.test.js
+++ b/src/waste-balances/repository/inmemory.test.js
@@ -41,7 +41,9 @@ const extendedIt = base.extend({
 
 describe('waste-balances repository - in-memory implementation', () => {
   it('should create repository instance', () => {
-    const repository = createInMemoryWasteBalancesRepository()
+    const repository = createInMemoryWasteBalancesRepository([], {
+      ledgerRepository: createInMemoryLedgerRepository()()
+    })
     const instance = repository()
     expect(instance).toBeDefined()
     expect(instance.findByAccreditationId).toBeTypeOf('function')
@@ -49,7 +51,9 @@ describe('waste-balances repository - in-memory implementation', () => {
 
   it('should expose internal storage for testing', () => {
     const initialStorage = [{ accreditationId: 'acc-1' }]
-    const repository = createInMemoryWasteBalancesRepository(initialStorage)()
+    const repository = createInMemoryWasteBalancesRepository(initialStorage, {
+      ledgerRepository: createInMemoryLedgerRepository()()
+    })()
     expect(repository._getStorageForTesting()).toBe(initialStorage)
   })
 

--- a/src/waste-balances/repository/inmemory.test.js
+++ b/src/waste-balances/repository/inmemory.test.js
@@ -1,5 +1,6 @@
 import { describe, it as base, expect, it } from 'vitest'
 import { createInMemoryWasteBalancesRepository } from './inmemory.js'
+import { createInMemoryLedgerRepository } from './ledger-inmemory.js'
 import { testWasteBalancesRepositoryContract } from './port.contract.js'
 
 const extendedIt = base.extend({
@@ -8,8 +9,22 @@ const extendedIt = base.extend({
     const storage = []
     await use(storage)
   },
-  wasteBalancesRepository: async ({ wasteBalanceStorage }, use) => {
-    const factory = createInMemoryWasteBalancesRepository(wasteBalanceStorage)
+  // eslint-disable-next-line no-empty-pattern
+  ledgerStorage: async ({}, use) => {
+    const storage = []
+    await use(storage)
+  },
+  ledgerRepository: async ({ ledgerStorage }, use) => {
+    const repository = createInMemoryLedgerRepository(ledgerStorage)()
+    await use(repository)
+  },
+  wasteBalancesRepository: async (
+    { wasteBalanceStorage, ledgerRepository },
+    use
+  ) => {
+    const factory = createInMemoryWasteBalancesRepository(wasteBalanceStorage, {
+      ledgerRepository
+    })
     await use(factory)
   },
   insertWasteBalance: async ({ wasteBalanceStorage }, use) => {

--- a/src/waste-balances/repository/marker-aware-read.js
+++ b/src/waste-balances/repository/marker-aware-read.js
@@ -11,24 +11,13 @@ import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
  * sweep populates the ledger before flipping the marker — but is treated as a
  * zero balance to keep the read path safe.
  *
- * `ledgerRepository` is optional so tests that exercise embedded/migrating
- * paths can wire the waste-balances repository without a ledger; an undefined
- * ledger combined with marker `'ledger'` is a wiring bug and trips an explicit
- * error rather than silently returning stale embedded amounts.
- *
  * @param {import('../domain/model.js').WasteBalance} balance
- * @param {import('./ledger-port.js').LedgerRepository | undefined} ledgerRepository
+ * @param {import('./ledger-port.js').LedgerRepository} ledgerRepository
  * @returns {Promise<import('../domain/model.js').WasteBalance>}
  */
 export const resolveBalanceAmounts = async (balance, ledgerRepository) => {
   if (balance.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER) {
     return balance
-  }
-
-  if (!ledgerRepository) {
-    throw new Error(
-      `Cannot resolve marker 'ledger' without a ledger repository (accreditationId=${balance.accreditationId})`
-    )
   }
 
   const latest = await ledgerRepository.findLatestByAccreditationId(

--- a/src/waste-balances/repository/marker-aware-read.js
+++ b/src/waste-balances/repository/marker-aware-read.js
@@ -1,3 +1,5 @@
+import Boom from '@hapi/boom'
+
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
 
 /**
@@ -7,9 +9,9 @@ import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
  * `'embedded'` and `'migrating'` markers leave the document unchanged because
  * the embedded write path is still authoritative for them.
  *
- * Marker `'ledger'` with an empty ledger should not occur in practice — the
- * sweep populates the ledger before flipping the marker — but is treated as a
- * zero balance to keep the read path safe.
+ * Marker `'ledger'` with an empty ledger is an invariant violation — the sweep
+ * must populate the ledger before flipping the marker. Throws so the
+ * inconsistency surfaces instead of being masked as a zero balance.
  *
  * @param {import('../domain/model.js').WasteBalance} balance
  * @param {import('./ledger-port.js').LedgerRepository} ledgerRepository
@@ -25,7 +27,9 @@ export const resolveBalanceAmounts = async (balance, ledgerRepository) => {
   )
 
   if (!latest) {
-    return { ...balance, amount: 0, availableAmount: 0 }
+    throw Boom.internal(
+      `Waste balance ${balance.accreditationId} has canonicalSource 'ledger' but no ledger transactions`
+    )
   }
 
   return {

--- a/src/waste-balances/repository/marker-aware-read.js
+++ b/src/waste-balances/repository/marker-aware-read.js
@@ -1,0 +1,47 @@
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
+
+/**
+ * Marker-aware substitution of `amount` / `availableAmount` on a waste-balance
+ * document. When `canonicalSource` is `'ledger'` the embedded amounts are stale
+ * and the latest ledger transaction's `closingBalance` is the source of truth;
+ * `'embedded'` and `'migrating'` markers leave the document unchanged because
+ * the embedded write path is still authoritative for them.
+ *
+ * Marker `'ledger'` with an empty ledger should not occur in practice — the
+ * sweep populates the ledger before flipping the marker — but is treated as a
+ * zero balance to keep the read path safe.
+ *
+ * `ledgerRepository` is optional so tests that exercise embedded/migrating
+ * paths can wire the waste-balances repository without a ledger; an undefined
+ * ledger combined with marker `'ledger'` is a wiring bug and trips an explicit
+ * error rather than silently returning stale embedded amounts.
+ *
+ * @param {import('../domain/model.js').WasteBalance} balance
+ * @param {import('./ledger-port.js').LedgerRepository | undefined} ledgerRepository
+ * @returns {Promise<import('../domain/model.js').WasteBalance>}
+ */
+export const resolveBalanceAmounts = async (balance, ledgerRepository) => {
+  if (balance.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER) {
+    return balance
+  }
+
+  if (!ledgerRepository) {
+    throw new Error(
+      `Cannot resolve marker 'ledger' without a ledger repository (accreditationId=${balance.accreditationId})`
+    )
+  }
+
+  const latest = await ledgerRepository.findLatestByAccreditationId(
+    balance.accreditationId
+  )
+
+  if (!latest) {
+    return { ...balance, amount: 0, availableAmount: 0 }
+  }
+
+  return {
+    ...balance,
+    amount: latest.closingBalance.amount,
+    availableAmount: latest.closingBalance.availableAmount
+  }
+}

--- a/src/waste-balances/repository/marker-aware-read.test.js
+++ b/src/waste-balances/repository/marker-aware-read.test.js
@@ -68,18 +68,18 @@ describe('resolveBalanceAmounts', () => {
     expect(result.availableAmount).toBe(175)
   })
 
-  it('returns zero amounts when marker is ledger but no ledger transaction exists', async () => {
+  it('throws when marker is ledger but no ledger transaction exists', async () => {
     const balance = buildBalance({
+      accreditationId: 'acc-empty-ledger',
       canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
       amount: 999,
       availableAmount: 999
     })
     const ledger = buildLedger(null)
 
-    const result = await resolveBalanceAmounts(balance, ledger)
-
-    expect(result.amount).toBe(0)
-    expect(result.availableAmount).toBe(0)
+    await expect(resolveBalanceAmounts(balance, ledger)).rejects.toThrow(
+      /acc-empty-ledger.*canonicalSource 'ledger' but no ledger transactions/
+    )
   })
 
   it('preserves all non-amount fields', async () => {

--- a/src/waste-balances/repository/marker-aware-read.test.js
+++ b/src/waste-balances/repository/marker-aware-read.test.js
@@ -82,30 +82,6 @@ describe('resolveBalanceAmounts', () => {
     expect(result.availableAmount).toBe(0)
   })
 
-  it('throws when marker is ledger and no ledger repository is wired', async () => {
-    const balance = buildBalance({
-      accreditationId: 'acc-no-ledger',
-      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
-    })
-
-    await expect(resolveBalanceAmounts(balance, undefined)).rejects.toThrow(
-      /acc-no-ledger/
-    )
-  })
-
-  it('does not require a ledger repository when marker is embedded', async () => {
-    const balance = buildBalance({
-      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED,
-      amount: 42,
-      availableAmount: 21
-    })
-
-    const result = await resolveBalanceAmounts(balance, undefined)
-
-    expect(result.amount).toBe(42)
-    expect(result.availableAmount).toBe(21)
-  })
-
   it('preserves all non-amount fields', async () => {
     const balance = buildBalance({
       canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,

--- a/src/waste-balances/repository/marker-aware-read.test.js
+++ b/src/waste-balances/repository/marker-aware-read.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { resolveBalanceAmounts } from './marker-aware-read.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
+
+const buildBalance = (overrides = {}) => ({
+  accreditationId: 'acc-1',
+  organisationId: 'org-1',
+  amount: 100,
+  availableAmount: 80,
+  canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED,
+  transactions: [],
+  ...overrides
+})
+
+const buildLedger = (latest) => ({
+  findLatestByAccreditationId: vi.fn().mockResolvedValue(latest)
+})
+
+describe('resolveBalanceAmounts', () => {
+  it('leaves an embedded balance unchanged', async () => {
+    const balance = buildBalance({
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED,
+      amount: 100,
+      availableAmount: 80
+    })
+    const ledger = buildLedger(null)
+
+    const result = await resolveBalanceAmounts(balance, ledger)
+
+    expect(result).toEqual(balance)
+    expect(ledger.findLatestByAccreditationId).not.toHaveBeenCalled()
+  })
+
+  it('leaves a migrating balance unchanged', async () => {
+    const balance = buildBalance({
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+      amount: 50,
+      availableAmount: 30
+    })
+    const ledger = buildLedger(null)
+
+    const result = await resolveBalanceAmounts(balance, ledger)
+
+    expect(result.amount).toBe(50)
+    expect(result.availableAmount).toBe(30)
+    expect(ledger.findLatestByAccreditationId).not.toHaveBeenCalled()
+  })
+
+  it('substitutes amounts from the latest ledger transaction when marker is ledger', async () => {
+    const balance = buildBalance({
+      accreditationId: 'acc-ledger',
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+      amount: 999,
+      availableAmount: 999
+    })
+    const ledger = buildLedger({
+      number: 5,
+      closingBalance: { amount: 200, availableAmount: 175 }
+    })
+
+    const result = await resolveBalanceAmounts(balance, ledger)
+
+    expect(ledger.findLatestByAccreditationId).toHaveBeenCalledWith(
+      'acc-ledger'
+    )
+    expect(result.amount).toBe(200)
+    expect(result.availableAmount).toBe(175)
+  })
+
+  it('returns zero amounts when marker is ledger but no ledger transaction exists', async () => {
+    const balance = buildBalance({
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+      amount: 999,
+      availableAmount: 999
+    })
+    const ledger = buildLedger(null)
+
+    const result = await resolveBalanceAmounts(balance, ledger)
+
+    expect(result.amount).toBe(0)
+    expect(result.availableAmount).toBe(0)
+  })
+
+  it('throws when marker is ledger and no ledger repository is wired', async () => {
+    const balance = buildBalance({
+      accreditationId: 'acc-no-ledger',
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+    })
+
+    await expect(resolveBalanceAmounts(balance, undefined)).rejects.toThrow(
+      /acc-no-ledger/
+    )
+  })
+
+  it('does not require a ledger repository when marker is embedded', async () => {
+    const balance = buildBalance({
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED,
+      amount: 42,
+      availableAmount: 21
+    })
+
+    const result = await resolveBalanceAmounts(balance, undefined)
+
+    expect(result.amount).toBe(42)
+    expect(result.availableAmount).toBe(21)
+  })
+
+  it('preserves all non-amount fields', async () => {
+    const balance = buildBalance({
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+      transactions: [{ id: 't1' }],
+      version: 7,
+      migratingSince: undefined
+    })
+    const ledger = buildLedger({
+      closingBalance: { amount: 10, availableAmount: 10 }
+    })
+
+    const result = await resolveBalanceAmounts(balance, ledger)
+
+    expect(result.transactions).toEqual([{ id: 't1' }])
+    expect(result.version).toBe(7)
+    expect(result.canonicalSource).toBe(WASTE_BALANCE_CANONICAL_SOURCE.LEDGER)
+  })
+})

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -8,6 +8,7 @@ import {
   performCreditFullBalanceForIssuedPrnCancellation
 } from './helpers.js'
 import { ensureLedgerCollection } from './ledger-mongodb.js'
+import { resolveBalanceAmounts } from './marker-aware-read.js'
 
 const WASTE_BALANCE_COLLECTION_NAME = 'waste-balances'
 
@@ -28,32 +29,42 @@ async function ensureCollection(db) {
   return collection
 }
 
-const performFindByAccreditationId = (db) => async (accreditationId) => {
-  const validatedAccreditationId = validateAccreditationId(accreditationId)
+const performFindByAccreditationId =
+  (db, ledgerRepository) => async (accreditationId) => {
+    const validatedAccreditationId = validateAccreditationId(accreditationId)
 
-  const doc = await db
-    .collection(WASTE_BALANCE_COLLECTION_NAME)
-    .findOne({ accreditationId: validatedAccreditationId })
+    const doc = await db
+      .collection(WASTE_BALANCE_COLLECTION_NAME)
+      .findOne({ accreditationId: validatedAccreditationId })
 
-  if (!doc) {
-    return null
+    if (!doc) {
+      return null
+    }
+
+    const { _id, ...domainFields } = doc
+    return resolveBalanceAmounts(
+      structuredClone({ id: _id.toString(), ...domainFields }),
+      ledgerRepository
+    )
   }
 
-  const { _id, ...domainFields } = doc
-  return structuredClone({ id: _id.toString(), ...domainFields })
-}
+const performFindByAccreditationIds =
+  (db, ledgerRepository) => async (accreditationIds) => {
+    const docs = await db
+      .collection(WASTE_BALANCE_COLLECTION_NAME)
+      .find({ accreditationId: { $in: accreditationIds } })
+      .toArray()
 
-const performFindByAccreditationIds = (db) => async (accreditationIds) => {
-  const docs = await db
-    .collection(WASTE_BALANCE_COLLECTION_NAME)
-    .find({ accreditationId: { $in: accreditationIds } })
-    .toArray()
-
-  return docs.map((doc) => {
-    const { _id, ...domainFields } = doc
-    return structuredClone({ id: _id.toString(), ...domainFields })
-  })
-}
+    return Promise.all(
+      docs.map((doc) => {
+        const { _id, ...domainFields } = doc
+        return resolveBalanceAmounts(
+          structuredClone({ id: _id.toString(), ...domainFields }),
+          ledgerRepository
+        )
+      })
+    )
+  }
 
 const performFlipCanonicalSourceToMigrating =
   (db) =>
@@ -216,9 +227,11 @@ export const createWasteBalancesRepository = async (db, dependencies = {}) => {
   await ensureCollection(db)
   await ensureLedgerCollection(db)
 
+  const { ledgerRepository } = dependencies
+
   return () => ({
-    findByAccreditationId: performFindByAccreditationId(db),
-    findByAccreditationIds: performFindByAccreditationIds(db),
+    findByAccreditationId: performFindByAccreditationId(db, ledgerRepository),
+    findByAccreditationIds: performFindByAccreditationIds(db, ledgerRepository),
     updateWasteBalanceTransactions: async (
       wasteRecords,
       { user, accreditation, overseasSites }

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -217,13 +217,13 @@ export const saveBalance = (db) => async (updatedBalance, newTransactions) => {
 /**
  * Creates a MongoDB-backed waste balances repository
  * @param {import('mongodb').Db} db - MongoDB database instance
- * @param {Object} [dependencies] - Optional dependencies
+ * @param {Object} dependencies
+ * @param {import('./ledger-port.js').LedgerRepository} dependencies.ledgerRepository
  * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [dependencies.systemLogsRepository]
- * @param {import('./ledger-port.js').LedgerRepository} [dependencies.ledgerRepository]
  * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [dependencies.featureFlags]
  * @returns {Promise<import('./port.js').WasteBalancesRepositoryFactory>}
  */
-export const createWasteBalancesRepository = async (db, dependencies = {}) => {
+export const createWasteBalancesRepository = async (db, dependencies) => {
   await ensureCollection(db)
   await ensureLedgerCollection(db)
 

--- a/src/waste-balances/repository/mongodb.test.js
+++ b/src/waste-balances/repository/mongodb.test.js
@@ -56,19 +56,25 @@ const it = mongoIt.extend({
 
 describe('MongoDB waste balances repository', () => {
   describe('repository creation', () => {
-    it('should create repository instance', async ({ mongoClient }) => {
+    it('should create repository instance', async ({
+      mongoClient,
+      ledgerRepository
+    }) => {
       const database = mongoClient.db(DATABASE_NAME)
-      const repository = await createWasteBalancesRepository(database)
+      const repository = await createWasteBalancesRepository(database, {
+        ledgerRepository
+      })
       const instance = repository()
       expect(instance).toBeDefined()
       expect(instance.findByAccreditationId).toBeTypeOf('function')
     })
 
     it('ensures the ledger collection indexes exist', async ({
-      mongoClient
+      mongoClient,
+      ledgerRepository
     }) => {
       const database = mongoClient.db(DATABASE_NAME)
-      await createWasteBalancesRepository(database)
+      await createWasteBalancesRepository(database, { ledgerRepository })
 
       const indexes = await database
         .collection(WASTE_BALANCE_LEDGER_COLLECTION_NAME)

--- a/src/waste-balances/repository/mongodb.test.js
+++ b/src/waste-balances/repository/mongodb.test.js
@@ -2,8 +2,11 @@ import { describe, beforeEach, expect } from 'vitest'
 import { it as mongoIt } from '#vite/fixtures/mongo.js'
 import { MongoClient } from 'mongodb'
 import { createWasteBalancesRepository } from './mongodb.js'
+import {
+  createMongoLedgerRepository,
+  WASTE_BALANCE_LEDGER_COLLECTION_NAME
+} from './ledger-mongodb.js'
 import { testWasteBalancesRepositoryContract } from './port.contract.js'
-import { WASTE_BALANCE_LEDGER_COLLECTION_NAME } from './ledger-mongodb.js'
 
 const DATABASE_NAME = 'epr-backend'
 const WASTE_BALANCE_COLLECTION_NAME = 'waste-balances'
@@ -15,9 +18,20 @@ const it = mongoIt.extend({
     await client.close()
   },
 
-  wasteBalancesRepository: async ({ mongoClient }, use) => {
+  ledgerRepository: async ({ mongoClient }, use) => {
     const database = mongoClient.db(DATABASE_NAME)
-    const factory = await createWasteBalancesRepository(database)
+    await database
+      .collection(WASTE_BALANCE_LEDGER_COLLECTION_NAME)
+      .deleteMany({})
+    const factory = await createMongoLedgerRepository(database)
+    await use(factory())
+  },
+
+  wasteBalancesRepository: async ({ mongoClient, ledgerRepository }, use) => {
+    const database = mongoClient.db(DATABASE_NAME)
+    const factory = await createWasteBalancesRepository(database, {
+      ledgerRepository
+    })
     await use(factory)
   },
 

--- a/src/waste-balances/routes/get.test.js
+++ b/src/waste-balances/routes/get.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { StatusCodes } from 'http-status-codes'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
+import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
 import { createInMemoryWasteBalancesRepository } from '#waste-balances/repository/inmemory.js'
 import { createTestServer } from '#test/create-test-server.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
@@ -21,24 +22,27 @@ describe('GET /v1/organisations/{organisationId}/waste-balances', () => {
     let wasteBalancesRepositoryFactory
 
     beforeEach(async () => {
-      wasteBalancesRepositoryFactory = createInMemoryWasteBalancesRepository([
-        {
-          accreditationId: accreditationId1,
-          organisationId,
-          amount: 1000,
-          availableAmount: 750,
-          transactions: [],
-          version: 1
-        },
-        {
-          accreditationId: accreditationId2,
-          organisationId,
-          amount: 2500,
-          availableAmount: 2500,
-          transactions: [],
-          version: 1
-        }
-      ])
+      wasteBalancesRepositoryFactory = createInMemoryWasteBalancesRepository(
+        [
+          {
+            accreditationId: accreditationId1,
+            organisationId,
+            amount: 1000,
+            availableAmount: 750,
+            transactions: [],
+            version: 1
+          },
+          {
+            accreditationId: accreditationId2,
+            organisationId,
+            amount: 2500,
+            availableAmount: 2500,
+            transactions: [],
+            version: 1
+          }
+        ],
+        { ledgerRepository: createInMemoryLedgerRepository()() }
+      )
 
       const featureFlags = createInMemoryFeatureFlags({})
 
@@ -150,16 +154,19 @@ describe('GET /v1/organisations/{organisationId}/waste-balances', () => {
 
     beforeEach(async () => {
       const wasteBalancesRepositoryFactory =
-        createInMemoryWasteBalancesRepository([
-          {
-            accreditationId: accreditationId1,
-            organisationId,
-            amount: 1000,
-            availableAmount: 750,
-            transactions: [],
-            version: 1
-          }
-        ])
+        createInMemoryWasteBalancesRepository(
+          [
+            {
+              accreditationId: accreditationId1,
+              organisationId,
+              amount: 1000,
+              availableAmount: 750,
+              transactions: [],
+              version: 1
+            }
+          ],
+          { ledgerRepository: createInMemoryLedgerRepository()() }
+        )
 
       const featureFlags = createInMemoryFeatureFlags({})
 
@@ -213,16 +220,19 @@ describe('GET /v1/organisations/{organisationId}/waste-balances', () => {
 
     beforeEach(async () => {
       const wasteBalancesRepositoryFactory =
-        createInMemoryWasteBalancesRepository([
-          {
-            accreditationId: accreditationId1,
-            organisationId,
-            amount: 1000,
-            availableAmount: 750,
-            transactions: [],
-            version: 1
-          }
-        ])
+        createInMemoryWasteBalancesRepository(
+          [
+            {
+              accreditationId: accreditationId1,
+              organisationId,
+              amount: 1000,
+              availableAmount: 750,
+              transactions: [],
+              version: 1
+            }
+          ],
+          { ledgerRepository: createInMemoryLedgerRepository()() }
+        )
 
       const featureFlags = createInMemoryFeatureFlags({})
 
@@ -248,16 +258,19 @@ describe('GET /v1/organisations/{organisationId}/waste-balances', () => {
     it('defaults null amount values to zero', async () => {
       const accreditationIdWithNulls = 'aaaaaaaaaaaaaaaaaaaaaaaa'
       const wasteBalancesRepositoryFactory =
-        createInMemoryWasteBalancesRepository([
-          {
-            accreditationId: accreditationIdWithNulls,
-            organisationId,
-            amount: null,
-            availableAmount: null,
-            transactions: [],
-            version: 1
-          }
-        ])
+        createInMemoryWasteBalancesRepository(
+          [
+            {
+              accreditationId: accreditationIdWithNulls,
+              organisationId,
+              amount: null,
+              availableAmount: null,
+              transactions: [],
+              version: 1
+            }
+          ],
+          { ledgerRepository: createInMemoryLedgerRepository()() }
+        )
 
       const featureFlags = createInMemoryFeatureFlags({})
       const server = await createTestServer({
@@ -292,16 +305,19 @@ describe('GET /v1/organisations/{organisationId}/waste-balances', () => {
       const accreditationIdDifferentOrg = 'bbbbbbbbbbbbbbbbbbbbbbbb'
 
       const wasteBalancesRepositoryFactory =
-        createInMemoryWasteBalancesRepository([
-          {
-            accreditationId: accreditationIdDifferentOrg,
-            organisationId: differentOrgId,
-            amount: 1000,
-            availableAmount: 750,
-            transactions: [],
-            version: 1
-          }
-        ])
+        createInMemoryWasteBalancesRepository(
+          [
+            {
+              accreditationId: accreditationIdDifferentOrg,
+              organisationId: differentOrgId,
+              amount: 1000,
+              availableAmount: 750,
+              transactions: [],
+              version: 1
+            }
+          ],
+          { ledgerRepository: createInMemoryLedgerRepository()() }
+        )
 
       const featureFlags = createInMemoryFeatureFlags({})
       const server = await createTestServer({
@@ -331,24 +347,27 @@ describe('GET /v1/organisations/{organisationId}/waste-balances', () => {
       const accreditationIdDifferentOrg = 'bbbbbbbbbbbbbbbbbbbbbbbb'
 
       const wasteBalancesRepositoryFactory =
-        createInMemoryWasteBalancesRepository([
-          {
-            accreditationId: accreditationId1,
-            organisationId,
-            amount: 1000,
-            availableAmount: 750,
-            transactions: [],
-            version: 1
-          },
-          {
-            accreditationId: accreditationIdDifferentOrg,
-            organisationId: differentOrgId,
-            amount: 2000,
-            availableAmount: 1500,
-            transactions: [],
-            version: 1
-          }
-        ])
+        createInMemoryWasteBalancesRepository(
+          [
+            {
+              accreditationId: accreditationId1,
+              organisationId,
+              amount: 1000,
+              availableAmount: 750,
+              transactions: [],
+              version: 1
+            },
+            {
+              accreditationId: accreditationIdDifferentOrg,
+              organisationId: differentOrgId,
+              amount: 2000,
+              availableAmount: 1500,
+              transactions: [],
+              version: 1
+            }
+          ],
+          { ledgerRepository: createInMemoryLedgerRepository()() }
+        )
 
       const featureFlags = createInMemoryFeatureFlags({})
       const server = await createTestServer({


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

When a waste-balance document carries `canonicalSource: 'ledger'`, the embedded `amount` / `availableAmount` are stale; the latest ledger transaction's `closingBalance` is the source of truth. `'embedded'` and `'migrating'` markers continue to read from the embedded fields unchanged because the embedded write path is still authoritative for them.

Substitution happens transparently inside `findByAccreditationId` and `findByAccreditationIds` so consumers (PRN lifecycle handlers, the `/v1/organisations/{id}/waste-balances` endpoint) see correct amounts without any caller-side wiring. The marker-driven routing matches the rollout design in [`waste-balance-ledger-rollout.md`](https://github.com/DEFRA/epr-re-ex-service/blob/main/docs/architecture/discovery/waste-balance-ledger-rollout.md).

Today no production accreditation has marker `'ledger'` (no sweep has run, no flag is on), so this change is a no-op until the rollout begins. The new contract tests exercise the substitution paths against both the in-memory and MongoDB adapters.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ