### PR TITLE
PAE-1441: Include unmarked waste-balances in divergence scan

### DIFF
--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -36,7 +36,9 @@ const findEmbeddedWasteBalances = async (db) => {
   const docs = await db
     .collection(WASTE_BALANCES_COLLECTION)
     .find(
-      { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED },
+      {
+        canonicalSource: { $ne: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER }
+      },
       {
         projection: {
           _id: 0,

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -138,12 +138,12 @@ describe('runBalanceDivergenceDiagnostic', () => {
     })
   })
 
-  it('queries waste-balances filtered to canonicalSource=embedded with a projection', async () => {
+  it('queries waste-balances for any document whose canonicalSource is not ledger so legacy docs without the marker are scanned too', async () => {
     await runBalanceDivergenceDiagnostic(mockServer)
 
     expect(collectionByName).toHaveBeenCalledWith('waste-balances')
     expect(mockFind).toHaveBeenCalledWith(
-      { canonicalSource: 'embedded' },
+      { canonicalSource: { $ne: 'ledger' } },
       expect.objectContaining({
         projection: expect.objectContaining({
           accreditationId: 1,


### PR DESCRIPTION
Ticket: [PAE-1441](https://eaflood.atlassian.net/browse/PAE-1441)
## Summary

The pre-cutover divergence diagnostic queried `waste-balances` with an equality match on `canonicalSource: 'embedded'`. Documents that predate the marker have no `canonicalSource` field at all, and equality match in MongoDB excludes those.

Switches the find filter to `{ canonicalSource: { $ne: 'ledger' } }`, which matches `embedded`, `migrating`, and missing — i.e. every document where the embedded array is still source of truth. Mirrors the precedent in `src/waste-balances/repository/marker-aware-read.js`, where the same tri-state is collapsed to "is or isn't ledger".

The diagnostic remains read-only and the scan target — accreditations whose visible balance will change at the ledger flag flip — is unchanged in intent; the fix just makes the filter capture them.


[PAE-1441]: https://eaflood.atlassian.net/browse/PAE-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ