### PR TITLE
PAE-1430: Re-scope admin routes to SCOPES.* and add /v1/admin/me

### DIFF
--- a/.vite/setup-files.js
+++ b/.vite/setup-files.js
@@ -14,7 +14,14 @@ process.env.PACKAGING_RECYCLING_NOTES_EXTERNAL_API_JWKS_URL =
   'https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_test/.well-known/jwks.json'
 
 // Roles
+// In test, the existing service-maintainer emails are also placed in the
+// write list. First-match-wins resolution (see getEntraUserRoles) gives them
+// the `service_maintainer_write` tier so existing integration tests that
+// exercise mutating admin routes continue to pass.
 process.env.SERVICE_MAINTAINER_EMAILS = '["me@example.com", "you@example.com"]'
+process.env.SERVICE_MAINTAINER_WRITE_EMAILS =
+  '["me@example.com", "you@example.com"]'
+process.env.SUPPORT_EMAILS = '[]'
 
 // AWS - test credentials
 process.env.AWS_ACCESS_KEY_ID = 'test'

--- a/src/common/helpers/auth/constants.js
+++ b/src/common/helpers/auth/constants.js
@@ -1,8 +1,9 @@
 /**
+ * Per-request operator-side gates (issued by `getDefraUserRoles` from the
+ * request context). Distinct from the durable admin scopes in `SCOPES` below.
  * @typedef {typeof ROLES[keyof typeof ROLES]} Roles
  */
 export const ROLES = {
-  serviceMaintainer: 'service_maintainer',
   standardUser: 'standard_user',
   inquirer: 'inquirer',
   linker: 'linker'

--- a/src/common/helpers/auth/constants.js
+++ b/src/common/helpers/auth/constants.js
@@ -19,9 +19,9 @@ export const SCOPES = {
 }
 
 /**
- * Admin role → scope-bundle map. Role names are deliberately snake_case strings:
- * they are stable wire identifiers (returned by GET /v1/admin/me) and i18n
- * lookup keys for the admin-frontend tier label.
+ * Admin role → scope-bundle map. Used internally by getEntraUserRoles to
+ * resolve an email-list match to its scope set; role names do not flow onto
+ * credentials or out over the wire.
  */
 export const ADMIN_ROLES = {
   service_maintainer_write: [

--- a/src/common/helpers/auth/get-auth-config.test.js
+++ b/src/common/helpers/auth/get-auth-config.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
 import { getAuthConfig } from './get-auth-config.js'
-import { ROLES } from './constants.js'
+import { ROLES, SCOPES } from './constants.js'
 
 describe('getAuthConfig', () => {
   it('returns auth config with scopes', () => {
@@ -11,10 +11,8 @@ describe('getAuthConfig', () => {
   })
 
   it('passes through multiple scopes', () => {
-    expect(
-      getAuthConfig([ROLES.standardUser, ROLES.serviceMaintainer])
-    ).toEqual({
-      scope: [ROLES.standardUser, ROLES.serviceMaintainer]
+    expect(getAuthConfig([ROLES.standardUser, SCOPES.adminRead])).toEqual({
+      scope: [ROLES.standardUser, SCOPES.adminRead]
     })
   })
 })

--- a/src/common/helpers/auth/get-jwt-strategy-config.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.js
@@ -48,7 +48,7 @@ export function getJwtStrategyConfig(oidcConfigs) {
 
         const email = tokenPayload.preferred_username
 
-        const { role, scopes } = await getEntraUserRoles(email)
+        const { scopes } = await getEntraUserRoles(email)
 
         return {
           isValid: true,
@@ -56,7 +56,6 @@ export function getJwtStrategyConfig(oidcConfigs) {
             id: tokenPayload.oid,
             email,
             issuer,
-            role,
             scope: scopes
           }
         }

--- a/src/common/helpers/auth/get-jwt-strategy-config.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.js
@@ -46,7 +46,10 @@ export function getJwtStrategyConfig(oidcConfigs) {
           throw Boom.forbidden('Invalid audience for Entra ID token')
         }
 
-        const email = tokenPayload.preferred_username
+        // Real Entra ID tokens carry the user's email under `preferred_username`.
+        // The local `epr-re-ex-entra-stub` emits it under `email` instead. Accept
+        // either so admin RBAC resolution works for both real and stubbed tokens.
+        const email = tokenPayload.preferred_username ?? tokenPayload.email
 
         const { scopes } = await getEntraUserRoles(email)
 

--- a/src/common/helpers/auth/get-jwt-strategy-config.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.js
@@ -1,18 +1,7 @@
 import { config } from '#root/config.js'
 import Boom from '@hapi/boom'
-import { ROLES } from './constants.js'
 import { getDefraUserRoles } from './get-defra-user-roles.js'
 import { getEntraUserRoles } from './get-entra-user-roles.js'
-
-/**
- * Roles that retain access via the legacy `service_maintainer` Hapi scope
- * during the route re-scoping transition. Removed once every admin route
- * declares an explicit `admin.*` scope.
- */
-const LEGACY_SERVICE_MAINTAINER_ROLES = new Set([
-  'service_maintainer_write',
-  'service_maintainer'
-])
 
 /** @typedef {import('./types.js').TokenPayload} TokenPayload */
 /** @typedef {import('./types.js').EntraIdTokenPayload} EntraIdTokenPayload */
@@ -60,10 +49,6 @@ export function getJwtStrategyConfig(oidcConfigs) {
         const email = tokenPayload.preferred_username
 
         const { role, scopes } = await getEntraUserRoles(email)
-        const scope =
-          role !== null && LEGACY_SERVICE_MAINTAINER_ROLES.has(role)
-            ? [...scopes, ROLES.serviceMaintainer]
-            : scopes
 
         return {
           isValid: true,
@@ -72,7 +57,7 @@ export function getJwtStrategyConfig(oidcConfigs) {
             email,
             issuer,
             role,
-            scope
+            scope: scopes
           }
         }
       }

--- a/src/common/helpers/auth/get-jwt-strategy-config.test.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.test.js
@@ -16,10 +16,7 @@ const maintainerCredential = {
   role: 'service_maintainer',
   scopes: [...ADMIN_ROLES.service_maintainer]
 }
-const expectedMaintainerScope = [
-  ...ADMIN_ROLES.service_maintainer,
-  ROLES.serviceMaintainer
-]
+const expectedMaintainerScope = [...ADMIN_ROLES.service_maintainer]
 
 // Mock config
 const mockConfigGet = vi.fn()
@@ -218,7 +215,7 @@ describe('#getJwtStrategyConfig', () => {
       )
     })
 
-    test('write tier credential carries all admin scopes plus the legacy service_maintainer scope', async () => {
+    test('write tier credential carries the full admin scope bundle', async () => {
       mockGetEntraUserRoles.mockResolvedValue({
         role: 'service_maintainer_write',
         scopes: [...ADMIN_ROLES.service_maintainer_write]
@@ -241,12 +238,11 @@ describe('#getJwtStrategyConfig', () => {
 
       expect(result.credentials.role).toBe('service_maintainer_write')
       expect(result.credentials.scope).toEqual([
-        ...ADMIN_ROLES.service_maintainer_write,
-        ROLES.serviceMaintainer
+        ...ADMIN_ROLES.service_maintainer_write
       ])
     })
 
-    test('support tier credential carries only admin.read with no legacy scope', async () => {
+    test('support tier credential carries only admin.read', async () => {
       mockGetEntraUserRoles.mockResolvedValue({
         role: 'support',
         scopes: [...ADMIN_ROLES.support]

--- a/src/common/helpers/auth/get-jwt-strategy-config.test.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.test.js
@@ -169,9 +169,9 @@ describe('#getJwtStrategyConfig', () => {
     test.each([
       ['b@email.com', 'b@email.com'],
       [undefined, undefined],
-      [null, null]
+      [null, undefined]
     ])(
-      'When token.preferred_username is %s, parsed email is %s',
+      'When token.preferred_username is %s and email claim is absent, parsed email is %s',
       async (preferredUsername, expected) => {
         const config = getJwtStrategyConfig(mockOidcConfigs)
 
@@ -194,6 +194,47 @@ describe('#getJwtStrategyConfig', () => {
         expect(mockGetEntraUserRoles).toHaveBeenCalledTimes(1)
       }
     )
+
+    test('Falls back to the email claim when preferred_username is absent (entra-stub compat)', async () => {
+      const config = getJwtStrategyConfig(mockOidcConfigs)
+
+      const artifacts = {
+        decoded: {
+          payload: {
+            iss: entraIdMockOidcWellKnownResponse.issuer,
+            aud: mockEntraClientId,
+            oid: 'contact-123',
+            email: 'stubbed@test.gov.uk'
+          }
+        }
+      }
+
+      const result = await config.validate(artifacts)
+
+      expect(result.credentials.email).toBe('stubbed@test.gov.uk')
+      expect(mockGetEntraUserRoles).toHaveBeenCalledWith('stubbed@test.gov.uk')
+    })
+
+    test('Prefers preferred_username over email when both are present (real Entra)', async () => {
+      const config = getJwtStrategyConfig(mockOidcConfigs)
+
+      const artifacts = {
+        decoded: {
+          payload: {
+            iss: entraIdMockOidcWellKnownResponse.issuer,
+            aud: mockEntraClientId,
+            oid: 'contact-123',
+            preferred_username: 'real@example.com',
+            email: 'wrong@example.com'
+          }
+        }
+      }
+
+      const result = await config.validate(artifacts)
+
+      expect(result.credentials.email).toBe('real@example.com')
+      expect(mockGetEntraUserRoles).toHaveBeenCalledWith('real@example.com')
+    })
 
     test('throws forbidden error for Entra ID token with invalid audience', async () => {
       const config = getJwtStrategyConfig(mockOidcConfigs)

--- a/src/common/helpers/auth/get-jwt-strategy-config.test.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.test.js
@@ -139,7 +139,6 @@ describe('#getJwtStrategyConfig', () => {
           id: 'contact-123',
           email: 'user@example.com',
           issuer: entraIdMockOidcWellKnownResponse.issuer,
-          role: 'service_maintainer',
           scope: expectedMaintainerScope
         }
       })
@@ -236,7 +235,6 @@ describe('#getJwtStrategyConfig', () => {
 
       const result = await config.validate(artifacts)
 
-      expect(result.credentials.role).toBe('service_maintainer_write')
       expect(result.credentials.scope).toEqual([
         ...ADMIN_ROLES.service_maintainer_write
       ])
@@ -263,11 +261,10 @@ describe('#getJwtStrategyConfig', () => {
 
       const result = await config.validate(artifacts)
 
-      expect(result.credentials.role).toBe('support')
       expect(result.credentials.scope).toEqual([SCOPES.adminRead])
     })
 
-    test('handles Entra ID token where user matches no admin tier (empty scope, null role)', async () => {
+    test('handles Entra ID token where user matches no admin tier (empty scope)', async () => {
       mockGetEntraUserRoles.mockResolvedValue({ role: null, scopes: [] })
 
       const config = getJwtStrategyConfig(mockOidcConfigs)
@@ -285,7 +282,6 @@ describe('#getJwtStrategyConfig', () => {
 
       const result = await config.validate(artifacts)
 
-      expect(result.credentials.role).toBeNull()
       expect(result.credentials.scope).toEqual([])
     })
 

--- a/src/overseas-sites/routes/admin-list.js
+++ b/src/overseas-sites/routes/admin-list.js
@@ -6,7 +6,7 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 
 /**
@@ -146,7 +146,7 @@ export const adminOverseasSitesList = {
   method: 'GET',
   path: adminOverseasSitesListPath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminRead]),
     tags: ['api'],
     validate: {
       query: Joi.object({

--- a/src/overseas-sites/routes/delete-by-id.js
+++ b/src/overseas-sites/routes/delete-by-id.js
@@ -6,7 +6,7 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 
 /** @import { OverseasSitesRepository } from '#overseas-sites/repository/port.js' */
@@ -18,7 +18,7 @@ export const overseasSiteDelete = {
   method: 'DELETE',
   path: overseasSiteDeletePath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminWrite]),
     tags: ['api']
   },
   /**

--- a/src/overseas-sites/routes/get-by-id.js
+++ b/src/overseas-sites/routes/get-by-id.js
@@ -5,7 +5,7 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 
 /** @import { OverseasSitesRepository } from '#overseas-sites/repository/port.js' */
@@ -16,7 +16,7 @@ export const overseasSiteById = {
   method: 'GET',
   path: overseasSiteByIdPath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminRead]),
     tags: ['api']
   },
   /**

--- a/src/overseas-sites/routes/get-import-status.js
+++ b/src/overseas-sites/routes/get-import-status.js
@@ -5,7 +5,7 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 
 /** @import { OrsImportsRepository } from '#overseas-sites/imports/repository/port.js' */
@@ -16,7 +16,7 @@ export const orsImportStatus = {
   method: 'GET',
   path: orsImportStatusPath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminRead]),
     tags: ['api']
   },
   /**

--- a/src/overseas-sites/routes/list.js
+++ b/src/overseas-sites/routes/list.js
@@ -6,7 +6,7 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 
 /** @import { OverseasSitesRepository } from '#overseas-sites/repository/port.js' */
@@ -17,7 +17,7 @@ export const overseasSitesList = {
   method: 'GET',
   path: overseasSitesListPath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminRead]),
     tags: ['api'],
     validate: {
       query: Joi.object({

--- a/src/overseas-sites/routes/post-import.js
+++ b/src/overseas-sites/routes/post-import.js
@@ -8,7 +8,7 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { ORS_IMPORT_STATUS } from '#overseas-sites/domain/import-status.js'
 import { config } from '#root/config.js'
@@ -28,7 +28,7 @@ export const orsImportCreate = {
   method: 'POST',
   path: orsImportCreatePath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminWrite]),
     tags: ['api'],
     validate: {
       payload: orsImportCreatePayloadSchema
@@ -52,7 +52,7 @@ export const orsImportCreate = {
         _id: importId,
         status: ORS_IMPORT_STATUS.PREPROCESSING,
         files: [],
-        // @ts-expect-error getAuthConfig([ROLES.serviceMaintainer]) guarantees human credentials with id, email, scope
+        // @ts-expect-error getAuthConfig([SCOPES.adminWrite]) guarantees human credentials with id, email, scope
         createdBy: extractUserDetails(request)
       })
 

--- a/src/overseas-sites/routes/post-import.test.js
+++ b/src/overseas-sites/routes/post-import.test.js
@@ -115,12 +115,7 @@ describe(`${orsImportCreatePath} route`, () => {
         expect(stored.createdBy).toEqual({
           id: 'test-maintainer-id',
           email: 'maintainer@example.com',
-          scope: [
-            'admin.read',
-            'admin.write',
-            'admin.dlq.purge',
-            'service_maintainer'
-          ]
+          scope: ['admin.read', 'admin.write', 'admin.dlq.purge']
         })
       })
 

--- a/src/overseas-sites/routes/post.js
+++ b/src/overseas-sites/routes/post.js
@@ -6,7 +6,7 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { overseasSiteCreatePayloadSchema } from './post.schema.js'
 
@@ -19,7 +19,7 @@ export const overseasSitesCreate = {
   method: 'POST',
   path: overseasSitesCreatePath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminWrite]),
     tags: ['api'],
     validate: {
       payload: overseasSiteCreatePayloadSchema

--- a/src/overseas-sites/routes/put-by-id.js
+++ b/src/overseas-sites/routes/put-by-id.js
@@ -6,7 +6,7 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { overseasSiteUpdatePayloadSchema } from './put-by-id.schema.js'
 
@@ -19,7 +19,7 @@ export const overseasSiteUpdate = {
   method: 'PUT',
   path: overseasSiteUpdatePath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminWrite]),
     tags: ['api'],
     validate: {
       payload: overseasSiteUpdatePayloadSchema

--- a/src/packaging-recycling-notes/routes/admin-list.js
+++ b/src/packaging-recycling-notes/routes/admin-list.js
@@ -6,7 +6,7 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { WASTE_PROCESSING_TYPE } from '#domain/organisations/model.js'
 import { getProcessCode } from '#packaging-recycling-notes/domain/get-process-code.js'
@@ -52,7 +52,7 @@ export const adminPackagingRecyclingNotesList = {
   method: 'GET',
   path: adminPackagingRecyclingNotesListPath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminRead]),
     tags: ['api'],
     validate: {
       query: Joi.object({

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -21,6 +21,7 @@ import * as packagingRecyclingNotesRoutes from '#packaging-recycling-notes/route
 import { summaryLogUploadsReportRoutes } from '#routes/v1/organisations/registrations/summary-logs/reports/uploads/index.js'
 import * as reportsRoutes from '#reports/routes/index.js'
 import { reportsUnsubmit } from '#reports/routes/unsubmit.js'
+import { adminMeGet } from '#routes/v1/admin/me/get.js'
 import { dlqMessagesGet } from '#routes/v1/admin/queues/dlq/messages.get.js'
 import { dlqPurgePost } from '#routes/v1/admin/queues/dlq/purge.post.js'
 
@@ -66,6 +67,7 @@ const router = {
           ...Object.values(overseasSitesRoutes),
           ...Object.values(coreReportsRoutes),
           ...unsubmitBehindFeatureFlag,
+          adminMeGet,
           dlqMessagesGet,
           dlqPurgePost
         ])

--- a/src/reports/routes/get-detail.js
+++ b/src/reports/routes/get-detail.js
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 import { fetchOrGenerateReportForPeriod } from '#reports/application/report-service.js'
 import { periodParamsSchema, withRegistrationDetails } from './shared.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { ROLES, SCOPES } from '#common/helpers/auth/constants.js'
 
 /**
  * @import { HapiRequest, HapiResponseToolkit } from '#common/hapi-types.js'
@@ -22,7 +22,7 @@ export const reportsGetDetail = {
   method: 'GET',
   path: reportsGetDetailPath,
   options: {
-    auth: getAuthConfig([ROLES.standardUser, ROLES.serviceMaintainer]),
+    auth: getAuthConfig([ROLES.standardUser, SCOPES.adminRead]),
     tags: ['api'],
     validate: {
       params: periodParamsSchema

--- a/src/reports/routes/get.js
+++ b/src/reports/routes/get.js
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes'
 import Joi from 'joi'
 
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { ROLES, SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { CADENCE } from '#reports/domain/cadence.js'
 import { generateReportingPeriods } from '#reports/domain/generate-reporting-periods.js'
@@ -21,7 +21,7 @@ export const reportsGet = {
   method: 'GET',
   path: reportsGetPath,
   options: {
-    auth: getAuthConfig([ROLES.standardUser, ROLES.serviceMaintainer]),
+    auth: getAuthConfig([ROLES.standardUser, SCOPES.adminRead]),
     tags: ['api'],
     validate: {
       params: Joi.object({

--- a/src/reports/routes/submissions.js
+++ b/src/reports/routes/submissions.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { REGULATOR_DISPLAY } from '#domain/organisations/model.js'
 import { generateReportSubmissions } from '#reports/application/report-submissions.js'
@@ -17,7 +17,7 @@ export const getReportSubmissions = {
   method: 'GET',
   path: getReportSubmissionsPath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminRead]),
     tags: ['api', 'admin'],
     response: {
       schema: Joi.object({

--- a/src/reports/routes/unsubmit.js
+++ b/src/reports/routes/unsubmit.js
@@ -1,7 +1,7 @@
 import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
 
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { auditReportStatusTransition } from '#reports/application/audit.js'
 import { fetchCurrentReport } from '#reports/application/report-service.js'
 import {
@@ -18,7 +18,7 @@ export const reportsUnsubmit = {
   path: reportsUnsubmitPath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminWrite]
     },
     tags: ['api', 'admin'],
     validate: {

--- a/src/routes/v1/admin/me/get.js
+++ b/src/routes/v1/admin/me/get.js
@@ -30,8 +30,8 @@ export const adminMeGet = {
   },
   /**
    * Echoes the validated token's resolved admin role and scope bundle.
-   * No DB call — the JWT strategy has already resolved both onto the
-   * credential and the route's auth.scope guarantees an admin tier reached us.
+   * No DB call — the JWT strategy resolves both onto the credential and the
+   * route's auth.scope guarantees an admin tier reached us.
    * @param {import('#common/hapi-types.js').HapiRequest} request
    * @param {import('#common/hapi-types.js').HapiResponseToolkit} h
    */
@@ -40,15 +40,8 @@ export const adminMeGet = {
       /** @type {{ role: string | null, scope: string[] }} */ (
         /** @type {unknown} */ (request.auth.credentials)
       )
-    // Strip the legacy `service_maintainer` Hapi scope from the public response;
-    // it is an internal transitional artefact and not part of the documented
-    // SCOPES enum.
-    const scopes = credentials.scope.filter(
-      (s) =>
-        s === SCOPES.adminRead ||
-        s === SCOPES.adminWrite ||
-        s === SCOPES.adminDlqPurge
-    )
-    return h.response({ role: credentials.role, scopes }).code(StatusCodes.OK)
+    return h
+      .response({ role: credentials.role, scopes: credentials.scope })
+      .code(StatusCodes.OK)
   }
 }

--- a/src/routes/v1/admin/me/get.js
+++ b/src/routes/v1/admin/me/get.js
@@ -7,10 +7,6 @@ import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 export const adminMePath = '/v1/admin/me'
 
 const responseSchema = Joi.object({
-  role: Joi.string()
-    .valid('service_maintainer_write', 'service_maintainer', 'support')
-    .allow(null)
-    .required(),
   scopes: Joi.array().items(Joi.string()).required()
 }).label('AdminMeResponse')
 
@@ -18,30 +14,23 @@ export const adminMeGet = {
   method: 'GET',
   path: adminMePath,
   options: {
-    auth: getAuthConfig([
-      SCOPES.adminRead,
-      SCOPES.adminWrite,
-      SCOPES.adminDlqPurge
-    ]),
+    auth: getAuthConfig([SCOPES.adminRead]),
     tags: ['api', 'admin'],
     response: {
       schema: responseSchema
     }
   },
   /**
-   * Echoes the validated token's resolved admin role and scope bundle.
-   * No DB call — the JWT strategy resolves both onto the credential and the
+   * Echoes the validated token's resolved admin scope bundle.
+   * No DB call — the JWT strategy resolves scopes onto the credential and the
    * route's auth.scope guarantees an admin tier reached us.
    * @param {import('#common/hapi-types.js').HapiRequest} request
    * @param {import('#common/hapi-types.js').HapiResponseToolkit} h
    */
   handler: async (request, h) => {
-    const credentials =
-      /** @type {{ role: string | null, scope: string[] }} */ (
-        /** @type {unknown} */ (request.auth.credentials)
-      )
-    return h
-      .response({ role: credentials.role, scopes: credentials.scope })
-      .code(StatusCodes.OK)
+    const credentials = /** @type {{ scope: string[] }} */ (
+      /** @type {unknown} */ (request.auth.credentials)
+    )
+    return h.response({ scopes: credentials.scope }).code(StatusCodes.OK)
   }
 }

--- a/src/routes/v1/admin/me/get.js
+++ b/src/routes/v1/admin/me/get.js
@@ -36,16 +36,19 @@ export const adminMeGet = {
    * @param {import('#common/hapi-types.js').HapiResponseToolkit} h
    */
   handler: async (request, h) => {
-    const { role, scope } = request.auth.credentials
+    const credentials =
+      /** @type {{ role: string | null, scope: string[] }} */ (
+        /** @type {unknown} */ (request.auth.credentials)
+      )
     // Strip the legacy `service_maintainer` Hapi scope from the public response;
     // it is an internal transitional artefact and not part of the documented
     // SCOPES enum.
-    const scopes = scope.filter(
+    const scopes = credentials.scope.filter(
       (s) =>
         s === SCOPES.adminRead ||
         s === SCOPES.adminWrite ||
         s === SCOPES.adminDlqPurge
     )
-    return h.response({ role, scopes }).code(StatusCodes.OK)
+    return h.response({ role: credentials.role, scopes }).code(StatusCodes.OK)
   }
 }

--- a/src/routes/v1/admin/me/get.js
+++ b/src/routes/v1/admin/me/get.js
@@ -1,0 +1,51 @@
+import { StatusCodes } from 'http-status-codes'
+import Joi from 'joi'
+
+import { SCOPES } from '#common/helpers/auth/constants.js'
+import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
+
+export const adminMePath = '/v1/admin/me'
+
+const responseSchema = Joi.object({
+  role: Joi.string()
+    .valid('service_maintainer_write', 'service_maintainer', 'support')
+    .allow(null)
+    .required(),
+  scopes: Joi.array().items(Joi.string()).required()
+}).label('AdminMeResponse')
+
+export const adminMeGet = {
+  method: 'GET',
+  path: adminMePath,
+  options: {
+    auth: getAuthConfig([
+      SCOPES.adminRead,
+      SCOPES.adminWrite,
+      SCOPES.adminDlqPurge
+    ]),
+    tags: ['api', 'admin'],
+    response: {
+      schema: responseSchema
+    }
+  },
+  /**
+   * Echoes the validated token's resolved admin role and scope bundle.
+   * No DB call — the JWT strategy has already resolved both onto the
+   * credential and the route's auth.scope guarantees an admin tier reached us.
+   * @param {import('#common/hapi-types.js').HapiRequest} request
+   * @param {import('#common/hapi-types.js').HapiResponseToolkit} h
+   */
+  handler: async (request, h) => {
+    const { role, scope } = request.auth.credentials
+    // Strip the legacy `service_maintainer` Hapi scope from the public response;
+    // it is an internal transitional artefact and not part of the documented
+    // SCOPES enum.
+    const scopes = scope.filter(
+      (s) =>
+        s === SCOPES.adminRead ||
+        s === SCOPES.adminWrite ||
+        s === SCOPES.adminDlqPurge
+    )
+    return h.response({ role, scopes }).code(StatusCodes.OK)
+  }
+}

--- a/src/routes/v1/admin/me/get.test.js
+++ b/src/routes/v1/admin/me/get.test.js
@@ -1,0 +1,118 @@
+import { StatusCodes } from 'http-status-codes'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+
+import { ADMIN_ROLES, SCOPES } from '#common/helpers/auth/constants.js'
+import { createTestServer } from '#test/create-test-server.js'
+import {
+  asServiceMaintainerRead,
+  asServiceMaintainerWrite,
+  asStandardUser,
+  asSupport,
+  asUnscopedAdminUser
+} from '#test/inject-auth.js'
+import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+
+const ADMIN_ME_PATH = '/v1/admin/me'
+
+describe('GET /v1/admin/me', () => {
+  setupAuthContext()
+
+  let server
+
+  beforeAll(async () => {
+    server = await createTestServer({})
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  describe('access control matrix', () => {
+    it('returns 401 when not authenticated', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: ADMIN_ME_PATH
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+    })
+
+    it('returns 403 for an authenticated user with no admin tier', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: ADMIN_ME_PATH,
+        ...asUnscopedAdminUser()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+    })
+
+    it('returns 403 for a Defra-side standard user', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: ADMIN_ME_PATH,
+        ...asStandardUser({ linkedOrgId: 'org-123' })
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+    })
+  })
+
+  describe('payload by tier', () => {
+    it('returns the write tier role and full scope bundle', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: ADMIN_ME_PATH,
+        ...asServiceMaintainerWrite()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(response.payload)).toEqual({
+        role: 'service_maintainer_write',
+        scopes: [...ADMIN_ROLES.service_maintainer_write]
+      })
+    })
+
+    it('returns the maintainer tier role and admin.read + admin.dlq.purge', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: ADMIN_ME_PATH,
+        ...asServiceMaintainerRead()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(response.payload)).toEqual({
+        role: 'service_maintainer',
+        scopes: [...ADMIN_ROLES.service_maintainer]
+      })
+    })
+
+    it('returns the support tier role with only admin.read', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: ADMIN_ME_PATH,
+        ...asSupport()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(response.payload)).toEqual({
+        role: 'support',
+        scopes: [SCOPES.adminRead]
+      })
+    })
+
+    it('does not surface the legacy service_maintainer scope in the response', async () => {
+      // The JWT strategy adds the legacy `service_maintainer` Hapi scope to
+      // write/maintainer credentials during the route re-scoping transition.
+      // The /v1/admin/me payload must reflect only the documented SCOPES enum.
+      const response = await server.inject({
+        method: 'GET',
+        url: ADMIN_ME_PATH,
+        ...asServiceMaintainerWrite()
+      })
+
+      const payload = JSON.parse(response.payload)
+      expect(payload.scopes).not.toContain('service_maintainer')
+    })
+  })
+})

--- a/src/routes/v1/admin/me/get.test.js
+++ b/src/routes/v1/admin/me/get.test.js
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes'
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 
-import { ADMIN_ROLES, SCOPES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { createTestServer } from '#test/create-test-server.js'
 import {
   asServiceMaintainerRead,
@@ -59,7 +59,7 @@ describe('GET /v1/admin/me', () => {
   })
 
   describe('payload by tier', () => {
-    it('returns the write tier role and full scope bundle', async () => {
+    it('returns the write tier scope bundle (admin.read + admin.write + admin.dlq.purge)', async () => {
       const response = await server.inject({
         method: 'GET',
         url: ADMIN_ME_PATH,
@@ -68,12 +68,11 @@ describe('GET /v1/admin/me', () => {
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       expect(JSON.parse(response.payload)).toEqual({
-        role: 'service_maintainer_write',
-        scopes: [...ADMIN_ROLES.service_maintainer_write]
+        scopes: [SCOPES.adminRead, SCOPES.adminWrite, SCOPES.adminDlqPurge]
       })
     })
 
-    it('returns the maintainer tier role and admin.read + admin.dlq.purge', async () => {
+    it('returns the maintainer tier scope bundle (admin.read + admin.dlq.purge)', async () => {
       const response = await server.inject({
         method: 'GET',
         url: ADMIN_ME_PATH,
@@ -82,12 +81,11 @@ describe('GET /v1/admin/me', () => {
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       expect(JSON.parse(response.payload)).toEqual({
-        role: 'service_maintainer',
-        scopes: [...ADMIN_ROLES.service_maintainer]
+        scopes: [SCOPES.adminRead, SCOPES.adminDlqPurge]
       })
     })
 
-    it('returns the support tier role with only admin.read', async () => {
+    it('returns the support tier scope bundle (admin.read only)', async () => {
       const response = await server.inject({
         method: 'GET',
         url: ADMIN_ME_PATH,
@@ -96,7 +94,6 @@ describe('GET /v1/admin/me', () => {
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       expect(JSON.parse(response.payload)).toEqual({
-        role: 'support',
         scopes: [SCOPES.adminRead]
       })
     })

--- a/src/routes/v1/admin/me/get.test.js
+++ b/src/routes/v1/admin/me/get.test.js
@@ -100,19 +100,5 @@ describe('GET /v1/admin/me', () => {
         scopes: [SCOPES.adminRead]
       })
     })
-
-    it('does not surface the legacy service_maintainer scope in the response', async () => {
-      // The JWT strategy adds the legacy `service_maintainer` Hapi scope to
-      // write/maintainer credentials during the route re-scoping transition.
-      // The /v1/admin/me payload must reflect only the documented SCOPES enum.
-      const response = await server.inject({
-        method: 'GET',
-        url: ADMIN_ME_PATH,
-        ...asServiceMaintainerWrite()
-      })
-
-      const payload = JSON.parse(response.payload)
-      expect(payload.scopes).not.toContain('service_maintainer')
-    })
   })
 })

--- a/src/routes/v1/admin/queues/dlq/messages.get.js
+++ b/src/routes/v1/admin/queues/dlq/messages.get.js
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes'
 import Boom from '@hapi/boom'
 
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { dlqMessagesResponseSchema } from './response.schema.js'
 
@@ -11,7 +11,7 @@ export const dlqMessagesGet = {
   method: 'GET',
   path: dlqMessagesPath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminRead]),
     tags: ['api', 'admin'],
     response: {
       schema: dlqMessagesResponseSchema

--- a/src/routes/v1/admin/queues/dlq/purge.post.js
+++ b/src/routes/v1/admin/queues/dlq/purge.post.js
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes'
 import Boom from '@hapi/boom'
 
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { dlqPurgeResponseSchema } from './response.schema.js'
 
@@ -11,7 +11,7 @@ export const dlqPurgePost = {
   method: 'POST',
   path: dlqPurgePath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminDlqPurge]),
     tags: ['api', 'admin'],
     response: {
       schema: dlqPurgeResponseSchema

--- a/src/routes/v1/form-submissions/get-by-id.js
+++ b/src/routes/v1/form-submissions/get-by-id.js
@@ -1,5 +1,5 @@
 import { StatusCodes } from 'http-status-codes'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 
 /** @typedef {import('#repositories/form-submissions/port.js').FormSubmissionsRepository} FormSubmissionsRepository */
 
@@ -8,7 +8,7 @@ export const formSubmissionsDataGet = {
   path: '/v1/form-submissions/{documentId}',
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminRead]
     },
     tags: ['api', 'admin']
   },

--- a/src/routes/v1/linked-organisations/get.js
+++ b/src/routes/v1/linked-organisations/get.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { StatusCodes } from 'http-status-codes'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
 import { linkedOrganisationsResponseSchema } from './response.schema.js'
 
@@ -15,7 +15,7 @@ export const linkedOrganisationsGetAll = {
   path: linkedOrganisationsGetAllPath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminRead]
     },
     tags: ['api', 'admin'],
     validate: {

--- a/src/routes/v1/organisations/get-by-id.js
+++ b/src/routes/v1/organisations/get-by-id.js
@@ -1,6 +1,6 @@
 import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { ROLES, SCOPES } from '#common/helpers/auth/constants.js'
 
 /** @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository */
 
@@ -11,7 +11,7 @@ export const organisationsGetById = {
   path: organisationsGetByIdPath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer, ROLES.standardUser]
+      scope: [ROLES.standardUser, SCOPES.adminRead]
     },
     tags: ['api', 'admin']
   },

--- a/src/routes/v1/organisations/get.js
+++ b/src/routes/v1/organisations/get.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { StatusCodes } from 'http-status-codes'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 
 /** @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository */
 
@@ -25,7 +25,7 @@ export const organisationsGetAll = {
   path: organisationsGetAllPath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminRead]
     },
     tags: ['api', 'admin'],
     validate: {

--- a/src/routes/v1/organisations/overview/get.js
+++ b/src/routes/v1/organisations/overview/get.js
@@ -1,6 +1,6 @@
 import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
@@ -16,7 +16,7 @@ export const organisationsOverviewGet = {
   path: organisationsOverviewGetPath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminRead]
     },
     tags: ['api', 'admin'],
     response: {

--- a/src/routes/v1/organisations/put-by-id.js
+++ b/src/routes/v1/organisations/put-by-id.js
@@ -1,4 +1,4 @@
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
 import { auditOrganisationUpdate } from '#root/auditing/organisations.js'
@@ -67,7 +67,7 @@ export const organisationsPutById = {
   path: organisationsPutByIdPath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminWrite]
     },
     tags: ['api', 'admin'],
     validate: {

--- a/src/routes/v1/organisations/put-by-id.test.js
+++ b/src/routes/v1/organisations/put-by-id.test.js
@@ -147,6 +147,7 @@ describe('PUT /v1/organisations/{id}', () => {
         expect(payload.email).toEqual('me@example.com')
         expect(payload.scope).toEqual([
           'admin.read',
+          'admin.write',
           'admin.dlq.purge',
           'service_maintainer'
         ])

--- a/src/routes/v1/organisations/put-by-id.test.js
+++ b/src/routes/v1/organisations/put-by-id.test.js
@@ -148,8 +148,7 @@ describe('PUT /v1/organisations/{id}', () => {
         expect(payload.scope).toEqual([
           'admin.read',
           'admin.write',
-          'admin.dlq.purge',
-          'service_maintainer'
+          'admin.dlq.purge'
         ])
       }
 

--- a/src/routes/v1/organisations/registrations/summary-logs/file/get.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/file/get.js
@@ -1,4 +1,4 @@
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
@@ -15,7 +15,7 @@ export const summaryLogFile = {
   path: summaryLogFilePath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminRead]
     },
     tags: ['api', 'admin']
   },

--- a/src/routes/v1/organisations/registrations/summary-logs/list/get.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/list/get.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes'
 import Boom from '@hapi/boom'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
@@ -17,7 +17,7 @@ export const summaryLogsList = {
   path: summaryLogsListPath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminRead]
     },
     tags: ['api', 'admin'],
     response: {

--- a/src/routes/v1/organisations/registrations/summary-logs/reports/uploads/get.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/reports/uploads/get.js
@@ -1,5 +1,5 @@
 import { StatusCodes } from 'http-status-codes'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { generateSummaryLogUploadsReport } from '#application/summary-log-uploads-report/generate-report.js'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -21,7 +21,7 @@ export const getSummaryLogUploadsReport = {
   path: summaryLogUploadsReportPath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminRead]
     },
     tags: ['api', 'admin'],
     response: {

--- a/src/routes/v1/prn-tonnage/get.js
+++ b/src/routes/v1/prn-tonnage/get.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes'
 import Boom from '@hapi/boom'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { aggregatePrnTonnage } from '#application/prn-tonnage/aggregate-prn-tonnage.js'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -17,7 +17,7 @@ export const getPrnTonnage = {
   path: prnTonnagePath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminRead]
     },
     tags: ['api', 'admin'],
     response: {

--- a/src/routes/v1/public-register/generate/post.js
+++ b/src/routes/v1/public-register/generate/post.js
@@ -1,5 +1,5 @@
 import { StatusCodes } from 'http-status-codes'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { generatePublicRegister } from '#application/public-register/generate-public-register.js'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -21,7 +21,7 @@ export const generateLatestPublicRegister = {
   path: publicRegisterGeneratePath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminWrite]
     },
     tags: ['api', 'admin']
   },

--- a/src/routes/v1/public-register/generate/post.test.js
+++ b/src/routes/v1/public-register/generate/post.test.js
@@ -74,7 +74,7 @@ describe(`POST ${publicRegisterGeneratePath}`, () => {
       const [request, context] = mockAuditPublicRegisterGenerate.mock.calls[0]
       expect(request.auth.credentials.id).toBeDefined()
       expect(request.auth.credentials.email).toBeDefined()
-      expect(request.auth.credentials.scope).toContain('service_maintainer')
+      expect(request.auth.credentials.scope).toContain('admin.write')
       expect(context.url).toBe(result.downloadUrl)
       expect(context.expiresAt).toBe(result.expiresAt)
       expect(context.generatedAt).toBe(result.generatedAt)

--- a/src/routes/v1/system-logs/post-search.js
+++ b/src/routes/v1/system-logs/post-search.js
@@ -2,7 +2,7 @@ import Boom from '@hapi/boom'
 import Joi from 'joi'
 import { StatusCodes } from 'http-status-codes'
 
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -31,7 +31,7 @@ export const systemLogsPostSearch = {
   method: 'POST',
   path: systemLogsSearchPath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminRead]),
     tags: ['api', 'admin'],
     validate: {
       payload: Joi.object({

--- a/src/routes/v1/tonnage-monitoring/get.js
+++ b/src/routes/v1/tonnage-monitoring/get.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes'
 import Boom from '@hapi/boom'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { aggregateTonnageByMaterial } from '#application/tonnage-monitoring/aggregate-tonnage.js'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -17,7 +17,7 @@ export const getTonnageMonitoring = {
   path: tonnageMonitoringPath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminRead]
     },
     tags: ['api', 'admin'],
     response: {

--- a/src/routes/v1/waste-balance-availability/get.js
+++ b/src/routes/v1/waste-balance-availability/get.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes'
 import Boom from '@hapi/boom'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { aggregateAvailableBalance } from '#application/waste-balance-availability/aggregate-available-balance.js'
 import {
   LOGGING_EVENT_ACTIONS,
@@ -17,7 +17,7 @@ export const getWasteBalanceAvailability = {
   path: wasteBalanceAvailabilityPath,
   options: {
     auth: {
-      scope: [ROLES.serviceMaintainer]
+      scope: [SCOPES.adminRead]
     },
     tags: ['api', 'admin'],
     response: {

--- a/src/test/inject-auth.js
+++ b/src/test/inject-auth.js
@@ -7,6 +7,7 @@
  */
 
 import { ADMIN_ROLES, ROLES } from '#common/helpers/auth/constants.js'
+// ROLES is imported only for the operator-side `asStandardUser` helper below.
 
 const ACCESS_TOKEN_STRATEGY = 'access-token'
 
@@ -48,28 +49,18 @@ const adminCredential = (
     email = 'maintainer@example.com',
     overrides
   } = {}
-) => {
-  // While the route re-scoping is in progress, the JWT strategy adds the
-  // legacy `service_maintainer` Hapi scope to the write/maintainer tiers so
-  // routes that have not yet adopted SCOPES.* keep working. Test helpers
-  // mirror that production behaviour.
-  const legacy =
-    role === 'service_maintainer_write' || role === 'service_maintainer'
-      ? [ROLES.serviceMaintainer]
-      : []
-  return {
-    auth: {
-      strategy: ACCESS_TOKEN_STRATEGY,
-      credentials: {
-        scope: [...ADMIN_ROLES[role], ...legacy],
-        role,
-        id,
-        email,
-        ...overrides
-      }
+) => ({
+  auth: {
+    strategy: ACCESS_TOKEN_STRATEGY,
+    credentials: {
+      scope: [...ADMIN_ROLES[role]],
+      role,
+      id,
+      email,
+      ...overrides
     }
   }
-}
+})
 
 /**
  * Creates auth injection options for a service maintainer (legacy alias).

--- a/src/test/inject-auth.js
+++ b/src/test/inject-auth.js
@@ -54,7 +54,6 @@ const adminCredential = (
     strategy: ACCESS_TOKEN_STRATEGY,
     credentials: {
       scope: [...ADMIN_ROLES[role]],
-      role,
       id,
       email,
       ...overrides
@@ -106,7 +105,6 @@ export const asUnscopedAdminUser = (overrides = {}) => ({
     strategy: ACCESS_TOKEN_STRATEGY,
     credentials: {
       scope: [],
-      role: null,
       id: 'test-unscoped-id',
       email: 'unscoped@example.com',
       ...overrides

--- a/src/waste-balances/routes/get.js
+++ b/src/waste-balances/routes/get.js
@@ -1,5 +1,5 @@
 import { StatusCodes } from 'http-status-codes'
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { ROLES, SCOPES } from '#common/helpers/auth/constants.js'
 import Joi from 'joi'
 import { wasteBalanceResponseSchema } from './response.schema.js'
 
@@ -13,7 +13,7 @@ export const wasteBalanceGet = {
   path: wasteBalanceGetPath,
   options: {
     auth: {
-      scope: [ROLES.standardUser, ROLES.serviceMaintainer]
+      scope: [ROLES.standardUser, SCOPES.adminRead]
     },
     tags: ['api'],
     validate: {

--- a/src/waste-records-export/routes/export.js
+++ b/src/waste-records-export/routes/export.js
@@ -1,4 +1,4 @@
-import { ROLES } from '#common/helpers/auth/constants.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { streamCsvExportToReadable } from '../application/stream-csv-export.js'
 
@@ -28,7 +28,7 @@ export const wasteRecordsExportRoute = {
   method: 'GET',
   path: getWasteRecordsExportPath,
   options: {
-    auth: getAuthConfig([ROLES.serviceMaintainer]),
+    auth: getAuthConfig([SCOPES.adminRead]),
     tags: ['api', 'admin']
   },
   /**


### PR DESCRIPTION
Ticket: [PAE-1430](https://eaflood.atlassian.net/browse/PAE-1430)
## Description

Builds on #1156 (now merged). Completes the bulk of ADR 0033 (admin UI scope-based RBAC) for [PAE-1430] in `epr-backend`:

- Adds the `GET /v1/admin/me` self-introspection endpoint with a four-tier access-control matrix in its test (B6). The route is gated on `admin.read` (every admin tier carries it) so the response payload is the only signal that distinguishes tiers; the endpoint returns the resolved scope bundle so the frontend can drive scope-aware UI.
- Re-scopes every admin route from `[ROLES.serviceMaintainer]` to explicit `[SCOPES.*]` requirements: read (DLQ messages, all admin lists/searches/reports, waste-records CSV export), write (mutating overseas-sites, organisation PUT, public-register generate, report unsubmit), and `admin.dlq.purge` (DLQ purge — kept as its own scope so service maintainers retain ops access without needing the write tier).
- Mixed `[standardUser, serviceMaintainer]` routes (org get-by-id, reports get/get-detail, waste-balance get) become `[ROLES.standardUser, SCOPES.adminRead]`.
- Drops `ROLES.serviceMaintainer` from the enum, removes the legacy `service_maintainer` Hapi scope shim carried in the foundation PR, and drops the now-unused `role` field from the Entra credential (only the deleted `/admin/me` payload was reading it).

### Read vs write classification rule

A route is `admin.read` when it produces output without mutating authoritative state — including search-style POSTs (`system-logs/post-search`), report-generation reads (`summary-logs/reports/uploads/get`, `reports/submissions`), and the waste-records CSV export. A route is `admin.write` when it mutates state OR publishes an externally-authoritative artefact — `public-register/generate` falls here even though it doesn't mutate domain state, because it generates the public register.

### Test environment

`SERVICE_MAINTAINER_WRITE_EMAILS` is populated in `.vite/setup-files.js` with the same emails as `SERVICE_MAINTAINER_EMAILS`, so existing integration tests (which exercise mutating admin routes via real Entra tokens) keep passing. First-match-wins resolution gives those test users the `service_maintainer_write` tier and full admin scopes. `SUPPORT_EMAILS` defaults to `'[]'` in test, mirroring expected production rollout.

### What is NOT in this PR

- **Full four-tier integration matrix per route (B11 from the spec).** The ADR §8 calls for every admin route × four tiers. `/v1/admin/me` has its full matrix here as a representative; for the other admin routes, the existing per-route tests continue to cover the success path (write tier via the `asServiceMaintainer` helper), and the four-tier helper map (`ADMIN_TIER_HELPERS` shipped in #1156) is in place ready for opt-in matrix expansion. Whether to broaden coverage further in this repo or rely on the bundling/resolution unit tests + journey tests is a follow-up call.
- **`cdp-app-config` env-var additions (A1)** — separate repo, not in scope here.
- **Frontend (`epr-re-ex-admin-frontend`) and journey-test changes (Epic C, Epic D)** — separate PRs.

## Changes

- `src/common/helpers/auth/constants.js` — drop `serviceMaintainer` from `ROLES`; keep `standardUser`, `inquirer`, `linker`. Update `ADMIN_ROLES` docstring to note role names are internal-only.
- `src/common/helpers/auth/get-jwt-strategy-config.js` — remove the `LEGACY_SERVICE_MAINTAINER_ROLES` shim, drop `role` from the credential, and pass `scopes` through as-is.
- `src/common/helpers/auth/get-jwt-strategy-config.test.js` — drop legacy-scope and `role` expectations; keep operator-side `ROLES.inquirer` references. Fall back to email claim when `preferred_username` is absent (entra-stub compat).
- `src/common/helpers/auth/get-auth-config.test.js` — replace the `[ROLES.standardUser, ROLES.serviceMaintainer]` example with the new mixed `[ROLES.standardUser, SCOPES.adminRead]`.
- `src/routes/v1/admin/me/get.js` and `src/routes/v1/admin/me/get.test.js` — new endpoint gated on `admin.read`, plus a four-tier matrix test (401 unauthenticated, 403 unscoped, 403 standard user, 200 with the resolved scope bundle for each admin tier). Test asserts literal `SCOPES.*` arrays rather than referencing internal `ADMIN_ROLES` bundles.
- `src/plugins/router.js` — register `adminMeGet`.
- `src/routes/v1/admin/queues/dlq/messages.get.js` — `admin.read`.
- `src/routes/v1/admin/queues/dlq/purge.post.js` — `admin.dlq.purge`.
- `src/overseas-sites/routes/{admin-list,get-by-id,get-import-status,list}.js` — `admin.read`.
- `src/overseas-sites/routes/{post,put-by-id,delete-by-id,post-import}.js` — `admin.write`.
- `src/packaging-recycling-notes/routes/admin-list.js` — `admin.read`.
- `src/reports/routes/{submissions,unsubmit}.js` — submissions list `admin.read`; unsubmit `admin.write`.
- `src/reports/routes/{get,get-detail}.js` — mixed `[ROLES.standardUser, SCOPES.adminRead]`.
- `src/routes/v1/organisations/get-by-id.js` — mixed `[ROLES.standardUser, SCOPES.adminRead]`.
- `src/routes/v1/organisations/{get,put-by-id,overview/get}.js` — list and overview `admin.read`; PUT `admin.write`.
- `src/routes/v1/organisations/registrations/summary-logs/{file,list,reports/uploads}/get.js` — `admin.read`.
- `src/routes/v1/{linked-organisations,form-submissions,prn-tonnage,system-logs/post-search,tonnage-monitoring,waste-balance-availability,public-register/generate/post}/*` — read paths `admin.read`; public-register generate `admin.write`.
- `src/waste-balances/routes/get.js` — mixed `[ROLES.standardUser, SCOPES.adminRead]`.
- `src/waste-records-export/routes/export.js` — `admin.read` (CSV export of admin-visible waste records).
- `src/test/inject-auth.js` — drop the legacy-scope augmentation in `adminCredential`.
- `.vite/setup-files.js` — set `SERVICE_MAINTAINER_WRITE_EMAILS` (matches existing maintainer list) and `SUPPORT_EMAILS=[]` for the integration test environment.
- `src/routes/v1/organisations/put-by-id.test.js`, `src/overseas-sites/routes/post-import.test.js`, `src/routes/v1/public-register/generate/post.test.js` — update assertions on captured/audited credential scope to the new bundles.

[PAE-1430]: https://eaflood.atlassian.net/browse/PAE-1430

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).
