### PR TITLE
PAE-1498: Waste record export: Included in Waste Balance ignores accreditation date range

### DIFF
--- a/src/domain/organisations/registration-utils.js
+++ b/src/domain/organisations/registration-utils.js
@@ -3,6 +3,7 @@ import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.
 
 /** @import { Organisation, RegAccStatus } from '#domain/organisations/model.js' */
 /** @import { RegistrationApproved } from '#domain/organisations/registration.js' */
+/** @import { Accreditation } from '#domain/organisations/accreditation.js' */
 
 const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
@@ -55,4 +56,27 @@ export function resolveAccreditationNumber(registration, org) {
       ACTIVE_ACCREDITATION_STATUSES.has(a.status)
   )
   return accreditation?.accreditationNumber ?? ''
+}
+
+/**
+ * Returns the active Accreditation object for a registration by looking up
+ * accreditationId in org.accreditations. Only approved/suspended accreditations
+ * are returned. Returns null when accreditationId is absent, no match is found,
+ * or the matched accreditation is not in an active status.
+ *
+ * @param {{ accreditationId?: string | null }} registration
+ * @param {{ accreditations: Array<{ id: string; status: RegAccStatus } & Accreditation> }} org
+ * @returns {Accreditation | null}
+ */
+export function resolveAccreditation(registration, org) {
+  if (!registration.accreditationId) {
+    return null
+  }
+  return (
+    org.accreditations.find(
+      (a) =>
+        a.id === registration.accreditationId &&
+        ACTIVE_ACCREDITATION_STATUSES.has(a.status)
+    ) ?? null
+  )
 }

--- a/src/domain/organisations/registration-utils.test.js
+++ b/src/domain/organisations/registration-utils.test.js
@@ -5,22 +5,61 @@ import {
   resolveAccreditation
 } from './registration-utils.js'
 
-const buildOrg = (overrides = {}) => ({
+/** @import { Organisation } from '#domain/organisations/model.js' */
+/** @import { Registration } from '#domain/organisations/registration.js' */
+
+const userFixture = {
+  fullName: 'Test User',
+  email: 'test@example.com',
+  phone: '01234567890'
+}
+
+/** @type {Organisation} */
+const orgFixture = {
   id: 'org-1',
   orgId: 500001,
-  companyDetails: { name: 'Acme Ltd' },
   accreditations: [],
   registrations: [],
-  ...overrides
-})
+  companyDetails: { name: 'Acme Ltd' },
+  formSubmission: { id: 'fs-1', time: new Date('2026-01-01') },
+  schemaVersion: 1,
+  status: 'active',
+  statusHistory: [{ status: 'approved', updatedAt: new Date('2026-01-01') }],
+  submittedToRegulator: 'ea',
+  submitterContactDetails: userFixture,
+  users: [],
+  version: 1,
+  wasteProcessingTypes: []
+}
 
-const buildReg = (overrides = {}) => ({
+/** @type {Registration} */
+const regFixture = {
   id: 'reg-1',
-  status: 'approved',
-  accreditationId: null,
+  accreditation: null,
+  applicationContactDetails: userFixture,
+  approvedPersons: [],
+  formSubmission: { id: 'fs-1', time: new Date('2026-01-01') },
+  material: 'plastic',
+  orgName: 'Acme Ltd',
+  site: {
+    address: {},
+    gridReference: 'TQ123456',
+    siteCapacity: []
+  },
+  submittedToRegulator: 'ea',
+  submitterContactDetails: userFixture,
+  wasteProcessingType: 'reprocessor',
   registrationNumber: 'REG-001',
-  ...overrides
-})
+  status: 'approved',
+  validFrom: '2026-01-01',
+  validTo: '2026-12-31'
+}
+
+/** @returns {Organisation} */
+const buildOrg = (overrides = {}) => ({ ...orgFixture, ...overrides })
+
+/** @returns {Registration} */
+const buildReg = (overrides = {}) => ({ ...regFixture, ...overrides })
 
 // ---------------------------------------------------------------------------
 // getReportableRegistrations

--- a/src/domain/organisations/registration-utils.test.js
+++ b/src/domain/organisations/registration-utils.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   getReportableRegistrations,
-  resolveAccreditationNumber
+  resolveAccreditationNumber,
+  resolveAccreditation
 } from './registration-utils.js'
 
 const buildOrg = (overrides = {}) => ({
@@ -162,5 +163,56 @@ describe('resolveAccreditationNumber', () => {
     const reg = buildReg({ accreditationId: 'acc-1' })
 
     expect(resolveAccreditationNumber(reg, org)).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveAccreditation
+// ---------------------------------------------------------------------------
+
+describe('resolveAccreditation', () => {
+  const accreditationFixture = {
+    id: 'acc-1',
+    status: 'approved',
+    validFrom: '2026-01-01',
+    validTo: '2026-12-31',
+    statusHistory: []
+  }
+
+  it('returns accreditation from org.accreditations when status is approved', () => {
+    const org = buildOrg({ accreditations: [accreditationFixture] })
+    const reg = buildReg({ accreditationId: 'acc-1' })
+
+    expect(resolveAccreditation(reg, org)).toBe(accreditationFixture)
+  })
+
+  it('returns accreditation from org.accreditations when status is suspended', () => {
+    const suspended = { ...accreditationFixture, status: 'suspended' }
+    const org = buildOrg({ accreditations: [suspended] })
+    const reg = buildReg({ accreditationId: 'acc-1' })
+
+    expect(resolveAccreditation(reg, org)).toBe(suspended)
+  })
+
+  it('returns null when registration has no accreditationId', () => {
+    const org = buildOrg({ accreditations: [accreditationFixture] })
+    const reg = buildReg({ accreditationId: null })
+
+    expect(resolveAccreditation(reg, org)).toBeNull()
+  })
+
+  it('returns null when accreditationId does not match any entry in org.accreditations', () => {
+    const org = buildOrg({ accreditations: [accreditationFixture] })
+    const reg = buildReg({ accreditationId: 'acc-unknown' })
+
+    expect(resolveAccreditation(reg, org)).toBeNull()
+  })
+
+  it('returns null when matched accreditation has a non-active status', () => {
+    const cancelled = { ...accreditationFixture, status: 'cancelled' }
+    const org = buildOrg({ accreditations: [cancelled] })
+    const reg = buildReg({ accreditationId: 'acc-1' })
+
+    expect(resolveAccreditation(reg, org)).toBeNull()
   })
 })

--- a/src/domain/organisations/registration.js
+++ b/src/domain/organisations/registration.js
@@ -1,6 +1,5 @@
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
-/** @import {GlassRecyclingProcess, Material, User} from '#domain/organisations/model.js' */
-/** @import {ReprocessingType} from '#domain/organisations/model.js' */
+/** @import {GlassRecyclingProcess, Material, RegAccStatus, ReprocessingType, User} from '#domain/organisations/model.js' */
 
 /**
  * @typedef {{
@@ -53,7 +52,7 @@
 /**
  * @typedef {RegistrationBase & {
  *  registrationNumber: string;
- *  status: 'approved'|'suspended';
+ *  status: Extract<RegAccStatus, 'approved'|'suspended'>;
  *  validFrom: string;
  *  validTo: string;
  * }} RegistrationApproved
@@ -63,7 +62,7 @@
  * @typedef {RegistrationBase & {
  *  registrationNumber?: string;
  *  cbduNumber?: string;
- *  status: 'created'|'rejected'|'cancelled'|'suspended';
+ *  status: Extract<RegAccStatus, 'created'|'rejected'|'cancelled'>;
  *  validFrom?: string;
  *  validTo?: string
  * }} RegistrationOther

--- a/src/waste-records-export/application/load-summary-log-map.js
+++ b/src/waste-records-export/application/load-summary-log-map.js
@@ -8,7 +8,7 @@
  * Memory cost is small (count is bounded by submissions per registration —
  * typically dozens at most).
  *
- * @param {SummaryLogsRepository} summaryLogsRepository
+ * @param {Pick<SummaryLogsRepository, 'findAllByOrgReg'>} summaryLogsRepository
  * @param {string} organisationId
  * @param {string} registrationId
  * @returns {Promise<Map<string, { submittedAt: string }>>}

--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -2,6 +2,7 @@ import { writeToString } from '@fast-csv/format'
 import { Readable } from 'node:stream'
 
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
+import { resolveAccreditation } from '#domain/organisations/registration-utils.js'
 import {
   buildHeaderRow,
   buildDataRow,
@@ -123,7 +124,7 @@ async function* streamRegistrationRows({
   wasteRecordsRepository,
   summaryLogsRepository
 }) {
-  const accreditation = registration.accreditation ?? null
+  const accreditation = resolveAccreditation(registration, org)
   const overseasSites = buildOverseasSitesContext(registration, sitesById)
   const summaryLogMap = await loadSummaryLogMap(
     summaryLogsRepository,

--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -25,10 +25,10 @@ const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
 /**
  * @typedef {Object} StreamCsvExportDeps
- * @property {OrganisationsRepository} organisationsRepository
- * @property {WasteRecordsRepository} wasteRecordsRepository
- * @property {SummaryLogsRepository} summaryLogsRepository
- * @property {OverseasSitesRepository} overseasSitesRepository
+ * @property {Pick<OrganisationsRepository, 'findAll'>} organisationsRepository
+ * @property {Pick<WasteRecordsRepository, 'findByRegistration' | 'findDistinctDataKeys'>} wasteRecordsRepository
+ * @property {Pick<SummaryLogsRepository, 'findAllByOrgReg'>} summaryLogsRepository
+ * @property {Pick<OverseasSitesRepository, 'findAll'>} overseasSitesRepository
  */
 
 const sortById = (a, b) => a.id.localeCompare(b.id)
@@ -112,8 +112,8 @@ const rowForRecord = ({
  * @param {Registration} input.registration
  * @param {Map<string, OverseasSite>} input.sitesById
  * @param {string[]} input.dataFieldColumns
- * @param {WasteRecordsRepository} input.wasteRecordsRepository
- * @param {SummaryLogsRepository} input.summaryLogsRepository
+ * @param {Pick<WasteRecordsRepository, 'findByRegistration'>} input.wasteRecordsRepository
+ * @param {Pick<SummaryLogsRepository, 'findAllByOrgReg'>} input.summaryLogsRepository
  * @returns {AsyncGenerator<string>}
  */
 async function* streamRegistrationRows({

--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -95,6 +95,7 @@ const rowForRecord = ({
   return buildDataRow({
     org,
     registration,
+    accreditation,
     record,
     summaryLogEntry,
     includedInWasteBalance,

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -329,6 +329,7 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     const cells = out[1].trim().split(',')
+    expect(cells[4]).toBe('"Yes"') // Accredited column
     expect(cells[7]).toBe('"true"')
   })
 
@@ -363,6 +364,7 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     const cells = out[1].trim().split(',')
+    expect(cells[4]).toBe('"Yes"') // Accredited column
     expect(cells[7]).toBe('"false"')
   })
 

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -21,6 +21,7 @@ const baseOrg = (overrides = {}) => ({
   companyDetails: { name: 'Acme Ltd' },
   submittedToRegulator: 'ea',
   registrations: [],
+  accreditations: [],
   ...overrides
 })
 
@@ -256,6 +257,113 @@ describe('streamCsvExport', () => {
     // "Included in Waste Balance" is the 8th metadata column (index 7) → "true"
     const cells = out[1].trim().split(',')
     expect(cells[7]).toBe('"true"')
+  })
+
+  const exporterAccreditation = {
+    id: 'acc-1',
+    status: 'approved',
+    validFrom: '2026-01-01',
+    validTo: '2026-12-31',
+    statusHistory: []
+  }
+
+  const exportedRecordForAccreditationTests = (dateOfExport) => ({
+    type: WASTE_RECORD_TYPE.EXPORTED,
+    rowId: '5001',
+    data: {
+      processingType: PROCESSING_TYPES.EXPORTER,
+      ROW_ID: '5001',
+      DATE_RECEIVED_FOR_EXPORT: '2026-02-01',
+      EWC_CODE: '15 01 02',
+      DESCRIPTION_WASTE: 'Plastic packaging',
+      WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+      GROSS_WEIGHT: 10,
+      TARE_WEIGHT: 1,
+      PALLET_WEIGHT: 0,
+      NET_WEIGHT: 9,
+      BAILING_WIRE_PROTOCOL: 'No',
+      HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
+      WEIGHT_OF_NON_TARGET_MATERIALS: 0,
+      RECYCLABLE_PROPORTION_PERCENTAGE: 100,
+      TONNAGE_RECEIVED_FOR_EXPORT: 9,
+      TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 9,
+      DATE_OF_EXPORT: dateOfExport,
+      BASEL_EXPORT_CODE: 'B3010',
+      CUSTOMS_CODES: '391510',
+      CONTAINER_NUMBER: 'CN-001',
+      DATE_RECEIVED_BY_OSR: '2026-04-01',
+      OSR_ID: '001',
+      DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE: 'No'
+    },
+    versions: [{ summaryLog: { id: 'sl-1' } }]
+  })
+
+  it('marks accredited exporter row as included when DATE_OF_EXPORT is within accreditation period', async () => {
+    const org = baseOrg({
+      accreditations: [exporterAccreditation],
+      registrations: [
+        baseRegistration({
+          accreditation: null,
+          accreditationId: 'acc-1',
+          overseasSites: { '001': { overseasSiteId: 'site-a' } }
+        })
+      ]
+    })
+    const deps = baseDeps({
+      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
+      wasteRecordsRepository: {
+        findByRegistration: vi
+          .fn()
+          .mockResolvedValue([
+            exportedRecordForAccreditationTests('2026-03-01')
+          ])
+      },
+      overseasSitesRepository: {
+        findAll: vi
+          .fn()
+          .mockResolvedValue([
+            { id: 'site-a', validFrom: new Date('2026-01-01') }
+          ])
+      }
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const cells = out[1].trim().split(',')
+    expect(cells[7]).toBe('"true"')
+  })
+
+  it('marks accredited exporter row as not included when DATE_OF_EXPORT is outside accreditation period', async () => {
+    const org = baseOrg({
+      accreditations: [exporterAccreditation],
+      registrations: [
+        baseRegistration({
+          accreditation: null,
+          accreditationId: 'acc-1',
+          overseasSites: { '001': { overseasSiteId: 'site-a' } }
+        })
+      ]
+    })
+    const deps = baseDeps({
+      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
+      wasteRecordsRepository: {
+        findByRegistration: vi
+          .fn()
+          .mockResolvedValue([
+            exportedRecordForAccreditationTests('2025-06-01')
+          ])
+      },
+      overseasSitesRepository: {
+        findAll: vi
+          .fn()
+          .mockResolvedValue([
+            { id: 'site-a', validFrom: new Date('2026-01-01') }
+          ])
+      }
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const cells = out[1].trim().split(',')
+    expect(cells[7]).toBe('"false"')
   })
 
   it('iterates organisations and registrations sorted by id for deterministic output', async () => {

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -1,4 +1,3 @@
-import { isRegistrationAccredited } from '#reports/domain/is-registration-accredited.js'
 import { uppercaseString } from '#common/helpers/formatters.js'
 
 import * as exporter from '#domain/summary-logs/table-schemas/exporter/fields.js'
@@ -8,6 +7,7 @@ import * as reprocessorOutput from '#domain/summary-logs/table-schemas/reprocess
 import * as reprocessorRegisteredOnly from '#domain/summary-logs/table-schemas/reprocessor-registered-only/fields.js'
 import * as shared from '#domain/summary-logs/table-schemas/shared/fields.js'
 
+/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 /** @import {Organisation} from '#domain/organisations/model.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
@@ -95,6 +95,7 @@ export const buildHeaderRow = (dataFieldColumns) => [
  * @typedef {Object} BuildDataRowInput
  * @property {Organisation} org
  * @property {Registration} registration
+ * @property {Accreditation | null} accreditation
  * @property {WasteRecord} record
  * @property {{ submittedAt: string } | null | undefined} summaryLogEntry
  * @property {boolean} includedInWasteBalance
@@ -111,12 +112,13 @@ export const buildHeaderRow = (dataFieldColumns) => [
 export const buildDataRow = ({
   org,
   registration,
+  accreditation,
   record,
   summaryLogEntry,
   includedInWasteBalance,
   dataFieldColumns
 }) => {
-  const accredited = isRegistrationAccredited(registration) ? 'Yes' : 'No'
+  const accredited = accreditation !== null ? 'Yes' : 'No'
   const data = record.data
 
   const metadata = [

--- a/src/waste-records-export/domain/csv-columns.test.js
+++ b/src/waste-records-export/domain/csv-columns.test.js
@@ -98,9 +98,9 @@ describe('csv-columns', () => {
       org: { companyDetails: { name: 'Acme Ltd' } },
       registration: {
         material: 'plastic',
-        submittedToRegulator: 'ea',
-        accreditation: { status: 'approved' }
+        submittedToRegulator: 'ea'
       },
+      accreditation: { status: 'approved' },
       record: {
         type: WASTE_RECORD_TYPE.RECEIVED,
         rowId: '1001',
@@ -174,7 +174,7 @@ describe('csv-columns', () => {
     it('emits "No" for Accredited when registration is registered-only', () => {
       const row = buildDataRow({
         ...baseInput,
-        registration: { ...baseInput.registration, accreditation: null }
+        accreditation: null
       })
       expect(row[4]).toBe('No')
     })


### PR DESCRIPTION
## Jira
[PAE-1498](https://eaflood.atlassian.net/browse/PAE-1498)

## Problem

The waste record CSV export's **Included in Waste Balance** column shows `true` for every row regardless of whether the row's dates fall within the accreditation period. This makes the column unreliable as an audit tool — e.g. a row with `DATE_RECEIVED_BY_OSR = 2025` (outside a 2026 accreditation) appears as included, even though the actual waste balance calculation correctly excludes it.

## Root cause

`organisationsRepository.findAll()` → `mapDocumentWithCurrentStatuses` sets `registration.accreditation = item.accreditation ?? null`. It does **not** hydrate `registration.accreditation` from `org.accreditations[]` using `accreditationId` — only `findRegistrationById` does that join.

streamRegistrationRows` used `registration.accreditation ?? null`, so `isAccreditedAtDates(dates, null)` returned `true` unconditionally (the `if (!accreditation) return true` guard), making every row appear as included.

The actual waste balance total (calculated at submission time via `findAccreditationById`) is correct; this is an export-only display bug.



[PAE-1498]: https://eaflood.atlassian.net/browse/PAE-1498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ