### PR TITLE
PAE-1498: Fix Included in Waste Balance always true for accreditationId-model registrations

### DIFF
--- a/src/domain/organisations/registration-utils.js
+++ b/src/domain/organisations/registration-utils.js
@@ -3,6 +3,7 @@ import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.
 
 /** @import { Organisation, RegAccStatus } from '#domain/organisations/model.js' */
 /** @import { RegistrationApproved } from '#domain/organisations/registration.js' */
+/** @import { Accreditation } from '#domain/organisations/accreditation.js' */
 
 const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
@@ -55,4 +56,27 @@ export function resolveAccreditationNumber(registration, org) {
       ACTIVE_ACCREDITATION_STATUSES.has(a.status)
   )
   return accreditation?.accreditationNumber ?? ''
+}
+
+/**
+ * Returns the active Accreditation object for a registration by looking up
+ * accreditationId in org.accreditations. Only approved/suspended accreditations
+ * are returned. Returns null when accreditationId is absent, no match is found,
+ * or the matched accreditation is not in an active status.
+ *
+ * @param {{ accreditationId?: string | null }} registration
+ * @param {{ accreditations: Array<{ id: string; status: RegAccStatus } & Accreditation> }} org
+ * @returns {Accreditation | null}
+ */
+export function resolveAccreditation(registration, org) {
+  if (!registration.accreditationId) {
+    return null
+  }
+  return (
+    org.accreditations.find(
+      (a) =>
+        a.id === registration.accreditationId &&
+        ACTIVE_ACCREDITATION_STATUSES.has(a.status)
+    ) ?? null
+  )
 }

--- a/src/domain/organisations/registration-utils.test.js
+++ b/src/domain/organisations/registration-utils.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   getReportableRegistrations,
-  resolveAccreditationNumber
+  resolveAccreditationNumber,
+  resolveAccreditation
 } from './registration-utils.js'
 
 const buildOrg = (overrides = {}) => ({
@@ -162,5 +163,56 @@ describe('resolveAccreditationNumber', () => {
     const reg = buildReg({ accreditationId: 'acc-1' })
 
     expect(resolveAccreditationNumber(reg, org)).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveAccreditation
+// ---------------------------------------------------------------------------
+
+describe('resolveAccreditation', () => {
+  const accreditationFixture = {
+    id: 'acc-1',
+    status: 'approved',
+    validFrom: '2026-01-01',
+    validTo: '2026-12-31',
+    statusHistory: []
+  }
+
+  it('returns accreditation from org.accreditations when status is approved', () => {
+    const org = buildOrg({ accreditations: [accreditationFixture] })
+    const reg = buildReg({ accreditationId: 'acc-1' })
+
+    expect(resolveAccreditation(reg, org)).toBe(accreditationFixture)
+  })
+
+  it('returns accreditation from org.accreditations when status is suspended', () => {
+    const suspended = { ...accreditationFixture, status: 'suspended' }
+    const org = buildOrg({ accreditations: [suspended] })
+    const reg = buildReg({ accreditationId: 'acc-1' })
+
+    expect(resolveAccreditation(reg, org)).toBe(suspended)
+  })
+
+  it('returns null when registration has no accreditationId', () => {
+    const org = buildOrg({ accreditations: [accreditationFixture] })
+    const reg = buildReg({ accreditationId: null })
+
+    expect(resolveAccreditation(reg, org)).toBeNull()
+  })
+
+  it('returns null when accreditationId does not match any entry in org.accreditations', () => {
+    const org = buildOrg({ accreditations: [accreditationFixture] })
+    const reg = buildReg({ accreditationId: 'acc-unknown' })
+
+    expect(resolveAccreditation(reg, org)).toBeNull()
+  })
+
+  it('returns null when matched accreditation has a non-active status', () => {
+    const cancelled = { ...accreditationFixture, status: 'cancelled' }
+    const org = buildOrg({ accreditations: [cancelled] })
+    const reg = buildReg({ accreditationId: 'acc-1' })
+
+    expect(resolveAccreditation(reg, org)).toBeNull()
   })
 })

--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -2,6 +2,7 @@ import { writeToString } from '@fast-csv/format'
 import { Readable } from 'node:stream'
 
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
+import { resolveAccreditation } from '#domain/organisations/registration-utils.js'
 import {
   buildHeaderRow,
   buildDataRow,
@@ -123,7 +124,7 @@ async function* streamRegistrationRows({
   wasteRecordsRepository,
   summaryLogsRepository
 }) {
-  const accreditation = registration.accreditation ?? null
+  const accreditation = resolveAccreditation(registration, org)
   const overseasSites = buildOverseasSitesContext(registration, sitesById)
   const summaryLogMap = await loadSummaryLogMap(
     summaryLogsRepository,

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -21,6 +21,7 @@ const baseOrg = (overrides = {}) => ({
   companyDetails: { name: 'Acme Ltd' },
   submittedToRegulator: 'ea',
   registrations: [],
+  accreditations: [],
   ...overrides
 })
 
@@ -256,6 +257,113 @@ describe('streamCsvExport', () => {
     // "Included in Waste Balance" is the 8th metadata column (index 7) → "true"
     const cells = out[1].trim().split(',')
     expect(cells[7]).toBe('"true"')
+  })
+
+  const exporterAccreditation = {
+    id: 'acc-1',
+    status: 'approved',
+    validFrom: '2026-01-01',
+    validTo: '2026-12-31',
+    statusHistory: []
+  }
+
+  const exportedRecordForAccreditationTests = (dateOfExport) => ({
+    type: WASTE_RECORD_TYPE.EXPORTED,
+    rowId: '5001',
+    data: {
+      processingType: PROCESSING_TYPES.EXPORTER,
+      ROW_ID: '5001',
+      DATE_RECEIVED_FOR_EXPORT: '2026-02-01',
+      EWC_CODE: '15 01 02',
+      DESCRIPTION_WASTE: 'Plastic packaging',
+      WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+      GROSS_WEIGHT: 10,
+      TARE_WEIGHT: 1,
+      PALLET_WEIGHT: 0,
+      NET_WEIGHT: 9,
+      BAILING_WIRE_PROTOCOL: 'No',
+      HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
+      WEIGHT_OF_NON_TARGET_MATERIALS: 0,
+      RECYCLABLE_PROPORTION_PERCENTAGE: 100,
+      TONNAGE_RECEIVED_FOR_EXPORT: 9,
+      TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 9,
+      DATE_OF_EXPORT: dateOfExport,
+      BASEL_EXPORT_CODE: 'B3010',
+      CUSTOMS_CODES: '391510',
+      CONTAINER_NUMBER: 'CN-001',
+      DATE_RECEIVED_BY_OSR: '2026-04-01',
+      OSR_ID: '001',
+      DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE: 'No'
+    },
+    versions: [{ summaryLog: { id: 'sl-1' } }]
+  })
+
+  it('marks accredited exporter row as included when DATE_OF_EXPORT is within accreditation period', async () => {
+    const org = baseOrg({
+      accreditations: [exporterAccreditation],
+      registrations: [
+        baseRegistration({
+          accreditation: null,
+          accreditationId: 'acc-1',
+          overseasSites: { '001': { overseasSiteId: 'site-a' } }
+        })
+      ]
+    })
+    const deps = baseDeps({
+      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
+      wasteRecordsRepository: {
+        findByRegistration: vi
+          .fn()
+          .mockResolvedValue([
+            exportedRecordForAccreditationTests('2026-03-01')
+          ])
+      },
+      overseasSitesRepository: {
+        findAll: vi
+          .fn()
+          .mockResolvedValue([
+            { id: 'site-a', validFrom: new Date('2026-01-01') }
+          ])
+      }
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const cells = out[1].trim().split(',')
+    expect(cells[7]).toBe('"true"')
+  })
+
+  it('marks accredited exporter row as not included when DATE_OF_EXPORT is outside accreditation period', async () => {
+    const org = baseOrg({
+      accreditations: [exporterAccreditation],
+      registrations: [
+        baseRegistration({
+          accreditation: null,
+          accreditationId: 'acc-1',
+          overseasSites: { '001': { overseasSiteId: 'site-a' } }
+        })
+      ]
+    })
+    const deps = baseDeps({
+      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
+      wasteRecordsRepository: {
+        findByRegistration: vi
+          .fn()
+          .mockResolvedValue([
+            exportedRecordForAccreditationTests('2025-06-01')
+          ])
+      },
+      overseasSitesRepository: {
+        findAll: vi
+          .fn()
+          .mockResolvedValue([
+            { id: 'site-a', validFrom: new Date('2026-01-01') }
+          ])
+      }
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const cells = out[1].trim().split(',')
+    expect(cells[7]).toBe('"false"')
   })
 
   it('iterates organisations and registrations sorted by id for deterministic output', async () => {


### PR DESCRIPTION
## Jira
[PAE-1498](https://eaflood.atlassian.net/browse/PAE-1498)

## Problem

The waste record CSV export's **Included in Waste Balance** column shows `true` for every row regardless of whether the row's dates fall within the accreditation period. This makes the column unreliable as an audit tool — e.g. a row with `DATE_RECEIVED_BY_OSR = 2025` (outside a 2026 accreditation) appears as included, even though the actual waste balance calculation correctly excludes it.

## Root cause

`organisationsRepository.findAll()` → `mapDocumentWithCurrentStatuses` sets `registration.accreditation = item.accreditation ?? null`. It does **not** hydrate `registration.accreditation` from `org.accreditations[]` using `accreditationId` — only `findRegistrationById` does that join.

For registrations using the new `accreditationId` model, `registration.accreditation` is therefore `null` after `findAll()`. `streamRegistrationRows` used `registration.accreditation ?? null`, so `isAccreditedAtDates(dates, null)` returned `true` unconditionally (the `if (!accreditation) return true` guard), making every row appear as included.

The actual waste balance total (calculated at submission time via `findAccreditationById`) is correct; this is an export-only display bug.

## Fix

Add `resolveAccreditation(registration, org)` to `registration-utils.js`:
- Looks up the accreditation from `org.accreditations[]` by `accreditationId`
- Only returns active (approved/suspended) accreditations — consistent with `resolveAccreditationNumber`
- Returns `null` when `accreditationId` is absent, no match is found, or the matched accreditation is not active

Use it in `streamRegistrationRows` replacing `registration.accreditation ?? null`.

## Changes

| File | Change |
|---|---|
| `src/domain/organisations/registration-utils.js` | Add `resolveAccreditation(registration, org)` |
| `src/waste-records-export/application/stream-csv-export.js` | Use `resolveAccreditation` instead of inline property |
| `src/domain/organisations/registration-utils.test.js` | 5 unit tests for `resolveAccreditation` |
| `src/waste-records-export/application/stream-csv-export.test.js` | 2 regression tests: exporter row within/outside accreditation period |

## Test plan

- [ ] `resolveAccreditation` unit tests: approved ✓, suspended ✓, no accreditationId → null ✓, no match → null ✓, cancelled → null ✓
- [ ] Export regression: row with `DATE_OF_EXPORT` within accreditation period → `"true"` in column 7
- [ ] Export regression: row with `DATE_OF_EXPORT` outside accreditation period → `"false"` in column 7
- [ ] Full test suite: 6,431 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PAE-1498]: https://eaflood.atlassian.net/browse/PAE-1498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ