### PR TITLE
PAE-456: Remove orsWasteBalanceValidation feature flag

### DIFF
--- a/src/application/summary-logs/submit.js
+++ b/src/application/summary-logs/submit.js
@@ -20,7 +20,6 @@ import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
  * @property {object} wasteBalancesRepository
  * @property {object} summaryLogExtractor
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
- * @property {import('#feature-flags/feature-flags.port.js').FeatureFlags} [featureFlags]
  * @property {import('#domain/summary-logs/worker/port.js').SubmitUser} user
  */
 
@@ -40,7 +39,6 @@ export const submitSummaryLog = async (summaryLogId, deps) => {
     wasteBalancesRepository,
     summaryLogExtractor,
     overseasSitesRepository,
-    featureFlags,
     user
   } = deps
 
@@ -81,7 +79,6 @@ export const submitSummaryLog = async (summaryLogId, deps) => {
     wasteBalancesRepository,
     organisationsRepository,
     overseasSitesRepository,
-    featureFlags,
     logger
   })
 

--- a/src/application/waste-records/sync-from-summary-log.js
+++ b/src/application/waste-records/sync-from-summary-log.js
@@ -240,7 +240,6 @@ const calculateMetrics = (wasteRecords) => {
  * @param {Object} dependencies.wasteBalancesRepository - The waste balances repository
  * @param {Object} dependencies.organisationsRepository - The organisations repository
  * @param {import('#overseas-sites/repository/port.js').OverseasSitesRepository} dependencies.overseasSitesRepository - The overseas sites repository
- * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [dependencies.featureFlags] - Feature flags for controlling ORS validation
  * @param {TypedLogger} dependencies.logger - Logger forwarded to extractor for trace correlation
  * @returns {Function} A function that accepts a summary log and returns a Promise
  */
@@ -251,7 +250,6 @@ export const syncFromSummaryLog = (dependencies) => {
     wasteBalancesRepository,
     organisationsRepository,
     overseasSitesRepository,
-    featureFlags,
     logger
   } = dependencies
 
@@ -315,17 +313,15 @@ export const syncFromSummaryLog = (dependencies) => {
 
     // 8. Resolve overseas sites for exporter ORS validation (VAL014)
     const processingType = parsedData?.meta?.PROCESSING_TYPE?.value
-    const shouldValidateOrs =
-      featureFlags?.isOrsWasteBalanceValidationEnabled?.() &&
+    const overseasSites =
       processingType === PROCESSING_TYPES.EXPORTER
-    const overseasSites = shouldValidateOrs
-      ? await resolveOverseasSites(
-          organisationsRepository,
-          overseasSitesRepository,
-          summaryLog.organisationId,
-          summaryLog.registrationId
-        )
-      : ORS_VALIDATION_DISABLED
+        ? await resolveOverseasSites(
+            organisationsRepository,
+            overseasSitesRepository,
+            summaryLog.organisationId,
+            summaryLog.registrationId
+          )
+        : ORS_VALIDATION_DISABLED
 
     // 9. Resolve accreditation and update waste balances
     if (accreditationId) {

--- a/src/application/waste-records/sync-from-summary-log.test.js
+++ b/src/application/waste-records/sync-from-summary-log.test.js
@@ -882,8 +882,7 @@ describe('syncFromSummaryLog', () => {
       wasteRecordRepository,
       wasteBalancesRepository,
       organisationsRepository,
-      overseasSitesRepository,
-      featureFlags: { isOrsWasteBalanceValidationEnabled: () => true }
+      overseasSitesRepository
     })
 
     await sync(summaryLog, TEST_USER)
@@ -965,8 +964,7 @@ describe('syncFromSummaryLog', () => {
       wasteRecordRepository,
       wasteBalancesRepository,
       organisationsRepository,
-      overseasSitesRepository,
-      featureFlags: { isOrsWasteBalanceValidationEnabled: () => true }
+      overseasSitesRepository
     })
 
     await sync(summaryLog, TEST_USER)
@@ -981,87 +979,6 @@ describe('syncFromSummaryLog', () => {
         validTo: '2023-12-31'
       },
       overseasSites: { '001': { validFrom } }
-    })
-  })
-
-  it('does not resolve overseas sites when orsWasteBalanceValidation flag is off', async () => {
-    const fileId = 'test-file-ors-flag-off'
-    const summaryLog = {
-      file: {
-        id: fileId,
-        uri: 's3://test-bucket/test-key'
-      },
-      organisationId: 'org-1',
-      registrationId: 'reg-1',
-      accreditationId: 'acc-1'
-    }
-
-    /** @type {any} */ const parsedData = {
-      meta: {
-        PROCESSING_TYPE: {
-          value: 'EXPORTER'
-        }
-      },
-      data: {
-        RECEIVED_LOADS_FOR_EXPORT: {
-          location: { sheet: 'Sheet1', row: 1, column: 'A' },
-          headers: [
-            'ROW_ID',
-            'DATE_RECEIVED_FOR_REPROCESSING',
-            FIELD_GROSS_WEIGHT
-          ],
-          rows: [
-            {
-              rowNumber: 2,
-              values: ['row-123', TEST_DATE_2025_01_15, TEST_WEIGHT_100_5]
-            }
-          ]
-        }
-      }
-    }
-
-    const extractor = createInMemorySummaryLogExtractor({
-      [fileId]: parsedData
-    })
-
-    const localOverseasSitesRepository = {
-      findByIds: vi
-        .fn()
-        .mockResolvedValue([
-          { id: 'site-aaa', validFrom: new Date('2024-01-01') }
-        ])
-    }
-
-    organisationsRepository.findRegistrationById = vi.fn().mockResolvedValue({
-      overseasSites: {
-        '001': { overseasSiteId: 'site-aaa' }
-      }
-    })
-
-    const featureFlags = { isOrsWasteBalanceValidationEnabled: () => false }
-
-    const sync = /** @type {any} */ (syncFromSummaryLog)({
-      extractor,
-      wasteRecordRepository,
-      wasteBalancesRepository,
-      organisationsRepository,
-      overseasSitesRepository: localOverseasSitesRepository,
-      featureFlags
-    })
-
-    await sync(summaryLog, TEST_USER)
-
-    expect(localOverseasSitesRepository.findByIds).not.toHaveBeenCalled()
-    expect(
-      wasteBalancesRepository.updateWasteBalanceTransactions
-    ).toHaveBeenCalledWith(expect.any(Array), {
-      user: TEST_USER,
-      accreditation: {
-        id: 'acc-default',
-        validFrom: '2023-01-01',
-        validTo: '2023-12-31'
-      },
-      overseasSites: ORS_VALIDATION_DISABLED
     })
   })
 

--- a/src/config.js
+++ b/src/config.js
@@ -358,12 +358,6 @@ const baseConfig = {
       default: false,
       env: 'FEATURE_FLAG_COPY_FORM_FILES_TO_S3'
     },
-    orsWasteBalanceValidation: {
-      doc: 'Feature Flag: Validate ORS approval status during exporter waste balance classification',
-      format: Boolean,
-      default: false,
-      env: 'FEATURE_FLAG_ORS_WASTE_BALANCE_VALIDATION'
-    },
     allowFullErrorOutput: {
       doc: 'Feature Flag: Allow full error output (including potentially sensitive payload / stack detail)',
       format: Boolean,

--- a/src/domain/summary-logs/table-schemas/shared/classification-reason.js
+++ b/src/domain/summary-logs/table-schemas/shared/classification-reason.js
@@ -7,8 +7,10 @@ export const CLASSIFICATION_REASON = Object.freeze({
 })
 
 /**
- * Sentinel indicating ORS validation is disabled by feature flag.
- * Pass this instead of an overseas sites map when the feature is off.
+ * Sentinel indicating no overseas-sites resolution applies for this caller —
+ * either because the processing type is not EXPORTER, or because the caller
+ * is reusing classification logic for a purpose that does not require ORS
+ * approval checks (e.g. date-range ignore detection).
  * @type {unique symbol}
  */
 export const ORS_VALIDATION_DISABLED = Symbol('ORS_VALIDATION_DISABLED')

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -8,9 +8,6 @@ export const createConfigFeatureFlags = (config) => ({
   isCopyFormFilesToS3Enabled() {
     return config.get('featureFlags.copyFormFilesToS3')
   },
-  isOrsWasteBalanceValidationEnabled() {
-    return config.get('featureFlags.orsWasteBalanceValidation')
-  },
   isWasteBalanceLedgerEnabled() {
     return config.get('featureFlags.wasteBalanceLedger')
   },

--- a/src/feature-flags/feature-flags.config.test.js
+++ b/src/feature-flags/feature-flags.config.test.js
@@ -23,21 +23,6 @@ describe('createConfigFeatureFlags', () => {
     expect(config.get).toHaveBeenCalledWith('featureFlags.copyFormFilesToS3')
   })
 
-  it('returns true when orsWasteBalanceValidation flag is enabled', () => {
-    const config = { get: vi.fn().mockReturnValue(true) }
-    const flags = createConfigFeatureFlags(config)
-    expect(flags.isOrsWasteBalanceValidationEnabled()).toBe(true)
-    expect(config.get).toHaveBeenCalledWith(
-      'featureFlags.orsWasteBalanceValidation'
-    )
-  })
-
-  it('returns false when orsWasteBalanceValidation flag is disabled', () => {
-    const config = { get: vi.fn().mockReturnValue(false) }
-    const flags = createConfigFeatureFlags(config)
-    expect(flags.isOrsWasteBalanceValidationEnabled()).toBe(false)
-  })
-
   it('returns true when wasteBalanceLedger flag is enabled', () => {
     const config = { get: vi.fn().mockReturnValue(true) }
     const flags = createConfigFeatureFlags(config)

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -9,9 +9,6 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   isDevEndpointsEnabled() {
     return flags.devEndpoints ?? false
   },
-  isOrsWasteBalanceValidationEnabled() {
-    return flags.orsWasteBalanceValidation ?? false
-  },
   isWasteBalanceLedgerEnabled() {
     return flags.wasteBalanceLedger ?? false
   },

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -32,25 +32,6 @@ describe('createInMemoryFeatureFlags', () => {
     expect(flags.isDevEndpointsEnabled()).toBe(false)
   })
 
-  it('returns true when orsWasteBalanceValidation flag is enabled', () => {
-    const flags = createInMemoryFeatureFlags({
-      orsWasteBalanceValidation: true
-    })
-    expect(flags.isOrsWasteBalanceValidationEnabled()).toBe(true)
-  })
-
-  it('returns false when orsWasteBalanceValidation flag is disabled', () => {
-    const flags = createInMemoryFeatureFlags({
-      orsWasteBalanceValidation: false
-    })
-    expect(flags.isOrsWasteBalanceValidationEnabled()).toBe(false)
-  })
-
-  it('returns false when orsWasteBalanceValidation flag is not provided', () => {
-    const flags = createInMemoryFeatureFlags({})
-    expect(flags.isOrsWasteBalanceValidationEnabled()).toBe(false)
-  })
-
   it('returns true when wasteBalanceLedger flag is enabled', () => {
     const flags = createInMemoryFeatureFlags({ wasteBalanceLedger: true })
     expect(flags.isWasteBalanceLedgerEnabled()).toBe(true)

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -2,7 +2,6 @@
  * @typedef {Object} FeatureFlags
  * @property {() => boolean} isDevEndpointsEnabled
  * @property {() => boolean} isCopyFormFilesToS3Enabled
- * @property {() => boolean} isOrsWasteBalanceValidationEnabled
  * @property {() => boolean} isWasteBalanceLedgerEnabled
  * @property {() => boolean} isReportUnsubmitEnabled
  */
@@ -11,7 +10,6 @@
  * @typedef {Object} FeatureFlagOverrides
  * @property {boolean} [devEndpoints]
  * @property {boolean} [copyFormFilesToS3]
- * @property {boolean} [orsWasteBalanceValidation]
  * @property {boolean} [wasteBalanceLedger]
  * @property {boolean} [reportUnsubmit]
  */

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-ors-validation.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-ors-validation.test.js
@@ -19,7 +19,7 @@ import {
   EXPORTER_HEADERS
 } from './integration-test-helpers.js'
 
-describe('ORS waste balance validation (VAL014) with feature flag enabled', () => {
+describe('ORS waste balance validation (VAL014)', () => {
   const { getServer } = setupAuthContext()
 
   beforeEach(() => {
@@ -93,8 +93,7 @@ describe('ORS waste balance validation (VAL014) with feature flag enabled', () =
 
   it('should include row with approved ORS in waste balance', async () => {
     const env = await setupWasteBalanceIntegrationEnvironment({
-      processingType: 'exporter',
-      featureFlagOverrides: { orsWasteBalanceValidation: true }
+      processingType: 'exporter'
     })
     const { wasteBalancesRepository, accreditationId } = env
 
@@ -115,8 +114,7 @@ describe('ORS waste balance validation (VAL014) with feature flag enabled', () =
 
   it('should exclude row with unapproved ORS from waste balance', async () => {
     const env = await setupWasteBalanceIntegrationEnvironment({
-      processingType: 'exporter',
-      featureFlagOverrides: { orsWasteBalanceValidation: true }
+      processingType: 'exporter'
     })
     const { wasteBalancesRepository, accreditationId } = env
 

--- a/src/server/queue-consumer/queue-consumer.plugin.js
+++ b/src/server/queue-consumer/queue-consumer.plugin.js
@@ -83,8 +83,7 @@ export const commandQueueConsumerPlugin = {
         organisationsRepository,
         wasteRecordsRepository,
         wasteBalancesRepository,
-        summaryLogExtractor,
-        featureFlags: server.featureFlags
+        summaryLogExtractor
       }
 
       const handlers = [...summaryLogCommandHandlers]

--- a/src/server/queue-consumer/queue-consumer.plugin.test.js
+++ b/src/server/queue-consumer/queue-consumer.plugin.test.js
@@ -32,7 +32,6 @@ describe('commandQueueConsumerPlugin', () => {
       events: {
         on: vi.fn()
       },
-      featureFlags: {},
       app: {
         summaryLogsRepository: {},
         organisationsRepository: {},
@@ -132,8 +131,7 @@ describe('commandQueueConsumerPlugin', () => {
           organisationsRepository: server.app.organisationsRepository,
           wasteRecordsRepository: server.app.wasteRecordsRepository,
           wasteBalancesRepository: server.app.wasteBalancesRepository,
-          summaryLogExtractor: expect.any(Object),
-          featureFlags: server.featureFlags
+          summaryLogExtractor: expect.any(Object)
         },
         [...summaryLogCommandHandlers]
       )

--- a/src/server/queue-consumer/summary-log-commands.js
+++ b/src/server/queue-consumer/summary-log-commands.js
@@ -23,7 +23,6 @@ import { submitSummaryLog } from '#application/summary-logs/submit.js'
  * @property {WasteRecordsRepository} wasteRecordsRepository
  * @property {WasteBalancesRepository} wasteBalancesRepository
  * @property {SummaryLogExtractor} summaryLogExtractor
- * @property {import('#feature-flags/feature-flags.port.js').FeatureFlags} featureFlags
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
  */
 

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -1,5 +1,4 @@
 import { logger } from '#common/helpers/logging/logger.js'
-import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
 import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
 import { createOverseasSitesRepository } from '#overseas-sites/repository/mongodb.js'
@@ -33,7 +32,6 @@ const LOCK_NAME = 'balance-divergence-diagnostic'
  * @property {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} prnRepository
  * @property {import('#repositories/waste-records/port.js').WasteRecordsRepository} wasteRecordsRepository
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
- * @property {boolean} orsValidationEnabled
  */
 
 /**
@@ -79,8 +77,7 @@ const compareForEmbedded = async (embedded, deps) => {
     organisationsRepository,
     prnRepository,
     wasteRecordsRepository,
-    overseasSitesRepository,
-    orsValidationEnabled
+    overseasSitesRepository
   } = deps
 
   const organisation = await organisationsRepository.findById(
@@ -111,14 +108,12 @@ const compareForEmbedded = async (embedded, deps) => {
   )
   const prns = await prnRepository.findByAccreditation(embedded.accreditationId)
 
-  const overseasSites = orsValidationEnabled
-    ? await resolveOverseasSites(
-        organisationsRepository,
-        overseasSitesRepository,
-        embedded.organisationId,
-        registration.id
-      )
-    : ORS_VALIDATION_DISABLED
+  const overseasSites = await resolveOverseasSites(
+    organisationsRepository,
+    overseasSitesRepository,
+    embedded.organisationId,
+    registration.id
+  )
 
   const rebuilt = computeRebuiltTotals({
     accreditation,
@@ -235,15 +230,12 @@ const buildDependencies = async (server) => {
   const overseasSitesRepository = (
     await createOverseasSitesRepository(server.db)
   )()
-  const orsValidationEnabled =
-    server.featureFlags.isOrsWasteBalanceValidationEnabled()
 
   return /** @type {DiagnosticDependencies} */ ({
     organisationsRepository,
     wasteRecordsRepository,
     prnRepository,
-    overseasSitesRepository,
-    orsValidationEnabled
+    overseasSitesRepository
   })
 }
 

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -6,7 +6,6 @@ import { createOverseasSitesRepository } from '#overseas-sites/repository/mongod
 import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/mongodb.js'
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
 import { computeRebuiltTotals } from '#waste-balances/application/compute-rebuilt-totals.js'
-import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
 
 import { runBalanceDivergenceDiagnostic } from './run-balance-divergence-diagnostic.js'
@@ -74,10 +73,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     mockServer = {
       db,
-      locker: { lock: vi.fn().mockResolvedValue(mockLock) },
-      featureFlags: {
-        isOrsWasteBalanceValidationEnabled: vi.fn().mockReturnValue(false)
-      }
+      locker: { lock: vi.fn().mockResolvedValue(mockLock) }
     }
 
     registrations = {}
@@ -278,14 +274,11 @@ describe('runBalanceDivergenceDiagnostic', () => {
       accreditation,
       wasteRecords,
       prns,
-      overseasSites: ORS_VALIDATION_DISABLED
+      overseasSites: {}
     })
   })
 
-  it('resolves overseas sites for the registration when the ORS validation flag is enabled', async () => {
-    mockServer.featureFlags.isOrsWasteBalanceValidationEnabled.mockReturnValue(
-      true
-    )
+  it('resolves overseas sites for the registration and passes them into the rebuild', async () => {
     setEmbeddedBalances([
       {
         accreditationId: 'acc-1',


### PR DESCRIPTION
Ticket: [PAE-456](https://eaflood.atlassian.net/browse/PAE-456)
The `orsWasteBalanceValidation` flag has been on in every CDP environment since the PAE-1323 work delivered, so the `false` branch is dead weight. This strips the convict entry, the feature-flags adapter surface (port typedef, config + in-memory implementations and their tests), and both production consumers — the balance-divergence diagnostic and the summary-log sync path — so ORS approval validation runs unconditionally for exporter waste-balance classification.

The `featureFlags` dep was being threaded through the queue-consumer plugin → `submit.js` → `syncFromSummaryLog` purely to feed this one check. With the check gone, `featureFlags` drops out of that whole chain as well; the `wasteBalancesRepository` is the only remaining consumer of `server.featureFlags`, and it picks it up directly at plugin registration (for the unrelated `wasteBalanceLedger` flag).

The `ORS_VALIDATION_DISABLED` sentinel survives. Its "ORS validation disabled by feature flag" framing is gone, but the symbol is still used by `markIgnoredByDateRange` in `validate.js`, the non-EXPORTER branch in `syncFromSummaryLog`, and the contract-test fixtures — all legitimate "no overseas-sites resolution applies for this caller" signals. The docstring has been rewritten to reflect that.

Paired with [DEFRA/cdp-app-config#3458](https://github.com/DEFRA/cdp-app-config/pull/3458), which deletes the now-orphan `FEATURE_FLAG_ORS_WASTE_BALANCE_VALIDATION=true` from the service env file.

[PAE-456]: https://eaflood.atlassian.net/browse/PAE-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ