### PR TITLE
PAE-1439: Add optimistic concurrency control to PRN status updates

### DIFF
--- a/src/packaging-recycling-notes/application/get-issued-tonnage.test.js
+++ b/src/packaging-recycling-notes/application/get-issued-tonnage.test.js
@@ -45,6 +45,7 @@ async function issuePrn(repo, { tonnage, issuedAt = IN_PERIOD }) {
 
   return repo.updateStatus({
     id: draft.id,
+    version: draft.version,
     status: PRN_STATUS.AWAITING_ACCEPTANCE,
     updatedAt: issuedAt,
     updatedBy: ACTOR,
@@ -60,8 +61,10 @@ async function issuePrn(repo, { tonnage, issuedAt = IN_PERIOD }) {
  * @param {{ acceptedAt?: Date }} options
  */
 async function acceptPrn(repo, id, { acceptedAt = IN_PERIOD } = {}) {
+  const current = await repo.findById(id)
   return repo.updateStatus({
     id,
+    version: current.version,
     status: PRN_STATUS.ACCEPTED,
     updatedAt: acceptedAt,
     updatedBy: ACTOR,

--- a/src/packaging-recycling-notes/application/update-status-concurrency.test.js
+++ b/src/packaging-recycling-notes/application/update-status-concurrency.test.js
@@ -8,7 +8,10 @@ import { REGULATOR } from '#domain/organisations/model.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
 import { createInMemoryWasteBalancesRepository } from '#waste-balances/repository/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
-import { buildAwaitingAuthorisationPrn } from '#packaging-recycling-notes/repository/contract/test-data.js'
+import {
+  buildAwaitingAuthorisationPrn,
+  buildAwaitingAcceptancePrn
+} from '#packaging-recycling-notes/repository/contract/test-data.js'
 
 vi.mock('./metrics.js', () => ({
   prnMetrics: {
@@ -28,27 +31,36 @@ const noopLogger = () => ({
 const PRN_ID = '507f1f77bcf86cd799439011'
 const ORG_ID = 'org-123'
 const ACC_ID = 'acc-456'
+const TONNAGE = 50
+const RINGFENCED_AVAILABLE = 950
+const ISSUED_AMOUNT = 950
 
-const buildIssuableSeed = () =>
-  buildAwaitingAuthorisationPrn({
-    id: PRN_ID,
-    organisation: {
-      id: ORG_ID,
-      name: 'Test Reprocessor',
-      tradingName: 'Trading Name'
-    },
-    accreditation: {
-      id: ACC_ID,
-      accreditationNumber: 'ACC-1',
-      accreditationYear: 2026,
-      material: 'plastic',
-      submittedToRegulator: REGULATOR.EA,
-      siteAddress: { line1: '1 Test Street', postcode: 'SW1A 1AA' }
-    },
-    tonnage: 50
+const PRN_BASE = {
+  id: PRN_ID,
+  organisation: {
+    id: ORG_ID,
+    name: 'Test Reprocessor',
+    tradingName: 'Trading Name'
+  },
+  accreditation: {
+    id: ACC_ID,
+    accreditationNumber: 'ACC-1',
+    accreditationYear: 2026,
+    material: 'plastic',
+    submittedToRegulator: REGULATOR.EA,
+    siteAddress: { line1: '1 Test Street', postcode: 'SW1A 1AA' }
+  },
+  tonnage: TONNAGE
+}
+
+const buildIssuableSeed = () => buildAwaitingAuthorisationPrn(PRN_BASE)
+const buildAwaitingCancellationSeed = () =>
+  buildAwaitingAcceptancePrn({
+    ...PRN_BASE,
+    status: { currentStatus: PRN_STATUS.AWAITING_CANCELLATION }
   })
 
-const buildBalanceSeed = () => ({
+const buildBalanceSeed = (overrides = {}) => ({
   id: 'wb-1',
   accreditationId: ACC_ID,
   organisationId: ORG_ID,
@@ -57,7 +69,8 @@ const buildBalanceSeed = () => ({
   transactions: [],
   version: 0,
   schemaVersion: 1,
-  canonicalSource: 'embedded'
+  canonicalSource: 'embedded',
+  ...overrides
 })
 
 const buildOrganisationsRepository = () => ({
@@ -65,6 +78,19 @@ const buildOrganisationsRepository = () => ({
     submittedToRegulator: REGULATOR.EA
   })
 })
+
+const expectOneWinsOneVersionConflict = (results) => {
+  const fulfilled = results.filter((r) => r.status === 'fulfilled')
+  const rejected = results.filter((r) => r.status === 'rejected')
+
+  expect(fulfilled).toHaveLength(1)
+  expect(rejected).toHaveLength(1)
+  expect(rejected[0].reason).toMatchObject({
+    isBoom: true,
+    output: { statusCode: 409 }
+  })
+  expect(rejected[0].reason.message).toMatch(/Version conflict/)
+}
 
 describe('updatePrnStatus concurrency', () => {
   it('debits the waste balance only once when two issuances race for the same PRN', async () => {
@@ -103,17 +129,92 @@ describe('updatePrnStatus concurrency', () => {
 
     const results = await Promise.allSettled([issue(), issue()])
 
-    const fulfilled = results.filter((r) => r.status === 'fulfilled')
-    const rejected = results.filter((r) => r.status === 'rejected')
-
-    expect(fulfilled).toHaveLength(1)
-    expect(rejected).toHaveLength(1)
-    expect(rejected[0].reason).toMatchObject({
-      isBoom: true,
-      output: { statusCode: 409 }
-    })
-    expect(rejected[0].reason.message).toMatch(/Version conflict/)
-
+    expectOneWinsOneVersionConflict(results)
     expect(deductSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('credits the waste balance only once when two deletes race for an awaiting_authorisation PRN', async () => {
+    const prnFactory = createInMemoryPackagingRecyclingNotesRepository([
+      buildIssuableSeed()
+    ])
+    const prnRepository = prnFactory(noopLogger())
+
+    const wasteFactory = createInMemoryWasteBalancesRepository(
+      [buildBalanceSeed({ availableAmount: RINGFENCED_AVAILABLE })],
+      { ledgerRepository: createInMemoryLedgerRepository()() }
+    )
+    const realWasteBalancesRepository = wasteFactory()
+    const creditSpy = vi.fn(
+      realWasteBalancesRepository.creditAvailableBalanceForPrnCancellation
+    )
+    const wasteBalancesRepository = {
+      ...realWasteBalancesRepository,
+      creditAvailableBalanceForPrnCancellation: creditSpy
+    }
+
+    const organisationsRepository = buildOrganisationsRepository()
+
+    const cancel = () =>
+      updatePrnStatus({
+        prnRepository,
+        wasteBalancesRepository,
+        organisationsRepository,
+        id: PRN_ID,
+        organisationId: ORG_ID,
+        accreditationId: ACC_ID,
+        newStatus: PRN_STATUS.DELETED,
+        actor: PRN_ACTOR.SIGNATORY,
+        user: { id: 'user-789', name: 'Test User' }
+      })
+
+    const results = await Promise.allSettled([cancel(), cancel()])
+
+    expectOneWinsOneVersionConflict(results)
+    expect(creditSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('credits the waste balance only once when two cancels race for an awaiting_cancellation PRN', async () => {
+    const prnFactory = createInMemoryPackagingRecyclingNotesRepository([
+      buildAwaitingCancellationSeed()
+    ])
+    const prnRepository = prnFactory(noopLogger())
+
+    const wasteFactory = createInMemoryWasteBalancesRepository(
+      [
+        buildBalanceSeed({
+          availableAmount: RINGFENCED_AVAILABLE,
+          amount: ISSUED_AMOUNT
+        })
+      ],
+      { ledgerRepository: createInMemoryLedgerRepository()() }
+    )
+    const realWasteBalancesRepository = wasteFactory()
+    const creditSpy = vi.fn(
+      realWasteBalancesRepository.creditFullBalanceForIssuedPrnCancellation
+    )
+    const wasteBalancesRepository = {
+      ...realWasteBalancesRepository,
+      creditFullBalanceForIssuedPrnCancellation: creditSpy
+    }
+
+    const organisationsRepository = buildOrganisationsRepository()
+
+    const cancel = () =>
+      updatePrnStatus({
+        prnRepository,
+        wasteBalancesRepository,
+        organisationsRepository,
+        id: PRN_ID,
+        organisationId: ORG_ID,
+        accreditationId: ACC_ID,
+        newStatus: PRN_STATUS.CANCELLED,
+        actor: PRN_ACTOR.SIGNATORY,
+        user: { id: 'user-789', name: 'Test User' }
+      })
+
+    const results = await Promise.allSettled([cancel(), cancel()])
+
+    expectOneWinsOneVersionConflict(results)
+    expect(creditSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/packaging-recycling-notes/application/update-status-concurrency.test.js
+++ b/src/packaging-recycling-notes/application/update-status-concurrency.test.js
@@ -110,6 +110,7 @@ describe('updatePrnStatus concurrency', () => {
       isBoom: true,
       output: { statusCode: 409 }
     })
+    expect(rejected[0].reason.message).toMatch(/Version conflict/)
 
     expect(deductSpy).toHaveBeenCalledTimes(1)
   })

--- a/src/packaging-recycling-notes/application/update-status-concurrency.test.js
+++ b/src/packaging-recycling-notes/application/update-status-concurrency.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  PRN_STATUS,
+  PRN_ACTOR
+} from '#packaging-recycling-notes/domain/model.js'
+import { REGULATOR } from '#domain/organisations/model.js'
+import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
+import { createInMemoryWasteBalancesRepository } from '#waste-balances/repository/inmemory.js'
+import { buildAwaitingAuthorisationPrn } from '#packaging-recycling-notes/repository/contract/test-data.js'
+
+vi.mock('./metrics.js', () => ({
+  prnMetrics: {
+    recordStatusTransition: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+const { updatePrnStatus } = await import('./update-status.js')
+
+const noopLogger = () => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn()
+})
+
+const PRN_ID = '507f1f77bcf86cd799439011'
+const ORG_ID = 'org-123'
+const ACC_ID = 'acc-456'
+
+const buildIssuableSeed = () =>
+  buildAwaitingAuthorisationPrn({
+    id: PRN_ID,
+    organisation: {
+      id: ORG_ID,
+      name: 'Test Reprocessor',
+      tradingName: 'Trading Name'
+    },
+    accreditation: {
+      id: ACC_ID,
+      accreditationNumber: 'ACC-1',
+      accreditationYear: 2026,
+      material: 'plastic',
+      submittedToRegulator: REGULATOR.EA,
+      siteAddress: { line1: '1 Test Street', postcode: 'SW1A 1AA' }
+    },
+    tonnage: 50
+  })
+
+const buildBalanceSeed = () => ({
+  id: 'wb-1',
+  accreditationId: ACC_ID,
+  organisationId: ORG_ID,
+  amount: 1000,
+  availableAmount: 1000,
+  transactions: [],
+  version: 0,
+  schemaVersion: 1,
+  canonicalSource: 'embedded'
+})
+
+const buildOrganisationsRepository = () => ({
+  findAccreditationById: vi.fn().mockResolvedValue({
+    submittedToRegulator: REGULATOR.EA
+  })
+})
+
+describe('updatePrnStatus concurrency', () => {
+  it('debits the waste balance only once when two issuances race for the same PRN', async () => {
+    const prnFactory = createInMemoryPackagingRecyclingNotesRepository([
+      buildIssuableSeed()
+    ])
+    const prnRepository = prnFactory(noopLogger())
+
+    const wasteFactory = createInMemoryWasteBalancesRepository([
+      buildBalanceSeed()
+    ])
+    const realWasteBalancesRepository = wasteFactory()
+    const deductSpy = vi.fn(
+      realWasteBalancesRepository.deductTotalBalanceForPrnIssue
+    )
+    const wasteBalancesRepository = {
+      ...realWasteBalancesRepository,
+      deductTotalBalanceForPrnIssue: deductSpy
+    }
+
+    const organisationsRepository = buildOrganisationsRepository()
+
+    const issue = () =>
+      updatePrnStatus({
+        prnRepository,
+        wasteBalancesRepository,
+        organisationsRepository,
+        id: PRN_ID,
+        organisationId: ORG_ID,
+        accreditationId: ACC_ID,
+        newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+        actor: PRN_ACTOR.SIGNATORY,
+        user: { id: 'user-789', name: 'Test User' }
+      })
+
+    const results = await Promise.allSettled([issue(), issue()])
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled')
+    const rejected = results.filter((r) => r.status === 'rejected')
+
+    expect(fulfilled).toHaveLength(1)
+    expect(rejected).toHaveLength(1)
+    expect(rejected[0].reason).toMatchObject({
+      isBoom: true,
+      output: { statusCode: 409 }
+    })
+
+    expect(deductSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/packaging-recycling-notes/application/update-status-concurrency.test.js
+++ b/src/packaging-recycling-notes/application/update-status-concurrency.test.js
@@ -7,6 +7,7 @@ import {
 import { REGULATOR } from '#domain/organisations/model.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
 import { createInMemoryWasteBalancesRepository } from '#waste-balances/repository/inmemory.js'
+import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
 import { buildAwaitingAuthorisationPrn } from '#packaging-recycling-notes/repository/contract/test-data.js'
 
 vi.mock('./metrics.js', () => ({
@@ -72,9 +73,10 @@ describe('updatePrnStatus concurrency', () => {
     ])
     const prnRepository = prnFactory(noopLogger())
 
-    const wasteFactory = createInMemoryWasteBalancesRepository([
-      buildBalanceSeed()
-    ])
+    const wasteFactory = createInMemoryWasteBalancesRepository(
+      [buildBalanceSeed()],
+      { ledgerRepository: createInMemoryLedgerRepository()() }
+    )
     const realWasteBalancesRepository = wasteFactory()
     const deductSpy = vi.fn(
       realWasteBalancesRepository.deductTotalBalanceForPrnIssue

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -251,16 +251,6 @@ export async function updatePrnStatus({
   const currentStatus = prn.status.currentStatus
   validateTransition(currentStatus, newStatus, actor)
 
-  await applyWasteBalanceEffects(wasteBalancesRepository, {
-    currentStatus,
-    newStatus,
-    accreditationId,
-    organisationId,
-    prnId: id,
-    tonnage: prn.tonnage,
-    userId: user.id
-  })
-
   const now = updatedAt ?? new Date()
   const updateParams = {
     id,
@@ -270,7 +260,7 @@ export async function updatePrnStatus({
     updatedAt: now
   }
 
-  // Issue with PRN number generation and collision retry
+  let updatedPrn
   if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
     updateParams.operation = {
       slot: 'issued',
@@ -285,34 +275,33 @@ export async function updatePrnStatus({
 
     assertAccreditationNotSuspended(accreditation)
 
-    const issuedPrn = await issuePrnWithRetry(prnRepository, updateParams, {
+    updatedPrn = await issuePrnWithRetry(prnRepository, updateParams, {
       regulator: accreditation.submittedToRegulator,
       isExport: prn.isExport,
       accreditationYear: prn.accreditation.accreditationYear
     })
+  } else {
+    const operationSlot = STATUS_OPERATION_SLOT[newStatus]
+    if (operationSlot) {
+      updateParams.operation = { slot: operationSlot, at: now, by: user }
+    }
 
-    await prnMetrics.recordStatusTransition({
-      fromStatus: currentStatus,
-      toStatus: newStatus,
-      material: prn.accreditation.material,
-      isExport: prn.isExport
-    })
+    updatedPrn = await prnRepository.updateStatus(updateParams)
 
-    return issuedPrn
+    if (!updatedPrn) {
+      throw Boom.badImplementation('Failed to update PRN status')
+    }
   }
 
-  // Add business operation slot for transitions that have one
-  const operationSlot = STATUS_OPERATION_SLOT[newStatus]
-  if (operationSlot) {
-    updateParams.operation = { slot: operationSlot, at: now, by: user }
-  }
-
-  // Simple status update without PRN number
-  const updatedPrn = await prnRepository.updateStatus(updateParams)
-
-  if (!updatedPrn) {
-    throw Boom.badImplementation('Failed to update PRN status')
-  }
+  await applyWasteBalanceEffects(wasteBalancesRepository, {
+    currentStatus,
+    newStatus,
+    accreditationId,
+    organisationId,
+    prnId: id,
+    tonnage: prn.tonnage,
+    userId: user.id
+  })
 
   await prnMetrics.recordStatusTransition({
     fromStatus: currentStatus,

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -264,6 +264,7 @@ export async function updatePrnStatus({
   const now = updatedAt ?? new Date()
   const updateParams = {
     id,
+    version: prn.version,
     status: newStatus,
     updatedBy: user,
     updatedAt: now

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -261,10 +261,14 @@ export async function updatePrnStatus({
     userId: user.id
   }
 
-  // Issuance debits the balance AFTER the CAS so concurrent issues can't
-  // double-debit. Other transitions keep the pre-flight check so an
-  // insufficient balance never produces a phantom PRN.
-  if (newStatus !== PRN_STATUS.AWAITING_ACCEPTANCE) {
+  const isCreation = newStatus === PRN_STATUS.AWAITING_AUTHORISATION
+
+  // Pre-flight balance effect is kept only for new-PRN creation, where a
+  // post-CAS balance failure would strand the PRN in a state with no
+  // legal user exit. For transitions on an existing PRN (issuance,
+  // cancellation, deletion) the per-PRN CAS gates the balance write so
+  // concurrent writers cannot double-debit or double-credit.
+  if (isCreation) {
     await applyWasteBalanceEffects(
       wasteBalancesRepository,
       balanceEffectsParams
@@ -300,11 +304,6 @@ export async function updatePrnStatus({
       isExport: prn.isExport,
       accreditationYear: prn.accreditation.accreditationYear
     })
-
-    await applyWasteBalanceEffects(
-      wasteBalancesRepository,
-      balanceEffectsParams
-    )
   } else {
     const operationSlot = STATUS_OPERATION_SLOT[newStatus]
     if (operationSlot) {
@@ -316,6 +315,13 @@ export async function updatePrnStatus({
     if (!updatedPrn) {
       throw Boom.badImplementation('Failed to update PRN status')
     }
+  }
+
+  if (!isCreation) {
+    await applyWasteBalanceEffects(
+      wasteBalancesRepository,
+      balanceEffectsParams
+    )
   }
 
   await prnMetrics.recordStatusTransition({

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -251,6 +251,26 @@ export async function updatePrnStatus({
   const currentStatus = prn.status.currentStatus
   validateTransition(currentStatus, newStatus, actor)
 
+  const balanceEffectsParams = {
+    currentStatus,
+    newStatus,
+    accreditationId,
+    organisationId,
+    prnId: id,
+    tonnage: prn.tonnage,
+    userId: user.id
+  }
+
+  // Issuance debits the balance AFTER the CAS so concurrent issues can't
+  // double-debit. Other transitions keep the pre-flight check so an
+  // insufficient balance never produces a phantom PRN.
+  if (newStatus !== PRN_STATUS.AWAITING_ACCEPTANCE) {
+    await applyWasteBalanceEffects(
+      wasteBalancesRepository,
+      balanceEffectsParams
+    )
+  }
+
   const now = updatedAt ?? new Date()
   const updateParams = {
     id,
@@ -280,6 +300,11 @@ export async function updatePrnStatus({
       isExport: prn.isExport,
       accreditationYear: prn.accreditation.accreditationYear
     })
+
+    await applyWasteBalanceEffects(
+      wasteBalancesRepository,
+      balanceEffectsParams
+    )
   } else {
     const operationSlot = STATUS_OPERATION_SLOT[newStatus]
     if (operationSlot) {
@@ -292,16 +317,6 @@ export async function updatePrnStatus({
       throw Boom.badImplementation('Failed to update PRN status')
     }
   }
-
-  await applyWasteBalanceEffects(wasteBalancesRepository, {
-    currentStatus,
-    newStatus,
-    accreditationId,
-    organisationId,
-    prnId: id,
-    tonnage: prn.tonnage,
-    userId: user.id
-  })
 
   await prnMetrics.recordStatusTransition({
     fromStatus: currentStatus,

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -209,6 +209,59 @@ async function applyWasteBalanceEffects(wasteBalancesRepository, params) {
 }
 
 /**
+ * Performs the repository write for a status transition.
+ * Issuance (AWAITING_ACCEPTANCE) verifies the accreditation and
+ * generates a unique PRN number; all other transitions just stamp
+ * an operation slot and update.
+ *
+ * @param {Object} params
+ * @returns {Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote>}
+ */
+async function applyStatusUpdate({
+  prnRepository,
+  organisationsRepository,
+  prn,
+  updateParams,
+  newStatus,
+  organisationId,
+  accreditationId,
+  user,
+  now
+}) {
+  if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
+    updateParams.operation = {
+      slot: 'issued',
+      at: now,
+      by: { id: user.id, name: user.name }
+    }
+
+    const accreditation = await organisationsRepository.findAccreditationById(
+      organisationId,
+      accreditationId
+    )
+
+    assertAccreditationNotSuspended(accreditation)
+
+    return issuePrnWithRetry(prnRepository, updateParams, {
+      regulator: accreditation.submittedToRegulator,
+      isExport: prn.isExport,
+      accreditationYear: prn.accreditation.accreditationYear
+    })
+  }
+
+  const operationSlot = STATUS_OPERATION_SLOT[newStatus]
+  if (operationSlot) {
+    updateParams.operation = { slot: operationSlot, at: now, by: user }
+  }
+
+  const updatedPrn = await prnRepository.updateStatus(updateParams)
+  if (!updatedPrn) {
+    throw Boom.badImplementation('Failed to update PRN status')
+  }
+  return updatedPrn
+}
+
+/**
  * Updates PRN status with all business logic
  *
  * @param {Object} params
@@ -284,38 +337,17 @@ export async function updatePrnStatus({
     updatedAt: now
   }
 
-  let updatedPrn
-  if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
-    updateParams.operation = {
-      slot: 'issued',
-      at: now,
-      by: { id: user.id, name: user.name }
-    }
-
-    const accreditation = await organisationsRepository.findAccreditationById(
-      organisationId,
-      accreditationId
-    )
-
-    assertAccreditationNotSuspended(accreditation)
-
-    updatedPrn = await issuePrnWithRetry(prnRepository, updateParams, {
-      regulator: accreditation.submittedToRegulator,
-      isExport: prn.isExport,
-      accreditationYear: prn.accreditation.accreditationYear
-    })
-  } else {
-    const operationSlot = STATUS_OPERATION_SLOT[newStatus]
-    if (operationSlot) {
-      updateParams.operation = { slot: operationSlot, at: now, by: user }
-    }
-
-    updatedPrn = await prnRepository.updateStatus(updateParams)
-
-    if (!updatedPrn) {
-      throw Boom.badImplementation('Failed to update PRN status')
-    }
-  }
+  const updatedPrn = await applyStatusUpdate({
+    prnRepository,
+    organisationsRepository,
+    prn,
+    updateParams,
+    newStatus,
+    organisationId,
+    accreditationId,
+    user,
+    now
+  })
 
   if (!isCreation) {
     await applyWasteBalanceEffects(

--- a/src/packaging-recycling-notes/application/update-status.test.js
+++ b/src/packaging-recycling-notes/application/update-status.test.js
@@ -249,10 +249,6 @@ describe('updatePrnStatus', () => {
         accreditation: { id: 'acc-456' },
         tonnage: 100,
         status: { currentStatus: PRN_STATUS.DRAFT }
-      }),
-      updateStatus: vi.fn().mockResolvedValue({
-        id: '507f1f77bcf86cd799439011',
-        status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
       })
     })
     const wasteBalancesRepository = {
@@ -856,10 +852,7 @@ describe('updatePrnStatus', () => {
           tonnage: 100,
           status: { currentStatus: PRN_STATUS.DRAFT }
         }),
-        updateStatus: vi.fn().mockResolvedValue({
-          id: '507f1f77bcf86cd799439011',
-          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
-        })
+        updateStatus: vi.fn()
       })
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue({
@@ -887,6 +880,7 @@ describe('updatePrnStatus', () => {
       expect(
         wasteBalancesRepository.deductAvailableBalanceForPrnCreation
       ).not.toHaveBeenCalled()
+      expect(prnRepository.updateStatus).not.toHaveBeenCalled()
     })
 
     it('throws conflict when PRN tonnage exceeds total waste balance at issue', async () => {
@@ -931,6 +925,7 @@ describe('updatePrnStatus', () => {
       expect(
         wasteBalancesRepository.deductTotalBalanceForPrnIssue
       ).not.toHaveBeenCalled()
+      expect(prnRepository.updateStatus).toHaveBeenCalledTimes(1)
     })
 
     it('allows creation when tonnage equals available waste balance exactly', async () => {
@@ -982,10 +977,7 @@ describe('updatePrnStatus', () => {
           tonnage: 1,
           status: { currentStatus: PRN_STATUS.DRAFT }
         }),
-        updateStatus: vi.fn().mockResolvedValue({
-          id: '507f1f77bcf86cd799439011',
-          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
-        })
+        updateStatus: vi.fn()
       })
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue({
@@ -1395,10 +1387,7 @@ describe('updatePrnStatus', () => {
           tonnage: 60,
           status: { currentStatus: PRN_STATUS.AWAITING_CANCELLATION }
         }),
-        updateStatus: vi.fn().mockResolvedValue({
-          id: '507f1f77bcf86cd799439011',
-          status: { currentStatus: PRN_STATUS.CANCELLED }
-        })
+        updateStatus: vi.fn()
       })
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue(null)
@@ -1477,10 +1466,7 @@ describe('updatePrnStatus', () => {
           isExport: false,
           status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
         }),
-        updateStatus: vi.fn().mockResolvedValue({
-          id: '507f1f77bcf86cd799439011',
-          status: { currentStatus: PRN_STATUS.DELETED }
-        })
+        updateStatus: vi.fn()
       }
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue(null)

--- a/src/packaging-recycling-notes/application/update-status.test.js
+++ b/src/packaging-recycling-notes/application/update-status.test.js
@@ -249,6 +249,10 @@ describe('updatePrnStatus', () => {
         accreditation: { id: 'acc-456' },
         tonnage: 100,
         status: { currentStatus: PRN_STATUS.DRAFT }
+      }),
+      updateStatus: vi.fn().mockResolvedValue({
+        id: '507f1f77bcf86cd799439011',
+        status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
       })
     })
     const wasteBalancesRepository = {
@@ -523,7 +527,11 @@ describe('updatePrnStatus', () => {
         tonnage: 75,
         status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
       }),
-      updateStatus: vi.fn()
+      updateStatus: vi.fn().mockResolvedValue({
+        id: '507f1f77bcf86cd799439011',
+        prnNumber: 'ER2600001',
+        status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
+      })
     })
     const wasteBalancesRepository = {
       findByAccreditationId: vi.fn().mockResolvedValue(null)
@@ -848,7 +856,10 @@ describe('updatePrnStatus', () => {
           tonnage: 100,
           status: { currentStatus: PRN_STATUS.DRAFT }
         }),
-        updateStatus: vi.fn()
+        updateStatus: vi.fn().mockResolvedValue({
+          id: '507f1f77bcf86cd799439011',
+          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+        })
       })
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue({
@@ -876,7 +887,6 @@ describe('updatePrnStatus', () => {
       expect(
         wasteBalancesRepository.deductAvailableBalanceForPrnCreation
       ).not.toHaveBeenCalled()
-      expect(prnRepository.updateStatus).not.toHaveBeenCalled()
     })
 
     it('throws conflict when PRN tonnage exceeds total waste balance at issue', async () => {
@@ -889,7 +899,11 @@ describe('updatePrnStatus', () => {
           tonnage: 100,
           status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
         }),
-        updateStatus: vi.fn()
+        updateStatus: vi.fn().mockResolvedValue({
+          id: '507f1f77bcf86cd799439011',
+          prnNumber: 'ER2600001',
+          status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
+        })
       })
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue({
@@ -917,7 +931,6 @@ describe('updatePrnStatus', () => {
       expect(
         wasteBalancesRepository.deductTotalBalanceForPrnIssue
       ).not.toHaveBeenCalled()
-      expect(prnRepository.updateStatus).not.toHaveBeenCalled()
     })
 
     it('allows creation when tonnage equals available waste balance exactly', async () => {
@@ -969,7 +982,10 @@ describe('updatePrnStatus', () => {
           tonnage: 1,
           status: { currentStatus: PRN_STATUS.DRAFT }
         }),
-        updateStatus: vi.fn()
+        updateStatus: vi.fn().mockResolvedValue({
+          id: '507f1f77bcf86cd799439011',
+          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+        })
       })
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue({
@@ -1003,7 +1019,11 @@ describe('updatePrnStatus', () => {
           tonnage: 1,
           status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
         }),
-        updateStatus: vi.fn()
+        updateStatus: vi.fn().mockResolvedValue({
+          id: '507f1f77bcf86cd799439011',
+          prnNumber: 'ER2600001',
+          status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
+        })
       })
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue({
@@ -1375,7 +1395,10 @@ describe('updatePrnStatus', () => {
           tonnage: 60,
           status: { currentStatus: PRN_STATUS.AWAITING_CANCELLATION }
         }),
-        updateStatus: vi.fn()
+        updateStatus: vi.fn().mockResolvedValue({
+          id: '507f1f77bcf86cd799439011',
+          status: { currentStatus: PRN_STATUS.CANCELLED }
+        })
       })
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue(null)
@@ -1454,7 +1477,10 @@ describe('updatePrnStatus', () => {
           isExport: false,
           status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
         }),
-        updateStatus: vi.fn()
+        updateStatus: vi.fn().mockResolvedValue({
+          id: '507f1f77bcf86cd799439011',
+          status: { currentStatus: PRN_STATUS.DELETED }
+        })
       }
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue(null)

--- a/src/packaging-recycling-notes/application/update-status.test.js
+++ b/src/packaging-recycling-notes/application/update-status.test.js
@@ -1387,7 +1387,10 @@ describe('updatePrnStatus', () => {
           tonnage: 60,
           status: { currentStatus: PRN_STATUS.AWAITING_CANCELLATION }
         }),
-        updateStatus: vi.fn()
+        updateStatus: vi.fn().mockResolvedValue({
+          id: '507f1f77bcf86cd799439011',
+          status: { currentStatus: PRN_STATUS.CANCELLED }
+        })
       })
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue(null)
@@ -1466,7 +1469,10 @@ describe('updatePrnStatus', () => {
           isExport: false,
           status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
         }),
-        updateStatus: vi.fn()
+        updateStatus: vi.fn().mockResolvedValue({
+          id: '507f1f77bcf86cd799439011',
+          status: { currentStatus: PRN_STATUS.DELETED }
+        })
       }
       const wasteBalancesRepository = {
         findByAccreditationId: vi.fn().mockResolvedValue(null)

--- a/src/packaging-recycling-notes/domain/model.js
+++ b/src/packaging-recycling-notes/domain/model.js
@@ -196,6 +196,7 @@ export function validateTransition(currentStatus, newStatus, actor) {
  * @typedef {{
  *   id: string;
  *   schemaVersion: number;
+ *   version: number;
  *   prnNumber?: string | null;
  *   organisation: OrganisationNameAndId;
  *   registrationId: string;

--- a/src/packaging-recycling-notes/repository/contract/optimistic-concurrency.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/optimistic-concurrency.contract.js
@@ -163,6 +163,36 @@ export const testOptimisticConcurrency = (it) => {
           PRN_STATUS.DELETED
         ]).toContain(final.status.currentStatus)
       })
+
+      it('surfaces 409 (not a duplicate-key 500) when two issues race for the same PRN', async () => {
+        const created = await repository.create(buildAwaitingAuthorisationPrn())
+        const baseSuffix = Date.now().toString().slice(-5)
+        const issueWithSuffix = (suffix) =>
+          repository.updateStatus({
+            id: created.id,
+            version: created.version,
+            status: PRN_STATUS.AWAITING_ACCEPTANCE,
+            updatedBy: issuerUser,
+            updatedAt: new Date(),
+            prnNumber: `ER26${baseSuffix}${suffix}`,
+            operation: { slot: 'issued', at: new Date(), by: issuerUser }
+          })
+
+        const results = await Promise.allSettled([
+          issueWithSuffix('A'),
+          issueWithSuffix('B')
+        ])
+
+        const fulfilled = results.filter((r) => r.status === 'fulfilled')
+        const rejected = results.filter((r) => r.status === 'rejected')
+
+        expect(fulfilled).toHaveLength(1)
+        expect(rejected).toHaveLength(1)
+        expect(rejected[0].reason).toMatchObject({
+          isBoom: true,
+          output: { statusCode: 409 }
+        })
+      })
     })
 
     describe('conflict logging', () => {

--- a/src/packaging-recycling-notes/repository/contract/optimistic-concurrency.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/optimistic-concurrency.contract.js
@@ -1,0 +1,227 @@
+import { describe, beforeEach, expect, vi } from 'vitest'
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { buildAwaitingAuthorisationPrn, buildDraftPrn } from './test-data.js'
+
+const updaterUser = { id: 'user-raiser', name: 'Raiser User' }
+const issuerUser = { id: 'user-issuer', name: 'Issuer User' }
+
+const updateToAwaitingAuthorisation = (repository, prn) =>
+  repository.updateStatus({
+    id: prn.id,
+    version: prn.version,
+    status: PRN_STATUS.AWAITING_AUTHORISATION,
+    updatedBy: updaterUser,
+    updatedAt: new Date()
+  })
+
+const updateToDeleted = (repository, prn) =>
+  repository.updateStatus({
+    id: prn.id,
+    version: prn.version,
+    status: PRN_STATUS.DELETED,
+    updatedBy: updaterUser,
+    updatedAt: new Date()
+  })
+
+export const testOptimisticConcurrency = (it) => {
+  describe('optimistic concurrency', () => {
+    let repository
+
+    beforeEach(async ({ prnRepository }) => {
+      repository = prnRepository
+    })
+
+    describe('version control', () => {
+      it('initialises version to 1 on create', async () => {
+        const created = await repository.create(buildDraftPrn())
+
+        expect(created.version).toBe(1)
+      })
+
+      it('persists version 1 so it can be read back', async () => {
+        const created = await repository.create(buildDraftPrn())
+
+        const found = await repository.findById(created.id)
+
+        expect(found.version).toBe(1)
+      })
+
+      it('increments version on successful updateStatus', async () => {
+        const created = await repository.create(buildDraftPrn())
+
+        const updated = await updateToAwaitingAuthorisation(repository, created)
+
+        expect(updated.version).toBe(2)
+        expect(updated.status.currentStatus).toBe(
+          PRN_STATUS.AWAITING_AUTHORISATION
+        )
+      })
+
+      it('exposes the new version after updateStatus through findById', async () => {
+        const created = await repository.create(buildDraftPrn())
+        await updateToAwaitingAuthorisation(repository, created)
+
+        const found = await repository.findById(created.id)
+
+        expect(found.version).toBe(2)
+      })
+
+      it('allows sequential updates that thread the version through', async () => {
+        const created = await repository.create(buildAwaitingAuthorisationPrn())
+
+        const issued = await repository.updateStatus({
+          id: created.id,
+          version: created.version,
+          status: PRN_STATUS.AWAITING_ACCEPTANCE,
+          updatedBy: issuerUser,
+          updatedAt: new Date(),
+          prnNumber: `ER26${Date.now().toString().slice(-5)}A`
+        })
+        expect(issued.version).toBe(2)
+
+        const accepted = await repository.updateStatus({
+          id: created.id,
+          version: issued.version,
+          status: PRN_STATUS.ACCEPTED,
+          updatedBy: { id: 'producer', name: 'Producer User' },
+          updatedAt: new Date()
+        })
+
+        const expectedFinalVersion = 3
+        expect(accepted.version).toBe(expectedFinalVersion)
+        expect(accepted.status.currentStatus).toBe(PRN_STATUS.ACCEPTED)
+      })
+
+      it('throws Boom.conflict when updating with a stale version', async () => {
+        const created = await repository.create(buildDraftPrn())
+
+        await updateToAwaitingAuthorisation(repository, created)
+
+        await expect(
+          updateToDeleted(repository, created)
+        ).rejects.toMatchObject({
+          isBoom: true,
+          output: { statusCode: 409 }
+        })
+      })
+
+      it('does not apply the update when the version is stale', async () => {
+        const created = await repository.create(buildDraftPrn())
+
+        await updateToAwaitingAuthorisation(repository, created)
+        await updateToDeleted(repository, created).catch(() => {})
+
+        const found = await repository.findById(created.id)
+        expect(found.status.currentStatus).toBe(
+          PRN_STATUS.AWAITING_AUTHORISATION
+        )
+        expect(found.version).toBe(2)
+      })
+
+      it('uses a descriptive message identifying expected and actual versions', async () => {
+        const created = await repository.create(buildDraftPrn())
+        await updateToAwaitingAuthorisation(repository, created)
+
+        const expectedCurrentVersion = 2
+        await expect(
+          updateToDeleted(repository, created)
+        ).rejects.toMatchObject({
+          isBoom: true,
+          output: {
+            statusCode: 409,
+            payload: {
+              message: `Version conflict: attempted to update PRN ${created.id} with version ${created.version} but current version is ${expectedCurrentVersion}`
+            }
+          }
+        })
+      })
+    })
+
+    describe('concurrent update race conditions', () => {
+      it('rejects one of two concurrent updates with the same version', async () => {
+        const created = await repository.create(buildDraftPrn())
+
+        const results = await Promise.allSettled([
+          updateToAwaitingAuthorisation(repository, created),
+          updateToDeleted(repository, created)
+        ])
+
+        const fulfilled = results.filter((r) => r.status === 'fulfilled')
+        const rejected = results.filter((r) => r.status === 'rejected')
+
+        expect(fulfilled).toHaveLength(1)
+        expect(rejected).toHaveLength(1)
+        expect(rejected[0].reason).toMatchObject({
+          isBoom: true,
+          output: { statusCode: 409 }
+        })
+
+        const final = await repository.findById(created.id)
+        expect(final.version).toBe(2)
+        expect([
+          PRN_STATUS.AWAITING_AUTHORISATION,
+          PRN_STATUS.DELETED
+        ]).toContain(final.status.currentStatus)
+      })
+    })
+
+    describe('conflict logging', () => {
+      it('logs version conflict with database/version_conflict_detected event metadata', async ({
+        prnRepositoryFactory
+      }) => {
+        const logger = {
+          info: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          debug: vi.fn()
+        }
+        const repo = prnRepositoryFactory(logger)
+        const created = await repo.create(buildDraftPrn())
+        await updateToAwaitingAuthorisation(repo, created)
+
+        await expect(updateToDeleted(repo, created)).rejects.toMatchObject({
+          isBoom: true,
+          output: { statusCode: 409 }
+        })
+
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            err: expect.any(Error),
+            message: `Version conflict detected for PRN ${created.id}`,
+            event: {
+              category: 'database',
+              action: 'version_conflict_detected',
+              reference: created.id
+            }
+          })
+        )
+      })
+
+      it('includes the conflict message on the logged error', async ({
+        prnRepositoryFactory
+      }) => {
+        const logger = {
+          info: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          debug: vi.fn()
+        }
+        const repo = prnRepositoryFactory(logger)
+        const created = await repo.create(buildDraftPrn())
+        await updateToAwaitingAuthorisation(repo, created)
+
+        await expect(updateToDeleted(repo, created)).rejects.toMatchObject({
+          isBoom: true,
+          output: { statusCode: 409 }
+        })
+
+        const logCall = logger.error.mock.calls[0][0]
+        expect(logCall.err).toBeInstanceOf(Error)
+        const expectedCurrentVersion = 2
+        expect(logCall.err.message).toBe(
+          `Version conflict: attempted to update PRN ${created.id} with version ${created.version} but current version is ${expectedCurrentVersion}`
+        )
+      })
+    })
+  })
+}

--- a/src/packaging-recycling-notes/repository/contract/prn-number-uniqueness.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/prn-number-uniqueness.contract.js
@@ -19,6 +19,7 @@ export const testPrnNumberUniqueness = (it) => {
 
         await repository.updateStatus({
           id: prn1.id,
+          version: prn1.version,
           status: PRN_STATUS.AWAITING_ACCEPTANCE,
           updatedBy: { id: 'user-issuer', name: 'Issuer User' },
           updatedAt: new Date(),
@@ -28,6 +29,7 @@ export const testPrnNumberUniqueness = (it) => {
         await expect(
           repository.updateStatus({
             id: prn2.id,
+            version: prn2.version,
             status: PRN_STATUS.AWAITING_ACCEPTANCE,
             updatedBy: { id: 'user-issuer', name: 'Issuer User' },
             updatedAt: new Date(),
@@ -43,6 +45,7 @@ export const testPrnNumberUniqueness = (it) => {
 
         const updated1 = await repository.updateStatus({
           id: prn1.id,
+          version: prn1.version,
           status: PRN_STATUS.AWAITING_ACCEPTANCE,
           updatedBy: { id: 'user-issuer', name: 'Issuer User' },
           updatedAt: new Date(),
@@ -51,6 +54,7 @@ export const testPrnNumberUniqueness = (it) => {
 
         const updated2 = await repository.updateStatus({
           id: prn2.id,
+          version: prn2.version,
           status: PRN_STATUS.AWAITING_ACCEPTANCE,
           updatedBy: { id: 'user-issuer', name: 'Issuer User' },
           updatedAt: new Date(),
@@ -67,6 +71,7 @@ export const testPrnNumberUniqueness = (it) => {
 
         const updated1 = await repository.updateStatus({
           id: prn1.id,
+          version: prn1.version,
           status: PRN_STATUS.CANCELLED,
           updatedBy: { id: 'user-canceller', name: 'Canceller User' },
           updatedAt: new Date()
@@ -74,6 +79,7 @@ export const testPrnNumberUniqueness = (it) => {
 
         const updated2 = await repository.updateStatus({
           id: prn2.id,
+          version: prn2.version,
           status: PRN_STATUS.CANCELLED,
           updatedBy: { id: 'user-canceller', name: 'Canceller User' },
           updatedAt: new Date()
@@ -92,6 +98,7 @@ export const testPrnNumberUniqueness = (it) => {
 
         await repository.updateStatus({
           id: prn1.id,
+          version: prn1.version,
           status: PRN_STATUS.AWAITING_ACCEPTANCE,
           updatedBy: { id: 'user-issuer', name: 'Issuer User' },
           updatedAt: new Date(),
@@ -101,6 +108,7 @@ export const testPrnNumberUniqueness = (it) => {
         const error = await repository
           .updateStatus({
             id: prn2.id,
+            version: prn2.version,
             status: PRN_STATUS.AWAITING_ACCEPTANCE,
             updatedBy: { id: 'user-issuer', name: 'Issuer User' },
             updatedAt: new Date(),

--- a/src/packaging-recycling-notes/repository/contract/test-data.js
+++ b/src/packaging-recycling-notes/repository/contract/test-data.js
@@ -32,6 +32,7 @@ export const buildPrn = (overrides = {}) => {
 
   return {
     schemaVersion: 2,
+    version: 1,
     organisation: {
       id: `org-${randomUUID()}`,
       name: 'Test Organisation',

--- a/src/packaging-recycling-notes/repository/contract/update-status.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/update-status.contract.js
@@ -16,6 +16,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         const updated = await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
           updatedBy: { id: 'user-raiser', name: 'Raiser User' },
           updatedAt: new Date()
@@ -31,6 +32,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         const updated = await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
           updatedBy: { id: 'user-raiser', name: 'Raiser User' },
           updatedAt: new Date()
@@ -52,6 +54,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         const updated = await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
           updatedBy: { id: 'user-raiser', name: 'Raiser User' },
           updatedAt: updateTime
@@ -66,6 +69,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         const updated = await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
           updatedBy: { id: 'user-raiser', name: 'Raiser User' },
           updatedAt: updateTime
@@ -79,6 +83,7 @@ export const testUpdateStatusBehaviour = (it) => {
       it('returns null when PRN not found', async () => {
         const result = await repository.updateStatus({
           id: '000000000000000000000000',
+          version: 1,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
           updatedBy: { id: 'user-test', name: 'Test User' },
           updatedAt: new Date()
@@ -92,6 +97,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         const updated = await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
           updatedBy: { id: 'user-test', name: 'Test User' },
           updatedAt: new Date()
@@ -105,6 +111,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         const updated = await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
           updatedBy: { id: 'user-test', name: 'Test User' },
           updatedAt: new Date()
@@ -121,6 +128,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         const updated = await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_ACCEPTANCE,
           updatedBy: { id: 'user-issuer', name: 'Issuer User' },
           updatedAt: new Date(),
@@ -136,6 +144,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_ACCEPTANCE,
           updatedBy: { id: 'user-issuer', name: 'Issuer User' },
           updatedAt: new Date(),
@@ -151,6 +160,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         const updated = await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
           updatedBy: { id: 'user-raiser', name: 'Raiser User' },
           updatedAt: new Date()
@@ -168,6 +178,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         const updated = await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_ACCEPTANCE,
           updatedBy: actor,
           updatedAt: now,
@@ -190,6 +201,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_ACCEPTANCE,
           updatedBy: { id: 'user-issuer', name: 'Issuer User' },
           updatedAt: now,
@@ -207,6 +219,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         const updated = await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
           updatedBy: { id: 'user-raiser', name: 'Raiser User' },
           updatedAt: new Date()
@@ -220,8 +233,9 @@ export const testUpdateStatusBehaviour = (it) => {
       it('tracks full status history across transitions', async () => {
         const created = await repository.create(buildDraftPrn())
 
-        await repository.updateStatus({
+        const intermediate = await repository.updateStatus({
           id: created.id,
+          version: created.version,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
           updatedBy: { id: 'user-raiser', name: 'Raiser User' },
           updatedAt: new Date()
@@ -229,6 +243,7 @@ export const testUpdateStatusBehaviour = (it) => {
 
         const final = await repository.updateStatus({
           id: created.id,
+          version: intermediate.version,
           status: PRN_STATUS.AWAITING_ACCEPTANCE,
           updatedBy: { id: 'user-issuer', name: 'Issuer User' },
           updatedAt: new Date(),

--- a/src/packaging-recycling-notes/repository/inmemory.plugin.js
+++ b/src/packaging-recycling-notes/repository/inmemory.plugin.js
@@ -1,9 +1,15 @@
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/event.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { registerRepository } from '#plugins/register-repository.js'
+import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 import { PrnNumberConflictError } from './port.js'
 import { validatePrnInsert } from './validation.js'
 
+/** @import { TypedLogger } from '#common/hapi-types.js' */
 /** @import { Organisation } from '#domain/organisations/model.js' */
 /** @import { PackagingRecyclingNote } from '../domain/model.js' */
 /** @import { FindByStatusParams, PaginatedResult, UpdateStatusParams } from './port.js' */
@@ -43,6 +49,11 @@ const performCreate = (storage) => async (prn) => {
   storage.set(id, structuredClone(prnWithId))
   return structuredClone(prnWithId)
 }
+
+const buildVersionConflictError = (id, expected, actual) =>
+  new Error(
+    `Version conflict: attempted to update PRN ${id} with version ${expected} but current version is ${actual}`
+  )
 
 /**
  * @param {Storage} storage
@@ -140,14 +151,37 @@ const performFindByStatus = (storage, excludeOrganisationIds) => {
 
 /**
  * @param {Storage} storage
+ * @param {TypedLogger} logger
  * @returns {(params: UpdateStatusParams) => Promise<PackagingRecyclingNote | null>}
  */
 const performUpdateStatus =
-  (storage) =>
-  async ({ id, status, updatedBy, updatedAt, prnNumber, operation }) => {
+  (storage, logger) =>
+  async ({
+    id,
+    version,
+    status,
+    updatedBy,
+    updatedAt,
+    prnNumber,
+    operation
+  }) => {
     const prn = storage.get(id)
     if (!prn) {
       return null
+    }
+
+    if (prn.version !== version) {
+      const conflictError = buildVersionConflictError(id, version, prn.version)
+      logger.error({
+        err: conflictError,
+        message: `Version conflict detected for PRN ${id}`,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.DB,
+          action: LOGGING_EVENT_ACTIONS.VERSION_CONFLICT_DETECTED,
+          reference: id
+        }
+      })
+      throw Boom.conflict(conflictError.message)
     }
 
     if (prnNumber) {
@@ -171,6 +205,7 @@ const performUpdateStatus =
 
     const updated = {
       ...prn,
+      version: prn.version + 1,
       updatedBy,
       updatedAt,
       status: statusUpdate
@@ -197,16 +232,16 @@ export function createInMemoryPackagingRecyclingNotesRepository(
 
   for (const prn of initialData) {
     const id = prn.id
-    storage.set(id, structuredClone({ ...prn, id }))
+    storage.set(id, structuredClone({ version: 1, ...prn, id }))
   }
 
-  return () => ({
+  return (/** @type {TypedLogger} */ logger) => ({
     create: performCreate(storage),
     findByAccreditation: performFindByAccreditation(storage),
     findById: performFindById(storage),
     findByPrnNumber: performFindByPrnNumber(storage),
     findByStatus: performFindByStatus(storage, excludeOrganisationIds),
-    updateStatus: performUpdateStatus(storage)
+    updateStatus: performUpdateStatus(storage, logger)
   })
 }
 
@@ -217,7 +252,6 @@ export function createInMemoryPackagingRecyclingNotesRepositoryPlugin(
     initialPrns,
     []
   )
-  const repository = factory()
 
   return {
     name: 'packagingRecyclingNotesRepository',
@@ -225,7 +259,7 @@ export function createInMemoryPackagingRecyclingNotesRepositoryPlugin(
       registerRepository(
         server,
         'packagingRecyclingNotesRepository',
-        () => repository
+        (request) => factory(request.logger)
       )
     }
   }

--- a/src/packaging-recycling-notes/repository/inmemory.plugin.js
+++ b/src/packaging-recycling-notes/repository/inmemory.plugin.js
@@ -232,7 +232,7 @@ export function createInMemoryPackagingRecyclingNotesRepository(
 
   for (const prn of initialData) {
     const id = prn.id
-    storage.set(id, structuredClone({ version: 1, ...prn, id }))
+    storage.set(id, structuredClone({ ...prn, version: prn.version ?? 1, id }))
   }
 
   return (/** @type {TypedLogger} */ logger) => ({

--- a/src/packaging-recycling-notes/repository/inmemory.test.js
+++ b/src/packaging-recycling-notes/repository/inmemory.test.js
@@ -1,14 +1,24 @@
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
-import { it as base, describe, expect } from 'vitest'
+import { it as base, describe, expect, vi } from 'vitest'
 import { buildCancelledPrn } from './contract/test-data.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from './inmemory.plugin.js'
 import { testPackagingRecyclingNotesRepositoryContract } from './port.contract.js'
 
 const it = base.extend({
   // eslint-disable-next-line no-empty-pattern
-  prnRepository: async ({}, use) => {
+  prnRepositoryFactory: async ({}, use) => {
     const factory = createInMemoryPackagingRecyclingNotesRepository([])
-    const repository = factory()
+    await use(factory)
+  },
+
+  prnRepository: async ({ prnRepositoryFactory }, use) => {
+    const mockLogger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn()
+    }
+    const repository = prnRepositoryFactory(mockLogger)
     await use(repository)
   }
 })

--- a/src/packaging-recycling-notes/repository/inmemory.test.js
+++ b/src/packaging-recycling-notes/repository/inmemory.test.js
@@ -1,6 +1,10 @@
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { ObjectId } from 'mongodb'
 import { it as base, describe, expect, vi } from 'vitest'
-import { buildCancelledPrn } from './contract/test-data.js'
+import {
+  buildAwaitingAuthorisationPrn,
+  buildCancelledPrn
+} from './contract/test-data.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from './inmemory.plugin.js'
 import { testPackagingRecyclingNotesRepositoryContract } from './port.contract.js'
 
@@ -142,6 +146,56 @@ describe('in-memory adapter organisation exclusion', () => {
       expect(result.hasMore).toBe(true)
       expect(result.nextCursor).toBe(realPrn1.id)
       expect(result.items.map((p) => p.id)).not.toContain(realPrn2.id)
+    }
+  )
+})
+
+describe('in-memory adapter legacy documents without a version field', () => {
+  const buildVersionlessSeed = () => {
+    const id = new ObjectId().toHexString()
+    const { version: _version, ...prnWithoutVersion } =
+      buildAwaitingAuthorisationPrn()
+    return { id, prn: { ...prnWithoutVersion, id } }
+  }
+
+  base('reads back as version 1', async () => {
+    const { id, prn } = buildVersionlessSeed()
+    const repository = createInMemoryPackagingRecyclingNotesRepository([prn])({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn()
+    })
+
+    const found = await repository.findById(id)
+
+    expect(found.version).toBe(1)
+  })
+
+  base(
+    'accepts a CAS update with version 1 and bumps to version 2',
+    async () => {
+      const { id, prn } = buildVersionlessSeed()
+      const repository = createInMemoryPackagingRecyclingNotesRepository([prn])(
+        {
+          info: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          debug: vi.fn()
+        }
+      )
+
+      const updated = await repository.updateStatus({
+        id,
+        version: 1,
+        status: PRN_STATUS.AWAITING_ACCEPTANCE,
+        updatedBy: { id: 'user-issuer', name: 'Issuer User' },
+        updatedAt: new Date(),
+        prnNumber: `TT2688888`
+      })
+
+      expect(updated.version).toBe(2)
+      expect(updated.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
     }
   )
 })

--- a/src/packaging-recycling-notes/repository/mongodb.js
+++ b/src/packaging-recycling-notes/repository/mongodb.js
@@ -96,25 +96,6 @@ async function ensureStatusDateIndex(collection) {
 }
 
 /**
- * Backfills the version field on legacy documents that pre-date OCC.
- * Idempotent: documents that already carry a version are not touched.
- *
- * @param {Collection} collection
- */
-async function backfillVersionField(collection) {
-  try {
-    await collection.updateMany(
-      { version: { $exists: false } },
-      { $set: { version: 1 } }
-    )
-  } catch (error) {
-    if (error.codeName !== 'NamespaceNotFound') {
-      throw error
-    }
-  }
-}
-
-/**
  * @param {Db} db
  * @returns {Promise<Collection>}
  */
@@ -128,8 +109,6 @@ async function ensureCollection(db) {
   await ensurePrnNumberIndex(collection)
 
   await ensureStatusDateIndex(collection)
-
-  await backfillVersionField(collection)
 
   return collection
 }
@@ -290,8 +269,9 @@ const resolveMissedUpdate = async (db, id, expectedVersion, logger) => {
     return null
   }
 
+  const actualVersion = existing.version ?? 1
   const conflictError = new Error(
-    `Version conflict: attempted to update PRN ${id} with version ${expectedVersion} but current version is ${existing.version}`
+    `Version conflict: attempted to update PRN ${id} with version ${expectedVersion} but current version is ${actualVersion}`
   )
   logger.error({
     err: conflictError,
@@ -336,10 +316,12 @@ const performUpdateStatus = async (
 
   try {
     const result = await db.collection(COLLECTION_NAME).findOneAndUpdate(
-      { _id: ObjectId.createFromHexString(id), version },
       {
-        $set: setFields,
-        $inc: { version: 1 },
+        _id: ObjectId.createFromHexString(id),
+        $expr: { $eq: [{ $ifNull: ['$version', 1] }, version] }
+      },
+      {
+        $set: { ...setFields, version: version + 1 },
         $push: /** @type {*} */ ({
           'status.history': { status, at: updatedAt, by: updatedBy }
         })

--- a/src/packaging-recycling-notes/repository/mongodb.js
+++ b/src/packaging-recycling-notes/repository/mongodb.js
@@ -1,5 +1,10 @@
+import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/event.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { PrnNumberConflictError } from './port.js'
 import { validatePrnInsert, validatePrnRead } from './validation.js'
@@ -8,6 +13,7 @@ import { validatePrnInsert, validatePrnRead } from './validation.js'
 /** @import { Organisation } from '#domain/organisations/model.js' */
 /** @import { PackagingRecyclingNote } from '#packaging-recycling-notes/domain/model.js' */
 /** @import { FindByStatusParams, PackagingRecyclingNotesRepositoryFactory, PaginatedResult, UpdateStatusParams } from './port.js' */
+/** @import { TypedLogger } from '#common/hapi-types.js' */
 
 const COLLECTION_NAME = 'packaging-recycling-notes'
 const MONGODB_DUPLICATE_KEY_ERROR_CODE = 11000
@@ -90,6 +96,25 @@ async function ensureStatusDateIndex(collection) {
 }
 
 /**
+ * Backfills the version field on legacy documents that pre-date OCC.
+ * Idempotent: documents that already carry a version are not touched.
+ *
+ * @param {Collection} collection
+ */
+async function backfillVersionField(collection) {
+  try {
+    await collection.updateMany(
+      { version: { $exists: false } },
+      { $set: { version: 1 } }
+    )
+  } catch (error) {
+    if (error.codeName !== 'NamespaceNotFound') {
+      throw error
+    }
+  }
+}
+
+/**
  * @param {Db} db
  * @returns {Promise<Collection>}
  */
@@ -103,6 +128,8 @@ async function ensureCollection(db) {
   await ensurePrnNumberIndex(collection)
 
   await ensureStatusDateIndex(collection)
+
+  await backfillVersionField(collection)
 
   return collection
 }
@@ -244,13 +271,50 @@ const performFindByStatus = (db, excludeOrganisationIds) => {
 }
 
 /**
+ * Resolves a missed CAS update into a 404 (PRN missing) or 409 (version conflict).
+ * Logs the version conflict for observability before throwing.
+ *
  * @param {Db} db
+ * @param {string} id
+ * @param {number} expectedVersion
+ * @param {TypedLogger} logger
+ * @returns {Promise<null>}
+ */
+const resolveMissedUpdate = async (db, id, expectedVersion, logger) => {
+  const objectId = ObjectId.createFromHexString(id)
+  const existing = await db
+    .collection(COLLECTION_NAME)
+    .findOne({ _id: objectId }, { projection: { version: 1 } })
+
+  if (!existing) {
+    return null
+  }
+
+  const conflictError = new Error(
+    `Version conflict: attempted to update PRN ${id} with version ${expectedVersion} but current version is ${existing.version}`
+  )
+  logger.error({
+    err: conflictError,
+    message: `Version conflict detected for PRN ${id}`,
+    event: {
+      category: LOGGING_EVENT_CATEGORIES.DB,
+      action: LOGGING_EVENT_ACTIONS.VERSION_CONFLICT_DETECTED,
+      reference: id
+    }
+  })
+  throw Boom.conflict(conflictError.message)
+}
+
+/**
+ * @param {Db} db
+ * @param {TypedLogger} logger
  * @param {UpdateStatusParams} params
  * @returns {Promise<PackagingRecyclingNote | null>}
  */
 const performUpdateStatus = async (
   db,
-  { id, status, updatedBy, updatedAt, prnNumber, operation }
+  logger,
+  { id, version, status, updatedBy, updatedAt, prnNumber, operation }
 ) => {
   const setFields = {
     'status.currentStatus': status,
@@ -272,9 +336,10 @@ const performUpdateStatus = async (
 
   try {
     const result = await db.collection(COLLECTION_NAME).findOneAndUpdate(
-      { _id: ObjectId.createFromHexString(id) },
+      { _id: ObjectId.createFromHexString(id), version },
       {
         $set: setFields,
+        $inc: { version: 1 },
         $push: /** @type {*} */ ({
           'status.history': { status, at: updatedAt, by: updatedBy }
         })
@@ -283,7 +348,7 @@ const performUpdateStatus = async (
     )
 
     if (!result) {
-      return null
+      return resolveMissedUpdate(db, id, version, logger)
     }
 
     return validatePrnRead({ ...result, id: result._id.toHexString() })
@@ -309,13 +374,13 @@ export const createPackagingRecyclingNotesRepository = async (
 ) => {
   await ensureCollection(db)
 
-  return () => ({
+  return (/** @type {TypedLogger} */ logger) => ({
     create: (prn) => performCreate(db, prn),
     findByAccreditation: (accreditationId) =>
       performFindByAccreditation(db, accreditationId),
     findById: (id) => performFindById(db, id),
     findByPrnNumber: (prnNumber) => performFindByPrnNumber(db, prnNumber),
     findByStatus: performFindByStatus(db, excludeOrganisationIds),
-    updateStatus: (params) => performUpdateStatus(db, params)
+    updateStatus: (params) => performUpdateStatus(db, logger, params)
   })
 }

--- a/src/packaging-recycling-notes/repository/mongodb.plugin.js
+++ b/src/packaging-recycling-notes/repository/mongodb.plugin.js
@@ -22,10 +22,8 @@ export const packagingRecyclingNotesRepositoryPlugin = {
       excludeOrganisationIds
     )
 
-    registerRepository(
-      server,
-      'packagingRecyclingNotesRepository',
-      createRepository
+    registerRepository(server, 'packagingRecyclingNotesRepository', (request) =>
+      createRepository(request.logger)
     )
   }
 }

--- a/src/packaging-recycling-notes/repository/mongodb.test.js
+++ b/src/packaging-recycling-notes/repository/mongodb.test.js
@@ -1,6 +1,6 @@
 import { it as mongoIt } from '#vite/fixtures/mongo.js'
 import { MongoClient } from 'mongodb'
-import { describe, expect } from 'vitest'
+import { describe, expect, vi } from 'vitest'
 import { createPackagingRecyclingNotesRepository } from './mongodb.js'
 import { testPackagingRecyclingNotesRepositoryContract } from './port.contract.js'
 import { PrnNumberConflictError } from './port.js'
@@ -21,7 +21,13 @@ const it = mongoIt.extend({
   },
 
   prnRepository: async ({ prnRepositoryFactory }, use) => {
-    const repository = prnRepositoryFactory()
+    const mockLogger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn()
+    }
+    const repository = prnRepositoryFactory(mockLogger)
     await use(repository)
   }
 })
@@ -48,6 +54,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         find: function () {
           return { toArray: async () => [] }
         },
+        updateMany: async () => ({ matchedCount: 0 }),
         findOneAndUpdate: async () => {
           throw otherError
         }
@@ -59,6 +66,7 @@ describe('MongoDB packaging recycling notes repository', () => {
       await expect(
         repository.updateStatus({
           id: hexId,
+          version: 1,
           status: 'awaiting_acceptance',
           updatedBy: { id: 'user-123', name: 'Test User' },
           updatedAt: new Date(),
@@ -85,6 +93,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         find: function () {
           return { toArray: async () => [] }
         },
+        updateMany: async () => ({ matchedCount: 0 }),
         findOneAndUpdate: async () => {
           throw duplicateKeyError
         }
@@ -96,6 +105,7 @@ describe('MongoDB packaging recycling notes repository', () => {
       await expect(
         repository.updateStatus({
           id: hexId,
+          version: 1,
           status: 'awaiting_acceptance',
           updatedBy: { id: 'user-123', name: 'Test User' },
           updatedAt: new Date(),
@@ -123,7 +133,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -164,7 +175,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -203,7 +215,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -238,7 +251,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -273,7 +287,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await expect(
@@ -308,7 +323,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await expect(
@@ -335,7 +351,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -375,7 +392,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       const factory = await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -406,7 +424,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await expect(
@@ -433,7 +452,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -469,7 +489,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -508,7 +529,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -540,7 +562,8 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -571,12 +594,69 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        }
+        },
+        updateMany: async () => ({ matchedCount: 0 })
       }
 
       await expect(
         createPackagingRecyclingNotesRepository(mockDb, [])
       ).rejects.toThrow('Connection refused')
+    })
+  })
+
+  describe('backfillVersionField error handling', () => {
+    it('swallows NamespaceNotFound errors when collection does not exist', async () => {
+      const nsError = new Error('ns does not exist')
+      nsError.codeName = 'NamespaceNotFound'
+
+      const mockDb = {
+        collection: function () {
+          return this
+        },
+        indexes: async () => [],
+        createIndex: async () => {},
+        findOne: async () => null,
+        insertOne: async () => ({
+          insertedId: { toHexString: () => '123456789012345678901234' }
+        }),
+        find: function () {
+          return { toArray: async () => [] }
+        },
+        updateMany: async () => {
+          throw nsError
+        }
+      }
+
+      await expect(
+        createPackagingRecyclingNotesRepository(mockDb, [])
+      ).resolves.toBeDefined()
+    })
+
+    it('re-throws non-NamespaceNotFound errors from updateMany', async () => {
+      const writeError = new Error('Write conflict')
+      writeError.codeName = 'WriteConflict'
+
+      const mockDb = {
+        collection: function () {
+          return this
+        },
+        indexes: async () => [],
+        createIndex: async () => {},
+        findOne: async () => null,
+        insertOne: async () => ({
+          insertedId: { toHexString: () => '123456789012345678901234' }
+        }),
+        find: function () {
+          return { toArray: async () => [] }
+        },
+        updateMany: async () => {
+          throw writeError
+        }
+      }
+
+      await expect(
+        createPackagingRecyclingNotesRepository(mockDb, [])
+      ).rejects.toThrow('Write conflict')
     })
   })
 })

--- a/src/packaging-recycling-notes/repository/mongodb.test.js
+++ b/src/packaging-recycling-notes/repository/mongodb.test.js
@@ -1,6 +1,8 @@
 import { it as mongoIt } from '#vite/fixtures/mongo.js'
 import { MongoClient } from 'mongodb'
 import { describe, expect, vi } from 'vitest'
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { buildAwaitingAuthorisationPrn } from './contract/test-data.js'
 import { createPackagingRecyclingNotesRepository } from './mongodb.js'
 import { testPackagingRecyclingNotesRepositoryContract } from './port.contract.js'
 import { PrnNumberConflictError } from './port.js'
@@ -54,7 +56,6 @@ describe('MongoDB packaging recycling notes repository', () => {
         find: function () {
           return { toArray: async () => [] }
         },
-        updateMany: async () => ({ matchedCount: 0 }),
         findOneAndUpdate: async () => {
           throw otherError
         }
@@ -93,7 +94,6 @@ describe('MongoDB packaging recycling notes repository', () => {
         find: function () {
           return { toArray: async () => [] }
         },
-        updateMany: async () => ({ matchedCount: 0 }),
         findOneAndUpdate: async () => {
           throw duplicateKeyError
         }
@@ -133,8 +133,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -175,8 +174,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -215,8 +213,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -251,8 +248,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -287,8 +283,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await expect(
@@ -323,8 +318,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await expect(
@@ -351,8 +345,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -392,8 +385,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       const factory = await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -424,8 +416,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await expect(
@@ -452,8 +443,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -489,8 +479,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -529,8 +518,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -562,8 +550,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await createPackagingRecyclingNotesRepository(mockDb, [])
@@ -594,8 +581,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }),
         find: function () {
           return { toArray: async () => [] }
-        },
-        updateMany: async () => ({ matchedCount: 0 })
+        }
       }
 
       await expect(
@@ -604,59 +590,71 @@ describe('MongoDB packaging recycling notes repository', () => {
     })
   })
 
-  describe('backfillVersionField error handling', () => {
-    it('swallows NamespaceNotFound errors when collection does not exist', async () => {
-      const nsError = new Error('ns does not exist')
-      nsError.codeName = 'NamespaceNotFound'
+  describe('legacy documents without a version field', () => {
+    const seedVersionlessPrn = async (mongoClient) => {
+      const collection = mongoClient
+        .db(DATABASE_NAME)
+        .collection('packaging-recycling-notes')
+      const { version: _version, ...prnWithoutVersion } =
+        buildAwaitingAuthorisationPrn()
+      const result = await collection.insertOne(prnWithoutVersion)
+      return result.insertedId.toHexString()
+    }
 
-      const mockDb = {
-        collection: function () {
-          return this
-        },
-        indexes: async () => [],
-        createIndex: async () => {},
-        findOne: async () => null,
-        insertOne: async () => ({
-          insertedId: { toHexString: () => '123456789012345678901234' }
-        }),
-        find: function () {
-          return { toArray: async () => [] }
-        },
-        updateMany: async () => {
-          throw nsError
-        }
-      }
+    it('reads back as version 1', async ({ mongoClient, prnRepository }) => {
+      const id = await seedVersionlessPrn(mongoClient)
 
-      await expect(
-        createPackagingRecyclingNotesRepository(mockDb, [])
-      ).resolves.toBeDefined()
+      const found = await prnRepository.findById(id)
+
+      expect(found.version).toBe(1)
     })
 
-    it('re-throws non-NamespaceNotFound errors from updateMany', async () => {
-      const writeError = new Error('Write conflict')
-      writeError.codeName = 'WriteConflict'
+    it('accepts a CAS update with version 1 and bumps to version 2', async ({
+      mongoClient,
+      prnRepository
+    }) => {
+      const id = await seedVersionlessPrn(mongoClient)
 
-      const mockDb = {
-        collection: function () {
-          return this
-        },
-        indexes: async () => [],
-        createIndex: async () => {},
-        findOne: async () => null,
-        insertOne: async () => ({
-          insertedId: { toHexString: () => '123456789012345678901234' }
-        }),
-        find: function () {
-          return { toArray: async () => [] }
-        },
-        updateMany: async () => {
-          throw writeError
-        }
-      }
+      const updated = await prnRepository.updateStatus({
+        id,
+        version: 1,
+        status: PRN_STATUS.AWAITING_ACCEPTANCE,
+        updatedBy: { id: 'user-issuer', name: 'Issuer User' },
+        updatedAt: new Date(),
+        prnNumber: `TT2699999`
+      })
 
+      expect(updated.version).toBe(2)
+      expect(updated.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+
+      const reread = await prnRepository.findById(id)
+      expect(reread.version).toBe(2)
+    })
+
+    it('reports actual version as 1 when conflict is detected', async ({
+      mongoClient,
+      prnRepository
+    }) => {
+      const id = await seedVersionlessPrn(mongoClient)
+
+      const staleVersion = 5
       await expect(
-        createPackagingRecyclingNotesRepository(mockDb, [])
-      ).rejects.toThrow('Write conflict')
+        prnRepository.updateStatus({
+          id,
+          version: staleVersion,
+          status: PRN_STATUS.AWAITING_ACCEPTANCE,
+          updatedBy: { id: 'user-issuer', name: 'Issuer User' },
+          updatedAt: new Date()
+        })
+      ).rejects.toMatchObject({
+        isBoom: true,
+        output: {
+          statusCode: 409,
+          payload: {
+            message: `Version conflict: attempted to update PRN ${id} with version ${staleVersion} but current version is 1`
+          }
+        }
+      })
     })
   })
 })

--- a/src/packaging-recycling-notes/repository/port.contract.js
+++ b/src/packaging-recycling-notes/repository/port.contract.js
@@ -2,6 +2,7 @@ import { testCreateBehaviour } from './contract/create.contract.js'
 import { testDataIsolation } from './contract/data-isolation.contract.js'
 import { testFindBehaviour } from './contract/find.contract.js'
 import { testFindByStatusBehaviour } from './contract/find-by-status.contract.js'
+import { testOptimisticConcurrency } from './contract/optimistic-concurrency.contract.js'
 import { testUpdateStatusBehaviour } from './contract/update-status.contract.js'
 import { testPrnNumberUniqueness } from './contract/prn-number-uniqueness.contract.js'
 
@@ -13,6 +14,7 @@ export const testPackagingRecyclingNotesRepositoryContract = (
     testDataIsolation(repositoryFactory)
     testFindBehaviour(repositoryFactory)
     testFindByStatusBehaviour(repositoryFactory)
+    testOptimisticConcurrency(repositoryFactory)
     testUpdateStatusBehaviour(repositoryFactory)
     testPrnNumberUniqueness(repositoryFactory)
   })

--- a/src/packaging-recycling-notes/repository/port.js
+++ b/src/packaging-recycling-notes/repository/port.js
@@ -48,7 +48,7 @@ export class PrnNumberConflictError extends Error {
  */
 
 /**
- * @typedef {() => PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepositoryFactory
+ * @typedef {(logger: import('#common/hapi-types.js').TypedLogger) => PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepositoryFactory
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/packaging-recycling-notes/repository/port.js
+++ b/src/packaging-recycling-notes/repository/port.js
@@ -13,6 +13,7 @@ export class PrnNumberConflictError extends Error {
 /**
  * @typedef {Object} UpdateStatusParams
  * @property {string} id - PRN ID
+ * @property {number} version - Expected current document version (compare-and-set token for OCC)
  * @property {import('#packaging-recycling-notes/domain/model.js').PrnStatus} status - New status
  * @property {{ id: string; name: string }} updatedBy - User making the change
  * @property {Date} updatedAt - Timestamp of the change

--- a/src/packaging-recycling-notes/repository/schema.js
+++ b/src/packaging-recycling-notes/repository/schema.js
@@ -87,6 +87,7 @@ const statusSchema = Joi.object({
 
 export const prnInsertSchema = Joi.object({
   schemaVersion: Joi.number().integer().valid(2).required(),
+  version: Joi.number().integer().min(1).default(1),
   prnNumber: Joi.string().allow(null).optional(),
   organisation: organisationNameAndIdSchema.required(),
   registrationId: Joi.string().required(),

--- a/src/packaging-recycling-notes/routes/status.test.js
+++ b/src/packaging-recycling-notes/routes/status.test.js
@@ -5,6 +5,7 @@ import {
   it,
   expect,
   beforeAll,
+  beforeEach,
   afterAll,
   afterEach
 } from 'vitest'
@@ -30,6 +31,7 @@ const prnId = '507f1f77bcf86cd799439011'
 
 const createMockPrn = (overrides = {}) => ({
   id: prnId,
+  version: 1,
   schemaVersion: 2,
   organisation: { id: organisationId, name: 'Test Organisation' },
   registrationId,
@@ -88,11 +90,6 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
     })
 
     beforeAll(async () => {
-      packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository([mockPrn])()
-      vi.spyOn(packagingRecyclingNotesRepository, 'findById')
-      vi.spyOn(packagingRecyclingNotesRepository, 'updateStatus')
-
       wasteBalancesRepository = {
         findByAccreditationId: vi
           .fn()
@@ -120,6 +117,18 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
       })
 
       await server.initialize()
+    })
+
+    beforeEach(() => {
+      packagingRecyclingNotesRepository =
+        createInMemoryPackagingRecyclingNotesRepository([mockPrn])({
+          info: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          debug: vi.fn()
+        })
+      vi.spyOn(packagingRecyclingNotesRepository, 'findById')
+      vi.spyOn(packagingRecyclingNotesRepository, 'updateStatus')
     })
 
     afterEach(() => {
@@ -566,6 +575,35 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
         expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
       })
 
+      it('returns 409 when a concurrent writer has already bumped the version', async () => {
+        const stale = await packagingRecyclingNotesRepository.findById(prnId)
+
+        await packagingRecyclingNotesRepository.updateStatus({
+          id: prnId,
+          version: stale.version,
+          status: PRN_STATUS.AWAITING_AUTHORISATION,
+          updatedBy: { id: 'other-writer', name: 'Other Writer' },
+          updatedAt: new Date(),
+          operation: {
+            slot: 'created',
+            at: new Date(),
+            by: { id: 'other-writer', name: 'Other Writer' }
+          }
+        })
+
+        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(stale)
+
+        const response = await server.inject({
+          method: 'POST',
+          url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${prnId}/status`,
+          ...asStandardUser({ linkedOrgId: organisationId }),
+          payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+        expect(response.payload).toContain('Version conflict')
+      })
+
       it('returns 404 when PRN belongs to different organisation', async () => {
         const differentOrgId = 'different-org'
 
@@ -829,11 +867,6 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
     })
 
     beforeAll(async () => {
-      packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository([mockPrn])()
-      vi.spyOn(packagingRecyclingNotesRepository, 'findById')
-      vi.spyOn(packagingRecyclingNotesRepository, 'updateStatus')
-
       wasteBalancesRepository = {
         findByAccreditationId: vi
           .fn()
@@ -861,6 +894,18 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
       })
 
       await server.initialize()
+    })
+
+    beforeEach(() => {
+      packagingRecyclingNotesRepository =
+        createInMemoryPackagingRecyclingNotesRepository([mockPrn])({
+          info: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          debug: vi.fn()
+        })
+      vi.spyOn(packagingRecyclingNotesRepository, 'findById')
+      vi.spyOn(packagingRecyclingNotesRepository, 'updateStatus')
     })
 
     afterEach(() => {

--- a/src/start-server.test.js
+++ b/src/start-server.test.js
@@ -93,6 +93,7 @@ vi.mock('#common/helpers/plugins/mongo-db-plugin.js', () => ({
             })
           }),
           updateOne: vi.fn().mockResolvedValue(undefined),
+          updateMany: vi.fn().mockResolvedValue({ matchedCount: 0 }),
           indexes: vi.fn().mockResolvedValue([])
         }
         server.decorate('server', 'db', {


### PR DESCRIPTION
Ticket: [PAE-1439](https://eaflood.atlassian.net/browse/PAE-1439)

## Summary

Two concurrent POSTs to the PRN status route were both passing validation, both writing the balance effect, and only one PRN write winning. The double write silently corrupted balances. This PR closes the race on two fronts: the PRN repository now CAS-gates writes on a per-document `version`, and `updatePrnStatus` runs the balance effect only after the CAS has chosen a winner — for every transition on an existing PRN.

## Repository CAS

- The PRN schema declares a `version` field (integer, defaults to 1 on insert).
- `updateStatus` CAS-gates writes by version. A missed CAS is disambiguated into 404 (document gone) or 409 (`Boom.conflict` with descriptive message and a `database / version_conflict_detected` structured log) by re-fetching just the version.
- The application layer threads the read version through to the repository so the CAS is exact.
- Documents missing the `version` field are tolerated at the adapter boundary rather than backfilled. Reads compensate via the Joi default on `version`, so a legacy document reads back as `version: 1`. The MongoDB CAS filter uses `$expr` with `$ifNull` so an expected version of 1 matches both `{ version: 1 }` and documents with no `version` field, and the update assigns `version: <expected> + 1` rather than incrementing — keeping post-state correct whether the field was present or absent. A backfill cannot guarantee that every document is touched before a fresh write lands, so per-call tolerance is the safer model.
- The in-memory adapter mirrors the same conflict semantics so both adapters share one contract test suite (`optimistic-concurrency.contract.js`) covering initialisation, increment, sequential threading, descriptive messages, structured logging, concurrent races (including the issue path where both writers also generate a `prnNumber`). Versionless-document tolerance is exercised by adapter-specific tests in `mongodb.test.js` and `inmemory.test.js`, since the seeding mechanism differs per adapter.
- The repository factory now requires a `TypedLogger` so version conflicts always produce a logged event.
- A route-level test asserts that `Boom.conflict` from the repository surfaces as 409 to the caller.

## CAS gates the balance effect

`applyWasteBalanceEffects` previously ran before the PRN CAS for every transition. For any transition on an existing PRN — issuance, deletion-from-awaiting-authorisation, cancellation-from-awaiting-cancellation — concurrent writers all passed `validateTransition`, all wrote the balance effect, and only one had its PRN write rejected. `updatePrnStatus` now performs the CAS first for these transitions and only the winner reaches the balance write, eliminating the symmetric double-debit (issuance) and double-credit (cancels) races.

Creation (`AWAITING_AUTHORISATION`) keeps its pre-flight balance check. The per-PRN CAS protects only same-document writes — it cannot help a new-PRN insert — and a post-CAS failure on creation would strand the PRN in a state with no legal user exit.

## Integration tests

`update-status-concurrency.test.js` wires the real in-memory PRN and waste-balance repositories together and fires two concurrent calls on the same PRN. Three scenarios: concurrent issuances, concurrent deletions from awaiting-authorisation, and concurrent cancellations from awaiting-cancellation. Each asserts the corresponding balance method is invoked exactly once and that the losing call returns 409. All three fail against the pre-reorder code (call count was 2) and pass after the reorder.

## Trade-off

A balance write that fails after the CAS leaves a residue: a phantom issued PRN with no debit, or a cancelled PRN whose tonnage was not credited back. Each occurrence is bounded to one PRN's worth, observable in the data (PRN history disagrees with balance transactions), and the lesser harm than the unbounded double-write race it replaces. Cross-writer balance races on different PRNs of the same accreditation are unaffected — they are addressed separately by the ledger flip in [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382).

[PAE-1439]: https://eaflood.atlassian.net/browse/PAE-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ