### PR TITLE
PAE-1382: Only match registrations in approved/cancelled/suspended state in divergence diagnostic

### DIFF
--- a/src/domain/organisations/registration.js
+++ b/src/domain/organisations/registration.js
@@ -63,7 +63,7 @@
  * @typedef {RegistrationBase & {
  *  registrationNumber?: string;
  *  cbduNumber?: string;
- *  status: 'created'|'rejected'|'archived';
+ *  status: 'created'|'rejected'|'cancelled'|'suspended';
  *  validFrom?: string;
  *  validTo?: string
  * }} RegistrationOther

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -9,6 +9,7 @@ import { computeRebuiltTotals } from '#waste-balances/application/compute-rebuil
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 
+/** @type {Set<import('#domain/organisations/registration.js').Registration['status']>} */
 const ACTIVE_REGISTRATION_STATUSES = new Set([
   REG_ACC_STATUS.APPROVED,
   REG_ACC_STATUS.CANCELLED,

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -7,6 +7,13 @@ import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-no
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
 import { computeRebuiltTotals } from '#waste-balances/application/compute-rebuilt-totals.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+
+const ACTIVE_REGISTRATION_STATUSES = new Set([
+  REG_ACC_STATUS.APPROVED,
+  REG_ACC_STATUS.CANCELLED,
+  REG_ACC_STATUS.SUSPENDED
+])
 
 const WASTE_BALANCES_COLLECTION = 'waste-balances'
 const LOCK_NAME = 'balance-divergence-diagnostic'
@@ -87,7 +94,9 @@ const compareForEmbedded = async (embedded, deps) => {
     )
   }
   const registration = organisation.registrations.find(
-    (r) => r.accreditationId === embedded.accreditationId
+    (r) =>
+      r.accreditationId === embedded.accreditationId &&
+      ACTIVE_REGISTRATION_STATUSES.has(r.status)
   )
   if (!registration) {
     throw new Error(

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -176,7 +176,12 @@ describe('runBalanceDivergenceDiagnostic', () => {
       }
     ])
     registrations['org-1'] = [
-      { id: 'reg-1', accreditationId: 'acc-1', registrationNumber: 'REG-1' }
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: 'REG-1',
+        status: 'approved'
+      }
     ]
     accreditations['org-1'] = [
       { id: 'acc-1', accreditationNumber: 'ACC-acc-1' }
@@ -249,7 +254,12 @@ describe('runBalanceDivergenceDiagnostic', () => {
       }
     ])
     registrations['org-1'] = [
-      { id: 'reg-1', accreditationId: 'acc-1', registrationNumber: 'REG-1' }
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: 'REG-1',
+        status: 'approved'
+      }
     ]
     accreditations['org-1'] = [accreditation]
     const wasteRecords = [{ rowId: 'r-1', type: 'received' }]
@@ -285,7 +295,12 @@ describe('runBalanceDivergenceDiagnostic', () => {
       }
     ])
     registrations['org-1'] = [
-      { id: 'reg-1', accreditationId: 'acc-1', registrationNumber: 'REG-1' }
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: 'REG-1',
+        status: 'approved'
+      }
     ]
     accreditations['org-1'] = [
       { id: 'acc-1', accreditationNumber: 'ACC-acc-1' }
@@ -379,6 +394,40 @@ describe('runBalanceDivergenceDiagnostic', () => {
     })
   })
 
+  it('logs a tagged error line when the only registration for an accreditation is in created or rejected state', async () => {
+    setEmbeddedBalances([
+      {
+        accreditationId: 'acc-1',
+        organisationId: 'org-1',
+        amount: 10,
+        availableAmount: 10
+      }
+    ])
+    accreditations['org-1'] = [{ id: 'acc-1', accreditationNumber: 'ACC-1' }]
+    registrations['org-1'] = [
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: 'REG-1',
+        status: 'created'
+      }
+    ]
+
+    await runBalanceDivergenceDiagnostic(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'No registration links to accreditation acc-1'
+        )
+      })
+    )
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=1'
+    })
+  })
+
   it('logs a tagged error line when an accreditation has no matching registration', async () => {
     setEmbeddedBalances([
       {
@@ -431,7 +480,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
       {
         id: 'reg-good',
         accreditationId: 'acc-good',
-        registrationNumber: 'REG-2'
+        registrationNumber: 'REG-2',
+        status: 'approved'
       }
     ]
     accreditations['org-2'] = [


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
- Filter the registration lookup in the balance divergence diagnostic to only match registrations in `approved`, `cancelled`, or `suspended` state
- Registrations in `created` or `rejected` state are excluded and surface as a rebuild failure in the diagnostic log
- Add `status` field to four existing test fixtures that were missing it to keep them passing under the new filter
- Add a new test covering the case where a registration exists but is in an excluded state

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ