### PR TITLE
PAE-1443: Exclude test organisations from waste records export

### DIFF
--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -1,6 +1,7 @@
 import { writeToString } from '@fast-csv/format'
 import { Readable } from 'node:stream'
 
+import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
 import {
   buildHeaderRow,
   buildDataRow,
@@ -9,6 +10,8 @@ import {
 import { isIncludedInWasteBalance } from '../domain/is-included-in-waste-balance.js'
 import { buildOverseasSitesContext } from '../domain/overseas-sites-context.js'
 import { loadSummaryLogMap } from './load-summary-log-map.js'
+
+const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
 /** @import {Organisation} from '#domain/organisations/model.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
@@ -182,7 +185,9 @@ export async function* streamCsvExport(deps) {
   const dataFieldColumns = buildDataFieldColumns(observedKeys)
   yield await encodeRow(buildHeaderRow(dataFieldColumns))
 
-  const orgsSorted = [...orgs].sort(sortById)
+  const orgsSorted = orgs
+    .filter((org) => !TEST_ORGANISATIONS.has(org.orgId))
+    .sort(sortById)
   for (const org of orgsSorted) {
     const registrations = [...(org.registrations ?? [])].sort(sortById)
     for (const registration of registrations) {

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -352,6 +352,41 @@ describe('streamCsvExport', () => {
     expect(out).toHaveLength(1) // header only
   })
 
+  it('excludes organisations configured as test organisations', async () => {
+    // 999999 is set as a test organisation via process.env.TEST_ORGANISATIONS
+    // in .vite/setup-files.js, matching the prod pattern of gating test orgs
+    // out of admin-visible data.
+    const testOrg = baseOrg({
+      id: 'org-test',
+      orgId: 999999,
+      companyDetails: { name: 'Test Org' },
+      registrations: [baseRegistration({ id: 'reg-test' })]
+    })
+    const realOrg = baseOrg({
+      id: 'org-real',
+      orgId: 123456,
+      companyDetails: { name: 'Real Org' },
+      registrations: [baseRegistration({ id: 'reg-real' })]
+    })
+    const findByRegistration = vi
+      .fn()
+      .mockResolvedValue([reprocessorReceivedRecord()])
+    const deps = baseDeps({
+      organisationsRepository: {
+        findAll: vi.fn().mockResolvedValue([testOrg, realOrg])
+      },
+      wasteRecordsRepository: { findByRegistration }
+    })
+
+    const out = await collect(streamCsvExport(deps))
+
+    expect(out).toHaveLength(2) // header + one row for the real org only
+    expect(out[1]).toContain('Real Org')
+    expect(out[1]).not.toContain('Test Org')
+    expect(findByRegistration).toHaveBeenCalledTimes(1)
+    expect(findByRegistration).toHaveBeenCalledWith('org-real', 'reg-real')
+  })
+
   it('propagates errors from the waste records iterator', async () => {
     const org = baseOrg({ registrations: [baseRegistration()] })
     const deps = baseDeps({


### PR DESCRIPTION
Ticket: [PAE-1443](https://eaflood.atlassian.net/browse/PAE-1443)
## Summary

- Test organisations were leaking into the admin waste-records CSV export. This PR aligns the export with the existing `TEST_ORGANISATION_IDS` filter pattern used by `public-register-transformer`, `report-submissions`, and the `linked-organisations` route.
- Filter is applied at the application-service level immediately after `organisationsRepository.findAll()`, before sorting and iteration. Test orgs neither contribute rows nor trigger `findByRegistration` lookups.
- Not environment-conditional in code — gating is driven by the `TEST_ORGANISATIONS` env var, which is populated per-environment via CDP secrets (empty in lower envs, populated in prod).

## Changes

- `src/waste-records-export/application/stream-csv-export.js` — import `TEST_ORGANISATION_IDS`, define a module-level `Set`, filter `orgs` before sorting.
- `src/waste-records-export/application/stream-csv-export.test.js` — add a test asserting a configured test org (`orgId: 999999`, set via `.vite/setup-files.js`) is excluded from the output and from `findByRegistration` calls, while a real org passes through.


[PAE-1443]: https://eaflood.atlassian.net/browse/PAE-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ