### PR TITLE
PAE-000: clear sonar majors blocking main quality gate

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,7 +21,7 @@ sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.coverage.exclusions=src/index.js,src/config.js,src/common/helpers/secure-context.js,src/domain/organisations/model.js,src/test/**,**/*.plugin.js
 
 # Disable S1481 - we use _ prefix for intentionally unused variables (enforced by ESLint)
-sonar.issue.ignore.multicriteria=e1,e2,e3
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
 sonar.issue.ignore.multicriteria.e1.ruleKey=javascript:S1481
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
 # Disable S2187 on contract-delegating test files - tests are defined in *.contract.js and invoked via shared helpers
@@ -30,3 +30,6 @@ sonar.issue.ignore.multicriteria.e2.resourceKey=**/inmemory.test.js
 # Disable S104 (file too many lines) on config.js - large by necessity as it defines the full convict schema
 sonar.issue.ignore.multicriteria.e3.ruleKey=javascript:S104
 sonar.issue.ignore.multicriteria.e3.resourceKey=src/config.js
+# Disable S3800 on Joi .custom() callbacks - dual return shape (value on success | helpers.error()) is Joi's documented contract
+sonar.issue.ignore.multicriteria.e4.ruleKey=javascript:S3800
+sonar.issue.ignore.multicriteria.e4.resourceKey=src/domain/summary-logs/table-schemas/shared/field-schemas.js

--- a/src/common/helpers/decimal-utils.test.js
+++ b/src/common/helpers/decimal-utils.test.js
@@ -226,7 +226,7 @@ describe('decimal-utils', () => {
     it('should handle floating point precision issues', () => {
       // In JavaScript: 0.1 + 0.2 !== 0.3
       const sum = 0.1 + 0.2
-      expect(sum === 0.3).toBe(false) // JavaScript fails
+      expect(sum === 0.3).toBe(false) // NOSONAR(javascript:S5914) demonstrates JS floating-point quirk
       expect(equals(add(0.1, 0.2), 0.3)).toBe(true) // Our function succeeds
     })
 

--- a/src/overseas-sites/routes/admin-list.js
+++ b/src/overseas-sites/routes/admin-list.js
@@ -165,10 +165,7 @@ export const adminOverseasSitesList = {
    */
   handler: async (request, h) => {
     const { logger, organisationsRepository, overseasSitesRepository } = request
-    const all =
-      /** @type {boolean | undefined} */ (
-        /** @type {unknown} */ (request.query.all)
-      ) === true
+    const all = Boolean(request.query.all)
     const page = Number(request.query.page ?? DEFAULT_PAGE)
     const pageSize = Number(request.query.pageSize ?? DEFAULT_PAGE_SIZE)
     const registrationNumber = normaliseRegistrationNumberFilter(

--- a/src/packaging-recycling-notes/routes/get-by-id.js
+++ b/src/packaging-recycling-notes/routes/get-by-id.js
@@ -73,10 +73,9 @@ export const packagingRecyclingNoteById = {
       // Verify the PRN exists, belongs to the requested organisation/accreditation,
       // and treat deleted PRNs as not found (soft delete)
       if (
-        !prn ||
-        prn.organisation.id !== organisationId ||
-        prn.accreditation.id !== accreditationId ||
-        prn.status.currentStatus === PRN_STATUS.DELETED
+        prn?.organisation.id !== organisationId ||
+        prn?.accreditation.id !== accreditationId ||
+        prn?.status.currentStatus === PRN_STATUS.DELETED
       ) {
         throw Boom.notFound('PRN not found')
       }

--- a/src/reports/domain/aggregation/aggregate-report-detail.js
+++ b/src/reports/domain/aggregation/aggregate-report-detail.js
@@ -205,7 +205,10 @@ function findLastUpload(wasteRecords) {
 
   for (const wasteRecord of wasteRecords) {
     for (const wasteRecordVersion of wasteRecord.versions) {
-      if (!lastUploadedAt || wasteRecordVersion.createdAt > lastUploadedAt) {
+      if (
+        !lastUploadedAt ||
+        Date.parse(wasteRecordVersion.createdAt) > Date.parse(lastUploadedAt)
+      ) {
         lastUploadedAt = wasteRecordVersion.createdAt
         summaryLogId = wasteRecordVersion.summaryLog.id
       }


### PR DESCRIPTION
## Summary

main's sonarcloud quality gate is failing on `new_major_violations = 5` (and `new_reliability_rating = 3` from one of those). this clears all five so main goes green again and unblocks merging open PRs.

- `S3003` parse iso timestamps via `Date.parse` before `>` comparison
- `S3800` suppress for `field-schemas.js` only (sonar-project.properties) -- joi `.custom()` requires the dual return shape (`string` on success, `helpers.error()` on failure) by design
- `S3403` simplify `request.query.all` cast-then-=== to `Boolean(...)` -- false positive masked by jsdoc casts
- `S5914` inline NOSONAR on `expect(0.1 + 0.2 === 0.3).toBe(false)` -- intentional fp-quirk demo
- `S6582` optional chaining in PRN lookup guard