### PR TITLE
PAE-1382: Log status, counts and contributions on divergence line

### DIFF
--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -129,7 +129,11 @@ const compareForEmbedded = async (embedded, deps) => {
     deltaAvailableAmount: formatDelta(
       embedded.availableAmount,
       rebuilt.availableAmount
-    )
+    ),
+    registrationStatus: registration.status,
+    accreditationStatus: accreditation.status,
+    wasteRecordCount: wasteRecords.length,
+    prnCount: prns.length
   }
 }
 
@@ -147,7 +151,11 @@ const formatDivergenceLine = (comparison) =>
     `deltaAmount=${comparison.deltaAmount}`,
     `currentAvailableAmount=${comparison.currentAvailableAmount}`,
     `rebuiltAvailableAmount=${comparison.rebuiltAvailableAmount}`,
-    `deltaAvailableAmount=${comparison.deltaAvailableAmount}`
+    `deltaAvailableAmount=${comparison.deltaAvailableAmount}`,
+    `registrationStatus=${comparison.registrationStatus}`,
+    `accreditationStatus=${comparison.accreditationStatus}`,
+    `wasteRecordCount=${comparison.wasteRecordCount}`,
+    `prnCount=${comparison.prnCount}`
   ].join(' ')
 
 const formatErrorLine = (embedded, error) =>

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -133,7 +133,10 @@ const compareForEmbedded = async (embedded, deps) => {
     registrationStatus: registration.status,
     accreditationStatus: accreditation.status,
     wasteRecordCount: wasteRecords.length,
-    prnCount: prns.length
+    wasteRecordContribution: rebuilt.wasteRecordContribution,
+    prnCount: prns.length,
+    prnAmountContribution: rebuilt.prnAmountContribution,
+    prnAvailableAmountContribution: rebuilt.prnAvailableAmountContribution
   }
 }
 
@@ -155,7 +158,10 @@ const formatDivergenceLine = (comparison) =>
     `registrationStatus=${comparison.registrationStatus}`,
     `accreditationStatus=${comparison.accreditationStatus}`,
     `wasteRecordCount=${comparison.wasteRecordCount}`,
-    `prnCount=${comparison.prnCount}`
+    `wasteRecordContribution=${comparison.wasteRecordContribution}`,
+    `prnCount=${comparison.prnCount}`,
+    `prnAmountContribution=${comparison.prnAmountContribution}`,
+    `prnAvailableAmountContribution=${comparison.prnAvailableAmountContribution}`
   ].join(' ')
 
 const formatErrorLine = (embedded, error) =>

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -215,13 +215,19 @@ describe('runBalanceDivergenceDiagnostic', () => {
     accreditations['org-1'] = [
       { id: 'acc-1', accreditationNumber: 'ACC-acc-1', status: 'approved' }
     ]
-    computeRebuiltTotals.mockReturnValue({ amount: 95, availableAmount: 80 })
+    computeRebuiltTotals.mockReturnValue({
+      amount: 95,
+      availableAmount: 80,
+      wasteRecordContribution: 95,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: -15
+    })
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-acc-1 currentAmount=100 rebuiltAmount=95 deltaAmount=-5 currentAvailableAmount=80 rebuiltAvailableAmount=80 deltaAvailableAmount=0 registrationStatus=approved accreditationStatus=approved wasteRecordCount=0 prnCount=0'
+        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-acc-1 currentAmount=100 rebuiltAmount=95 deltaAmount=-5 currentAvailableAmount=80 rebuiltAvailableAmount=80 deltaAvailableAmount=0 registrationStatus=approved accreditationStatus=approved wasteRecordCount=0 wasteRecordContribution=95 prnCount=0 prnAmountContribution=0 prnAvailableAmountContribution=-15'
     })
     expect(logger.info).toHaveBeenCalledWith({
       message:
@@ -319,13 +325,19 @@ describe('runBalanceDivergenceDiagnostic', () => {
       }
     ]
     accreditations['org-1'] = [{ id: 'acc-pending', status: 'created' }]
-    computeRebuiltTotals.mockReturnValue({ amount: 7, availableAmount: 7 })
+    computeRebuiltTotals.mockReturnValue({
+      amount: 7,
+      availableAmount: 7,
+      wasteRecordContribution: 7,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=<none> currentAmount=10 rebuiltAmount=7 deltaAmount=-3 currentAvailableAmount=10 rebuiltAvailableAmount=7 deltaAvailableAmount=-3 registrationStatus=approved accreditationStatus=created wasteRecordCount=0 prnCount=0'
+        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=<none> currentAmount=10 rebuiltAmount=7 deltaAmount=-3 currentAvailableAmount=10 rebuiltAvailableAmount=7 deltaAvailableAmount=-3 registrationStatus=approved accreditationStatus=created wasteRecordCount=0 wasteRecordContribution=7 prnCount=0 prnAmountContribution=0 prnAvailableAmountContribution=0'
     })
   })
 
@@ -351,13 +363,19 @@ describe('runBalanceDivergenceDiagnostic', () => {
     ]
     wasteRecordsRepository.findByRegistration.mockResolvedValue([{}, {}, {}])
     prnRepository.findByAccreditation.mockResolvedValue([{}, {}])
-    computeRebuiltTotals.mockReturnValue({ amount: 0, availableAmount: 0 })
+    computeRebuiltTotals.mockReturnValue({
+      amount: 0,
+      availableAmount: 0,
+      wasteRecordContribution: 0,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=null accreditationNumber=ACC-1 currentAmount=2084.27 rebuiltAmount=0 deltaAmount=-2084.27 currentAvailableAmount=2084.27 rebuiltAvailableAmount=0 deltaAvailableAmount=-2084.27 registrationStatus=cancelled accreditationStatus=cancelled wasteRecordCount=3 prnCount=2'
+        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=null accreditationNumber=ACC-1 currentAmount=2084.27 rebuiltAmount=0 deltaAmount=-2084.27 currentAvailableAmount=2084.27 rebuiltAvailableAmount=0 deltaAvailableAmount=-2084.27 registrationStatus=cancelled accreditationStatus=cancelled wasteRecordCount=3 wasteRecordContribution=0 prnCount=2 prnAmountContribution=0 prnAvailableAmountContribution=0'
     })
   })
 

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -205,10 +205,15 @@ describe('runBalanceDivergenceDiagnostic', () => {
       }
     ])
     registrations['org-1'] = [
-      { id: 'reg-1', accreditationId: 'acc-1', registrationNumber: 'REG-1' }
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: 'REG-1',
+        status: 'approved'
+      }
     ]
     accreditations['org-1'] = [
-      { id: 'acc-1', accreditationNumber: 'ACC-acc-1' }
+      { id: 'acc-1', accreditationNumber: 'ACC-acc-1', status: 'approved' }
     ]
     computeRebuiltTotals.mockReturnValue({ amount: 95, availableAmount: 80 })
 
@@ -216,7 +221,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-acc-1 currentAmount=100 rebuiltAmount=95 deltaAmount=-5 currentAvailableAmount=80 rebuiltAvailableAmount=80 deltaAvailableAmount=0'
+        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-acc-1 currentAmount=100 rebuiltAmount=95 deltaAmount=-5 currentAvailableAmount=80 rebuiltAvailableAmount=80 deltaAvailableAmount=0 registrationStatus=approved accreditationStatus=approved wasteRecordCount=0 prnCount=0'
     })
     expect(logger.info).toHaveBeenCalledWith({
       message:
@@ -309,17 +314,50 @@ describe('runBalanceDivergenceDiagnostic', () => {
       {
         id: 'reg-1',
         accreditationId: 'acc-pending',
-        registrationNumber: 'REG-1'
+        registrationNumber: 'REG-1',
+        status: 'approved'
       }
     ]
-    accreditations['org-1'] = [{ id: 'acc-pending' }]
+    accreditations['org-1'] = [{ id: 'acc-pending', status: 'created' }]
     computeRebuiltTotals.mockReturnValue({ amount: 7, availableAmount: 7 })
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=<none> currentAmount=10 rebuiltAmount=7 deltaAmount=-3 currentAvailableAmount=10 rebuiltAvailableAmount=7 deltaAvailableAmount=-3'
+        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=<none> currentAmount=10 rebuiltAmount=7 deltaAmount=-3 currentAvailableAmount=10 rebuiltAvailableAmount=7 deltaAvailableAmount=-3 registrationStatus=approved accreditationStatus=created wasteRecordCount=0 prnCount=0'
+    })
+  })
+
+  it('logs registration status, accreditation status and input counts so cancelled-registration zero-rebuilds are recognisable', async () => {
+    setEmbeddedBalances([
+      {
+        accreditationId: 'acc-1',
+        organisationId: 'org-1',
+        amount: 2084.27,
+        availableAmount: 2084.27
+      }
+    ])
+    registrations['org-1'] = [
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: null,
+        status: 'cancelled'
+      }
+    ]
+    accreditations['org-1'] = [
+      { id: 'acc-1', accreditationNumber: 'ACC-1', status: 'cancelled' }
+    ]
+    wasteRecordsRepository.findByRegistration.mockResolvedValue([{}, {}, {}])
+    prnRepository.findByAccreditation.mockResolvedValue([{}, {}])
+    computeRebuiltTotals.mockReturnValue({ amount: 0, availableAmount: 0 })
+
+    await runBalanceDivergenceDiagnostic(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=null accreditationNumber=ACC-1 currentAmount=2084.27 rebuiltAmount=0 deltaAmount=-2084.27 currentAvailableAmount=2084.27 rebuiltAvailableAmount=0 deltaAvailableAmount=-2084.27 registrationStatus=cancelled accreditationStatus=cancelled wasteRecordCount=3 prnCount=2'
     })
   })
 

--- a/src/waste-balances/application/compute-rebuilt-totals.js
+++ b/src/waste-balances/application/compute-rebuilt-totals.js
@@ -90,7 +90,13 @@ function* prnDeltasOf(prn) {
  * @param {WasteRecord[]} params.wasteRecords
  * @param {PackagingRecyclingNote[]} params.prns
  * @param {OverseasSitesContext} params.overseasSites
- * @returns {{ amount: number, availableAmount: number }}
+ * @returns {{
+ *   amount: number,
+ *   availableAmount: number,
+ *   wasteRecordContribution: number,
+ *   prnAmountContribution: number,
+ *   prnAvailableAmountContribution: number
+ * }}
  */
 export const computeRebuiltTotals = ({
   accreditation,
@@ -98,24 +104,36 @@ export const computeRebuiltTotals = ({
   prns,
   overseasSites
 }) => {
-  let amount = 0
-  let availableAmount = 0
+  let wasteRecordContribution = 0
+  let prnAmountContribution = 0
+  let prnAvailableAmountContribution = 0
 
   for (const record of wasteRecords) {
     const tonnage = getTargetAmount(record, accreditation, overseasSites)
     if (tonnage === 0) {
       continue
     }
-    amount = toNumber(add(amount, tonnage))
-    availableAmount = toNumber(add(availableAmount, tonnage))
+    wasteRecordContribution = toNumber(add(wasteRecordContribution, tonnage))
   }
 
   for (const prn of prns) {
     for (const delta of prnDeltasOf(prn)) {
-      amount = toNumber(add(amount, delta.amount))
-      availableAmount = toNumber(add(availableAmount, delta.availableAmount))
+      prnAmountContribution = toNumber(
+        add(prnAmountContribution, delta.amount)
+      )
+      prnAvailableAmountContribution = toNumber(
+        add(prnAvailableAmountContribution, delta.availableAmount)
+      )
     }
   }
 
-  return { amount, availableAmount }
+  return {
+    amount: toNumber(add(wasteRecordContribution, prnAmountContribution)),
+    availableAmount: toNumber(
+      add(wasteRecordContribution, prnAvailableAmountContribution)
+    ),
+    wasteRecordContribution,
+    prnAmountContribution,
+    prnAvailableAmountContribution
+  }
 }

--- a/src/waste-balances/application/compute-rebuilt-totals.js
+++ b/src/waste-balances/application/compute-rebuilt-totals.js
@@ -118,9 +118,7 @@ export const computeRebuiltTotals = ({
 
   for (const prn of prns) {
     for (const delta of prnDeltasOf(prn)) {
-      prnAmountContribution = toNumber(
-        add(prnAmountContribution, delta.amount)
-      )
+      prnAmountContribution = toNumber(add(prnAmountContribution, delta.amount))
       prnAvailableAmountContribution = toNumber(
         add(prnAvailableAmountContribution, delta.availableAmount)
       )

--- a/src/waste-balances/application/compute-rebuilt-totals.test.js
+++ b/src/waste-balances/application/compute-rebuilt-totals.test.js
@@ -75,7 +75,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 0, availableAmount: 0 })
+    expect(result).toEqual({
+      amount: 0,
+      availableAmount: 0,
+      wasteRecordContribution: 0,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
   })
 
   it('credits both balance fields by the sum of waste-record target amounts', () => {
@@ -89,7 +95,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 10, availableAmount: 10 })
+    expect(result).toEqual({
+      amount: 10,
+      availableAmount: 10,
+      wasteRecordContribution: 10,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
   })
 
   it('skips records whose schema returns a non-INCLUDED outcome', () => {
@@ -103,7 +115,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 4, availableAmount: 4 })
+    expect(result).toEqual({
+      amount: 4,
+      availableAmount: 4,
+      wasteRecordContribution: 4,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
   })
 
   it('skips records flagged excludedFromWasteBalance', () => {
@@ -120,7 +138,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 0, availableAmount: 0 })
+    expect(result).toEqual({
+      amount: 0,
+      availableAmount: 0,
+      wasteRecordContribution: 0,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
   })
 
   it('skips records whose schema has no classifyForWasteBalance', () => {
@@ -135,7 +159,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 0, availableAmount: 0 })
+    expect(result).toEqual({
+      amount: 0,
+      availableAmount: 0,
+      wasteRecordContribution: 0,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
   })
 
   it('debits availableAmount only when a PRN is in AWAITING_AUTHORISATION', () => {
@@ -146,7 +176,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 10, availableAmount: 7 })
+    expect(result).toEqual({
+      amount: 10,
+      availableAmount: 7,
+      wasteRecordContribution: 10,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: -3
+    })
   })
 
   it('debits both fields when a PRN is in AWAITING_ACCEPTANCE', () => {
@@ -167,7 +203,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 7, availableAmount: 7 })
+    expect(result).toEqual({
+      amount: 7,
+      availableAmount: 7,
+      wasteRecordContribution: 10,
+      prnAmountContribution: -3,
+      prnAvailableAmountContribution: -3
+    })
   })
 
   it('keeps the issued debit through ACCEPTED', () => {
@@ -189,7 +231,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 6, availableAmount: 6 })
+    expect(result).toEqual({
+      amount: 6,
+      availableAmount: 6,
+      wasteRecordContribution: 10,
+      prnAmountContribution: -4,
+      prnAvailableAmountContribution: -4
+    })
   })
 
   it('reverses pre-issue PRN cancellations to net zero', () => {
@@ -210,7 +258,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 10, availableAmount: 10 })
+    expect(result).toEqual({
+      amount: 10,
+      availableAmount: 10,
+      wasteRecordContribution: 10,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
   })
 
   it('reverses pre-issue deletion to net zero', () => {
@@ -231,7 +285,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 10, availableAmount: 10 })
+    expect(result).toEqual({
+      amount: 10,
+      availableAmount: 10,
+      wasteRecordContribution: 10,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
   })
 
   it('reverses post-issue cancellation to net zero on both fields', () => {
@@ -254,7 +314,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 10, availableAmount: 10 })
+    expect(result).toEqual({
+      amount: 10,
+      availableAmount: 10,
+      wasteRecordContribution: 10,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
   })
 
   it('emits no balance effect for DRAFT-only or DISCARDED PRNs', () => {
@@ -279,7 +345,13 @@ describe('computeRebuiltTotals', () => {
       overseasSites
     })
 
-    expect(result).toEqual({ amount: 10, availableAmount: 10 })
+    expect(result).toEqual({
+      amount: 10,
+      availableAmount: 10,
+      wasteRecordContribution: 10,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
   })
 
   it('uses exact decimal arithmetic for the running totals', () => {
@@ -294,6 +366,40 @@ describe('computeRebuiltTotals', () => {
     })
 
     expect(result.amount).toBe(0.3)
+  })
+
+  it('breaks the rebuilt totals down by input so divergence diagnostics can attribute the rebuild to waste records vs PRN activity', () => {
+    const result = computeRebuiltTotals({
+      accreditation,
+      wasteRecords: [
+        wasteRecord({ rowId: 'r-1', data: { tonnage: 12 } }),
+        wasteRecord({ rowId: 'r-2', data: { tonnage: 8 } })
+      ],
+      prns: [
+        prn({
+          id: 'prn-issued',
+          tonnage: 5,
+          history: [
+            [PRN_STATUS.DRAFT, '2025-01-02T00:00:00.000Z'],
+            [PRN_STATUS.AWAITING_AUTHORISATION, '2025-01-03T00:00:00.000Z'],
+            [PRN_STATUS.AWAITING_ACCEPTANCE, '2025-01-04T00:00:00.000Z']
+          ]
+        }),
+        prn({
+          id: 'prn-pending',
+          tonnage: 2,
+          history: [
+            [PRN_STATUS.DRAFT, '2025-01-06T00:00:00.000Z'],
+            [PRN_STATUS.AWAITING_AUTHORISATION, '2025-01-07T00:00:00.000Z']
+          ]
+        })
+      ],
+      overseasSites
+    })
+
+    expect(result.wasteRecordContribution).toBe(20)
+    expect(result.prnAmountContribution).toBe(-5)
+    expect(result.prnAvailableAmountContribution).toBe(-7)
   })
 
   it('combines waste-record credits and PRN debits across lifecycle states', () => {
@@ -341,6 +447,12 @@ describe('computeRebuiltTotals', () => {
 
     // 20t credit; issued PRN debits both fields by 5t; pending PRN debits
     // available by 2t; cancelled-pre-issue nets to zero on both fields
-    expect(result).toEqual({ amount: 15, availableAmount: 13 })
+    expect(result).toEqual({
+      amount: 15,
+      availableAmount: 13,
+      wasteRecordContribution: 20,
+      prnAmountContribution: -5,
+      prnAvailableAmountContribution: -7
+    })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)

The pre-cutover waste-balance divergence diagnostic logs a per-accreditation line for every embedded balance whose rebuilt total disagrees with the stored value. Previously the line told you the balance had diverged but nothing about whether the rebuilder had any inputs to work with, so a zero-rebuild against a non-zero embedded balance was indistinguishable from a real per-record classification drift.

Each divergence line now also records:

- `registrationStatus` and `accreditationStatus` so cancelled/created cases are obvious without a Mongo dive
- `wasteRecordCount` and `prnCount` so a missing-inputs zero-rebuild is recognisable on sight
- `wasteRecordContribution`, `prnAmountContribution`, and `prnAvailableAmountContribution` so the rebuilt total can be attributed across inputs — waste-record credits vs the amount-axis and available-axis sides of PRN activity

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ