### PR TITLE
PAE-1430: Foundation for admin scope-based RBAC (SCOPES, ADMIN_ROLES, role resolution)

### DIFF
--- a/src/common/helpers/auth/constants.js
+++ b/src/common/helpers/auth/constants.js
@@ -7,3 +7,12 @@ export const ROLES = {
   inquirer: 'inquirer',
   linker: 'linker'
 }
+
+/**
+ * @typedef {typeof SCOPES[keyof typeof SCOPES]} Scopes
+ */
+export const SCOPES = {
+  adminRead: 'admin.read',
+  adminWrite: 'admin.write',
+  adminDlqPurge: 'admin.dlq.purge'
+}

--- a/src/common/helpers/auth/constants.js
+++ b/src/common/helpers/auth/constants.js
@@ -16,3 +16,18 @@ export const SCOPES = {
   adminWrite: 'admin.write',
   adminDlqPurge: 'admin.dlq.purge'
 }
+
+/**
+ * Admin role → scope-bundle map. Role names are deliberately snake_case strings:
+ * they are stable wire identifiers (returned by GET /v1/admin/me) and i18n
+ * lookup keys for the admin-frontend tier label.
+ */
+export const ADMIN_ROLES = {
+  service_maintainer_write: [
+    SCOPES.adminRead,
+    SCOPES.adminWrite,
+    SCOPES.adminDlqPurge
+  ],
+  service_maintainer: [SCOPES.adminRead, SCOPES.adminDlqPurge],
+  support: [SCOPES.adminRead]
+}

--- a/src/common/helpers/auth/constants.test.js
+++ b/src/common/helpers/auth/constants.test.js
@@ -1,0 +1,31 @@
+import { describe, test, expect } from 'vitest'
+
+import { ADMIN_ROLES, SCOPES } from './constants.js'
+
+describe('ADMIN_ROLES', () => {
+  test('service_maintainer_write bundles all admin scopes', () => {
+    expect(ADMIN_ROLES.service_maintainer_write).toEqual([
+      SCOPES.adminRead,
+      SCOPES.adminWrite,
+      SCOPES.adminDlqPurge
+    ])
+  })
+
+  test('service_maintainer carries admin.read and admin.dlq.purge but not admin.write', () => {
+    expect(ADMIN_ROLES.service_maintainer).toEqual([
+      SCOPES.adminRead,
+      SCOPES.adminDlqPurge
+    ])
+    expect(ADMIN_ROLES.service_maintainer).not.toContain(SCOPES.adminWrite)
+  })
+
+  test('support carries only admin.read', () => {
+    expect(ADMIN_ROLES.support).toEqual([SCOPES.adminRead])
+  })
+
+  test('every admin role includes admin.read so any tier can call read routes', () => {
+    for (const scopes of Object.values(ADMIN_ROLES)) {
+      expect(scopes).toContain(SCOPES.adminRead)
+    }
+  })
+})

--- a/src/common/helpers/auth/get-entra-user-roles.js
+++ b/src/common/helpers/auth/get-entra-user-roles.js
@@ -1,29 +1,40 @@
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { ADMIN_ROLES } from '#common/helpers/auth/constants.js'
 import { getConfig } from '#root/config.js'
 
-/** @typedef {import('./types.js').EntraIdTokenPayload} EntraIdTokenPayload */
+/**
+ * Email lists are evaluated in this order; first match wins.
+ * A user appearing in multiple lists silently takes the highest tier.
+ */
+const ADMIN_ROLE_RESOLUTION_ORDER = [
+  ['service_maintainer_write', 'roles.serviceMaintainersWrite'],
+  ['service_maintainer', 'roles.serviceMaintainers'],
+  ['support', 'roles.support']
+]
 
 /**
- * Determines the roles for an Entra ID user based on their token
- * @param {string} userEmail - The user's email address (taken from Entra ID access token)
- * @returns {Promise<string[]>} Array of role strings
+ * @typedef {{ role: string | null, scopes: string[] }} ResolvedAdminRole
+ */
+
+/**
+ * Resolves an Entra ID user's admin role and bundled scopes from
+ * email-list config. Email comparison is case-insensitive.
+ * @param {string | undefined | null} userEmail - Email from the validated Entra access token.
+ * @returns {Promise<ResolvedAdminRole>}
  */
 export async function getEntraUserRoles(userEmail) {
-  const stringifiedServiceMaintainersList = getConfig().get(
-    'roles.serviceMaintainers'
-  )
-
-  const thisUserRoles = []
-  // This should never thrown an error as the config is validated when the server is started
-  const serviceMaintainersList = JSON.parse(stringifiedServiceMaintainersList)
-
-  if (
-    serviceMaintainersList.some(
-      (email) => email.toLowerCase() === userEmail?.toLowerCase()
-    )
-  ) {
-    thisUserRoles.push(ROLES.serviceMaintainer)
+  if (!userEmail) {
+    return { role: null, scopes: [] }
   }
 
-  return thisUserRoles
+  const config = getConfig()
+  const lowerEmail = userEmail.toLowerCase()
+
+  for (const [role, configKey] of ADMIN_ROLE_RESOLUTION_ORDER) {
+    const list = JSON.parse(config.get(configKey))
+    if (list.some((email) => email.toLowerCase() === lowerEmail)) {
+      return { role, scopes: [...ADMIN_ROLES[role]] }
+    }
+  }
+
+  return { role: null, scopes: [] }
 }

--- a/src/common/helpers/auth/get-entra-user-roles.test.js
+++ b/src/common/helpers/auth/get-entra-user-roles.test.js
@@ -1,7 +1,7 @@
 import { vi, describe, test, expect, beforeEach, afterEach } from 'vitest'
 
 import { getEntraUserRoles } from './get-entra-user-roles.js'
-import { ROLES } from './constants.js'
+import { ADMIN_ROLES, SCOPES } from './constants.js'
 
 const mockConfigGet = vi.fn()
 
@@ -11,164 +11,210 @@ vi.mock('../../../config.js', () => ({
   })
 }))
 
-describe('#getEntraUserRoles', () => {
-  const mockServiceMaintainersList = [
-    'maintainer1@example.com',
-    'maintainer2@example.com',
-    'admin@defra.gov.uk'
-  ]
+const ROLE_CONFIG_KEYS = {
+  service_maintainer_write: 'roles.serviceMaintainersWrite',
+  service_maintainer: 'roles.serviceMaintainers',
+  support: 'roles.support'
+}
 
+function setListsForRole(role, email) {
+  const lists = {
+    'roles.serviceMaintainersWrite': [],
+    'roles.serviceMaintainers': [],
+    'roles.support': []
+  }
+  if (role) {
+    lists[ROLE_CONFIG_KEYS[role]] = [email]
+  }
+  mockConfigGet.mockImplementation((key) => JSON.stringify(lists[key]))
+}
+
+function setListsExplicit({ write = [], maintainer = [], support = [] } = {}) {
+  const lists = {
+    'roles.serviceMaintainersWrite': write,
+    'roles.serviceMaintainers': maintainer,
+    'roles.support': support
+  }
+  mockConfigGet.mockImplementation((key) => JSON.stringify(lists[key]))
+}
+
+describe('#getEntraUserRoles', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockConfigGet.mockReturnValue(JSON.stringify(mockServiceMaintainersList))
+    setListsExplicit()
   })
 
   afterEach(() => {
     vi.clearAllMocks()
   })
 
-  describe('when user is a service maintainer', () => {
-    test.each([
-      'maintainer1@example.com', // lowercase
-      'MAINTAINER1@EXAMPLE.COM', // uppercase
-      'MaInTaInEr1@ExAmPlE.cOm' // mixed case
-    ])(
-      'returns service maintainer role when (case-insensitive) email matches - %s',
-      async (email) => {
-        const result = await getEntraUserRoles(email)
+  describe('single-list membership', () => {
+    test('returns service_maintainer_write for an email in the write list', async () => {
+      setListsForRole('service_maintainer_write', 'writer@example.com')
 
-        expect(result).toEqual([ROLES.serviceMaintainer])
-        expect(mockConfigGet).toHaveBeenCalledWith('roles.serviceMaintainers')
-        expect(mockConfigGet).toHaveBeenCalledTimes(1)
-      }
-    )
+      const result = await getEntraUserRoles('writer@example.com')
 
-    test('returns service maintainer role for last email in list', async () => {
-      const result = await getEntraUserRoles('admin@defra.gov.uk')
+      expect(result).toEqual({
+        role: 'service_maintainer_write',
+        scopes: [...ADMIN_ROLES.service_maintainer_write]
+      })
+    })
 
-      expect(result).toEqual([ROLES.serviceMaintainer])
+    test('returns service_maintainer for an email in the maintainer list only', async () => {
+      setListsForRole('service_maintainer', 'maintainer@example.com')
+
+      const result = await getEntraUserRoles('maintainer@example.com')
+
+      expect(result).toEqual({
+        role: 'service_maintainer',
+        scopes: [...ADMIN_ROLES.service_maintainer]
+      })
+    })
+
+    test('returns support for an email in the support list only', async () => {
+      setListsForRole('support', 'support@example.com')
+
+      const result = await getEntraUserRoles('support@example.com')
+
+      expect(result).toEqual({
+        role: 'support',
+        scopes: [...ADMIN_ROLES.support]
+      })
+    })
+
+    test('returns null role and empty scopes for an email in no list', async () => {
+      const result = await getEntraUserRoles('unknown@example.com')
+
+      expect(result).toEqual({ role: null, scopes: [] })
     })
   })
 
-  describe('when user is not a service maintainer', () => {
-    test('returns empty array when email does not match any maintainer', async () => {
-      const result = await getEntraUserRoles('regular-user@example.com')
+  describe('first-match-wins precedence', () => {
+    test('write tier wins over maintainer tier when in both lists', async () => {
+      setListsExplicit({
+        write: ['shared@example.com'],
+        maintainer: ['shared@example.com']
+      })
 
-      expect(result).toEqual([])
+      const result = await getEntraUserRoles('shared@example.com')
+
+      expect(result.role).toBe('service_maintainer_write')
     })
 
-    test('returns empty array when service maintainers list is empty', async () => {
-      mockConfigGet.mockReturnValue(JSON.stringify([]))
+    test('write tier wins over support tier when in both lists', async () => {
+      setListsExplicit({
+        write: ['shared@example.com'],
+        support: ['shared@example.com']
+      })
 
-      const result = await getEntraUserRoles('user@example.com')
+      const result = await getEntraUserRoles('shared@example.com')
 
-      expect(result).toEqual([])
+      expect(result.role).toBe('service_maintainer_write')
+    })
+
+    test('maintainer tier wins over support tier when in both lists', async () => {
+      setListsExplicit({
+        maintainer: ['shared@example.com'],
+        support: ['shared@example.com']
+      })
+
+      const result = await getEntraUserRoles('shared@example.com')
+
+      expect(result.role).toBe('service_maintainer')
+    })
+
+    test('write tier still wins when present in all three lists', async () => {
+      setListsExplicit({
+        write: ['shared@example.com'],
+        maintainer: ['shared@example.com'],
+        support: ['shared@example.com']
+      })
+
+      const result = await getEntraUserRoles('shared@example.com')
+
+      expect(result.role).toBe('service_maintainer_write')
+    })
+  })
+
+  describe('case-insensitivity', () => {
+    test.each([
+      'maintainer@example.com',
+      'MAINTAINER@EXAMPLE.COM',
+      'MaInTaInEr@ExAmPlE.cOm'
+    ])('matches regardless of email casing (%s)', async (queryEmail) => {
+      setListsForRole('service_maintainer', 'maintainer@example.com')
+
+      const result = await getEntraUserRoles(queryEmail)
+
+      expect(result.role).toBe('service_maintainer')
+    })
+
+    test('matches when stored email is uppercase and query is lowercase', async () => {
+      setListsForRole('support', 'SUPPORT@EXAMPLE.COM')
+
+      const result = await getEntraUserRoles('support@example.com')
+
+      expect(result.role).toBe('support')
     })
   })
 
   describe('edge cases', () => {
-    test('handles undefined email', async () => {
+    test('returns null role for undefined email', async () => {
+      setListsForRole('service_maintainer', 'maintainer@example.com')
+
       const result = await getEntraUserRoles(undefined)
 
-      expect(result).toEqual([])
+      expect(result).toEqual({ role: null, scopes: [] })
     })
 
-    test('handles null email', async () => {
+    test('returns null role for null email', async () => {
+      setListsForRole('service_maintainer', 'maintainer@example.com')
+
       const result = await getEntraUserRoles(null)
 
-      expect(result).toEqual([])
+      expect(result).toEqual({ role: null, scopes: [] })
     })
 
-    test('handles whitespace in email addresses', async () => {
-      const result = await getEntraUserRoles(' maintainer1@example.com ')
+    test('does not match emails surrounded by whitespace', async () => {
+      setListsForRole('service_maintainer', 'maintainer@example.com')
 
-      expect(result).toEqual([])
+      const result = await getEntraUserRoles(' maintainer@example.com ')
+
+      expect(result.role).toBeNull()
     })
 
-    test('handles token payload where userEmail is undefined and list has items', async () => {
-      // This tests the branch where serviceMaintainersList.some is called
-      // but userEmail is undefined, so the comparison never matches
-      mockConfigGet.mockReturnValue(
-        JSON.stringify(['maintainer@example.com', 'admin@example.com'])
-      )
+    test('returns a fresh scopes array each call (mutation safe)', async () => {
+      setListsForRole('service_maintainer', 'maintainer@example.com')
 
-      const result = await getEntraUserRoles(undefined)
+      const first = await getEntraUserRoles('maintainer@example.com')
+      first.scopes.push('extra')
 
-      expect(result).toEqual([])
-      expect(mockConfigGet).toHaveBeenCalledWith('roles.serviceMaintainers')
-    })
+      const second = await getEntraUserRoles('maintainer@example.com')
 
-    test('handles service maintainers list with single email', async () => {
-      mockConfigGet.mockReturnValue(JSON.stringify(['single@example.com']))
-
-      const result = await getEntraUserRoles('single@example.com')
-
-      expect(result).toEqual([ROLES.serviceMaintainer])
-    })
-  })
-
-  describe('config integration', () => {
-    test('calls getConfig with correct key', async () => {
-      await getEntraUserRoles('test@example.com')
-
-      expect(mockConfigGet).toHaveBeenCalledWith('roles.serviceMaintainers')
-    })
-
-    test('handles valid JSON string from config', async () => {
-      const maintainers = ['user1@example.com', 'user2@example.com']
-      mockConfigGet.mockReturnValue(JSON.stringify(maintainers))
-
-      const result = await getEntraUserRoles('user1@example.com')
-
-      expect(result).toEqual([ROLES.serviceMaintainer])
-    })
-
-    test('handles complex email addresses', async () => {
-      const complexEmails = [
-        'first.last+tag@subdomain.example.com',
-        'user_name@example.co.uk'
-      ]
-      mockConfigGet.mockReturnValue(JSON.stringify(complexEmails))
-
-      const result = await getEntraUserRoles(
-        'first.last+tag@subdomain.example.com'
-      )
-
-      expect(result).toEqual([ROLES.serviceMaintainer])
-    })
-  })
-
-  describe('return value structure', () => {
-    test('returns a fresh array instance each time', async () => {
-      const result1 = await getEntraUserRoles('maintainer1@example.com')
-      const result2 = await getEntraUserRoles('maintainer1@example.com')
-
-      expect(result1).not.toBe(result2)
-      expect(result1).toEqual(result2)
-    })
-
-    test('returns array that can be safely mutated', async () => {
-      const result = await getEntraUserRoles('maintainer1@example.com')
-      result.push('extra-role')
-
-      const result2 = await getEntraUserRoles('maintainer1@example.com')
-
-      expect(result2).toEqual([ROLES.serviceMaintainer])
-      expect(result2).not.toContain('extra-role')
+      expect(second.scopes).not.toContain('extra')
+      expect(second.scopes).toContain(SCOPES.adminRead)
     })
   })
 
   describe('concurrent calls', () => {
-    test('handles multiple concurrent calls correctly', async () => {
-      const [result1, result2, result3] = await Promise.all([
-        getEntraUserRoles('maintainer1@example.com'),
-        getEntraUserRoles('regular@example.com'),
-        getEntraUserRoles('maintainer2@example.com')
+    test('resolves multiple emails correctly in parallel', async () => {
+      setListsExplicit({
+        write: ['writer@example.com'],
+        maintainer: ['maintainer@example.com'],
+        support: ['support@example.com']
+      })
+
+      const [a, b, c, d] = await Promise.all([
+        getEntraUserRoles('writer@example.com'),
+        getEntraUserRoles('maintainer@example.com'),
+        getEntraUserRoles('support@example.com'),
+        getEntraUserRoles('nobody@example.com')
       ])
 
-      expect(result1).toEqual([ROLES.serviceMaintainer])
-      expect(result2).toEqual([])
-      expect(result3).toEqual([ROLES.serviceMaintainer])
+      expect(a.role).toBe('service_maintainer_write')
+      expect(b.role).toBe('service_maintainer')
+      expect(c.role).toBe('support')
+      expect(d.role).toBeNull()
     })
   })
 })

--- a/src/common/helpers/auth/get-jwt-strategy-config.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.js
@@ -1,7 +1,18 @@
 import { config } from '#root/config.js'
 import Boom from '@hapi/boom'
+import { ROLES } from './constants.js'
 import { getDefraUserRoles } from './get-defra-user-roles.js'
 import { getEntraUserRoles } from './get-entra-user-roles.js'
+
+/**
+ * Roles that retain access via the legacy `service_maintainer` Hapi scope
+ * during the route re-scoping transition. Removed once every admin route
+ * declares an explicit `admin.*` scope.
+ */
+const LEGACY_SERVICE_MAINTAINER_ROLES = new Set([
+  'service_maintainer_write',
+  'service_maintainer'
+])
 
 /** @typedef {import('./types.js').TokenPayload} TokenPayload */
 /** @typedef {import('./types.js').EntraIdTokenPayload} EntraIdTokenPayload */
@@ -48,7 +59,10 @@ export function getJwtStrategyConfig(oidcConfigs) {
 
         const email = tokenPayload.preferred_username
 
-        const scope = await getEntraUserRoles(email)
+        const { role, scopes } = await getEntraUserRoles(email)
+        const scope = LEGACY_SERVICE_MAINTAINER_ROLES.has(role)
+          ? [...scopes, ROLES.serviceMaintainer]
+          : scopes
 
         return {
           isValid: true,
@@ -56,6 +70,7 @@ export function getJwtStrategyConfig(oidcConfigs) {
             id: tokenPayload.oid,
             email,
             issuer,
+            role,
             scope
           }
         }

--- a/src/common/helpers/auth/get-jwt-strategy-config.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.js
@@ -60,9 +60,10 @@ export function getJwtStrategyConfig(oidcConfigs) {
         const email = tokenPayload.preferred_username
 
         const { role, scopes } = await getEntraUserRoles(email)
-        const scope = LEGACY_SERVICE_MAINTAINER_ROLES.has(role)
-          ? [...scopes, ROLES.serviceMaintainer]
-          : scopes
+        const scope =
+          role !== null && LEGACY_SERVICE_MAINTAINER_ROLES.has(role)
+            ? [...scopes, ROLES.serviceMaintainer]
+            : scopes
 
         return {
           isValid: true,

--- a/src/common/helpers/auth/get-jwt-strategy-config.test.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.test.js
@@ -9,8 +9,17 @@ import {
 } from '#vite/helpers/mock-entra-oidc.js'
 import Boom from '@hapi/boom'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { ROLES } from './constants.js'
+import { ROLES, SCOPES, ADMIN_ROLES } from './constants.js'
 import { getJwtStrategyConfig } from './get-jwt-strategy-config.js'
+
+const maintainerCredential = {
+  role: 'service_maintainer',
+  scopes: [...ADMIN_ROLES.service_maintainer]
+}
+const expectedMaintainerScope = [
+  ...ADMIN_ROLES.service_maintainer,
+  ROLES.serviceMaintainer
+]
 
 // Mock config
 const mockConfigGet = vi.fn()
@@ -46,7 +55,7 @@ describe('#getJwtStrategyConfig', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetEntraUserRoles.mockResolvedValue([ROLES.serviceMaintainer])
+    mockGetEntraUserRoles.mockResolvedValue(maintainerCredential)
   })
 
   afterEach(() => {
@@ -133,7 +142,8 @@ describe('#getJwtStrategyConfig', () => {
           id: 'contact-123',
           email: 'user@example.com',
           issuer: entraIdMockOidcWellKnownResponse.issuer,
-          scope: [ROLES.serviceMaintainer]
+          role: 'service_maintainer',
+          scope: expectedMaintainerScope
         }
       })
     })
@@ -208,9 +218,11 @@ describe('#getJwtStrategyConfig', () => {
       )
     })
 
-    test('uses scope from getEntraUserRoles', async () => {
-      const customScope = ['custom-role-1', 'custom-role-2']
-      mockGetEntraUserRoles.mockResolvedValue(customScope)
+    test('write tier credential carries all admin scopes plus the legacy service_maintainer scope', async () => {
+      mockGetEntraUserRoles.mockResolvedValue({
+        role: 'service_maintainer_write',
+        scopes: [...ADMIN_ROLES.service_maintainer_write]
+      })
 
       const config = getJwtStrategyConfig(mockOidcConfigs)
 
@@ -227,11 +239,40 @@ describe('#getJwtStrategyConfig', () => {
 
       const result = await config.validate(artifacts)
 
-      expect(result.credentials.scope).toEqual(customScope)
+      expect(result.credentials.role).toBe('service_maintainer_write')
+      expect(result.credentials.scope).toEqual([
+        ...ADMIN_ROLES.service_maintainer_write,
+        ROLES.serviceMaintainer
+      ])
     })
 
-    test('handles Entra ID token with empty scope from getEntraUserRoles', async () => {
-      mockGetEntraUserRoles.mockResolvedValue([])
+    test('support tier credential carries only admin.read with no legacy scope', async () => {
+      mockGetEntraUserRoles.mockResolvedValue({
+        role: 'support',
+        scopes: [...ADMIN_ROLES.support]
+      })
+
+      const config = getJwtStrategyConfig(mockOidcConfigs)
+
+      const artifacts = {
+        decoded: {
+          payload: {
+            iss: entraIdMockOidcWellKnownResponse.issuer,
+            aud: mockEntraClientId,
+            oid: 'contact-123',
+            email: 'support@example.com'
+          }
+        }
+      }
+
+      const result = await config.validate(artifacts)
+
+      expect(result.credentials.role).toBe('support')
+      expect(result.credentials.scope).toEqual([SCOPES.adminRead])
+    })
+
+    test('handles Entra ID token where user matches no admin tier (empty scope, null role)', async () => {
+      mockGetEntraUserRoles.mockResolvedValue({ role: null, scopes: [] })
 
       const config = getJwtStrategyConfig(mockOidcConfigs)
 
@@ -248,6 +289,7 @@ describe('#getJwtStrategyConfig', () => {
 
       const result = await config.validate(artifacts)
 
+      expect(result.credentials.role).toBeNull()
       expect(result.credentials.scope).toEqual([])
     })
 
@@ -788,7 +830,7 @@ describe('#getJwtStrategyConfig', () => {
         ])
 
         expect(entraResult.credentials.id).toBe('entra-contact')
-        expect(entraResult.credentials.scope).toEqual([ROLES.serviceMaintainer])
+        expect(entraResult.credentials.scope).toEqual(expectedMaintainerScope)
         expect(defraResult.credentials.id).toBe('defra-contact')
         expect(defraResult.credentials.scope).toEqual([ROLES.inquirer])
       })

--- a/src/common/helpers/validate-config.js
+++ b/src/common/helpers/validate-config.js
@@ -1,16 +1,20 @@
-export function validateConfig(config) {
-  let serviceMaintainers
-  try {
-    serviceMaintainers = JSON.parse(config.get('roles.serviceMaintainers'))
-  } catch {
-    throw new Error(
-      'Invalid roles.serviceMaintainers configuration: malformed JSON'
-    )
-  }
+const ROLE_EMAIL_LIST_KEYS = [
+  'roles.serviceMaintainers',
+  'roles.serviceMaintainersWrite',
+  'roles.support'
+]
 
-  if (!Array.isArray(serviceMaintainers)) {
-    throw new Error(
-      'Invalid roles.serviceMaintainers configuration: not an array'
-    )
+export function validateConfig(config) {
+  for (const key of ROLE_EMAIL_LIST_KEYS) {
+    let parsed
+    try {
+      parsed = JSON.parse(config.get(key))
+    } catch {
+      throw new Error(`Invalid ${key} configuration: malformed JSON`)
+    }
+
+    if (!Array.isArray(parsed)) {
+      throw new Error(`Invalid ${key} configuration: not an array`)
+    }
   }
 }

--- a/src/common/helpers/validate-config.test.js
+++ b/src/common/helpers/validate-config.test.js
@@ -2,71 +2,87 @@ import { describe, test, expect, vi } from 'vitest'
 
 import { validateConfig } from './validate-config.js'
 
+const ROLE_KEYS = [
+  'roles.serviceMaintainers',
+  'roles.serviceMaintainersWrite',
+  'roles.support'
+]
+
+function mockConfigForKeys(values) {
+  return {
+    get: vi.fn((key) => values[key])
+  }
+}
+
+function mockConfigAllValid() {
+  return mockConfigForKeys({
+    'roles.serviceMaintainers': '["user1", "user2"]',
+    'roles.serviceMaintainersWrite': '["writer1"]',
+    'roles.support': '[]'
+  })
+}
+
 describe('#validateConfig', () => {
-  describe('when roles.serviceMaintainers is valid', () => {
-    test('does not throw when provided with a valid JSON array', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('["user1", "user2", "user3"]')
-      }
-
-      expect(() => validateConfig(mockConfig)).not.toThrow()
-      expect(mockConfig.get).toHaveBeenCalledWith('roles.serviceMaintainers')
+  describe('when all role lists are valid', () => {
+    test('does not throw when all keys are valid JSON arrays', () => {
+      expect(() => validateConfig(mockConfigAllValid())).not.toThrow()
     })
 
-    test('does not throw when provided with an empty array', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('[]')
-      }
+    test('does not throw when all lists are empty', () => {
+      const mockConfig = mockConfigForKeys({
+        'roles.serviceMaintainers': '[]',
+        'roles.serviceMaintainersWrite': '[]',
+        'roles.support': '[]'
+      })
 
       expect(() => validateConfig(mockConfig)).not.toThrow()
     })
 
-    test('does not throw when provided with an array of objects', () => {
-      const mockConfig = {
-        get: vi
-          .fn()
-          .mockReturnValue(
-            '[{"id": 1, "name": "user1"}, {"id": 2, "name": "user2"}]'
-          )
-      }
+    test('does not throw for arrays of objects or mixed types', () => {
+      const mockConfig = mockConfigForKeys({
+        'roles.serviceMaintainers':
+          '[{"id": 1, "name": "user1"}, {"id": 2, "name": "user2"}]',
+        'roles.serviceMaintainersWrite': '[1, "string", true, null]',
+        'roles.support': '[]'
+      })
 
       expect(() => validateConfig(mockConfig)).not.toThrow()
     })
 
-    test('does not throw when provided with an array containing mixed types', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('[1, "string", true, null]')
-      }
+    test('reads all three role list keys', () => {
+      const mockConfig = mockConfigAllValid()
 
-      expect(() => validateConfig(mockConfig)).not.toThrow()
+      validateConfig(mockConfig)
+
+      for (const key of ROLE_KEYS) {
+        expect(mockConfig.get).toHaveBeenCalledWith(key)
+      }
+      expect(mockConfig.get).toHaveBeenCalledTimes(ROLE_KEYS.length)
     })
   })
 
-  describe('when roles.serviceMaintainers contains malformed JSON', () => {
-    test('throws when JSON is invalid', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('not valid json')
+  describe('when a role list contains malformed JSON', () => {
+    test.each(ROLE_KEYS)('throws naming the offending key (%s)', (key) => {
+      const values = {
+        'roles.serviceMaintainers': '[]',
+        'roles.serviceMaintainersWrite': '[]',
+        'roles.support': '[]'
       }
+      values[key] = 'not valid json'
+
+      const mockConfig = mockConfigForKeys(values)
 
       expect(() => validateConfig(mockConfig)).toThrow(
-        'Invalid roles.serviceMaintainers configuration: malformed JSON'
+        `Invalid ${key} configuration: malformed JSON`
       )
     })
 
     test('throws when JSON is incomplete', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('["user1", "user2"')
-      }
-
-      expect(() => validateConfig(mockConfig)).toThrow(
-        'Invalid roles.serviceMaintainers configuration: malformed JSON'
-      )
-    })
-
-    test('throws when JSON has trailing comma', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('["user1", "user2",]')
-      }
+      const mockConfig = mockConfigForKeys({
+        'roles.serviceMaintainers': '["user1", "user2"',
+        'roles.serviceMaintainersWrite': '[]',
+        'roles.support': '[]'
+      })
 
       expect(() => validateConfig(mockConfig)).toThrow(
         'Invalid roles.serviceMaintainers configuration: malformed JSON'
@@ -74,92 +90,63 @@ describe('#validateConfig', () => {
     })
   })
 
-  describe('when roles.serviceMaintainers is not an array', () => {
-    test('throws error when value is a string', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('"just a string"')
+  describe('when a role list is not an array', () => {
+    test.each(ROLE_KEYS)('throws naming the offending key (%s)', (key) => {
+      const values = {
+        'roles.serviceMaintainers': '[]',
+        'roles.serviceMaintainersWrite': '[]',
+        'roles.support': '[]'
       }
+      values[key] = '{"key": "value"}'
+
+      const mockConfig = mockConfigForKeys(values)
 
       expect(() => validateConfig(mockConfig)).toThrow(
-        'Invalid roles.serviceMaintainers configuration: not an array'
+        `Invalid ${key} configuration: not an array`
       )
     })
 
-    test('throws error when value is an object', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('{"key": "value"}')
+    test.each(['"just a string"', '123', 'true', 'null'])(
+      'throws when serviceMaintainers value is %s',
+      (jsonValue) => {
+        const mockConfig = mockConfigForKeys({
+          'roles.serviceMaintainers': jsonValue,
+          'roles.serviceMaintainersWrite': '[]',
+          'roles.support': '[]'
+        })
+
+        expect(() => validateConfig(mockConfig)).toThrow(
+          'Invalid roles.serviceMaintainers configuration: not an array'
+        )
       }
-
-      expect(() => validateConfig(mockConfig)).toThrow(
-        'Invalid roles.serviceMaintainers configuration: not an array'
-      )
-    })
-
-    test('throws error when value is a number', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('123')
-      }
-
-      expect(() => validateConfig(mockConfig)).toThrow(
-        'Invalid roles.serviceMaintainers configuration: not an array'
-      )
-    })
-
-    test('throws error when value is boolean', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('true')
-      }
-
-      expect(() => validateConfig(mockConfig)).toThrow(
-        'Invalid roles.serviceMaintainers configuration: not an array'
-      )
-    })
-
-    test('throws error when value is null', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('null')
-      }
-
-      expect(() => validateConfig(mockConfig)).toThrow(
-        'Invalid roles.serviceMaintainers configuration: not an array'
-      )
-    })
+    )
   })
 
   describe('edge cases', () => {
     test('handles array with nested arrays', () => {
-      const mockConfig = {
-        get: vi
-          .fn()
-          .mockReturnValue('[["nested", "array"], ["another", "one"]]')
-      }
+      const mockConfig = mockConfigForKeys({
+        'roles.serviceMaintainers': '[["nested", "array"], ["another", "one"]]',
+        'roles.serviceMaintainersWrite': '[]',
+        'roles.support': '[]'
+      })
 
       expect(() => validateConfig(mockConfig)).not.toThrow()
     })
 
-    test('handles array with whitespace in JSON', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue(`
+    test('handles whitespace in JSON', () => {
+      const mockConfig = mockConfigForKeys({
+        'roles.serviceMaintainers': `
           [
             "user1",
             "user2",
             "user3"
           ]
-        `)
-      }
+        `,
+        'roles.serviceMaintainersWrite': '[]',
+        'roles.support': '[]'
+      })
 
       expect(() => validateConfig(mockConfig)).not.toThrow()
-    })
-
-    test('calls config.get with correct parameter', () => {
-      const mockConfig = {
-        get: vi.fn().mockReturnValue('[]')
-      }
-
-      validateConfig(mockConfig)
-
-      expect(mockConfig.get).toHaveBeenCalledTimes(1)
-      expect(mockConfig.get).toHaveBeenCalledWith('roles.serviceMaintainers')
     })
   })
 })

--- a/src/config.js
+++ b/src/config.js
@@ -312,6 +312,18 @@ const baseConfig = {
       format: String,
       env: 'SERVICE_MAINTAINER_EMAILS',
       default: '["me@example.com", "you@example.com"]'
+    },
+    serviceMaintainersWrite: {
+      doc: 'JSON array of admin emails granted the service_maintainer_write tier (admin.read + admin.write + admin.dlq.purge). Empty in production by default; populated for dev/test.',
+      format: String,
+      env: 'SERVICE_MAINTAINER_WRITE_EMAILS',
+      default: '[]'
+    },
+    support: {
+      doc: 'JSON array of admin emails granted the support tier (admin.read only). Empty in production by default; populated for dev/test.',
+      format: String,
+      env: 'SUPPORT_EMAILS',
+      default: '[]'
     }
   },
   packagingRecyclingNotesExternalApi: {

--- a/src/overseas-sites/routes/post-import.test.js
+++ b/src/overseas-sites/routes/post-import.test.js
@@ -115,7 +115,12 @@ describe(`${orsImportCreatePath} route`, () => {
         expect(stored.createdBy).toEqual({
           id: 'test-maintainer-id',
           email: 'maintainer@example.com',
-          scope: ['service_maintainer']
+          scope: [
+            'admin.read',
+            'admin.write',
+            'admin.dlq.purge',
+            'service_maintainer'
+          ]
         })
       })
 

--- a/src/routes/v1/organisations/put-by-id.test.js
+++ b/src/routes/v1/organisations/put-by-id.test.js
@@ -145,7 +145,11 @@ describe('PUT /v1/organisations/{id}', () => {
       const verifyCreatedBy = (payload) => {
         expect(payload.id).toEqual('test-user-id')
         expect(payload.email).toEqual('me@example.com')
-        expect(payload.scope).toEqual(['service_maintainer'])
+        expect(payload.scope).toEqual([
+          'admin.read',
+          'admin.dlq.purge',
+          'service_maintainer'
+        ])
       }
 
       const verifyEvent = (payload) => {

--- a/src/test/inject-auth.js
+++ b/src/test/inject-auth.js
@@ -37,6 +37,10 @@ export const asStandardUser = ({ linkedOrgId, ...overrides }) => {
   }
 }
 
+/**
+ * @param {string} role
+ * @param {{ id?: string, email?: string, overrides?: object }} [opts]
+ */
 const adminCredential = (
   role,
   {

--- a/src/test/inject-auth.js
+++ b/src/test/inject-auth.js
@@ -6,7 +6,7 @@
  * use the full auth stack with setupAuthContext() and real tokens.
  */
 
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { ADMIN_ROLES, ROLES } from '#common/helpers/auth/constants.js'
 
 const ACCESS_TOKEN_STRATEGY = 'access-token'
 
@@ -37,19 +37,91 @@ export const asStandardUser = ({ linkedOrgId, ...overrides }) => {
   }
 }
 
+const adminCredential = (
+  role,
+  {
+    id = 'test-maintainer-id',
+    email = 'maintainer@example.com',
+    overrides
+  } = {}
+) => {
+  // While the route re-scoping is in progress, the JWT strategy adds the
+  // legacy `service_maintainer` Hapi scope to the write/maintainer tiers so
+  // routes that have not yet adopted SCOPES.* keep working. Test helpers
+  // mirror that production behaviour.
+  const legacy =
+    role === 'service_maintainer_write' || role === 'service_maintainer'
+      ? [ROLES.serviceMaintainer]
+      : []
+  return {
+    auth: {
+      strategy: ACCESS_TOKEN_STRATEGY,
+      credentials: {
+        scope: [...ADMIN_ROLES[role], ...legacy],
+        role,
+        id,
+        email,
+        ...overrides
+      }
+    }
+  }
+}
+
 /**
- * Creates auth injection options for a service maintainer
+ * Creates auth injection options for a service maintainer (legacy alias).
+ *
+ * Maps to the write-tier (`service_maintainer_write`) bundle so existing
+ * tests that depended on a maintainer having full admin access continue to
+ * pass after routes are re-scoped to explicit `admin.*` requirements.
+ *
+ * For matrix-style four-tier tests use the explicit per-tier helpers below.
  * @param {object} [overrides] - Optional credential overrides
  * @returns {object} Auth options for server.inject()
  */
-export const asServiceMaintainer = (overrides = {}) => ({
+export const asServiceMaintainer = (overrides = {}) =>
+  adminCredential('service_maintainer_write', { overrides })
+
+/**
+ * Carries admin.read, admin.write, and admin.dlq.purge.
+ */
+export const asServiceMaintainerWrite = (overrides = {}) =>
+  adminCredential('service_maintainer_write', { overrides })
+
+/**
+ * Carries admin.read and admin.dlq.purge (no admin.write).
+ */
+export const asServiceMaintainerRead = (overrides = {}) =>
+  adminCredential('service_maintainer', { overrides })
+
+/**
+ * Carries only admin.read.
+ */
+export const asSupport = (overrides = {}) =>
+  adminCredential('support', {
+    id: 'test-support-id',
+    email: 'support@example.com',
+    overrides
+  })
+
+/**
+ * Authenticated identity with no admin tier — every admin-scoped route 403s.
+ */
+export const asUnscopedAdminUser = (overrides = {}) => ({
   auth: {
     strategy: ACCESS_TOKEN_STRATEGY,
     credentials: {
-      scope: [ROLES.serviceMaintainer],
-      id: 'test-maintainer-id',
-      email: 'maintainer@example.com',
+      scope: [],
+      role: null,
+      id: 'test-unscoped-id',
+      email: 'unscoped@example.com',
       ...overrides
     }
   }
 })
+
+export const ADMIN_TIER_HELPERS = {
+  service_maintainer_write: asServiceMaintainerWrite,
+  service_maintainer: asServiceMaintainerRead,
+  support: asSupport,
+  unscoped: asUnscopedAdminUser
+}


### PR DESCRIPTION
Ticket: [PAE-1430](https://eaflood.atlassian.net/browse/PAE-1430)
## Description

Foundation slice of ADR 0033 (admin UI scope-based RBAC) for [PAE-1430]. Introduces the new `SCOPES` enum, `ADMIN_ROLES` bundling map, three-tier email-list role resolution, and a richer Entra credential payload — without yet re-scoping any admin route.

This is intentionally split from the route re-scoping work to keep review surface manageable. A follow-up PR will:

- Re-scope every admin route from `[ROLES.serviceMaintainer]` to explicit `[SCOPES.*]` requirements (DLQ, mixed-tier, mutating, and currently-unscoped admin routes).
- Add the `GET /v1/admin/me` self-introspection endpoint.
- Add the four-tier integration matrix (per ADR §8).
- Drop `ROLES.serviceMaintainer` and remove the legacy compat shim added below.

### Behaviour during transition

The JWT strategy now resolves an admin user to one of three roles (`service_maintainer_write`, `service_maintainer`, `support`) and attaches the matching `admin.*` scope bundle to the credential. While the route re-scoping is in progress, the strategy *also* attaches the legacy `service_maintainer` Hapi scope to the write and maintainer tiers so existing admin routes continue to authorise correctly. The `support` tier deliberately does not get the legacy scope — it had no admin access before and still gets none until routes adopt `admin.read`.

### Deploy ordering

Two new env vars (`SERVICE_MAINTAINER_WRITE_EMAILS`, `SUPPORT_EMAILS`) are read from `cdp-app-config`. Defaults to `'[]'` so existing deployments remain functional, but the `cdp-app-config` PR adding these keys should land before this PR is deployed to any environment that wants to populate them.

## Changes

- `src/common/helpers/auth/constants.js` — add `SCOPES` enum (`admin.read`, `admin.write`, `admin.dlq.purge`) and `ADMIN_ROLES` map (snake_case role names are stable wire identifiers and i18n lookup keys).
- `src/common/helpers/auth/constants.test.js` — new unit tests for the `ADMIN_ROLES` bundling.
- `src/common/helpers/auth/get-entra-user-roles.js` — replace single-list lookup with first-match-wins resolution across three lists; return `{ role, scopes }` instead of a plain scope array.
- `src/common/helpers/auth/get-entra-user-roles.test.js` — replace coverage with single-list, multi-list precedence, case-insensitivity, edge cases, and concurrency tests for the new shape.
- `src/common/helpers/auth/get-jwt-strategy-config.js` — destructure `{ role, scopes }` from the helper, attach both to credentials, and add the legacy `service_maintainer` Hapi scope for write/maintainer tiers (transitional).
- `src/common/helpers/auth/get-jwt-strategy-config.test.js` — update mocks/expectations for the new shape; add explicit support-tier and unscoped cases.
- `src/common/helpers/validate-config.js` — validate all three role list keys (DRY) instead of just `roles.serviceMaintainers`.
- `src/common/helpers/validate-config.test.js` — restructure tests around the multi-key validator.
- `src/config.js` — add `roles.serviceMaintainersWrite` (env `SERVICE_MAINTAINER_WRITE_EMAILS`) and `roles.support` (env `SUPPORT_EMAILS`); both default to `'[]'`.
- `src/test/inject-auth.js` — add `asServiceMaintainerWrite`, `asServiceMaintainerRead`, `asSupport`, `asUnscopedAdminUser`, plus an `ADMIN_TIER_HELPERS` map keyed by role for matrix-style tests. Existing `asServiceMaintainer` is retained as an alias for the write tier.
- `src/overseas-sites/routes/post-import.test.js`, `src/routes/v1/organisations/put-by-id.test.js` — update assertions where they captured the literal `service_maintainer` scope on persisted audit records (now a richer bundle).

[PAE-1430]: https://eaflood.atlassian.net/browse/PAE-1430

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).
