### PR TITLE
PAE-1470: Log top 10 waste balance document sizes at startup

### DIFF
--- a/src/server/run-balance-size-diagnostic.integration.test.js
+++ b/src/server/run-balance-size-diagnostic.integration.test.js
@@ -1,0 +1,146 @@
+import { describe, beforeEach, expect } from 'vitest'
+import { it as mongoIt } from '#vite/fixtures/mongo.js'
+import { MongoClient } from 'mongodb'
+import { findTopWasteBalancesBySize } from './run-balance-size-diagnostic.js'
+
+const DATABASE_NAME = 'epr-backend'
+const COLLECTION_NAME = 'waste-balances'
+
+const it = mongoIt.extend({
+  db: async ({ db: uri }, use) => {
+    const client = await MongoClient.connect(uri)
+    const database = client.db(DATABASE_NAME)
+    await use(database)
+    await client.close()
+  }
+})
+
+const transaction = (id) => ({
+  id,
+  type: 'credit',
+  createdAt: '2026-05-14T00:00:00.000Z',
+  createdBy: { id: 'user-1', name: 'user-1' },
+  amount: 1,
+  openingAmount: 0,
+  closingAmount: 1,
+  openingAvailableAmount: 0,
+  closingAvailableAmount: 1,
+  entities: [
+    {
+      id: 'wr-1',
+      currentVersionId: 'wr-1',
+      previousVersionIds: [],
+      type: 'waste_record:received'
+    }
+  ]
+})
+
+const balance = ({
+  id,
+  accreditationId,
+  organisationId = 'org-1',
+  transactionCount = 0,
+  canonicalSource = 'embedded'
+}) => ({
+  _id: id,
+  accreditationId,
+  organisationId,
+  amount: 0,
+  availableAmount: 0,
+  schemaVersion: 1,
+  version: 1,
+  canonicalSource,
+  transactions: Array.from({ length: transactionCount }, (_, i) =>
+    transaction(`${accreditationId}-txn-${i}`)
+  )
+})
+
+describe('findTopWasteBalancesBySize (integration)', () => {
+  beforeEach(async ({ db }) => {
+    await db.collection(COLLECTION_NAME).deleteMany({})
+  })
+
+  it('returns empty when no balances exist', async ({ db }) => {
+    expect(await findTopWasteBalancesBySize(db)).toEqual([])
+  })
+
+  it('orders results by descending bsonSize and returns transactionCount alongside', async ({
+    db
+  }) => {
+    await db.collection(COLLECTION_NAME).insertMany([
+      balance({
+        id: 'bal-small',
+        accreditationId: 'acc-small',
+        transactionCount: 1
+      }),
+      balance({
+        id: 'bal-big',
+        accreditationId: 'acc-big',
+        transactionCount: 50
+      }),
+      balance({
+        id: 'bal-medium',
+        accreditationId: 'acc-medium',
+        transactionCount: 10
+      })
+    ])
+
+    const rows = await findTopWasteBalancesBySize(db)
+
+    expect(rows.map((r) => r.accreditationId)).toEqual([
+      'acc-big',
+      'acc-medium',
+      'acc-small'
+    ])
+    expect(rows.map((r) => r.transactionCount)).toEqual([50, 10, 1])
+    expect(rows[0].bsonSize).toBeGreaterThan(rows[1].bsonSize)
+    expect(rows[1].bsonSize).toBeGreaterThan(rows[2].bsonSize)
+  })
+
+  it('excludes ledger-canonical balances from the snapshot', async ({ db }) => {
+    await db.collection(COLLECTION_NAME).insertMany([
+      balance({
+        id: 'bal-emb',
+        accreditationId: 'acc-emb',
+        transactionCount: 5,
+        canonicalSource: 'embedded'
+      }),
+      balance({
+        id: 'bal-mig',
+        accreditationId: 'acc-mig',
+        transactionCount: 5,
+        canonicalSource: 'migrating'
+      }),
+      balance({
+        id: 'bal-ledger',
+        accreditationId: 'acc-ledger',
+        transactionCount: 100,
+        canonicalSource: 'ledger'
+      })
+    ])
+
+    const rows = await findTopWasteBalancesBySize(db)
+
+    expect(rows.map((r) => r.accreditationId).sort()).toEqual([
+      'acc-emb',
+      'acc-mig'
+    ])
+  })
+
+  it('caps results at 10 even when more embedded balances exist', async ({
+    db
+  }) => {
+    const docs = Array.from({ length: 15 }, (_, i) =>
+      balance({
+        id: `bal-${i}`,
+        accreditationId: `acc-${i}`,
+        transactionCount: 15 - i
+      })
+    )
+    await db.collection(COLLECTION_NAME).insertMany(docs)
+
+    const rows = await findTopWasteBalancesBySize(db)
+
+    expect(rows).toHaveLength(10)
+  })
+})

--- a/src/server/run-balance-size-diagnostic.js
+++ b/src/server/run-balance-size-diagnostic.js
@@ -1,0 +1,109 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import { computePercentOfBsonLimit } from '#waste-balances/application/growth-observability.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+
+const WASTE_BALANCES_COLLECTION = 'waste-balances'
+const LOCK_NAME = 'balance-size-diagnostic'
+const TOP_N = 10
+
+/**
+ * @typedef {Object} BalanceSizeRow
+ * @property {string} organisationId
+ * @property {string} accreditationId
+ * @property {number} transactionCount
+ * @property {number} bsonSize
+ */
+
+const TOP_BY_SIZE_PIPELINE = [
+  {
+    $match: { canonicalSource: { $ne: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER } }
+  },
+  {
+    $project: {
+      _id: 0,
+      organisationId: 1,
+      accreditationId: 1,
+      transactionCount: { $size: { $ifNull: ['$transactions', []] } },
+      bsonSize: { $bsonSize: '$$ROOT' }
+    }
+  },
+  { $sort: { bsonSize: -1 } },
+  { $limit: TOP_N }
+]
+
+/**
+ * @param {import('mongodb').Db} db
+ * @returns {Promise<BalanceSizeRow[]>}
+ */
+export const findTopWasteBalancesBySize = async (db) => {
+  const docs = await db
+    .collection(WASTE_BALANCES_COLLECTION)
+    .aggregate(TOP_BY_SIZE_PIPELINE, { allowDiskUse: true })
+    .toArray()
+  return /** @type {BalanceSizeRow[]} */ (/** @type {unknown} */ (docs))
+}
+
+const formatSnapshotLine = (row) =>
+  [
+    'Waste balance document size snapshot:',
+    `organisationId=${row.organisationId}`,
+    `accreditationId=${row.accreditationId}`,
+    `transactionCount=${row.transactionCount}`,
+    `bsonSize=${row.bsonSize}`,
+    `percentOfBsonLimit=${computePercentOfBsonLimit(row.bsonSize)}`
+  ].join(' ')
+
+const runDiagnostic = async (server) => {
+  logger.info({
+    message: `Running waste-balance size diagnostic (top ${TOP_N} by descending bsonSize)`
+  })
+
+  const rows = await findTopWasteBalancesBySize(server.db)
+
+  if (rows.length === 0) {
+    logger.info({
+      message: 'Waste-balance size diagnostic: no embedded balances found'
+    })
+    return
+  }
+
+  for (const row of rows) {
+    logger.info({ message: formatSnapshotLine(row) })
+  }
+}
+
+/**
+ * One-shot startup diagnostic that logs the top N embedded waste-balance
+ * documents by descending BSON size. Mirrors the per-write growth log emitted
+ * by `recordWasteBalanceGrowth`, so the same OpenSearch query surfaces both
+ * the live append trail and the boot-time snapshot of the largest documents.
+ *
+ * Ledger-canonical accreditations are excluded — the ledger collection isn't
+ * subject to per-document growth pressure.
+ *
+ * Read-only, safe under live traffic. Runs under a cross-instance lock so a
+ * single pod per deploy executes the scan.
+ *
+ * @param {Object} server - Hapi server instance
+ */
+export const runBalanceSizeDiagnostic = async (server) => {
+  try {
+    const lock = await server.locker.lock(LOCK_NAME)
+    if (!lock) {
+      logger.info({
+        message: 'Unable to obtain lock, skipping waste-balance size diagnostic'
+      })
+      return
+    }
+    try {
+      await runDiagnostic(server)
+    } finally {
+      await lock.free()
+    }
+  } catch (error) {
+    logger.error({
+      err: error,
+      message: 'Failed to run waste-balance size diagnostic'
+    })
+  }
+}

--- a/src/server/run-balance-size-diagnostic.test.js
+++ b/src/server/run-balance-size-diagnostic.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { runBalanceSizeDiagnostic } from './run-balance-size-diagnostic.js'
+import { logger } from '#common/helpers/logging/logger.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const HALF_LIMIT_BYTES = 8 * 1024 * 1024
+
+describe('runBalanceSizeDiagnostic', () => {
+  let mockServer
+  let mockLock
+  let mockAggregate
+  let mockToArray
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockLock = { free: vi.fn().mockResolvedValue(undefined) }
+
+    mockToArray = vi.fn().mockResolvedValue([])
+    mockAggregate = vi.fn().mockReturnValue({ toArray: mockToArray })
+    const db = {
+      collection: vi.fn().mockReturnValue({ aggregate: mockAggregate })
+    }
+
+    mockServer = {
+      db,
+      locker: {
+        lock: vi.fn().mockResolvedValue(mockLock)
+      }
+    }
+  })
+
+  it('acquires a lock scoped to the diagnostic and releases it afterwards', async () => {
+    await runBalanceSizeDiagnostic(mockServer)
+
+    expect(mockServer.locker.lock).toHaveBeenCalledWith(
+      'balance-size-diagnostic'
+    )
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('skips running when the lock is held by another instance', async () => {
+    mockServer.locker.lock.mockResolvedValue(null)
+
+    await runBalanceSizeDiagnostic(mockServer)
+
+    expect(mockServer.db.collection).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Unable to obtain lock, skipping waste-balance size diagnostic'
+    })
+  })
+
+  it('runs the aggregation against the waste-balances collection with allowDiskUse', async () => {
+    await runBalanceSizeDiagnostic(mockServer)
+
+    expect(mockServer.db.collection).toHaveBeenCalledWith('waste-balances')
+    expect(mockAggregate).toHaveBeenCalledWith(expect.any(Array), {
+      allowDiskUse: true
+    })
+  })
+
+  it('uses a pipeline that excludes ledger-canonical docs, projects bsonSize from $$ROOT, sorts descending, and limits to 10', async () => {
+    await runBalanceSizeDiagnostic(mockServer)
+
+    const [pipeline] = mockAggregate.mock.calls[0]
+    expect(pipeline).toEqual([
+      { $match: { canonicalSource: { $ne: 'ledger' } } },
+      {
+        $project: {
+          _id: 0,
+          organisationId: 1,
+          accreditationId: 1,
+          transactionCount: { $size: { $ifNull: ['$transactions', []] } },
+          bsonSize: { $bsonSize: '$$ROOT' }
+        }
+      },
+      { $sort: { bsonSize: -1 } },
+      { $limit: 10 }
+    ])
+  })
+
+  it('logs the start of the diagnostic before running the aggregation', async () => {
+    await runBalanceSizeDiagnostic(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Running waste-balance size diagnostic (top 10 by descending bsonSize)'
+    })
+  })
+
+  it('logs a no-data line when the aggregation returns no embedded balances', async () => {
+    mockToArray.mockResolvedValue([])
+
+    await runBalanceSizeDiagnostic(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Waste-balance size diagnostic: no embedded balances found'
+    })
+  })
+
+  it('logs one snapshot line per result with the same fields as the per-write growth log', async () => {
+    mockToArray.mockResolvedValue([
+      {
+        organisationId: 'org-A',
+        accreditationId: 'acc-1',
+        transactionCount: 42,
+        bsonSize: HALF_LIMIT_BYTES
+      },
+      {
+        organisationId: 'org-B',
+        accreditationId: 'acc-2',
+        transactionCount: 7,
+        bsonSize: 1024
+      }
+    ])
+
+    await runBalanceSizeDiagnostic(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste balance document size snapshot: organisationId=org-A accreditationId=acc-1 transactionCount=42 bsonSize=8388608 percentOfBsonLimit=50'
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste balance document size snapshot: organisationId=org-B accreditationId=acc-2 transactionCount=7 bsonSize=1024 percentOfBsonLimit=0.01'
+    })
+  })
+
+  it('releases the lock and logs an error when the aggregation throws', async () => {
+    const error = new Error('aggregate exploded')
+    mockAggregate.mockImplementation(() => {
+      throw error
+    })
+
+    await runBalanceSizeDiagnostic(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run waste-balance size diagnostic'
+    })
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('tolerates the locker itself throwing', async () => {
+    const error = new Error('locker unavailable')
+    mockServer.locker.lock.mockRejectedValue(error)
+
+    await runBalanceSizeDiagnostic(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run waste-balance size diagnostic'
+    })
+  })
+})

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -42,6 +42,7 @@ import { commandQueueConsumerPlugin } from '#server/queue-consumer/queue-consume
 import { runFormsDataMigration } from '#server/run-forms-data-migration.js'
 import { copyFormFilesToS3 } from '#server/copy-form-files-to-s3.js'
 import { runBalanceDivergenceDiagnostic } from '#server/run-balance-divergence-diagnostic.js'
+import { runBalanceSizeDiagnostic } from '#server/run-balance-size-diagnostic.js'
 import { runRowIdCollisionDiagnostic } from '#server/run-row-id-collision-diagnostic.js'
 
 /** @import { Lifecycle } from '@hapi/hapi' */
@@ -219,6 +220,7 @@ async function createServer(options = {}) {
     copyFormFilesToS3(server)
     runRowIdCollisionDiagnostic(server)
     runBalanceDivergenceDiagnostic(server)
+    runBalanceSizeDiagnostic(server)
   })
 
   return server

--- a/src/waste-balances/application/growth-observability.js
+++ b/src/waste-balances/application/growth-observability.js
@@ -1,7 +1,14 @@
 import { BSON } from 'mongodb'
 import { logger } from '#common/helpers/logging/logger.js'
 
-const BSON_DOCUMENT_MAX_SIZE_BYTES = 16 * 1024 * 1024
+export const BSON_DOCUMENT_MAX_SIZE_BYTES = 16 * 1024 * 1024
+
+/**
+ * @param {number} bsonSize
+ * @returns {number} percent of the 16MB BSON limit, rounded to 2 decimal places
+ */
+export const computePercentOfBsonLimit = (bsonSize) =>
+  Math.round((bsonSize / BSON_DOCUMENT_MAX_SIZE_BYTES) * 10000) / 100
 
 /**
  * Emit a structured log line capturing how close an embedded waste-balance
@@ -24,8 +31,7 @@ const BSON_DOCUMENT_MAX_SIZE_BYTES = 16 * 1024 * 1024
  */
 export const recordWasteBalanceGrowth = (updatedBalance, newTransactions) => {
   const bsonSize = BSON.calculateObjectSize(updatedBalance)
-  const percentOfBsonLimit =
-    Math.round((bsonSize / BSON_DOCUMENT_MAX_SIZE_BYTES) * 10000) / 100
+  const percentOfBsonLimit = computePercentOfBsonLimit(bsonSize)
   const transactionCount = updatedBalance.transactions.length
   const newTransactionCount = newTransactions.length
 


### PR DESCRIPTION
Ticket: [PAE-1470](https://eaflood.atlassian.net/browse/PAE-1470)
## Summary

Adds a one-shot startup diagnostic that logs the top 10 embedded waste-balance documents by descending BSON size, mirroring the per-write growth log emitted by `recordWasteBalanceGrowth` (added in #1177).

## Why

#1177 gave us visibility on document growth at every embedded write, but the per-write line only fires when an accreditation is actively written to. We have no baseline of which accreditations are already large at boot. The startup snapshot fills that gap: every deploy, one pod emits the current top 10 by size, so the same OpenSearch query surfaces both the live append trail and the boot-time snapshot of the largest documents. This is what we need to prioritise which accreditations to migrate to the ledger first.

## What changed

- New `src/server/run-balance-size-diagnostic.js`. Runs a server-side aggregation that filters out ledger-canonical balances, computes `$bsonSize` and `transactionCount` per doc, sorts descending, and limits to the top 10. Logs one `Waste balance document size snapshot:` line per result with `organisationId`, `accreditationId`, `transactionCount`, `bsonSize`, `percentOfBsonLimit` — the same fields as the per-write growth log so a single search returns both.
- Wired into `onPostStart` in `src/server/server.js` alongside the existing divergence and row-id collision diagnostics. Same lock pattern (`balance-size-diagnostic` lock name) so one pod per deploy runs the scan.
- Refactored `recordWasteBalanceGrowth` to share a `computePercentOfBsonLimit` helper and exported `BSON_DOCUMENT_MAX_SIZE_BYTES` so both the per-write line and the startup snapshot agree on the limit.
- Unit and integration tests for the diagnostic; integration test proves the `$bsonSize` aggregation operator works against the real Mongo fixture and the sort/limit ordering is correct.

## Notes

The aggregation uses `$bsonSize` (MongoDB 4.4+). Our cluster runs MongoDB 8.2 so this is well within range.

[PAE-1470]: https://eaflood.atlassian.net/browse/PAE-1470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ