### PR TITLE
PAE-1439: Pin balance integrity invariants raised by audit

### DIFF
--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
@@ -1138,4 +1138,122 @@ describe('Waste balance arithmetic integration tests', () => {
       }
     )
   })
+
+  describe('balance integrity under contention and supersession', () => {
+    it('credits availableAmount for both PRNs when two concurrent pending cancellations race', async () => {
+      const env = await setupWasteBalanceIntegrationEnvironment({
+        processingType: 'exporter'
+      })
+      const { wasteBalancesRepository, accreditationId } = env
+
+      await performSummaryLogSubmission(
+        env,
+        'log-pending-cancel-race',
+        'file-pending-cancel-race',
+        'waste-pending-cancel-race.xlsx',
+        createUploadData([{ rowId: 1001, exportTonnage: 200 }])
+      )
+
+      const prnA = await createPrn(env, 50)
+      await transitionPrnStatus(env, prnA.id, PRN_STATUS.AWAITING_AUTHORISATION)
+      const prnB = await createPrn(env, 50)
+      await transitionPrnStatus(env, prnB.id, PRN_STATUS.AWAITING_AUTHORISATION)
+
+      await Promise.allSettled([
+        transitionPrnStatus(env, prnA.id, PRN_STATUS.DELETED),
+        transitionPrnStatus(env, prnB.id, PRN_STATUS.DELETED)
+      ])
+
+      const balanceAfter =
+        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      expect(balanceAfter.amount).toBe(200)
+      expect(balanceAfter.availableAmount).toBe(200)
+    })
+
+    it('does not strand a balance debit when two concurrent creations race on the same PRN', async () => {
+      const env = await setupWasteBalanceIntegrationEnvironment({
+        processingType: 'exporter'
+      })
+      const { wasteBalancesRepository, accreditationId } = env
+
+      await performSummaryLogSubmission(
+        env,
+        'log-same-prn-create-race',
+        'file-same-prn-create-race',
+        'waste-same-prn-create-race.xlsx',
+        createUploadData([{ rowId: 1001, exportTonnage: 100 }])
+      )
+
+      const prn = await createPrn(env, 50)
+
+      await Promise.allSettled([
+        transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION),
+        transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION)
+      ])
+
+      const balanceAfter =
+        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      expect(balanceAfter.amount).toBe(100)
+      expect(balanceAfter.availableAmount).toBe(50)
+    })
+
+    it('debits availableAmount for both PRNs when two concurrent creations race on the same accreditation with sufficient balance', async () => {
+      const env = await setupWasteBalanceIntegrationEnvironment({
+        processingType: 'exporter'
+      })
+      const { wasteBalancesRepository, accreditationId } = env
+
+      await performSummaryLogSubmission(
+        env,
+        'log-create-race-sufficient',
+        'file-create-race-sufficient',
+        'waste-create-race-sufficient.xlsx',
+        createUploadData([{ rowId: 1001, exportTonnage: 200 }])
+      )
+
+      const prnA = await createPrn(env, 30)
+      const prnB = await createPrn(env, 30)
+
+      await Promise.allSettled([
+        transitionPrnStatus(env, prnA.id, PRN_STATUS.AWAITING_AUTHORISATION),
+        transitionPrnStatus(env, prnB.id, PRN_STATUS.AWAITING_AUTHORISATION)
+      ])
+
+      const balanceAfter =
+        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      expect(balanceAfter.amount).toBe(200)
+      expect(balanceAfter.availableAmount).toBe(140)
+    })
+
+    it('debits the balance once when the same waste records are submitted via two summary logs', async () => {
+      const env = await setupWasteBalanceIntegrationEnvironment({
+        processingType: 'exporter'
+      })
+      const { wasteBalancesRepository, accreditationId } = env
+
+      await performSummaryLogSubmission(
+        env,
+        'log-supersede-a',
+        'file-supersede-a',
+        'waste-supersede-a.xlsx',
+        createUploadData([{ rowId: 1001, exportTonnage: 100 }])
+      )
+
+      const balanceAfterA =
+        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      expect(balanceAfterA.amount).toBe(100)
+
+      await performSummaryLogSubmission(
+        env,
+        'log-supersede-b',
+        'file-supersede-b',
+        'waste-supersede-b.xlsx',
+        createUploadData([{ rowId: 1001, exportTonnage: 100 }])
+      )
+
+      const balanceAfterB =
+        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      expect(balanceAfterB.amount).toBe(100)
+    })
+  })
 })


### PR DESCRIPTION
Ticket: [PAE-1439](https://eaflood.atlassian.net/browse/PAE-1439)

## Summary

The PAE-1439 audit raised concerns about partial-failure and contention scenarios across waste-balance writers — concurrent cancellations losing credits, same-PRN concurrent transitions stranding debits, summary-log retry double-debiting after a TTL recovery. Investigation against current code showed all four properties hold today; this branch pins them as outside-in integration tests so a future refactor (notably the ledger flip in [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)) cannot regress them silently.

The properties hold via per-document MongoDB serialization on the balance write, the per-PRN CAS rejecting same-PRN second writers before any balance work, and the calculator's rowId-keyed delta logic for supersession.

## Tests

- `credits availableAmount for both PRNs when two concurrent pending cancellations race` — concurrent DELETEs on two PRNs of the same accreditation, both credits land.
- `does not strand a balance debit when two concurrent creations race on the same PRN` — concurrent transitions to AWAITING_AUTHORISATION on the same PRN; one wins cleanly, balance reflects single debit.
- `debits availableAmount for both PRNs when two concurrent creations race on the same accreditation with sufficient balance` — concurrent creations with sufficient balance for both, both debits land.
- `debits the balance once when the same waste records are submitted via two summary logs` — supersession via fresh summary log id with identical content does not double-debit.

These run as `it()`, not `it.fails` — they pass on current code. Distinct in framing from [#1159](https://github.com/DEFRA/epr-backend/pull/1159), which uses `it.fails` for the genuinely-broken issuance partial-failure case.

[PAE-1439]: https://eaflood.atlassian.net/browse/PAE-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ