### PR TITLE
PAE-1424: Fix submittedDate shown for unsubmitted reports on public register

### DIFF
--- a/.vite/helpers/build-unsubmitted-report.js
+++ b/.vite/helpers/build-unsubmitted-report.js
@@ -1,0 +1,26 @@
+import { REPORT_STATUS } from '#reports/domain/report-status.js'
+import { buildSubmittedReport } from './build-submitted-report.js'
+
+const SUBMITTER = { id: 'user-1', name: 'Jane Smith', position: 'Officer' }
+
+/**
+ * Creates a report, submits it, then unsubmits it (back to ready_to_submit).
+ *
+ * @param {import('#reports/repository/port.js').ReportsRepository} reportsRepository
+ * @param {Partial<import('#reports/repository/port.js').CreateReportParams>} [overrides]
+ * @returns {Promise<string>} the report id
+ */
+export async function buildUnsubmittedReport(
+  reportsRepository,
+  overrides = {}
+) {
+  const id = await buildSubmittedReport(reportsRepository, overrides)
+  await reportsRepository.updateReportStatus({
+    reportId: id,
+    version: 3,
+    status: REPORT_STATUS.READY_TO_SUBMIT,
+    slot: 'unsubmitted',
+    changedBy: SUBMITTER
+  })
+  return id
+}

--- a/src/common/helpers/polling/wait-for-version.js
+++ b/src/common/helpers/polling/wait-for-version.js
@@ -6,10 +6,11 @@ const RETRY_DELAY_MS = 25
  * Polls repository until expected version appears or timeout occurs.
  * Works with both inmemory adapter (eventual consistency) and real MongoDB.
  *
- * @param {object} repository - Repository instance with findById method
+ * @template {{ version: number }} T
+ * @param {{ findById: (id: string) => Promise<T> }} repository - Repository instance with findById method
  * @param {string} id - Resource ID to poll
  * @param {number} expectedVersion - Version number to wait for
- * @returns {Promise<{version: number}>}
+ * @returns {Promise<T>}
  * @throws {Error} If expected version not reached after MAX_RETRIES
  */
 export const waitForVersion = async (repository, id, expectedVersion) => {

--- a/src/reports/application/report-compliance.js
+++ b/src/reports/application/report-compliance.js
@@ -2,6 +2,7 @@ import { CADENCE } from '#reports/domain/cadence.js'
 import { generateReportingPeriods } from '#reports/domain/generate-reporting-periods.js'
 import { mergeReportingPeriods } from '#reports/domain/merge-reporting-periods.js'
 import { generateComplianceReportingPeriods } from '#reports/domain/compliance-reporting-periods.js'
+import { REPORT_STATUS } from '#reports/domain/report-status.js'
 import {
   getReportableRegistrations,
   resolveAccreditationNumber
@@ -92,7 +93,12 @@ export async function generateReportCompliance(
       for (const mergedPeriod of merged) {
         submittedDates.set(
           `${mergedPeriod.year}:${cadence}:${mergedPeriod.period}`,
-          mergedPeriod.report?.submittedAt?.slice(0, 10) ?? null
+          mergedPeriod.report?.status === REPORT_STATUS.SUBMITTED
+            ? /** @type {string} */ (mergedPeriod.report.submittedAt).slice(
+                0,
+                10
+              )
+            : null
         )
       }
     }

--- a/src/reports/application/report-compliance.test.js
+++ b/src/reports/application/report-compliance.test.js
@@ -4,6 +4,7 @@ import { createInMemoryOrganisationsRepository } from '#repositories/organisatio
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import { buildApprovedOrg } from '#vite/helpers/build-approved-org.js'
 import { buildSubmittedReport } from '#vite/helpers/build-submitted-report.js'
+import { buildUnsubmittedReport } from '#vite/helpers/build-unsubmitted-report.js'
 import {
   ORGANISATION_STATUS,
   REG_ACC_STATUS,
@@ -203,6 +204,38 @@ describe('generateReportCompliance', () => {
               ['2026:monthly:2', null],
               ['2026:monthly:3', null]
             ])
+          }
+        ]
+      ])
+    })
+  })
+
+  it('returns null submittedDate for a report that has been unsubmitted', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    const org = await buildApprovedOrg(orgRepo)
+    const reg = org.registrations[0]
+
+    await buildUnsubmittedReport(reportsRepo, {
+      organisationId: org.id,
+      registrationId: reg.id,
+      year: 2026,
+      cadence: 'monthly',
+      period: 1
+    })
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          reg.id,
+          {
+            registrationId: reg.id,
+            organisationId: org.id,
+            submittedDates: MONTHLY_EMPTY_DATES
           }
         ]
       ])


### PR DESCRIPTION
Ticket: [PAE-1424](https://eaflood.atlassian.net/browse/PAE-1424)
- Guard `submittedDates` population in `generateReportCompliance` so the date is only recorded when `report.status === SUBMITTED`; an unsubmitted report (status `READY_TO_SUBMIT`) now yields `null` instead of the stale original submission date
- Add `buildUnsubmittedReport` test helper and a new test asserting the compliance entry shows `null` for a period whose report has been unsubmitted

[PAE-1424]: https://eaflood.atlassian.net/browse/PAE-1424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ