### PR TITLE
PAE-1424: Add compliance reporting periods to public register CSV

### DIFF
--- a/src/application/public-register/csv-generator.js
+++ b/src/application/public-register/csv-generator.js
@@ -6,9 +6,10 @@ import { formatDateTimeDots } from '#common/helpers/date-formatter.js'
 /**
  * Generates a CSV string from transformed data
  * @param {PublicRegisterRow[]} rows - Output from transform function
+ * @param {import('#reports/domain/compliance-reporting-periods.js').CompliancePeriod[]} [periods] - Compliance periods for dynamic columns
  * @returns {Promise<string>} - CSV string with BOM
  */
-export async function generateCsv(rows) {
+export async function generateCsv(rows, periods = []) {
   const headerMapping = [
     ['type', 'Type'],
     ['businessName', 'Business name'],
@@ -28,7 +29,8 @@ export async function generateCsv(rows) {
     ['activeDate', 'Active Date'],
     ['accreditationStatus', 'Accreditation status'],
     ['dateLastChanged', 'Date status last changed'],
-    ['tonnageBand', 'Tonnage Band']
+    ['tonnageBand', 'Tonnage Band'],
+    ...periods.map((p) => [p.label, p.label])
   ]
 
   const generatedAtTimestamp = formatDateTimeDots(new Date())

--- a/src/application/public-register/csv-generator.test.js
+++ b/src/application/public-register/csv-generator.test.js
@@ -51,17 +51,25 @@ describe('generateCsv', () => {
   })
 
   it('should generate a CSV string with correct headers and data rows', async () => {
-    const csvOutput = await generateCsv(mockInput)
+    const periods = [
+      { label: 'Jan Report', key: '2026:monthly:1' },
+      { label: 'Q1 Report', key: '2026:quarterly:1' }
+    ]
+    const rows = [
+      { ...mockInput[0], 'Jan Report': '05/01/2026', 'Q1 Report': 'N/A' },
+      { ...mockInput[1], 'Jan Report': '', 'Q1 Report': '15/04/2026' }
+    ]
 
-    const expectedCsv =
-      '\uFEFF' + // ← Add BOM to expected string
-      'Generated at 04.02.26 14:49,,,,,,,,,,,,,,,\n' +
-      'Type,Business name,Companies House Number,Org ID,"Registered office\n' +
-      'Head office\n' +
-      'Main place of business in UK",Appropriate Agency,Registration number,Trading name,Registered Reprocessing site (UK),Packaging Waste Category,Annex II Process,Accreditation No,Active Date,Accreditation status,Date status last changed,Tonnage Band\n' +
-      'Reprocessor,Waste Ltd,12345678,500001,"1 Waste Road, London, N1 1AA",EA,R12345678PL,Waste Recovery,"2 Waste Site, London, EC1 1AA",Plastic,R3,A123456PL,22/01/2026,Approved,22/01/2026,"Up to 10,000 tonnes"\n' +
-      'Exporter,Export Co,12345679,500002,"10 Export Street, Bristol, BS1 2AB",SEPA,R87654321AL,Export Trading,,Aluminium,R4,,,,,'
+    const csv = await generateCsv(rows, periods)
 
-    expect(csvOutput).toBe(expectedCsv)
+    expect(csv).toBe(
+      '﻿' +
+        'Generated at 04.02.26 14:49,,,,,,,,,,,,,,,,,\n' +
+        'Type,Business name,Companies House Number,Org ID,"Registered office\n' +
+        'Head office\n' +
+        'Main place of business in UK",Appropriate Agency,Registration number,Trading name,Registered Reprocessing site (UK),Packaging Waste Category,Annex II Process,Accreditation No,Active Date,Accreditation status,Date status last changed,Tonnage Band,Jan Report,Q1 Report\n' +
+        'Reprocessor,Waste Ltd,12345678,500001,"1 Waste Road, London, N1 1AA",EA,R12345678PL,Waste Recovery,"2 Waste Site, London, EC1 1AA",Plastic,R3,A123456PL,22/01/2026,Approved,22/01/2026,"Up to 10,000 tonnes",05/01/2026,N/A\n' +
+        'Exporter,Export Co,12345679,500002,"10 Export Street, Bristol, BS1 2AB",SEPA,R87654321AL,Export Trading,,Aluminium,R4,,,,,,,15/04/2026'
+    )
   })
 })

--- a/src/application/public-register/generate-public-register.js
+++ b/src/application/public-register/generate-public-register.js
@@ -1,5 +1,6 @@
 import { transform } from '#application/public-register/public-register-transformer.js'
 import { generateCsv } from '#application/public-register/csv-generator.js'
+import { generateReportCompliance } from '#reports/application/report-compliance.js'
 import { randomUUID } from 'node:crypto'
 import { logger } from '#common/helpers/logging/logger.js'
 
@@ -8,10 +9,12 @@ import { logger } from '#common/helpers/logging/logger.js'
  * @param {Date} date
  * @returns {string}
  */
+const DATE_PART_WIDTH = 2
+
 function formatDateYYYYMMDD(date) {
   const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
+  const month = String(date.getMonth() + 1).padStart(DATE_PART_WIDTH, '0')
+  const day = String(date.getDate()).padStart(DATE_PART_WIDTH, '0')
   return `${year}${month}${day}`
 }
 
@@ -20,15 +23,20 @@ function formatDateYYYYMMDD(date) {
  *
  * @param {import('#repositories/organisations/port.js').OrganisationsRepository} organisationRepo - Organisation repository
  * @param {import('#domain/public-register/repository/port.js').PublicRegisterRepository} publicRegisterRepo - Public register repository
+ * @param {import('#reports/repository/port.js').ReportsRepository} reportsRepository - Reports repository
  * @returns {Promise<import('#domain/public-register/repository/port.js').PresignedUrlResult>} Pre-signed URL with expiry info for the generated public register file
  */
 export async function generatePublicRegister(
   organisationRepo,
-  publicRegisterRepo
+  publicRegisterRepo,
+  reportsRepository
 ) {
   logger.info({ message: 'Public register generation started' })
 
-  const organisations = await organisationRepo.findAll()
+  const [organisations, complianceData] = await Promise.all([
+    organisationRepo.findAll(),
+    generateReportCompliance(organisationRepo, reportsRepository)
+  ])
   logger.info({
     message: `Retrieved ${organisations.length} organisations from repository`
   })
@@ -36,13 +44,16 @@ export async function generatePublicRegister(
   logger.info({
     message: 'Starting transformation of organisations to public register rows'
   })
-  const publicRegisterRows = await transform(organisations)
+  const publicRegisterRows = await transform(organisations, complianceData)
   logger.info({
     message: `Transformation complete: ${publicRegisterRows.length} rows generated`
   })
 
   logger.info({ message: 'Generating CSV from transformed data' })
-  const publicRegisterCsv = await generateCsv(publicRegisterRows)
+  const publicRegisterCsv = await generateCsv(
+    publicRegisterRows,
+    complianceData.periods
+  )
   logger.info({
     message: `CSV generation complete: ${publicRegisterCsv.length} characters`
   })

--- a/src/application/public-register/integration.test.js
+++ b/src/application/public-register/integration.test.js
@@ -1,18 +1,28 @@
-import { describe, expect, it, beforeEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { generatePublicRegister } from './generate-public-register.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createInMemoryPublicRegisterRepository } from '#adapters/repositories/public-register/inmemory.js'
+import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import { buildApprovedOrg } from '#vite/helpers/build-approved-org.js'
-import { formatDate } from '#common/helpers/date-formatter.js'
-import { getValidDateRange } from '#repositories/organisations/contract/test-data.js'
+import { formatDateTimeDots } from '#common/helpers/date-formatter.js'
+
+const FIXED_DATE = new Date('2026-04-17T10:00:00.000Z')
 
 describe('generatePublicRegister', () => {
   let organisationRepo
   let publicRegisterRepo
+  let reportsRepo
 
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(FIXED_DATE)
     organisationRepo = createInMemoryOrganisationsRepository()()
     publicRegisterRepo = createInMemoryPublicRegisterRepository()
+    reportsRepo = createInMemoryReportsRepository()()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('generates public register with approved registration and accreditation', async () => {
@@ -20,30 +30,24 @@ describe('generatePublicRegister', () => {
 
     const result = await generatePublicRegister(
       organisationRepo,
-      publicRegisterRepo
+      publicRegisterRepo,
+      reportsRepo
     )
 
     expect(result.url).toBeTruthy()
 
     const csvData = await publicRegisterRepo.fetchFromPresignedUrl(result.url)
+    const generatedAt = formatDateTimeDots(FIXED_DATE)
 
-    const { VALID_FROM } = getValidDateRange()
-    const activeDate = formatDate(VALID_FROM)
-    const dateLastUpdated = formatDate(new Date(Date.now()))
-
-    const lines = csvData.split('\n').filter((line) => line.length > 0)
-    expect(lines.length).toBe(5) // generated at row + header (3 lines) + data row
-
-    expect(lines[0]).toMatch(
-      /^(\uFEFF)?Generated at \d{2}\.\d{2}\.\d{2} \d{2}:\d{2}(,){15}$/
+    // At 2026-04-17: Jan, Feb, Mar (monthly) + Q1 (quarterly) → 20 columns total
+    // Accredited operator (monthly cadence): monthly periods show '' (not submitted), Q1 shows N/A
+    expect(csvData).toBe(
+      '﻿' +
+        `Generated at ${generatedAt},,,,,,,,,,,,,,,,,,,\n` +
+        'Type,Business name,Companies House Number,Org ID,"Registered office\n' +
+        'Head office\n' +
+        'Main place of business in UK",Appropriate Agency,Registration number,Trading name,Registered Reprocessing site (UK),Packaging Waste Category,Annex II Process,Accreditation No,Active Date,Accreditation status,Date status last changed,Tonnage Band,Jan Report,Feb Report,Mar Report,Q1 Report\n' +
+        'Reprocessor,ACME ltd,AC012345,200001,"Palace of Westminster, London, SW1A 0AA",EA,REG1,ACME ltd,"7 Glass processing site, London, SW2A 0AA",Glass-remelt,R5,ACC1,17/04/2026,Approved,17/04/2026,"Over 10,000 tonnes",,,,N/A'
     )
-
-    // Verify header (starts on line 1)
-    expect(lines[1]).toContain('Type,Business name,Companies House Number')
-
-    // Verify data row
-    expect(lines[4]).toContain('Reprocessor,ACME ltd,AC012345,200001')
-    expect(lines[4]).toContain(activeDate)
-    expect(lines[4]).toContain(dateLastUpdated)
   })
 })

--- a/src/application/public-register/public-register-transformer.js
+++ b/src/application/public-register/public-register-transformer.js
@@ -138,7 +138,7 @@ function processBatch(batch, reportComplianceData) {
  * Transforms organisations into public register row objects
  * Processes in chunks to avoid blocking event loop
  * @param {Organisation[]} organisations - Array of organisation entities
- * @param {ReportComplianceData} [reportComplianceData] - Compliance data to populate period columns
+ * @param {ReportComplianceData} reportComplianceData - Compliance data to populate period columns
  * @returns {Promise<PublicRegisterRow[]>} - Array of row objects ready for CSV export
  */
 export async function transform(organisations, reportComplianceData) {

--- a/src/application/public-register/public-register-transformer.js
+++ b/src/application/public-register/public-register-transformer.js
@@ -4,6 +4,7 @@
 
 /** @import {Organisation} from '#domain/organisations/model.js' */
 /** @import {PublicRegisterRow} from './types.js' */
+/** @import {ReportComplianceData} from '#reports/application/report-compliance.js' */
 
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 import {
@@ -28,13 +29,32 @@ const INCLUDED_STATUSES = new Set([
 const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 const BATCH_SIZE = Number(config.get('publicRegister.batchSize'))
 
+function buildReportComplianceFields(periods, registrationReportSubmissions) {
+  return Object.fromEntries(
+    periods.map((period) => {
+      if (!registrationReportSubmissions.submittedDates.has(period.key)) {
+        return [period.label, 'N/A']
+      }
+      const date = registrationReportSubmissions.submittedDates.get(period.key)
+      return [period.label, date ? formatDate(date) : '']
+    })
+  )
+}
+
 /**
  * @param {Organisation} org
  * @param {*} registration
  * @param {*} accreditation
+ * @param {Record<string, string>} reportComplianceFields
+
  * @returns {PublicRegisterRow}
  */
-function transformRegAcc(org, registration, accreditation) {
+function transformRegAcc(
+  org,
+  registration,
+  accreditation,
+  reportComplianceFields
+) {
   return {
     type: capitalize(registration.wasteProcessingType),
     businessName: org.companyDetails.name,
@@ -56,7 +76,8 @@ function transformRegAcc(org, registration, accreditation) {
     accreditationNo: accreditation?.accreditationNumber || '',
     tonnageBand: formatTonnageBand(accreditation?.prnIssuance?.tonnageBand),
     activeDate: formatDate(accreditation?.validFrom),
-    dateLastChanged: formatDate(getLastStatusUpdateDate(accreditation))
+    dateLastChanged: formatDate(getLastStatusUpdateDate(accreditation)),
+    ...reportComplianceFields
   }
 }
 
@@ -86,9 +107,11 @@ function isTestOrg(org) {
 
 /**
  * @param {Organisation[]} batch
+ * @param {ReportComplianceData} reportComplianceData
  * @returns {PublicRegisterRow[]}
  */
-function processBatch(batch) {
+function processBatch(batch, reportComplianceData) {
+  const { periods, entries } = reportComplianceData
   return batch
     .filter((org) => !isTestOrg(org))
     .flatMap((org) =>
@@ -97,7 +120,16 @@ function processBatch(batch) {
           registration,
           org.accreditations
         )
-        return transformRegAcc(org, registration, accreditation)
+        const entry = entries.get(registration.id)
+        const reportComplianceFields = entry
+          ? buildReportComplianceFields(periods, entry)
+          : {}
+        return transformRegAcc(
+          org,
+          registration,
+          accreditation,
+          reportComplianceFields
+        )
       })
     )
 }
@@ -106,13 +138,14 @@ function processBatch(batch) {
  * Transforms organisations into public register row objects
  * Processes in chunks to avoid blocking event loop
  * @param {Organisation[]} organisations - Array of organisation entities
+ * @param {ReportComplianceData} [reportComplianceData] - Compliance data to populate period columns
  * @returns {Promise<PublicRegisterRow[]>} - Array of row objects ready for CSV export
  */
-export async function transform(organisations) {
+export async function transform(organisations, reportComplianceData) {
   const results = []
 
   for (const batch of chunk(organisations, BATCH_SIZE)) {
-    results.push(...processBatch(batch))
+    results.push(...processBatch(batch, reportComplianceData))
     await new Promise((resolve) => setImmediate(resolve))
   }
 

--- a/src/application/public-register/public-register-transformer.test.js
+++ b/src/application/public-register/public-register-transformer.test.js
@@ -101,7 +101,7 @@ describe('transform', () => {
       accreditations: [accreditation]
     })
 
-    const rows = await transform([org])
+    const rows = await transform([org], { periods: [], entries: new Map() })
 
     expect(rows).toStrictEqual([
       {
@@ -146,7 +146,7 @@ describe('transform', () => {
       accreditations: [accreditation]
     })
 
-    const rows = await transform([org])
+    const rows = await transform([org], { periods: [], entries: new Map() })
 
     expect(rows).toStrictEqual([
       {
@@ -189,7 +189,7 @@ describe('transform', () => {
       const registration = createTestRegistration({ status })
       const org = createTestOrganisation({ registrations: [registration] })
 
-      const rows = await transform([org])
+      const rows = await transform([org], { periods: [], entries: new Map() })
 
       expect(rows).toEqual([
         {
@@ -263,7 +263,7 @@ describe('transform', () => {
         accreditations: [accreditation]
       })
 
-      const rows = await transform([org])
+      const rows = await transform([org], { periods: [], entries: new Map() })
 
       expect(rows).toEqual([
         {
@@ -312,7 +312,7 @@ describe('transform', () => {
       ]
     })
 
-    const rows = await transform([org])
+    const rows = await transform([org], { periods: [], entries: new Map() })
 
     expect(rows).toHaveLength(1)
     expect(rows[0].registrationNumber).toBe('R11111111PL')
@@ -354,7 +354,7 @@ describe('transform', () => {
       ]
     })
 
-    const rows = await transform([org])
+    const rows = await transform([org], { periods: [], entries: new Map() })
 
     expect(rows).toEqual([
       {
@@ -384,7 +384,7 @@ describe('transform', () => {
       accreditations: []
     })
 
-    const rows = await transform([org])
+    const rows = await transform([org], { periods: [], entries: new Map() })
 
     expect(rows).toHaveLength(0)
   })
@@ -461,7 +461,10 @@ describe('transform', () => {
       accreditations: []
     })
 
-    const rows = await transform([org1, org2, org3])
+    const rows = await transform([org1, org2, org3], {
+      periods: [],
+      entries: new Map()
+    })
 
     expect(rows).toEqual([
       {
@@ -532,7 +535,7 @@ describe('transform', () => {
       registrations: [registration]
     })
 
-    const rows = await transform([org])
+    const rows = await transform([org], { periods: [], entries: new Map() })
 
     expect(rows).toHaveLength(1)
     expect(rows[0].businessName).toBe('Test Company Ltd')
@@ -550,12 +553,53 @@ describe('transform', () => {
       registrations: [registration]
     })
 
-    const rows = await transform([org])
+    const rows = await transform([org], { periods: [], entries: new Map() })
 
     expect(rows).toHaveLength(1)
     expect(rows[0].businessName).toBe('Test Company Ltd')
     expect(rows[0].companiesHouseNumber).toBe('')
     expect(rows[0].orgId).toBe(org.orgId)
+  })
+
+  describe('compliance fields', () => {
+    const buildEntry = (submittedDates) => {
+      const registration = createTestRegistration()
+      const org = createTestOrganisation({ registrations: [registration] })
+      const entries = new Map([
+        [
+          registration.id,
+          {
+            registrationId: registration.id,
+            organisationId: org.id,
+            submittedDates
+          }
+        ]
+      ])
+      return { org, entries }
+    }
+
+    const period = { label: 'Jan Report', key: '2026:monthly:1' }
+    const periods = [period]
+
+    it("returns 'N/A' when the period key is absent from submittedDates", async () => {
+      const { org, entries } = buildEntry(new Map())
+      const rows = await transform([org], { periods, entries })
+      expect(rows[0]['Jan Report']).toBe('N/A')
+    })
+
+    it("returns '' when the period key is present but not yet submitted", async () => {
+      const { org, entries } = buildEntry(new Map([['2026:monthly:1', null]]))
+      const rows = await transform([org], { periods, entries })
+      expect(rows[0]['Jan Report']).toBe('')
+    })
+
+    it('returns formatted date when the period has been submitted', async () => {
+      const { org, entries } = buildEntry(
+        new Map([['2026:monthly:1', '2026-01-15']])
+      )
+      const rows = await transform([org], { periods, entries })
+      expect(rows[0]['Jan Report']).toBe('15/01/2026')
+    })
   })
 
   it('should filter out test organisations from results', async () => {
@@ -602,7 +646,10 @@ describe('transform', () => {
       ]
     })
 
-    const rows = await transform([testOrg, normalOrg])
+    const rows = await transform([testOrg, normalOrg], {
+      periods: [],
+      entries: new Map()
+    })
 
     // Only the normal org should be in results, test org should be filtered out
     expect(rows).toHaveLength(1)

--- a/src/application/public-register/types.js
+++ b/src/application/public-register/types.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {Object} PublicRegisterRow
+ * @typedef {Object} PublicRegisterRowBase
  * @property {string} type - Waste processing type (e.g., 'Reprocessor', 'Exporter')
  * @property {string} businessName - Business name
  * @property {string} registeredOffice - Registered office address
@@ -16,6 +16,20 @@
  * @property {string} tonnageBand - Tonnage band (empty string if no accreditation)
  * @property {string} activeDate - Active date in DD/MM/YYYY format (empty string if no accreditation)
  * @property {string} dateLastChanged - Date status last changed in DD/MM/YYYY format (empty string if no accreditation)
+ */
+
+/**
+ * @typedef {'Jan Report' | 'Feb Report' | 'Mar Report' | 'Apr Report' |
+ *           'May Report' | 'Jun Report' | 'Jul Report' | 'Aug Report' |
+ *           'Sep Report' | 'Oct Report' | 'Nov Report' | 'Dec Report' |
+ *           'Q1 Report' | 'Q2 Report' | 'Q3 Report' | 'Q4 Report'} CompliancePeriodLabel
+ */
+
+/**
+ * Dynamic compliance fields are keyed by period label (e.g. 'Jan Report', 'Q1 Report').
+ * Values: 'DD/MM/YYYY' if submitted, 'N/A' if the period cadence does not apply, '' otherwise.
+ *
+ * @typedef {PublicRegisterRowBase & Partial<Record<CompliancePeriodLabel, string>>} PublicRegisterRow
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/domain/organisations/registration-utils.js
+++ b/src/domain/organisations/registration-utils.js
@@ -1,21 +1,22 @@
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
 
-/** @import { Organisation } from '#domain/organisations/model.js' */
+/** @import { Organisation, RegAccStatus } from '#domain/organisations/model.js' */
 /** @import { RegistrationApproved } from '#domain/organisations/registration.js' */
 
 const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
-const REPORTABLE_STATUSES = new Set([
-  REG_ACC_STATUS.APPROVED,
-  REG_ACC_STATUS.SUSPENDED,
-  REG_ACC_STATUS.CANCELLED
-])
+const REPORTABLE_STATUSES = /** @type {Set<RegAccStatus>} */ (
+  new Set([
+    REG_ACC_STATUS.APPROVED,
+    REG_ACC_STATUS.SUSPENDED,
+    REG_ACC_STATUS.CANCELLED
+  ])
+)
 
-const ACTIVE_ACCREDITATION_STATUSES = new Set([
-  REG_ACC_STATUS.APPROVED,
-  REG_ACC_STATUS.SUSPENDED
-])
+const ACTIVE_ACCREDITATION_STATUSES = /** @type {Set<RegAccStatus>} */ (
+  new Set([REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.SUSPENDED])
+)
 
 /**
  * Returns all reportable (approved/suspended/cancelled) registrations across all non-test organisations.
@@ -41,7 +42,7 @@ export function getReportableRegistrations(orgs) {
  * or '' when no active (approved/suspended) accreditation is found.
  *
  * @param {{ accreditationId?: string | null }} registration
- * @param {{ accreditations: Array<{ id: string, status: string, accreditationNumber?: string | null }> }} org
+ * @param {{ accreditations: Array<{ id: string, status: RegAccStatus, accreditationNumber?: string | null }> }} org
  * @returns {string}
  */
 export function resolveAccreditationNumber(registration, org) {

--- a/src/domain/organisations/registration-utils.js
+++ b/src/domain/organisations/registration-utils.js
@@ -1,0 +1,57 @@
+import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+/** @import { RegistrationApproved } from '#domain/organisations/registration.js' */
+
+const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
+
+const REPORTABLE_STATUSES = new Set([
+  REG_ACC_STATUS.APPROVED,
+  REG_ACC_STATUS.SUSPENDED,
+  REG_ACC_STATUS.CANCELLED
+])
+
+const ACTIVE_ACCREDITATION_STATUSES = new Set([
+  REG_ACC_STATUS.APPROVED,
+  REG_ACC_STATUS.SUSPENDED
+])
+
+/**
+ * Returns all reportable (approved/suspended/cancelled) registrations across all non-test organisations.
+ *
+ * @param {Organisation[]} orgs
+ * @returns {Array<{ org: Organisation, registration: RegistrationApproved }>}
+ */
+export function getReportableRegistrations(orgs) {
+  return orgs
+    .filter((org) => !TEST_ORGANISATIONS.has(org.orgId))
+    .flatMap((org) =>
+      org.registrations
+        .filter((registration) => REPORTABLE_STATUSES.has(registration.status))
+        .map((registration) => ({
+          org,
+          registration: /** @type {RegistrationApproved} */ (registration)
+        }))
+    )
+}
+
+/**
+ * Returns the accreditationNumber for the registration's linked accreditation,
+ * or '' when no active (approved/suspended) accreditation is found.
+ *
+ * @param {{ accreditationId?: string | null }} registration
+ * @param {{ accreditations: Array<{ id: string, status: string, accreditationNumber?: string | null }> }} org
+ * @returns {string}
+ */
+export function resolveAccreditationNumber(registration, org) {
+  if (!registration.accreditationId) {
+    return ''
+  }
+  const accreditation = org.accreditations.find(
+    (a) =>
+      a.id === registration.accreditationId &&
+      ACTIVE_ACCREDITATION_STATUSES.has(a.status)
+  )
+  return accreditation?.accreditationNumber ?? ''
+}

--- a/src/domain/organisations/registration-utils.test.js
+++ b/src/domain/organisations/registration-utils.test.js
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getReportableRegistrations,
+  resolveAccreditationNumber
+} from './registration-utils.js'
+
+const buildOrg = (overrides = {}) => ({
+  id: 'org-1',
+  orgId: 500001,
+  companyDetails: { name: 'Acme Ltd' },
+  accreditations: [],
+  registrations: [],
+  ...overrides
+})
+
+const buildReg = (overrides = {}) => ({
+  id: 'reg-1',
+  status: 'approved',
+  accreditationId: null,
+  registrationNumber: 'REG-001',
+  ...overrides
+})
+
+// ---------------------------------------------------------------------------
+// getReportableRegistrations
+// ---------------------------------------------------------------------------
+
+describe('getReportableRegistrations', () => {
+  it('includes approved registrations', () => {
+    const org = buildOrg({ registrations: [buildReg({ status: 'approved' })] })
+
+    const result = getReportableRegistrations([org])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].registration.status).toBe('approved')
+  })
+
+  it('includes suspended registrations', () => {
+    const org = buildOrg({ registrations: [buildReg({ status: 'suspended' })] })
+
+    expect(getReportableRegistrations([org])).toHaveLength(1)
+  })
+
+  it('includes cancelled registrations', () => {
+    const org = buildOrg({ registrations: [buildReg({ status: 'cancelled' })] })
+
+    expect(getReportableRegistrations([org])).toHaveLength(1)
+  })
+
+  it('excludes created registrations', () => {
+    const org = buildOrg({ registrations: [buildReg({ status: 'created' })] })
+
+    expect(getReportableRegistrations([org])).toHaveLength(0)
+  })
+
+  it('excludes rejected registrations', () => {
+    const org = buildOrg({ registrations: [buildReg({ status: 'rejected' })] })
+
+    expect(getReportableRegistrations([org])).toHaveLength(0)
+  })
+
+  it('excludes test organisations by orgId', () => {
+    const testOrg = buildOrg({
+      orgId: 999999,
+      registrations: [buildReg({ status: 'approved' })]
+    })
+
+    expect(getReportableRegistrations([testOrg])).toHaveLength(0)
+  })
+
+  it('flattens registrations across multiple orgs', () => {
+    const org1 = buildOrg({
+      id: 'org-1',
+      registrations: [buildReg({ id: 'reg-1', status: 'approved' })]
+    })
+    const org2 = buildOrg({
+      id: 'org-2',
+      registrations: [buildReg({ id: 'reg-2', status: 'approved' })]
+    })
+
+    const result = getReportableRegistrations([org1, org2])
+
+    expect(result).toHaveLength(2)
+    expect(result.map((r) => r.registration.id)).toEqual(['reg-1', 'reg-2'])
+  })
+
+  it('pairs each registration with its org', () => {
+    const org = buildOrg({ registrations: [buildReg({ status: 'approved' })] })
+
+    const result = getReportableRegistrations([org])
+
+    expect(result[0].org).toBe(org)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveAccreditationNumber
+// ---------------------------------------------------------------------------
+
+describe('resolveAccreditationNumber', () => {
+  it('returns accreditationNumber for an approved accreditation', () => {
+    const org = buildOrg({
+      accreditations: [
+        { id: 'acc-1', status: 'approved', accreditationNumber: 'ACC-001' }
+      ]
+    })
+    const reg = buildReg({ accreditationId: 'acc-1' })
+
+    expect(resolveAccreditationNumber(reg, org)).toBe('ACC-001')
+  })
+
+  it('returns accreditationNumber for a suspended accreditation', () => {
+    const org = buildOrg({
+      accreditations: [
+        { id: 'acc-1', status: 'suspended', accreditationNumber: 'ACC-999' }
+      ]
+    })
+    const reg = buildReg({ accreditationId: 'acc-1' })
+
+    expect(resolveAccreditationNumber(reg, org)).toBe('ACC-999')
+  })
+
+  it('returns empty string when registration has no accreditationId', () => {
+    const org = buildOrg({
+      accreditations: [
+        { id: 'acc-1', status: 'approved', accreditationNumber: 'ACC-001' }
+      ]
+    })
+    const reg = buildReg({ accreditationId: null })
+
+    expect(resolveAccreditationNumber(reg, org)).toBe('')
+  })
+
+  it('returns empty string when accreditation status is created', () => {
+    const org = buildOrg({
+      accreditations: [
+        { id: 'acc-1', status: 'created', accreditationNumber: 'ACC-001' }
+      ]
+    })
+    const reg = buildReg({ accreditationId: 'acc-1' })
+
+    expect(resolveAccreditationNumber(reg, org)).toBe('')
+  })
+
+  it('returns empty string when accreditation status is rejected', () => {
+    const org = buildOrg({
+      accreditations: [
+        { id: 'acc-1', status: 'rejected', accreditationNumber: 'ACC-001' }
+      ]
+    })
+    const reg = buildReg({ accreditationId: 'acc-1' })
+
+    expect(resolveAccreditationNumber(reg, org)).toBe('')
+  })
+
+  it('returns empty string when accreditation has null accreditationNumber', () => {
+    const org = buildOrg({
+      accreditations: [
+        { id: 'acc-1', status: 'approved', accreditationNumber: null }
+      ]
+    })
+    const reg = buildReg({ accreditationId: 'acc-1' })
+
+    expect(resolveAccreditationNumber(reg, org)).toBe('')
+  })
+})

--- a/src/reports/application/report-compliance.js
+++ b/src/reports/application/report-compliance.js
@@ -78,7 +78,7 @@ export async function generateReportCompliance(
     const periodicReports =
       reportsByRegistration.get(`${org.id}::${registration.id}`) ?? []
 
-    /** @type {Map<string, string>} */
+    /** @type {Map<string, string | null>} */
     const submittedDates = new Map()
 
     for (const year of years) {

--- a/src/reports/application/report-compliance.js
+++ b/src/reports/application/report-compliance.js
@@ -1,0 +1,108 @@
+import { CADENCE } from '#reports/domain/cadence.js'
+import { generateReportingPeriods } from '#reports/domain/generate-reporting-periods.js'
+import { mergeReportingPeriods } from '#reports/domain/merge-reporting-periods.js'
+import { generateComplianceReportingPeriods } from '#reports/domain/compliance-reporting-periods.js'
+import {
+  getReportableRegistrations,
+  resolveAccreditationNumber
+} from '#domain/organisations/registration-utils.js'
+
+/**
+ * @typedef {import('#reports/domain/compliance-reporting-periods.js').CompliancePeriod} CompliancePeriod
+ */
+
+/**
+ * @typedef {{
+ *   registrationId: string;
+ *   organisationId: string;
+ *   submittedDates: Map<string, string | null>;
+ * }} ReportComplianceEntry
+ */
+
+/**
+ * @typedef {{
+ *   periods: CompliancePeriod[];
+ *   entries: Map<string, ReportComplianceEntry>;
+ * }} ReportComplianceData
+ */
+
+/**
+ * Groups all periodic reports by `${organisationId}::${registrationId}`.
+ *
+ * @param {import('#reports/repository/port.js').PeriodicReport[]} allPeriodicReports
+ * @returns {Map<string, import('#reports/repository/port.js').PeriodicReport[]>}
+ */
+function groupByRegistration(allPeriodicReports) {
+  return allPeriodicReports.reduce((map, pr) => {
+    const key = `${pr.organisationId}::${pr.registrationId}`
+    const existing = map.get(key) ?? []
+    return map.set(key, [...existing, pr])
+  }, new Map())
+}
+
+/**
+ * Builds a map of report compliance data for all approved/suspended registrations.
+ *
+ * Each entry in `entries` is keyed by `registrationId` and contains only the
+ * periods that were actually submitted (`submittedDates`). The consumer can
+ * determine whether an absent key represents "not yet submitted" or "N/A" by
+ * comparing the compliance period's cadence against the registration's cadence
+ * (encoded in the key as `${year}:${cadence}:${period}`).
+ *
+ * @param {import('#repositories/organisations/port.js').OrganisationsRepository} organisationsRepository
+ * @param {import('#reports/repository/port.js').ReportsRepository} reportsRepository
+ * @param {Date} [now]
+ * @returns {Promise<ReportComplianceData>}
+ */
+export async function generateReportCompliance(
+  organisationsRepository,
+  reportsRepository,
+  now = new Date()
+) {
+  const periods = generateComplianceReportingPeriods()
+  const years = [...new Set(periods.map((p) => p.year))]
+
+  const orgs = await organisationsRepository.findAll()
+  const registrations = getReportableRegistrations(orgs)
+
+  const allPeriodicReports = await reportsRepository.findAllPeriodicReports()
+  const reportsByRegistration = groupByRegistration(allPeriodicReports)
+
+  /** @type {Map<string, ReportComplianceEntry>} */
+  const entries = new Map()
+
+  for (const { org, registration } of registrations) {
+    const accreditationNumber = resolveAccreditationNumber(registration, org)
+    const cadence = accreditationNumber ? CADENCE.monthly : CADENCE.quarterly
+
+    const periodicReports =
+      reportsByRegistration.get(`${org.id}::${registration.id}`) ?? []
+
+    /** @type {Map<string, string>} */
+    const submittedDates = new Map()
+
+    for (const year of years) {
+      const computedPeriods = generateReportingPeriods(cadence, year, now)
+      const merged = mergeReportingPeriods(
+        computedPeriods,
+        periodicReports,
+        cadence
+      )
+
+      for (const mergedPeriod of merged) {
+        submittedDates.set(
+          `${mergedPeriod.year}:${cadence}:${mergedPeriod.period}`,
+          mergedPeriod.report?.submittedAt?.slice(0, 10) ?? null
+        )
+      }
+    }
+
+    entries.set(registration.id, {
+      registrationId: registration.id,
+      organisationId: org.id,
+      submittedDates
+    })
+  }
+
+  return { periods, entries }
+}

--- a/src/reports/application/report-compliance.test.js
+++ b/src/reports/application/report-compliance.test.js
@@ -1,0 +1,361 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { generateReportCompliance } from './report-compliance.js'
+import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
+import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
+import { buildApprovedOrg } from '#vite/helpers/build-approved-org.js'
+import { buildSubmittedReport } from '#vite/helpers/build-submitted-report.js'
+import {
+  ORGANISATION_STATUS,
+  REG_ACC_STATUS,
+  REPROCESSING_TYPE
+} from '#domain/organisations/model.js'
+import {
+  buildOrganisation,
+  prepareOrgUpdate,
+  getValidDateRange
+} from '#repositories/organisations/contract/test-data.js'
+import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds an org where the registration is approved but the accreditation
+ * remains in 'created' status — i.e. a registered-only (quarterly) operator.
+ */
+async function buildRegisteredOnlyOrg(orgRepo) {
+  const org = buildOrganisation()
+  const INITIAL_VERSION = 1
+
+  await orgRepo.insert(org)
+
+  const { VALID_FROM, VALID_TO } = getValidDateRange()
+
+  const approvedRegistrations = [
+    {
+      ...org.registrations[0],
+      status: REG_ACC_STATUS.APPROVED,
+      registrationNumber: 'REG1',
+      reprocessingType: REPROCESSING_TYPE.INPUT,
+      validFrom: VALID_FROM,
+      validTo: VALID_TO
+    }
+  ]
+
+  await orgRepo.replace(
+    org.id,
+    INITIAL_VERSION,
+    prepareOrgUpdate(org, {
+      status: ORGANISATION_STATUS.APPROVED,
+      registrations: approvedRegistrations
+    })
+  )
+
+  return waitForVersion(orgRepo, org.id, INITIAL_VERSION + 1)
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests
+// ---------------------------------------------------------------------------
+
+const FIXED_DATE = new Date('2026-04-17T10:00:00.000Z')
+const SUBMITTED_DATE = '2026-04-17'
+
+// All ended reporting periods for the current year (2026) at FIXED_DATE 2026-04-17:
+// Jan, Feb, Mar, Q1 — Apr has not yet ended.
+const EXPECTED_PERIODS = [
+  {
+    key: '2026:monthly:1',
+    cadence: 'monthly',
+    year: 2026,
+    period: 1,
+    label: 'Jan Report',
+    startDate: '2026-01-01',
+    endDate: '2026-01-31',
+    dueDate: '2026-02-20'
+  },
+  {
+    key: '2026:monthly:2',
+    cadence: 'monthly',
+    year: 2026,
+    period: 2,
+    label: 'Feb Report',
+    startDate: '2026-02-01',
+    endDate: '2026-02-28',
+    dueDate: '2026-03-20'
+  },
+  {
+    key: '2026:monthly:3',
+    cadence: 'monthly',
+    year: 2026,
+    period: 3,
+    label: 'Mar Report',
+    startDate: '2026-03-01',
+    endDate: '2026-03-31',
+    dueDate: '2026-04-20'
+  },
+  {
+    key: '2026:quarterly:1',
+    cadence: 'quarterly',
+    year: 2026,
+    period: 1,
+    label: 'Q1 Report',
+    startDate: '2026-01-01',
+    endDate: '2026-03-31',
+    dueDate: '2026-04-20'
+  }
+]
+
+// submittedDates for a monthly operator with no submissions (all applicable period keys present, values null)
+const MONTHLY_EMPTY_DATES = new Map([
+  ['2026:monthly:1', null],
+  ['2026:monthly:2', null],
+  ['2026:monthly:3', null]
+])
+
+describe('generateReportCompliance', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(FIXED_DATE)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns an ordered periods list covering both cadences', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    const org = await buildApprovedOrg(orgRepo)
+    const reg = org.registrations[0]
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          reg.id,
+          {
+            registrationId: reg.id,
+            organisationId: org.id,
+            submittedDates: MONTHLY_EMPTY_DATES
+          }
+        ]
+      ])
+    })
+  })
+
+  it('places monthly March before quarterly Q1 in the periods list', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    const org = await buildApprovedOrg(orgRepo)
+    const reg = org.registrations[0]
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
+    // EXPECTED_PERIODS has Mar 2026 (index 14) before Q1 2026 (index 15)
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          reg.id,
+          {
+            registrationId: reg.id,
+            organisationId: org.id,
+            submittedDates: MONTHLY_EMPTY_DATES
+          }
+        ]
+      ])
+    })
+  })
+
+  it('records submitted date for an accredited (monthly) operator', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    const org = await buildApprovedOrg(orgRepo)
+    const reg = org.registrations[0]
+
+    await buildSubmittedReport(reportsRepo, {
+      organisationId: org.id,
+      registrationId: reg.id,
+      year: 2026,
+      cadence: 'monthly',
+      period: 1
+    })
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          reg.id,
+          {
+            registrationId: reg.id,
+            organisationId: org.id,
+            submittedDates: new Map([
+              ['2026:monthly:1', SUBMITTED_DATE],
+              ['2026:monthly:2', null],
+              ['2026:monthly:3', null]
+            ])
+          }
+        ]
+      ])
+    })
+  })
+
+  it('records submitted date for a registered-only (quarterly) operator', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    const org = await buildRegisteredOnlyOrg(orgRepo)
+    const reg = org.registrations[0]
+
+    await buildSubmittedReport(reportsRepo, {
+      organisationId: org.id,
+      registrationId: reg.id,
+      year: 2026,
+      cadence: 'quarterly',
+      period: 1
+    })
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          reg.id,
+          {
+            registrationId: reg.id,
+            organisationId: org.id,
+            submittedDates: new Map([['2026:quarterly:1', SUBMITTED_DATE]])
+          }
+        ]
+      ])
+    })
+  })
+
+  it('has null values in submittedDates for applicable but unsubmitted periods', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    const org = await buildApprovedOrg(orgRepo)
+    const reg = org.registrations[0]
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          reg.id,
+          {
+            registrationId: reg.id,
+            organisationId: org.id,
+            submittedDates: MONTHLY_EMPTY_DATES
+          }
+        ]
+      ])
+    })
+  })
+
+  it('produces one entry per registration across multiple orgs', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    const org1 = await buildApprovedOrg(orgRepo)
+    const org2 = await buildApprovedOrg(orgRepo)
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          org1.registrations[0].id,
+          {
+            registrationId: org1.registrations[0].id,
+            organisationId: org1.id,
+            submittedDates: MONTHLY_EMPTY_DATES
+          }
+        ],
+        [
+          org2.registrations[0].id,
+          {
+            registrationId: org2.registrations[0].id,
+            organisationId: org2.id,
+            submittedDates: MONTHLY_EMPTY_DATES
+          }
+        ]
+      ])
+    })
+  })
+
+  it('excludes test organisations from entries', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    // orgId 999999 is a test org (see parse-test-organisations config)
+    await buildApprovedOrg(orgRepo, { orgId: 999999 })
+    const normalOrg = await buildApprovedOrg(orgRepo)
+    const normalReg = normalOrg.registrations[0]
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          normalReg.id,
+          {
+            registrationId: normalReg.id,
+            organisationId: normalOrg.id,
+            submittedDates: MONTHLY_EMPTY_DATES
+          }
+        ]
+      ])
+    })
+  })
+
+  it('includes submissions from earlier months within the current year', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    const org = await buildApprovedOrg(orgRepo)
+    const reg = org.registrations[0]
+
+    await buildSubmittedReport(reportsRepo, {
+      organisationId: org.id,
+      registrationId: reg.id,
+      year: 2026,
+      cadence: 'monthly',
+      period: 2
+    })
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          reg.id,
+          {
+            registrationId: reg.id,
+            organisationId: org.id,
+            submittedDates: new Map([
+              ['2026:monthly:1', null],
+              ['2026:monthly:2', SUBMITTED_DATE],
+              ['2026:monthly:3', null]
+            ])
+          }
+        ]
+      ])
+    })
+  })
+})

--- a/src/reports/application/report-submissions.js
+++ b/src/reports/application/report-submissions.js
@@ -6,13 +6,11 @@ import { generateReportingPeriods } from '#reports/domain/generate-reporting-per
 import { mergeReportingPeriods } from '#reports/domain/merge-reporting-periods.js'
 import { formatMaterial, capitalize } from '#common/helpers/formatters.js'
 import { formatPeriodLabel } from '#reports/domain/period-labels.js'
+import { REGULATOR_DISPLAY } from '#domain/organisations/model.js'
 import {
-  REG_ACC_STATUS,
-  REGULATOR_DISPLAY
-} from '#domain/organisations/model.js'
-import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
-
-const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
+  getReportableRegistrations,
+  resolveAccreditationNumber
+} from '#domain/organisations/registration-utils.js'
 
 /**
  * @typedef {Object} TonnageFields
@@ -54,35 +52,6 @@ const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
 /** @typedef {SubmissionBaseFields & TonnageFields} ReportSubmissionsRow */
 
-/** @type {Set<string>} */
-const INCLUDED_STATUSES = new Set([
-  REG_ACC_STATUS.APPROVED,
-  REG_ACC_STATUS.SUSPENDED
-])
-
-/**
- * @param {import('#repositories/organisations/port.js').OrganisationsRepository} organisationsRepository
- * @returns {Promise<Array<{ org: Organisation, registration: RegistrationApproved }>>}
- */
-async function getRegistrations(organisationsRepository) {
-  const orgs = await organisationsRepository.findAll()
-  return orgs
-    .filter((org) => !TEST_ORGANISATIONS.has(org.orgId))
-    .flatMap((org) =>
-      org.registrations
-        .filter((registration) => INCLUDED_STATUSES.has(registration.status))
-        .map((registration) => ({
-          org,
-          registration: /** @type {RegistrationApproved} */ (registration)
-        }))
-    )
-}
-
-/**
- * @param {RegistrationApproved} registration
- * @param {Organisation} org
- * @returns {string}
- */
 /**
  * @param {number | null | undefined} value
  * @returns {string}
@@ -104,17 +73,6 @@ function sumSentOn(wasteSent) {
       wasteSent.tonnageSentToExporter +
       wasteSent.tonnageSentToAnotherSite
   )
-}
-
-function resolveAccreditationNumber(registration, org) {
-  if (!registration.accreditationId) {
-    return ''
-  }
-  const accreditation = org.accreditations.find(
-    (a) =>
-      a.id === registration.accreditationId && INCLUDED_STATUSES.has(a.status)
-  )
-  return accreditation?.accreditationNumber ?? ''
 }
 
 /**
@@ -218,7 +176,9 @@ async function buildSubmissionRows(
   currentYear,
   reportsByKey
 ) {
-  const registrations = await getRegistrations(organisationsRepository)
+  const registrations = getReportableRegistrations(
+    await organisationsRepository.findAll()
+  )
 
   /** @type {ReportSubmissionsRow[]} */
   return registrations.flatMap(({ org, registration }) => {

--- a/src/reports/domain/compliance-reporting-periods.js
+++ b/src/reports/domain/compliance-reporting-periods.js
@@ -1,0 +1,100 @@
+import { CADENCE } from './cadence.js'
+import { generateReportingPeriods } from './generate-reporting-periods.js'
+
+/**
+ * @typedef {{
+ *   key: string;
+ *   cadence: string;
+ *   year: number;
+ *   period: number;
+ *   label: string;
+ *   startDate: string;
+ *   endDate: string;
+ *   dueDate: string;
+ * }} CompliancePeriod
+ */
+
+const MONTH_ABBR = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec'
+]
+
+/**
+ * @param {string} cadence
+ * @param {number} period
+ * @returns {string} e.g. 'Jan Report', 'Q1 Report'
+ */
+function complianceLabel(cadence, period) {
+  return cadence === 'monthly'
+    ? `${MONTH_ABBR[period - 1]} Report`
+    : `Q${period} Report`
+}
+
+/**
+ * @param {object} p - Period from generateReportingPeriods
+ * @param {string} cadence
+ * @returns {CompliancePeriod}
+ */
+function annotate(p, cadence) {
+  return {
+    key: `${p.year}:${cadence}:${p.period}`,
+    cadence,
+    year: p.year,
+    period: p.period,
+    label: complianceLabel(cadence, p.period),
+    startDate: p.startDate,
+    endDate: p.endDate,
+    dueDate: p.dueDate
+  }
+}
+
+/** @param {{ period: number }} p */
+function isQuarterEnd(p) {
+  return p.period % 3 === 0
+}
+
+/**
+ * @param {number} year
+ * @param {Date} now
+ * @returns {Map<number, object>}
+ */
+function quarterlyByPeriod(year, now) {
+  return new Map(
+    generateReportingPeriods(CADENCE.quarterly, year, now).map((q) => [
+      q.period,
+      q
+    ])
+  )
+}
+
+/**
+ * Returns all ended reporting periods (both cadences) for the current calendar year,
+ * from January 1 through today, ordered ascending by end date with monthly
+ * before quarterly on the same end date.
+ *
+ * @returns {CompliancePeriod[]}
+ */
+export function generateComplianceReportingPeriods() {
+  const now = new Date()
+  const year = now.getUTCFullYear()
+  const quarterly = quarterlyByPeriod(year, now)
+
+  const result = []
+  for (const p of generateReportingPeriods(CADENCE.monthly, year, now)) {
+    result.push(annotate(p, CADENCE.monthly))
+    if (isQuarterEnd(p)) {
+      result.push(annotate(quarterly.get(p.period / 3), CADENCE.quarterly))
+    }
+  }
+  return result
+}

--- a/src/reports/domain/compliance-reporting-periods.js
+++ b/src/reports/domain/compliance-reporting-periods.js
@@ -14,6 +14,8 @@ import { generateReportingPeriods } from './generate-reporting-periods.js'
  * }} CompliancePeriod
  */
 
+const MONTHS_PER_QUARTER = 3
+
 const MONTH_ABBR = [
   'Jan',
   'Feb',
@@ -60,7 +62,7 @@ function annotate(p, cadence) {
 
 /** @param {{ period: number }} p */
 function isQuarterEnd(p) {
-  return p.period % 3 === 0
+  return p.period % MONTHS_PER_QUARTER === 0
 }
 
 /**
@@ -93,7 +95,12 @@ export function generateComplianceReportingPeriods() {
   for (const p of generateReportingPeriods(CADENCE.monthly, year, now)) {
     result.push(annotate(p, CADENCE.monthly))
     if (isQuarterEnd(p)) {
-      result.push(annotate(quarterly.get(p.period / 3), CADENCE.quarterly))
+      result.push(
+        annotate(
+          quarterly.get(p.period / MONTHS_PER_QUARTER),
+          CADENCE.quarterly
+        )
+      )
     }
   }
   return result

--- a/src/reports/domain/compliance-reporting-periods.test.js
+++ b/src/reports/domain/compliance-reporting-periods.test.js
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { generateComplianceReportingPeriods } from './compliance-reporting-periods.js'
+
+describe('generateComplianceReportingPeriods', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns [] when no period has ended yet', () => {
+    vi.setSystemTime(new Date('2026-01-15T00:00:00Z'))
+
+    expect(generateComplianceReportingPeriods()).toEqual([])
+  })
+
+  it('returns Jan only when January has just ended', () => {
+    vi.setSystemTime(new Date('2026-02-01T00:00:00Z'))
+
+    expect(generateComplianceReportingPeriods()).toEqual([
+      {
+        key: '2026:monthly:1',
+        cadence: 'monthly',
+        year: 2026,
+        period: 1,
+        label: 'Jan Report',
+        startDate: '2026-01-01',
+        endDate: '2026-01-31',
+        dueDate: '2026-02-20'
+      }
+    ])
+  })
+
+  it('returns monthly periods followed by Q1 when now is mid-April', () => {
+    vi.setSystemTime(new Date('2025-04-15T00:00:00Z'))
+
+    expect(generateComplianceReportingPeriods()).toEqual([
+      {
+        key: '2025:monthly:1',
+        cadence: 'monthly',
+        year: 2025,
+        period: 1,
+        label: 'Jan Report',
+        startDate: '2025-01-01',
+        endDate: '2025-01-31',
+        dueDate: '2025-02-20'
+      },
+      {
+        key: '2025:monthly:2',
+        cadence: 'monthly',
+        year: 2025,
+        period: 2,
+        label: 'Feb Report',
+        startDate: '2025-02-01',
+        endDate: '2025-02-28',
+        dueDate: '2025-03-20'
+      },
+      {
+        key: '2025:monthly:3',
+        cadence: 'monthly',
+        year: 2025,
+        period: 3,
+        label: 'Mar Report',
+        startDate: '2025-03-01',
+        endDate: '2025-03-31',
+        dueDate: '2025-04-20'
+      },
+      {
+        key: '2025:quarterly:1',
+        cadence: 'quarterly',
+        year: 2025,
+        period: 1,
+        label: 'Q1 Report',
+        startDate: '2025-01-01',
+        endDate: '2025-03-31',
+        dueDate: '2025-04-20'
+      }
+    ])
+  })
+
+  it('returns ended periods through Q2 when now is mid-July', () => {
+    vi.setSystemTime(new Date('2025-07-15T00:00:00Z'))
+
+    expect(generateComplianceReportingPeriods()).toEqual([
+      {
+        key: '2025:monthly:1',
+        cadence: 'monthly',
+        year: 2025,
+        period: 1,
+        label: 'Jan Report',
+        startDate: '2025-01-01',
+        endDate: '2025-01-31',
+        dueDate: '2025-02-20'
+      },
+      {
+        key: '2025:monthly:2',
+        cadence: 'monthly',
+        year: 2025,
+        period: 2,
+        label: 'Feb Report',
+        startDate: '2025-02-01',
+        endDate: '2025-02-28',
+        dueDate: '2025-03-20'
+      },
+      {
+        key: '2025:monthly:3',
+        cadence: 'monthly',
+        year: 2025,
+        period: 3,
+        label: 'Mar Report',
+        startDate: '2025-03-01',
+        endDate: '2025-03-31',
+        dueDate: '2025-04-20'
+      },
+      {
+        key: '2025:quarterly:1',
+        cadence: 'quarterly',
+        year: 2025,
+        period: 1,
+        label: 'Q1 Report',
+        startDate: '2025-01-01',
+        endDate: '2025-03-31',
+        dueDate: '2025-04-20'
+      },
+      {
+        key: '2025:monthly:4',
+        cadence: 'monthly',
+        year: 2025,
+        period: 4,
+        label: 'Apr Report',
+        startDate: '2025-04-01',
+        endDate: '2025-04-30',
+        dueDate: '2025-05-20'
+      },
+      {
+        key: '2025:monthly:5',
+        cadence: 'monthly',
+        year: 2025,
+        period: 5,
+        label: 'May Report',
+        startDate: '2025-05-01',
+        endDate: '2025-05-31',
+        dueDate: '2025-06-20'
+      },
+      {
+        key: '2025:monthly:6',
+        cadence: 'monthly',
+        year: 2025,
+        period: 6,
+        label: 'Jun Report',
+        startDate: '2025-06-01',
+        endDate: '2025-06-30',
+        dueDate: '2025-07-20'
+      },
+      {
+        key: '2025:quarterly:2',
+        cadence: 'quarterly',
+        year: 2025,
+        period: 2,
+        label: 'Q2 Report',
+        startDate: '2025-04-01',
+        endDate: '2025-06-30',
+        dueDate: '2025-07-20'
+      }
+    ])
+  })
+})

--- a/src/routes/v1/public-register/generate/post.js
+++ b/src/routes/v1/public-register/generate/post.js
@@ -12,6 +12,7 @@ import { auditPublicRegisterGenerate } from '#root/auditing/public-register.js'
  * @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository
  * @typedef {import('#domain/public-register/repository/port.js').PublicRegisterRepository} PublicRegisterRepository
  * @typedef {import('#repositories/system-logs/port.js').SystemLogsRepository} SystemLogsRepository
+ * @typedef {import('#reports/repository/port.js').ReportsRepository} ReportsRepository
  */
 
 export const publicRegisterGeneratePath = '/v1/public-register/generate'
@@ -26,16 +27,21 @@ export const generateLatestPublicRegister = {
     tags: ['api', 'admin']
   },
   /**
-   * @param {import('#common/hapi-types.js').HapiRequest & {organisationsRepository: OrganisationsRepository, publicRegisterRepository: PublicRegisterRepository, systemLogsRepository: SystemLogsRepository}} request
+   * @param {import('#common/hapi-types.js').HapiRequest & {organisationsRepository: OrganisationsRepository, publicRegisterRepository: PublicRegisterRepository, systemLogsRepository: SystemLogsRepository, reportsRepository: ReportsRepository}} request
    * @param {Object} h - Hapi response toolkit
    */
   handler: async (request, h) => {
-    const { organisationsRepository, publicRegisterRepository, logger } =
-      request
+    const {
+      organisationsRepository,
+      publicRegisterRepository,
+      reportsRepository,
+      logger
+    } = request
     try {
       const result = await generatePublicRegister(
         organisationsRepository,
-        publicRegisterRepository
+        publicRegisterRepository,
+        reportsRepository
       )
 
       const generatedTime = new Date().toISOString()


### PR DESCRIPTION
Ticket: [PAE-1424](https://eaflood.atlassian.net/browse/PAE-1424)
- Add dynamic compliance period columns (Jan–Dec, Q1–Q4) to the public register CSV, sourced from `generateReportCompliance`
- Include cancelled registrations in compliance reporting alongside approved and suspended
- Encode period applicability in `submittedDates` map (key present = applicable, absent = N/A; value null = not yet submitted, date string = submitted)
- Extract compliance field building out of `transformRegAcc` into a dedicated `buildReportComplianceFields` function

[PAE-1424]: https://eaflood.atlassian.net/browse/PAE-1424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ