### PR TITLE
PAE-250: Remove stale protobufjs override

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
   "overrides": {
     "fast-xml-parser": "5.7.3",
     "glob": "11.1.0",
-    "protobufjs": "7.5.6",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

The `protobufjs@7.5.6` npm override was added to address a previous transitive
vulnerability. The parent dependency (`@grpc/proto-loader`) has since updated
its own dependency range to resolve a non-vulnerable version of protobufjs
without the override.

This PR removes the stale override entry from `package.json` and updates
`package-lock.json` accordingly.

Verified clean against both `npm audit` and `snyk test` after removal.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ