### PR TITLE
PAE-1439: Add failing tests for phantom-PRN issuance bug

### DIFF
--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
@@ -1016,9 +1016,9 @@ describe('Waste balance arithmetic integration tests', () => {
     })
   })
 
-  describe('post-CAS balance failure leaves PRNs phantom-issued', () => {
+  describe('rejected issuance does not transition the PRN', () => {
     it.fails(
-      'leaves the PRN in awaiting_authorisation when the post-CAS balance debit fails',
+      'keeps the PRN in awaiting_authorisation when total balance is insufficient at issue time',
       async () => {
         const env = await setupWasteBalanceIntegrationEnvironment({
           processingType: 'exporter'
@@ -1073,7 +1073,7 @@ describe('Waste balance arithmetic integration tests', () => {
     )
 
     it.fails(
-      'leaves only one PRN issued when two concurrent issuances race for the same accreditation',
+      'issues only one PRN when two concurrent issuances exceed the total balance',
       async () => {
         const env = await setupWasteBalanceIntegrationEnvironment({
           processingType: 'exporter'

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
@@ -1015,4 +1015,127 @@ describe('Waste balance arithmetic integration tests', () => {
       expect(cancellationTransactions[0].entities[0].id).toBe(prn1.id)
     })
   })
+
+  describe('post-CAS balance failure leaves PRNs phantom-issued', () => {
+    it.fails(
+      'leaves the PRN in awaiting_authorisation when the post-CAS balance debit fails',
+      async () => {
+        const env = await setupWasteBalanceIntegrationEnvironment({
+          processingType: 'exporter'
+        })
+        const {
+          packagingRecyclingNotesRepository,
+          wasteBalancesRepository,
+          accreditationId,
+          organisationId
+        } = env
+
+        await performSummaryLogSubmission(
+          env,
+          'log-phantom-1',
+          'file-phantom-1',
+          'waste-phantom-1.xlsx',
+          createUploadData([{ rowId: 1001, exportTonnage: 100 }])
+        )
+
+        const prn = await createPrn(env, 50)
+        await transitionPrnStatus(
+          env,
+          prn.id,
+          PRN_STATUS.AWAITING_AUTHORISATION
+        )
+
+        await wasteBalancesRepository.deductTotalBalanceForPrnIssue({
+          accreditationId,
+          organisationId,
+          prnId: 'other-prn',
+          tonnage: 80,
+          userId: 'test-user'
+        })
+
+        const result = await transitionPrnStatus(
+          env,
+          prn.id,
+          PRN_STATUS.AWAITING_ACCEPTANCE
+        )
+        expect(result.statusCode).toBe(409)
+
+        const refetched = await packagingRecyclingNotesRepository.findById(
+          prn.id
+        )
+
+        expect(refetched.status.currentStatus).toBe(
+          PRN_STATUS.AWAITING_AUTHORISATION
+        )
+        expect(refetched.prnNumber).toBeUndefined()
+        expect(refetched.status.issued).toBeUndefined()
+      }
+    )
+
+    it.fails(
+      'leaves only one PRN issued when two concurrent issuances race for the same accreditation',
+      async () => {
+        const env = await setupWasteBalanceIntegrationEnvironment({
+          processingType: 'exporter'
+        })
+        const {
+          packagingRecyclingNotesRepository,
+          wasteBalancesRepository,
+          accreditationId,
+          organisationId
+        } = env
+
+        await performSummaryLogSubmission(
+          env,
+          'log-cross-prn',
+          'file-cross-prn',
+          'waste-cross-prn.xlsx',
+          createUploadData([{ rowId: 1001, exportTonnage: 100 }])
+        )
+
+        const prnA = await createPrn(env, 50)
+        await transitionPrnStatus(
+          env,
+          prnA.id,
+          PRN_STATUS.AWAITING_AUTHORISATION
+        )
+
+        const prnB = await createPrn(env, 50)
+        await transitionPrnStatus(
+          env,
+          prnB.id,
+          PRN_STATUS.AWAITING_AUTHORISATION
+        )
+
+        await wasteBalancesRepository.deductTotalBalanceForPrnIssue({
+          accreditationId,
+          organisationId,
+          prnId: 'other-prn',
+          tonnage: 20,
+          userId: 'test-user'
+        })
+
+        await Promise.allSettled([
+          transitionPrnStatus(env, prnA.id, PRN_STATUS.AWAITING_ACCEPTANCE),
+          transitionPrnStatus(env, prnB.id, PRN_STATUS.AWAITING_ACCEPTANCE)
+        ])
+
+        const refetchedA = await packagingRecyclingNotesRepository.findById(
+          prnA.id
+        )
+        const refetchedB = await packagingRecyclingNotesRepository.findById(
+          prnB.id
+        )
+
+        const issuedCount = [refetchedA, refetchedB].filter(
+          (p) => p.status.currentStatus === PRN_STATUS.AWAITING_ACCEPTANCE
+        ).length
+        expect(issuedCount).toBe(1)
+
+        const balance =
+          await wasteBalancesRepository.findByAccreditationId(accreditationId)
+        expect(balance.amount).toBe(30)
+      }
+    )
+  })
 })


### PR DESCRIPTION
Ticket: [PAE-1439](https://eaflood.atlassian.net/browse/PAE-1439)
## Summary

The PAE-1439 reorder put `applyStatusUpdate` before `applyWasteBalanceEffects` for `AWAITING_ACCEPTANCE` so the per-PRN CAS gates the balance debit. That ordering leaves a window: when the post-CAS balance debit throws (e.g. `amount` is insufficient after a concurrent debit on a different PRN against the same accreditation), the PRN has already transitioned to `AWAITING_ACCEPTANCE` with a number assigned. The caller receives a 409 but the PRN is phantom-issued — favourable to the customer and a fraud-vector concern.

This branch adds two integration tests that pin that behaviour, marked `it.fails` so they pass while the bug exists and flip the suite to red the moment the underlying issue is fixed.

`leaves the PRN in awaiting_authorisation when the post-CAS balance debit fails` reuses the existing setup that shrinks `amount` after `AWAITING_AUTHORISATION` and asserts the PRN state after the 409 — `currentStatus`, absent `prnNumber`, absent `status.issued`.

`leaves only one PRN issued when two concurrent issuances race for the same accreditation` exercises cross-PRN contention: two PRNs in `AWAITING_AUTHORISATION`, `amount` shrunk so only one issuance can fit, concurrent requests via `Promise.allSettled`. Asserts exactly one PRN ends in `AWAITING_ACCEPTANCE` and `balance.amount` is debited once.

The underlying fix is tracked separately. When it lands, both `it.fails` markers should be removed.

[PAE-1439]: https://eaflood.atlassian.net/browse/PAE-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ