### PR TITLE
PAE-1382: Add stream application primitives

### DIFF
--- a/src/waste-balances/application/append-to-stream.js
+++ b/src/waste-balances/application/append-to-stream.js
@@ -1,0 +1,160 @@
+import { add, subtract, toNumber } from '#common/helpers/decimal-utils.js'
+
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+
+const ZERO_BALANCE = Object.freeze({ amount: 0, availableAmount: 0 })
+
+/**
+ * @param {import('../repository/stream-port.js').StreamEvent | null} latest
+ */
+const openingBalanceFrom = (latest) =>
+  latest === null ? { ...ZERO_BALANCE } : { ...latest.closingBalance }
+
+/**
+ * @param {import('../repository/stream-port.js').StreamEvent | null} latest
+ */
+const nextNumberFrom = (latest) => (latest === null ? 1 : latest.number + 1)
+
+/**
+ * Compute closing balance for a summary-log-submitted event.
+ *
+ * The caller supplies the aggregate `creditTotal` for this submission.
+ * We read the previous summary-log-submitted event (if any) and compute
+ * `delta = creditTotal - previousCreditTotal`. Both `amount` and
+ * `availableAmount` shift by delta.
+ *
+ * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} opening
+ * @param {number} creditTotal
+ * @param {number} previousCreditTotal
+ * @returns {import('../repository/stream-schema.js').StreamBalanceSnapshot}
+ */
+const closingForSummaryLogSubmitted = (
+  opening,
+  creditTotal,
+  previousCreditTotal
+) => {
+  const delta = subtract(creditTotal, previousCreditTotal)
+  return {
+    amount: toNumber(add(opening.amount, delta)),
+    availableAmount: toNumber(add(opening.availableAmount, delta))
+  }
+}
+
+/**
+ * Compute closing balance for a PRN event.
+ *
+ * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} opening
+ * @param {import('../repository/stream-schema.js').StreamEventKind} kind
+ * @param {number} prnAmount
+ * @returns {import('../repository/stream-schema.js').StreamBalanceSnapshot}
+ */
+const closingForPrn = (opening, kind, prnAmount) => {
+  switch (kind) {
+    case STREAM_EVENT_KIND.PRN_CREATED:
+      return {
+        amount: opening.amount,
+        availableAmount: toNumber(subtract(opening.availableAmount, prnAmount))
+      }
+    case STREAM_EVENT_KIND.PRN_ISSUED:
+      return {
+        amount: toNumber(subtract(opening.amount, prnAmount)),
+        availableAmount: opening.availableAmount
+      }
+    case STREAM_EVENT_KIND.PRN_CREATION_CANCELLED:
+      return {
+        amount: opening.amount,
+        availableAmount: toNumber(add(opening.availableAmount, prnAmount))
+      }
+    case STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE:
+      return {
+        amount: toNumber(add(opening.amount, prnAmount)),
+        availableAmount: toNumber(add(opening.availableAmount, prnAmount))
+      }
+    default:
+      throw new Error(`Unknown PRN event kind: ${kind}`)
+  }
+}
+
+/**
+ * Append a single event to the waste balance stream.
+ *
+ * Reads the latest event to determine the opening balance and next slot
+ * number, computes the closing balance based on the event kind, and
+ * persists the event.
+ *
+ * For `summary-log-submitted` events, also reads the latest event of
+ * that kind to determine the previous `creditTotal` for delta computation.
+ *
+ * Slot conflicts and idempotency conflicts surface directly to the caller.
+ *
+ * @param {{
+ *   repository: import('../repository/stream-port.js').WasteBalanceStreamRepository,
+ *   registrationId: string,
+ *   accreditationId: string | null,
+ *   organisationId: string
+ * }} context
+ * @param {{
+ *   kind: import('../repository/stream-schema.js').StreamEventKind,
+ *   payload: import('../repository/stream-schema.js').SummaryLogSubmittedPayload | import('../repository/stream-schema.js').PrnPayload,
+ *   createdBy: import('../repository/stream-schema.js').StreamUserSummary
+ * }} event
+ * @returns {Promise<import('../repository/stream-port.js').StreamEvent>}
+ */
+export const appendToStream = async (
+  { repository, registrationId, accreditationId, organisationId },
+  { kind, payload, createdBy }
+) => {
+  const latest = await repository.findLatestByPartition(
+    registrationId,
+    accreditationId
+  )
+
+  const openingBalance = openingBalanceFrom(latest)
+  const number = nextNumberFrom(latest)
+
+  let closingBalance
+
+  if (kind === STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED) {
+    const { creditTotal } =
+      /** @type {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} */ (
+        payload
+      )
+
+    const previousSubmission = await repository.findLatestByPartitionAndKind(
+      registrationId,
+      accreditationId,
+      STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED
+    )
+
+    const previousCreditTotal = previousSubmission
+      ? /** @type {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} */ (
+          previousSubmission.payload
+        ).creditTotal
+      : 0
+
+    closingBalance = closingForSummaryLogSubmitted(
+      openingBalance,
+      creditTotal,
+      previousCreditTotal
+    )
+  } else {
+    const { amount } =
+      /** @type {import('../repository/stream-schema.js').PrnPayload} */ (
+        payload
+      )
+    closingBalance = closingForPrn(openingBalance, kind, amount)
+  }
+
+  return repository.appendEvent({
+    registrationId,
+    accreditationId,
+    organisationId,
+    number,
+    kind,
+    payload,
+    openingBalance,
+    closingBalance,
+    createdAt: new Date(),
+    createdBy
+  })
+}

--- a/src/waste-balances/application/append-to-stream.test.js
+++ b/src/waste-balances/application/append-to-stream.test.js
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { createInMemoryStreamRepository } from '../repository/stream-inmemory.js'
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import { StreamSlotConflictError } from '../repository/stream-port.js'
+import { appendToStream } from './append-to-stream.js'
+
+const buildContext = (overrides = {}) => ({
+  registrationId: 'reg-1',
+  accreditationId: 'acc-1',
+  organisationId: 'org-1',
+  ...overrides
+})
+
+const createdBy = { id: 'user-1', name: 'Test User' }
+
+describe('appendToStream', () => {
+  describe('summary-log-submitted', () => {
+    it('first submission: delta equals creditTotal, opening balance is zero', async () => {
+      const repository = createInMemoryStreamRepository()()
+      const context = {
+        repository,
+        ...buildContext()
+      }
+
+      const result = await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-1', creditTotal: 1500 },
+        createdBy
+      })
+
+      expect(result.number).toBe(1)
+      expect(result.openingBalance).toEqual({ amount: 0, availableAmount: 0 })
+      expect(result.closingBalance).toEqual({
+        amount: 1500,
+        availableAmount: 1500
+      })
+    })
+
+    it('second submission: delta is creditTotal minus previousCreditTotal', async () => {
+      const repository = createInMemoryStreamRepository()()
+      const context = { repository, ...buildContext() }
+
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-1', creditTotal: 2000 },
+        createdBy
+      })
+
+      const result = await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-2', creditTotal: 3500 },
+        createdBy
+      })
+
+      expect(result.number).toBe(2)
+      expect(result.openingBalance).toEqual({
+        amount: 2000,
+        availableAmount: 2000
+      })
+      expect(result.closingBalance).toEqual({
+        amount: 3500,
+        availableAmount: 3500
+      })
+    })
+
+    it('submission with lower creditTotal than previous produces a negative delta', async () => {
+      const repository = createInMemoryStreamRepository()()
+      const context = { repository, ...buildContext() }
+
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-1', creditTotal: 2000 },
+        createdBy
+      })
+
+      const result = await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-2', creditTotal: 1000 },
+        createdBy
+      })
+
+      expect(result.closingBalance).toEqual({
+        amount: 1000,
+        availableAmount: 1000
+      })
+    })
+
+    it('uses openingBalance from the latest event of any kind, not just latest submission', async () => {
+      const repository = createInMemoryStreamRepository()()
+      const context = { repository, ...buildContext() }
+
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-1', creditTotal: 2000 },
+        createdBy
+      })
+
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.PRN_CREATED,
+        payload: { prnId: 'prn-1', amount: 800 },
+        createdBy
+      })
+
+      const result = await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-2', creditTotal: 3500 },
+        createdBy
+      })
+
+      expect(result.number).toBe(3)
+      expect(result.openingBalance).toEqual({
+        amount: 2000,
+        availableAmount: 1200
+      })
+      expect(result.closingBalance).toEqual({
+        amount: 3500,
+        availableAmount: 2700
+      })
+    })
+
+    it('slot conflict surfaces to caller', async () => {
+      const slotConflict = new StreamSlotConflictError('reg-1', 'acc-1', 1)
+      const repository = /** @type {*} */ ({
+        findLatestByPartition: vi.fn().mockResolvedValue(null),
+        findLatestByPartitionAndKind: vi.fn().mockResolvedValue(null),
+        appendEvent: vi.fn().mockRejectedValue(slotConflict)
+      })
+
+      await expect(
+        appendToStream(
+          { repository, ...buildContext() },
+          {
+            kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+            payload: { summaryLogId: 'log-1', creditTotal: 100 },
+            createdBy
+          }
+        )
+      ).rejects.toBe(slotConflict)
+    })
+  })
+
+  describe('prn-created', () => {
+    it('decrements closingBalance.availableAmount by PRN amount; amount unchanged', async () => {
+      const repository = createInMemoryStreamRepository()()
+      const context = { repository, ...buildContext() }
+
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+        createdBy
+      })
+
+      const result = await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.PRN_CREATED,
+        payload: { prnId: 'prn-1', amount: 300 },
+        createdBy
+      })
+
+      expect(result.closingBalance).toEqual({
+        amount: 1000,
+        availableAmount: 700
+      })
+    })
+
+    it('openingBalance taken from latest event', async () => {
+      const repository = createInMemoryStreamRepository()()
+      const context = { repository, ...buildContext() }
+
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+        createdBy
+      })
+
+      const result = await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.PRN_CREATED,
+        payload: { prnId: 'prn-1', amount: 300 },
+        createdBy
+      })
+
+      expect(result.openingBalance).toEqual({
+        amount: 1000,
+        availableAmount: 1000
+      })
+    })
+  })
+
+  describe('prn-issued', () => {
+    it('decrements closingBalance.amount by PRN amount; availableAmount unchanged', async () => {
+      const repository = createInMemoryStreamRepository()()
+      const context = { repository, ...buildContext() }
+
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+        createdBy
+      })
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.PRN_CREATED,
+        payload: { prnId: 'prn-1', amount: 300 },
+        createdBy
+      })
+
+      const result = await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.PRN_ISSUED,
+        payload: { prnId: 'prn-1', amount: 300 },
+        createdBy
+      })
+
+      expect(result.closingBalance).toEqual({
+        amount: 700,
+        availableAmount: 700
+      })
+    })
+  })
+
+  describe('prn-creation-cancelled', () => {
+    it('increments closingBalance.availableAmount by PRN amount; amount unchanged', async () => {
+      const repository = createInMemoryStreamRepository()()
+      const context = { repository, ...buildContext() }
+
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+        createdBy
+      })
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.PRN_CREATED,
+        payload: { prnId: 'prn-1', amount: 300 },
+        createdBy
+      })
+
+      const result = await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
+        payload: { prnId: 'prn-1', amount: 300 },
+        createdBy
+      })
+
+      expect(result.closingBalance).toEqual({
+        amount: 1000,
+        availableAmount: 1000
+      })
+    })
+  })
+
+  describe('prn-cancelled-after-issue', () => {
+    it('increments both closingBalance.amount and closingBalance.availableAmount', async () => {
+      const repository = createInMemoryStreamRepository()()
+      const context = { repository, ...buildContext() }
+
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+        createdBy
+      })
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.PRN_CREATED,
+        payload: { prnId: 'prn-1', amount: 300 },
+        createdBy
+      })
+      await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.PRN_ISSUED,
+        payload: { prnId: 'prn-1', amount: 300 },
+        createdBy
+      })
+
+      const result = await appendToStream(context, {
+        kind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+        payload: { prnId: 'prn-1', amount: 300 },
+        createdBy
+      })
+
+      expect(result.closingBalance).toEqual({
+        amount: 1000,
+        availableAmount: 1000
+      })
+    })
+  })
+
+  describe('unknown kind', () => {
+    it('throws for an unrecognised PRN event kind', async () => {
+      const repository = /** @type {*} */ ({
+        findLatestByPartition: vi.fn().mockResolvedValue(null),
+        findLatestByPartitionAndKind: vi.fn().mockResolvedValue(null),
+        appendEvent: vi.fn()
+      })
+
+      await expect(
+        appendToStream(
+          { repository, ...buildContext() },
+          {
+            kind: /** @type {*} */ ('unknown-kind'),
+            payload: { prnId: 'prn-1', amount: 100 },
+            createdBy
+          }
+        )
+      ).rejects.toThrow('Unknown PRN event kind: unknown-kind')
+    })
+  })
+})

--- a/src/waste-balances/application/update-via-stream.js
+++ b/src/waste-balances/application/update-via-stream.js
@@ -1,0 +1,73 @@
+/** @import {OverseasSitesContext} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
+
+import { add, toNumber } from '#common/helpers/decimal-utils.js'
+
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import { appendToStream } from './append-to-stream.js'
+import { recordWasteBalanceUpdateAudit } from './audit.js'
+import { getTargetAmount } from './target-amount.js'
+
+/**
+ * Apply a summary-log submission to the event stream.
+ *
+ * Computes the aggregate `creditTotal` (sum of all row-level target
+ * amounts), then appends a single `summary-log-submitted` event. The
+ * stream's delta arithmetic (creditTotal minus previous creditTotal)
+ * replaces the per-row delta reconciliation of the ADR-0031 ledger.
+ *
+ * @param {Object} params
+ * @param {Array<import('#domain/waste-records/model.js').WasteRecord>} params.wasteRecords
+ * @param {{ id: string, validFrom?: string, validTo?: string }} params.accreditation
+ * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} params.streamRepository
+ * @param {Object} [params.dependencies]
+ * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [params.dependencies.systemLogsRepository]
+ * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} params.user
+ * @param {OverseasSitesContext} params.overseasSites
+ * @param {string} params.summaryLogId
+ */
+export const performUpdateViaStream = async ({
+  wasteRecords,
+  accreditation,
+  streamRepository,
+  dependencies = {},
+  user,
+  overseasSites,
+  summaryLogId
+}) => {
+  if (wasteRecords.length === 0) {
+    return
+  }
+
+  const organisationId = wasteRecords[0].organisationId
+  const registrationId = wasteRecords[0].registrationId
+
+  let creditTotal = 0
+  for (const record of wasteRecords) {
+    creditTotal = toNumber(
+      add(creditTotal, getTargetAmount(record, accreditation, overseasSites))
+    )
+  }
+
+  const event = await appendToStream(
+    {
+      repository: streamRepository,
+      registrationId,
+      accreditationId: accreditation.id,
+      organisationId
+    },
+    {
+      kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+      payload: { summaryLogId, creditTotal },
+      createdBy: { id: user.id, name: user.email }
+    }
+  )
+
+  await recordWasteBalanceUpdateAudit({
+    systemLogsRepository: dependencies.systemLogsRepository,
+    accreditationId: accreditation.id,
+    amount: event.closingBalance.amount,
+    availableAmount: event.closingBalance.availableAmount,
+    newTransactions: [event],
+    user
+  })
+}

--- a/src/waste-balances/application/update-via-stream.test.js
+++ b/src/waste-balances/application/update-via-stream.test.js
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { createInMemoryStreamRepository } from '../repository/stream-inmemory.js'
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import { performUpdateViaStream } from './update-via-stream.js'
+import {
+  WASTE_RECORD_TYPE,
+  VERSION_STATUS
+} from '#domain/waste-records/model.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+
+vi.mock('@defra/cdp-auditing', () => ({
+  audit: vi.fn()
+}))
+
+vi.mock('#root/config.js', () => ({
+  config: {
+    get: vi.fn((key) => {
+      if (key === 'audit.maxPayloadSizeBytes') {
+        return 10000
+      }
+      return undefined
+    })
+  }
+}))
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    warn: vi.fn()
+  }
+}))
+
+const includingSchema = /** @type {*} */ ({
+  classifyForWasteBalance: (data) => ({
+    outcome: ROW_OUTCOME.INCLUDED,
+    transactionAmount: data.tonnage
+  })
+})
+
+vi.mock('#domain/summary-logs/table-schemas/index.js', () => ({
+  findSchemaForProcessingType: vi.fn()
+}))
+
+const accreditationId = 'acc-1'
+
+const accreditation = {
+  id: accreditationId,
+  validFrom: '2023-01-01',
+  validTo: '2030-12-31'
+}
+
+const overseasSites = /** @type {*} */ (new Map())
+const user = {
+  id: 'user-1',
+  email: 'user@example.test',
+  scope: ['standard_user']
+}
+
+const buildExporterRecord = ({
+  rowId,
+  tonnage,
+  versionId = `version-${rowId}`,
+  summaryLogId = 'log-1'
+}) => ({
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  accreditationId,
+  rowId: String(rowId),
+  type: WASTE_RECORD_TYPE.EXPORTED,
+  versions: [
+    {
+      id: versionId,
+      createdAt: '2025-01-20T10:00:00.000Z',
+      status: VERSION_STATUS.CREATED,
+      summaryLog: { id: summaryLogId, uri: 's3://bucket/log' },
+      data: {}
+    }
+  ],
+  data: { processingType: 'EXPORTER', tonnage },
+  excludedFromWasteBalance: false
+})
+
+describe('performUpdateViaStream', () => {
+  let streamRepository
+  let systemLogsRepository
+
+  beforeEach(async () => {
+    streamRepository = createInMemoryStreamRepository()()
+    systemLogsRepository = { insert: vi.fn().mockResolvedValue(undefined) }
+    const { findSchemaForProcessingType } =
+      await import('#domain/summary-logs/table-schemas/index.js')
+    vi.mocked(findSchemaForProcessingType).mockReturnValue(includingSchema)
+  })
+
+  describe('first submission', () => {
+    it('appends a single summary-log-submitted event with aggregate creditTotal', async () => {
+      const records = [
+        buildExporterRecord({ rowId: '1', tonnage: 100 }),
+        buildExporterRecord({ rowId: '2', tonnage: 50 })
+      ]
+
+      await performUpdateViaStream({
+        wasteRecords: records,
+        accreditation,
+        streamRepository,
+        dependencies: { systemLogsRepository },
+        user,
+        overseasSites,
+        summaryLogId: 'log-A'
+      })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        accreditationId
+      )
+      expect(latest.number).toBe(1)
+      expect(latest.kind).toBe(STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
+      expect(latest.payload).toEqual({
+        summaryLogId: 'log-A',
+        creditTotal: 150
+      })
+      expect(latest.closingBalance).toEqual({
+        amount: 150,
+        availableAmount: 150
+      })
+    })
+  })
+
+  describe('subsequent submission', () => {
+    it('computes delta from previous creditTotal', async () => {
+      await performUpdateViaStream({
+        wasteRecords: [
+          buildExporterRecord({ rowId: '1', tonnage: 100 }),
+          buildExporterRecord({ rowId: '2', tonnage: 50 })
+        ],
+        accreditation,
+        streamRepository,
+        dependencies: { systemLogsRepository },
+        user,
+        overseasSites,
+        summaryLogId: 'log-A'
+      })
+
+      await performUpdateViaStream({
+        wasteRecords: [
+          buildExporterRecord({ rowId: '1', tonnage: 100, versionId: 'v-1b' }),
+          buildExporterRecord({ rowId: '2', tonnage: 80, versionId: 'v-2b' }),
+          buildExporterRecord({ rowId: '3', tonnage: 20 })
+        ],
+        accreditation,
+        streamRepository,
+        dependencies: { systemLogsRepository },
+        user,
+        overseasSites,
+        summaryLogId: 'log-B'
+      })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        accreditationId
+      )
+      expect(latest.number).toBe(2)
+      expect(latest.payload).toEqual({
+        summaryLogId: 'log-B',
+        creditTotal: 200
+      })
+      expect(latest.closingBalance).toEqual({
+        amount: 200,
+        availableAmount: 200
+      })
+    })
+  })
+
+  describe('excluded records', () => {
+    it('skips records with excludedFromWasteBalance flag', async () => {
+      const records = [
+        buildExporterRecord({ rowId: '1', tonnage: 100 }),
+        {
+          ...buildExporterRecord({ rowId: '2', tonnage: 50 }),
+          excludedFromWasteBalance: true
+        }
+      ]
+
+      await performUpdateViaStream({
+        wasteRecords: records,
+        accreditation,
+        streamRepository,
+        dependencies: { systemLogsRepository },
+        user,
+        overseasSites,
+        summaryLogId: 'log-A'
+      })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        accreditationId
+      )
+      expect(latest.payload.creditTotal).toBe(100)
+    })
+  })
+
+  describe('empty input', () => {
+    it('does not touch the stream when no waste records are provided', async () => {
+      const appendSpy = vi.spyOn(streamRepository, 'appendEvent')
+
+      await performUpdateViaStream({
+        wasteRecords: [],
+        accreditation,
+        streamRepository,
+        dependencies: { systemLogsRepository },
+        user,
+        overseasSites,
+        summaryLogId: 'log-A'
+      })
+
+      expect(appendSpy).not.toHaveBeenCalled()
+      expect(systemLogsRepository.insert).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('audit emission', () => {
+    it('inserts one system-log entry covering the submission', async () => {
+      await performUpdateViaStream({
+        wasteRecords: [
+          buildExporterRecord({ rowId: '1', tonnage: 100 }),
+          buildExporterRecord({ rowId: '2', tonnage: 50 })
+        ],
+        accreditation,
+        streamRepository,
+        dependencies: { systemLogsRepository },
+        user,
+        overseasSites,
+        summaryLogId: 'log-A'
+      })
+
+      expect(systemLogsRepository.insert).toHaveBeenCalledTimes(1)
+      const [entry] = systemLogsRepository.insert.mock.calls[0]
+      expect(entry.event).toEqual({
+        category: 'waste-reporting',
+        subCategory: 'waste-balance',
+        action: 'update'
+      })
+      expect(entry.context.accreditationId).toBe(accreditationId)
+      expect(entry.context.amount).toBe(150)
+      expect(entry.context.availableAmount).toBe(150)
+      expect(entry.context.newTransactions).toHaveLength(1)
+    })
+  })
+
+  describe('classifier outcome', () => {
+    it('treats records with non-INCLUDED outcome as zero contribution', async () => {
+      const { findSchemaForProcessingType } =
+        await import('#domain/summary-logs/table-schemas/index.js')
+      vi.mocked(findSchemaForProcessingType).mockReturnValue(
+        /** @type {*} */ ({
+          classifyForWasteBalance: () => ({
+            outcome: 'ignored',
+            reasons: [{ code: 'OUTSIDE_ACCREDITATION_PERIOD' }]
+          })
+        })
+      )
+
+      await performUpdateViaStream({
+        wasteRecords: [buildExporterRecord({ rowId: '1', tonnage: 100 })],
+        accreditation,
+        streamRepository,
+        dependencies: { systemLogsRepository },
+        user,
+        overseasSites,
+        summaryLogId: 'log-A'
+      })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        accreditationId
+      )
+      expect(latest.payload.creditTotal).toBe(0)
+    })
+  })
+
+  describe('actor attribution', () => {
+    it('stamps createdBy from the SubmitUser', async () => {
+      await performUpdateViaStream({
+        wasteRecords: [buildExporterRecord({ rowId: '1', tonnage: 50 })],
+        accreditation,
+        streamRepository,
+        dependencies: { systemLogsRepository },
+        user,
+        overseasSites,
+        summaryLogId: 'log-A'
+      })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        accreditationId
+      )
+      expect(latest.createdBy).toEqual({ id: user.id, name: user.email })
+    })
+  })
+})


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)

## Summary

- Adds `appendToStream` primitive: reads the latest event, computes closing balances per event kind, and appends a single event with sequential numbering
- Adds `performUpdateViaStream`: aggregates row-level target amounts into a single `creditTotal` per submission
- Purely additive: nothing calls these yet. This is PR 2 of 6 splitting #1179

## Test plan

- [x] 11 append-to-stream tests pass (all five event kinds plus slot conflict)
- [x] 7 update-via-stream tests pass
- [x] 100% coverage
- [x] Type check clean

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ