### PR TITLE
PAE-250: Fix fast-xml-builder XML injection and XXE vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7929,9 +7929,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
       "funding": [
         {
           "type": "github",
@@ -7944,9 +7944,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -7956,7 +7956,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -10173,9 +10173,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "unzipper": "0.10.14"
   },
   "overrides": {
-    "fast-xml-parser": "5.7.1",
+    "fast-xml-parser": "5.7.3",
     "glob": "11.1.0",
     "uuid": "14.0.0"
   },


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Bumps the existing `fast-xml-parser` npm override from `5.7.1` to `5.7.3` to remove two high-severity advisories against `fast-xml-builder` that were being pulled in via `@aws-sdk/xml-builder > fast-xml-parser`:

- [GHSA-5wm8-gmm8-39j9](https://github.com/advisories/GHSA-5wm8-gmm8-39j9) — attribute values with unwanted quotes can bypass the sanitisation, allowing malicious or unwanted attributes through.
- [GHSA-45c6-75p6-83cc](https://github.com/advisories/GHSA-45c6-75p6-83cc) — the comment-value regex can be bypassed, opening an XML injection path.

Snyk also flags this dependency path as [SNYK-JS-FASTXMLBUILDER-16540557](https://security.snyk.io/vuln/SNYK-JS-FASTXMLBUILDER-16540557) and [SNYK-JS-FASTXMLBUILDER-16540558](https://security.snyk.io/vuln/SNYK-JS-FASTXMLBUILDER-16540558).

## Why an override

`@aws-sdk/xml-builder` exact-pins an older `fast-xml-parser` (`5.3.6`) that itself has high-severity advisories. The existing override was already overriding to `5.7.1` for that reason, but `5.7.1` still pulls vulnerable `fast-xml-builder ^1.1.5`. Bumping to `5.7.3` pulls `fast-xml-builder ^1.1.7` (resolves to `1.1.9`), which has the patched comment/attribute handling.

We can drop this override once the AWS SDK widens its `fast-xml-parser` range.

## Verification

- `npm audit` reports 0 vulnerabilities on the new lockfile.
- `npm ls fast-xml-parser fast-xml-builder` confirms the override applied: `fast-xml-parser@5.7.3 (overridden) → fast-xml-builder@1.1.9`.
- The other simple overrides (`glob: 11.1.0`, `uuid: 14.0.0`) were tested for staleness — both still suppress active findings (`SNYK-JS-INFLIGHT-6095116` via `exceljs > archiver > glob`, `SNYK-JS-UUID-16133035` via `exceljs > uuid`), so they stay.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ