### PR TITLE
PAE-250: Adopt updated security/npm standards

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -78,7 +78,7 @@ jobs:
 
       - uses: actions/dependency-review-action@v4
         with:
-          fail-on-severity: high
+          fail-on-severity: moderate
 
   test-journey:
     name: Run Journey Tests

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -66,6 +66,20 @@ jobs:
           restore-keys: |
             mongodb-binaries-${{ runner.os }}-
 
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    needs: pr-prep
+    if: needs.pr-prep.outputs.docs-only != 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
   test-journey:
     name: Run Journey Tests
     runs-on: ubuntu-latest

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 save-exact=true
 engine-strict=true
 allow-git=none
-min-release-age=3
+ignore-scripts=true
+min-release-age=7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,11 +138,14 @@ This project uses ADRs and `adr-tools`, to create new ADRs:
 
 ### Setup
 
-Install application dependencies:
+After cloning, install dependencies and configure git hooks:
 
 ```bash
-npm install
+npm ci
+npm run setup:husky
 ```
+
+`.npmrc` sets `ignore-scripts=true` (per the [Defra Node.js standard](https://defra.github.io/software-development-standards/standards/node_standards/)) to defend against compromised-package supply-chain attacks. That blocks the project's own `postinstall` step (which would otherwise wire husky's `core.hooksPath` into `.git/config`), so it's run explicitly as a second step. Running scripts via `npm run` directly is not affected by `ignore-scripts`.
 
 ### Testing endpoints
 


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Adopts the updated Defra Software Development Standards (announced 2026-05-08) in epr-backend.

Adds a `dependency-review` job to the pull-request workflow using `actions/dependency-review-action@v4` with `fail-on-severity: moderate`, scoped to `contents: read` and skipped for docs-only PRs. The job fails the check when a PR introduces dependencies with moderate, high, or critical vulnerabilities listed in the GitHub Advisory Database — a PR-time gate that complements Dependabot's reactive workflow.

Hardens `.npmrc` with two settings required by the updated Node.js standard. `ignore-scripts=true` blocks lifecycle scripts on package install (defence against compromised-package supply-chain attacks). `min-release-age=7` (raised from 3) widens the window for the npm community to detect a compromised release before this repo consumes it.

Updates `CONTRIBUTING.md` so fresh clones know to run `npm ci` followed by `npm run setup:husky`. The new `ignore-scripts=true` setting blocks the project's own `postinstall` step, so without explicit instruction a new dev would silently lack pre-commit hooks until they hit a CI failure.

Standards references:

- https://defra.github.io/software-development-standards/standards/security_standards/
- https://defra.github.io/software-development-standards/standards/node_standards/
- https://defra.github.io/software-development-standards/guides/continuous_integration/

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ