### PR TITLE
PAE-1470: Log document-growth metrics on every embedded waste-balance write

### DIFF
--- a/src/waste-balances/application/growth-observability.js
+++ b/src/waste-balances/application/growth-observability.js
@@ -1,0 +1,38 @@
+import { BSON } from 'mongodb'
+import { logger } from '#common/helpers/logging/logger.js'
+
+const BSON_DOCUMENT_MAX_SIZE_BYTES = 16 * 1024 * 1024
+
+/**
+ * Emit a structured log line capturing how close an embedded waste-balance
+ * document is to the 16MB BSON limit. Every embedded write path (summary-log
+ * row updates and the four PRN operations) routes through `saveBalance`, which
+ * calls this helper so growth from all sources is visible.
+ *
+ * The ledger-append path doesn't go through `saveBalance` and is out of scope.
+ *
+ * Fields are encoded into the `message` string as space-separated `key=value`
+ * pairs to match the typed CdpIndexedLog schema while keeping each field
+ * searchable in OpenSearch.
+ *
+ * @param {import('../domain/model.js').WasteBalance} updatedBalance
+ * @param {import('../domain/model.js').WasteBalanceTransaction[]} newTransactions
+ */
+export const recordWasteBalanceGrowth = (updatedBalance, newTransactions) => {
+  const bsonSize = BSON.calculateObjectSize(updatedBalance)
+  const percentOfBsonLimit =
+    Math.round((bsonSize / BSON_DOCUMENT_MAX_SIZE_BYTES) * 10000) / 100
+  const transactionCount = updatedBalance.transactions.length
+  const newTransactionCount = newTransactions.length
+
+  logger.info({
+    message:
+      `Waste balance document growth:` +
+      ` accreditationId=${updatedBalance.accreditationId}` +
+      ` canonicalSource=${updatedBalance.canonicalSource}` +
+      ` transactionCount=${transactionCount}` +
+      ` newTransactionCount=${newTransactionCount}` +
+      ` bsonSize=${bsonSize}` +
+      ` percentOfBsonLimit=${percentOfBsonLimit}`
+  })
+}

--- a/src/waste-balances/application/growth-observability.js
+++ b/src/waste-balances/application/growth-observability.js
@@ -11,6 +11,10 @@ const BSON_DOCUMENT_MAX_SIZE_BYTES = 16 * 1024 * 1024
  *
  * The ledger-append path doesn't go through `saveBalance` and is out of scope.
  *
+ * `bsonSize` is the size of the in-memory `updatedBalance` rather than a query
+ * of the persisted document; it is an approximation suitable for tracking the
+ * trend toward the 16MB ceiling, not a precise on-disk measurement.
+ *
  * Fields are encoded into the `message` string as space-separated `key=value`
  * pairs to match the typed CdpIndexedLog schema while keeping each field
  * searchable in OpenSearch.

--- a/src/waste-balances/application/growth-observability.js
+++ b/src/waste-balances/application/growth-observability.js
@@ -32,6 +32,7 @@ export const recordWasteBalanceGrowth = (updatedBalance, newTransactions) => {
   logger.info({
     message:
       `Waste balance document growth:` +
+      ` organisationId=${updatedBalance.organisationId}` +
       ` accreditationId=${updatedBalance.accreditationId}` +
       ` transactionCount=${transactionCount}` +
       ` newTransactionCount=${newTransactionCount}` +

--- a/src/waste-balances/application/growth-observability.js
+++ b/src/waste-balances/application/growth-observability.js
@@ -33,7 +33,6 @@ export const recordWasteBalanceGrowth = (updatedBalance, newTransactions) => {
     message:
       `Waste balance document growth:` +
       ` accreditationId=${updatedBalance.accreditationId}` +
-      ` canonicalSource=${updatedBalance.canonicalSource}` +
       ` transactionCount=${transactionCount}` +
       ` newTransactionCount=${newTransactionCount}` +
       ` bsonSize=${bsonSize}` +

--- a/src/waste-balances/application/growth-observability.test.js
+++ b/src/waste-balances/application/growth-observability.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { logger } from '#common/helpers/logging/logger.js'
+import { BSON } from 'mongodb'
+import { recordWasteBalanceGrowth } from './growth-observability.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn()
+  }
+}))
+
+const buildBalance = (overrides = {}) => ({
+  id: '00000000-0000-0000-0000-000000000001',
+  accreditationId: 'acc-123',
+  organisationId: 'org-1',
+  amount: 0,
+  availableAmount: 0,
+  transactions: [],
+  version: 1,
+  schemaVersion: 1,
+  canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED,
+  ...overrides
+})
+
+const buildTransaction = (overrides = {}) => ({
+  id: 'txn-1',
+  type: 'credit',
+  createdAt: '2026-05-14T00:00:00.000Z',
+  createdBy: { id: 'user-1', name: 'user-1' },
+  amount: 1,
+  openingAmount: 0,
+  closingAmount: 1,
+  openingAvailableAmount: 0,
+  closingAvailableAmount: 1,
+  entities: [
+    {
+      id: 'wr-1',
+      currentVersionId: 'wr-1',
+      previousVersionIds: [],
+      type: 'waste_record:received'
+    }
+  ],
+  ...overrides
+})
+
+const messageOf = () => vi.mocked(logger.info).mock.calls[0][0].message
+
+describe('recordWasteBalanceGrowth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('logs accreditationId, canonicalSource and transaction counts', () => {
+    const transactions = [buildTransaction(), buildTransaction({ id: 'txn-2' })]
+    const updatedBalance = buildBalance({
+      accreditationId: 'acc-xyz',
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+      transactions
+    })
+
+    recordWasteBalanceGrowth(updatedBalance, [transactions[1]])
+
+    expect(logger.info).toHaveBeenCalledTimes(1)
+    const message = messageOf()
+    expect(message).toContain('Waste balance document growth')
+    expect(message).toContain('accreditationId=acc-xyz')
+    expect(message).toContain('canonicalSource=migrating')
+    expect(message).toContain('transactionCount=2')
+    expect(message).toContain('newTransactionCount=1')
+  })
+
+  it('reports the BSON size of the updated balance document', () => {
+    const transactions = [buildTransaction()]
+    const updatedBalance = buildBalance({ transactions })
+
+    recordWasteBalanceGrowth(updatedBalance, transactions)
+
+    const expectedSize = BSON.calculateObjectSize(updatedBalance)
+    expect(messageOf()).toContain(`bsonSize=${expectedSize}`)
+  })
+
+  it('reports the BSON size as a percentage of the 16MB document limit', () => {
+    const transactions = [buildTransaction()]
+    const updatedBalance = buildBalance({ transactions })
+
+    recordWasteBalanceGrowth(updatedBalance, transactions)
+
+    const expectedSize = BSON.calculateObjectSize(updatedBalance)
+    const expectedPercent =
+      Math.round((expectedSize / (16 * 1024 * 1024)) * 10000) / 100
+
+    expect(messageOf()).toContain(`percentOfBsonLimit=${expectedPercent}`)
+  })
+
+  it('reports a percentage near zero when the document is empty', () => {
+    const updatedBalance = buildBalance({ transactions: [] })
+
+    recordWasteBalanceGrowth(updatedBalance, [])
+
+    const message = messageOf()
+    expect(message).toContain('transactionCount=0')
+    expect(message).toContain('newTransactionCount=0')
+    const percentMatch = message.match(/percentOfBsonLimit=([\d.]+)/)
+    expect(percentMatch).not.toBeNull()
+    const percent = Number(percentMatch[1])
+    expect(percent).toBeLessThan(0.01)
+    expect(percent).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/src/waste-balances/application/growth-observability.test.js
+++ b/src/waste-balances/application/growth-observability.test.js
@@ -51,11 +51,10 @@ describe('recordWasteBalanceGrowth', () => {
     vi.clearAllMocks()
   })
 
-  it('logs accreditationId, canonicalSource and transaction counts', () => {
+  it('logs accreditationId and transaction counts', () => {
     const transactions = [buildTransaction(), buildTransaction({ id: 'txn-2' })]
     const updatedBalance = buildBalance({
       accreditationId: 'acc-xyz',
-      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
       transactions
     })
 
@@ -65,7 +64,6 @@ describe('recordWasteBalanceGrowth', () => {
     const message = messageOf()
     expect(message).toContain('Waste balance document growth')
     expect(message).toContain('accreditationId=acc-xyz')
-    expect(message).toContain('canonicalSource=migrating')
     expect(message).toContain('transactionCount=2')
     expect(message).toContain('newTransactionCount=1')
   })

--- a/src/waste-balances/application/growth-observability.test.js
+++ b/src/waste-balances/application/growth-observability.test.js
@@ -51,9 +51,10 @@ describe('recordWasteBalanceGrowth', () => {
     vi.clearAllMocks()
   })
 
-  it('logs accreditationId and transaction counts', () => {
+  it('logs organisationId, accreditationId and transaction counts', () => {
     const transactions = [buildTransaction(), buildTransaction({ id: 'txn-2' })]
     const updatedBalance = buildBalance({
+      organisationId: 'org-abc',
       accreditationId: 'acc-xyz',
       transactions
     })
@@ -63,6 +64,7 @@ describe('recordWasteBalanceGrowth', () => {
     expect(logger.info).toHaveBeenCalledTimes(1)
     const message = messageOf()
     expect(message).toContain('Waste balance document growth')
+    expect(message).toContain('organisationId=org-abc')
     expect(message).toContain('accreditationId=acc-xyz')
     expect(message).toContain('transactionCount=2')
     expect(message).toContain('newTransactionCount=1')

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -9,6 +9,7 @@ import {
 } from './helpers.js'
 import { ensureLedgerCollection } from './ledger-mongodb.js'
 import { resolveBalanceAmounts } from './marker-aware-read.js'
+import { recordWasteBalanceGrowth } from '../application/growth-observability.js'
 
 const WASTE_BALANCE_COLLECTION_NAME = 'waste-balances'
 
@@ -212,6 +213,8 @@ export const saveBalance = (db) => async (updatedBalance, newTransactions) => {
     }),
     { upsert: true }
   )
+
+  recordWasteBalanceGrowth(updatedBalance, newTransactions)
 }
 
 /**

--- a/src/waste-balances/repository/mongodb.test.js
+++ b/src/waste-balances/repository/mongodb.test.js
@@ -152,9 +152,6 @@ describe('MongoDB waste balances repository', () => {
       )
       const message = vi.mocked(logger.info).mock.calls[0][0].message
       expect(message).toContain('accreditationId=acc-growth-1')
-      expect(message).toContain(
-        `canonicalSource=${WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED}`
-      )
       expect(message).toContain('transactionCount=1')
       expect(message).toContain('newTransactionCount=1')
       expect(message).toMatch(/bsonSize=\d+/)

--- a/src/waste-balances/repository/mongodb.test.js
+++ b/src/waste-balances/repository/mongodb.test.js
@@ -1,12 +1,20 @@
-import { describe, beforeEach, expect } from 'vitest'
+import { describe, beforeEach, expect, vi } from 'vitest'
 import { it as mongoIt } from '#vite/fixtures/mongo.js'
 import { MongoClient } from 'mongodb'
-import { createWasteBalancesRepository } from './mongodb.js'
+import { logger } from '#common/helpers/logging/logger.js'
+import { createWasteBalancesRepository, saveBalance } from './mongodb.js'
 import {
   createMongoLedgerRepository,
   WASTE_BALANCE_LEDGER_COLLECTION_NAME
 } from './ledger-mongodb.js'
 import { testWasteBalancesRepositoryContract } from './port.contract.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn()
+  }
+}))
 
 const DATABASE_NAME = 'epr-backend'
 const WASTE_BALANCE_COLLECTION_NAME = 'waste-balances'
@@ -95,6 +103,62 @@ describe('MongoDB waste balances repository', () => {
 
     describe('waste balances repository contract', () => {
       testWasteBalancesRepositoryContract(it)
+    })
+  })
+
+  describe('document growth observability', () => {
+    beforeEach(async ({ mongoClient }) => {
+      vi.mocked(logger.info).mockClear()
+      await mongoClient
+        .db(DATABASE_NAME)
+        .collection(WASTE_BALANCE_COLLECTION_NAME)
+        .deleteMany({})
+    })
+
+    it('emits a growth log line after persisting an embedded balance', async ({
+      mongoClient
+    }) => {
+      const db = mongoClient.db(DATABASE_NAME)
+      const transaction = {
+        id: 'txn-1',
+        type: 'credit',
+        createdAt: '2026-05-14T00:00:00.000Z',
+        createdBy: { id: 'user-1', name: 'user-1' },
+        amount: 1,
+        openingAmount: 0,
+        closingAmount: 1,
+        openingAvailableAmount: 0,
+        closingAvailableAmount: 1,
+        entities: []
+      }
+      const balance = {
+        id: '00000000-0000-0000-0000-000000000010',
+        accreditationId: 'acc-growth-1',
+        organisationId: 'org-1',
+        amount: 1,
+        availableAmount: 1,
+        transactions: [transaction],
+        version: 1,
+        schemaVersion: 1,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      }
+
+      await saveBalance(db)(balance, [transaction])
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('Waste balance document growth')
+        })
+      )
+      const message = vi.mocked(logger.info).mock.calls[0][0].message
+      expect(message).toContain('accreditationId=acc-growth-1')
+      expect(message).toContain(
+        `canonicalSource=${WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED}`
+      )
+      expect(message).toContain('transactionCount=1')
+      expect(message).toContain('newTransactionCount=1')
+      expect(message).toMatch(/bsonSize=\d+/)
+      expect(message).toMatch(/percentOfBsonLimit=[\d.]+/)
     })
   })
 })

--- a/src/waste-balances/repository/mongodb.test.js
+++ b/src/waste-balances/repository/mongodb.test.js
@@ -134,7 +134,7 @@ describe('MongoDB waste balances repository', () => {
       const balance = {
         id: '00000000-0000-0000-0000-000000000010',
         accreditationId: 'acc-growth-1',
-        organisationId: 'org-1',
+        organisationId: 'org-growth-1',
         amount: 1,
         availableAmount: 1,
         transactions: [transaction],
@@ -151,6 +151,7 @@ describe('MongoDB waste balances repository', () => {
         })
       )
       const message = vi.mocked(logger.info).mock.calls[0][0].message
+      expect(message).toContain('organisationId=org-growth-1')
       expect(message).toContain('accreditationId=acc-growth-1')
       expect(message).toContain('transactionCount=1')
       expect(message).toContain('newTransactionCount=1')


### PR DESCRIPTION
Ticket: [PAE-1470](https://eaflood.atlassian.net/browse/PAE-1470)
## Summary

Adds a structured log line emitted after every embedded waste-balance write so we can see how close each accreditation's document is to MongoDB's 16MB BSON ceiling.

## Why

`waste-balances` is one document per accreditation with an ever-growing embedded `transactions[]` array. Five write paths append to that array — summary-log row updates and four PRN operations (create, issue, cancel, cancel-post-issue) — and today none of them emit document-size telemetry. The existing `recordWasteBalanceUpdateAudit` fires only on summary-log writes and captures the new transactions, not the running total or document size. PRN-driven growth is silent altogether. Without visibility we cannot prioritise which accreditations to migrate to the ledger first, nor detect a document approaching the BSON cliff before it causes an outage.

## What changed

- New `recordWasteBalanceGrowth` helper in `src/waste-balances/application/growth-observability.js`. Computes BSON size via `BSON.calculateObjectSize` and percent of the 16MB limit, then emits a `logger.info` line with `accreditationId`, `transactionCount`, `newTransactionCount`, `bsonSize`, and `percentOfBsonLimit`. Fields are encoded as space-separated `key=value` pairs into the typed `CdpIndexedLog.message` string, matching the existing `run-balance-divergence-diagnostic.js` pattern.
- Wired into `saveBalance` in `src/waste-balances/repository/mongodb.js`. The MongoDB adapter's `saveBalance` is the single chokepoint all five embedded write paths converge on, so one insertion point guarantees coverage of summary-log and PRN writes without per-caller changes.
- Unit tests for the helper and an integration test driving `saveBalance` through the real Mongo fixture to prove the wire-up survives the round-trip.

## Out of scope

The ledger-append path (`canonicalSource: 'ledger'`) does not go through `saveBalance` and the ledger collection has no per-document growth concern. No instrumentation added there.

[PAE-1470]: https://eaflood.atlassian.net/browse/PAE-1470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ