### PR TITLE
PAE-1536: log summary-log validation issues

### DIFF
--- a/src/application/summary-logs/load-counts.js
+++ b/src/application/summary-logs/load-counts.js
@@ -1,10 +1,8 @@
 import { VERSION_STATUS } from '#domain/waste-records/model.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 
-/**
- * @typedef {import('./validate.js').ValidatedWasteRecord} ValidatedWasteRecord
- * @typedef {import('#common/validation/validation-issues.js').ValidationIssue} ValidationIssue
- */
+/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {ValidationIssue} from '#common/validation/validation-issues.js' */
 
 /**
  * @typedef {Object} LoadCategory

--- a/src/application/summary-logs/validate-issue-logging.js
+++ b/src/application/summary-logs/validate-issue-logging.js
@@ -6,14 +6,20 @@ import { LOCATION_KEYS } from '#common/validation/validation-issues.js'
 
 /** @import {IndexedLogProperties, TypedLogger} from '#common/helpers/logging/logger.js' */
 /** @import {ValidationIssue, ValidationIssueContext, ValidationIssueCounts, ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
-/** @import {SummaryLog} from '#domain/summary-logs/model.js' */
+/** @import {StoredFile, SummaryLog} from '#domain/summary-logs/model.js' */
 
 /**
- * SummaryLog after the validator has confirmed it's past PREPROCESSING (org/reg
- * guaranteed by upstream business logic but the SummaryLog typedef leaves them
- * optional to cover the PREPROCESSING state too).
+ * SummaryLog after the validator has confirmed it's past PREPROCESSING. The
+ * base typedef leaves org/reg/accreditation optional and admits the pending
+ * file shape to cover PREPROCESSING; this narrows them to the guarantees
+ * upstream business logic provides by the VALIDATING state.
  *
- * @typedef {SummaryLog & { organisationId: string, registrationId: string }} SubmittedSummaryLog
+ * @typedef {SummaryLog & {
+ *   organisationId: string,
+ *   registrationId: string,
+ *   accreditationId?: string,
+ *   file: StoredFile
+ * }} SubmittedSummaryLog
  */
 
 /**

--- a/src/application/summary-logs/validate-issue-logging.js
+++ b/src/application/summary-logs/validate-issue-logging.js
@@ -1,0 +1,120 @@
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/index.js'
+import { LOCATION_KEYS } from '#common/validation/validation-issues.js'
+
+/** @import {IndexedLogProperties, TypedLogger} from '#common/helpers/logging/logger.js' */
+/** @import {ValidationIssue, ValidationIssueContext, createValidationIssues} from '#common/validation/validation-issues.js' */
+/** @import {SummaryLog} from '#domain/summary-logs/model.js' */
+
+/**
+ * SummaryLog after the validator has confirmed it's past PREPROCESSING (org/reg
+ * guaranteed by upstream business logic but the SummaryLog typedef leaves them
+ * optional to cover the PREPROCESSING state too).
+ *
+ * @typedef {SummaryLog & { organisationId: string, registrationId: string }} SubmittedSummaryLog
+ */
+
+/**
+ * @param {ValidationIssueContext} [context]
+ * @returns {string} Semicolon-delimited composite, empty parts omitted
+ */
+const buildLocationId = (context) => {
+  const location = context?.location
+  if (!location) {
+    return ''
+  }
+  return LOCATION_KEYS.filter((key) => location[key] !== undefined)
+    .map((key) => `${key}=${location[key]}`)
+    .join(';')
+}
+
+/**
+ * @param {ValidationIssue} issue
+ * @param {string} summaryLogId
+ * @returns {IndexedLogProperties}
+ */
+const buildIssueLogPayload = (issue, summaryLogId) => ({
+  message: `Summary log validation issue: ${issue.code}`,
+  event: {
+    kind: 'event',
+    category: LOGGING_EVENT_CATEGORIES.SERVER,
+    action: LOGGING_EVENT_ACTIONS.SUMMARY_LOG_VALIDATION_ISSUE,
+    outcome: 'failure',
+    type: 'error',
+    reference: summaryLogId,
+    reason: issue.code
+  },
+  error: {
+    code: issue.code,
+    type: issue.severity,
+    message: issue.message,
+    id: buildLocationId(issue.context)
+  }
+})
+
+/**
+ * @param {ValidationIssue[]} allIssues
+ * @param {string} summaryLogId
+ * @param {string} organisationId
+ * @param {string} registrationId
+ * @returns {IndexedLogProperties}
+ */
+const buildSummaryLogPayload = (
+  allIssues,
+  summaryLogId,
+  organisationId,
+  registrationId
+) => {
+  const counts = { fatal: 0, error: 0, warning: 0 }
+  allIssues.forEach((issue) => {
+    counts[issue.severity]++
+  })
+  return {
+    message: `Summary log validation completed: fatal=${counts.fatal} error=${counts.error} warning=${counts.warning} org=${organisationId} reg=${registrationId}`,
+    event: {
+      kind: 'event',
+      category: LOGGING_EVENT_CATEGORIES.SERVER,
+      action: LOGGING_EVENT_ACTIONS.SUMMARY_LOG_VALIDATION_COMPLETED,
+      outcome: 'failure',
+      reference: summaryLogId
+    }
+  }
+}
+
+/**
+ * Emits a warn-level log per validation issue plus a single summary log so
+ * support can investigate failures via OpenSearch DQL. No-op when there are
+ * no issues. PII (issue.context.actual) and org/reg are never included in
+ * per-issue logs; org/reg appear only in the run-level summary log.
+ *
+ * @param {{
+ *   summaryLogId: string,
+ *   summaryLog: SubmittedSummaryLog,
+ *   issues: ReturnType<typeof createValidationIssues>,
+ *   logger: TypedLogger
+ * }} params
+ */
+export const logValidationIssues = ({
+  summaryLogId,
+  summaryLog,
+  issues,
+  logger
+}) => {
+  const allIssues = issues.getAllIssues()
+  if (allIssues.length === 0) {
+    return
+  }
+  allIssues.forEach((issue) => {
+    logger.warn(buildIssueLogPayload(issue, summaryLogId))
+  })
+  logger.warn(
+    buildSummaryLogPayload(
+      allIssues,
+      summaryLogId,
+      summaryLog.organisationId,
+      summaryLog.registrationId
+    )
+  )
+}

--- a/src/application/summary-logs/validate-issue-logging.js
+++ b/src/application/summary-logs/validate-issue-logging.js
@@ -35,24 +35,27 @@ const buildLocationId = (context) => {
  * @param {string} summaryLogId
  * @returns {IndexedLogProperties}
  */
-const buildIssueLogPayload = (issue, summaryLogId) => ({
-  message: `Summary log validation issue: ${issue.code}`,
-  event: {
-    kind: 'event',
-    category: LOGGING_EVENT_CATEGORIES.SERVER,
-    action: LOGGING_EVENT_ACTIONS.SUMMARY_LOG_VALIDATION_ISSUE,
-    outcome: 'failure',
-    type: 'error',
-    reference: summaryLogId,
-    reason: issue.code
-  },
-  error: {
-    code: issue.code,
-    type: issue.severity,
-    message: issue.message,
-    id: buildLocationId(issue.context)
+const buildIssueLogPayload = (issue, summaryLogId) => {
+  const id = buildLocationId(issue.context)
+  return {
+    message: `Summary log validation issue: ${issue.code}`,
+    event: {
+      kind: 'event',
+      category: LOGGING_EVENT_CATEGORIES.SERVER,
+      action: LOGGING_EVENT_ACTIONS.SUMMARY_LOG_VALIDATION_ISSUE,
+      outcome: 'failure',
+      type: 'error',
+      reference: summaryLogId,
+      reason: issue.code
+    },
+    error: {
+      code: issue.code,
+      type: issue.severity,
+      message: issue.message,
+      ...(id && { id })
+    }
   }
-})
+}
 
 /**
  * @param {ValidationIssue[]} allIssues

--- a/src/application/summary-logs/validate-issue-logging.js
+++ b/src/application/summary-logs/validate-issue-logging.js
@@ -58,33 +58,27 @@ const buildIssueLogPayload = (issue, summaryLogId) => {
 }
 
 /**
- * @param {ValidationIssue[]} allIssues
+ * @param {ReturnType<ReturnType<typeof createValidationIssues>['getCounts']>} counts
  * @param {string} summaryLogId
  * @param {string} organisationId
  * @param {string} registrationId
  * @returns {IndexedLogProperties}
  */
 const buildSummaryLogPayload = (
-  allIssues,
+  counts,
   summaryLogId,
   organisationId,
   registrationId
-) => {
-  const counts = { fatal: 0, error: 0, warning: 0 }
-  allIssues.forEach((issue) => {
-    counts[issue.severity]++
-  })
-  return {
-    message: `Summary log validation completed: fatal=${counts.fatal} error=${counts.error} warning=${counts.warning} org=${organisationId} reg=${registrationId}`,
-    event: {
-      kind: 'event',
-      category: LOGGING_EVENT_CATEGORIES.SERVER,
-      action: LOGGING_EVENT_ACTIONS.SUMMARY_LOG_VALIDATION_COMPLETED,
-      outcome: 'failure',
-      reference: summaryLogId
-    }
+) => ({
+  message: `Summary log validation completed: fatal=${counts.fatal} error=${counts.error} warning=${counts.warning} org=${organisationId} reg=${registrationId}`,
+  event: {
+    kind: 'event',
+    category: LOGGING_EVENT_CATEGORIES.SERVER,
+    action: LOGGING_EVENT_ACTIONS.SUMMARY_LOG_VALIDATION_COMPLETED,
+    outcome: 'failure',
+    reference: summaryLogId
   }
-}
+})
 
 /**
  * Emits a warn-level log per validation issue plus a single summary log so
@@ -105,16 +99,15 @@ export const logValidationIssues = ({
   issues,
   logger
 }) => {
-  const allIssues = issues.getAllIssues()
-  if (allIssues.length === 0) {
+  if (!issues.hasIssues()) {
     return
   }
-  allIssues.forEach((issue) => {
+  issues.getAllIssues().forEach((issue) => {
     logger.warn(buildIssueLogPayload(issue, summaryLogId))
   })
   logger.warn(
     buildSummaryLogPayload(
-      allIssues,
+      issues.getCounts(),
       summaryLogId,
       summaryLog.organisationId,
       summaryLog.registrationId

--- a/src/application/summary-logs/validate-issue-logging.js
+++ b/src/application/summary-logs/validate-issue-logging.js
@@ -4,6 +4,8 @@ import {
 } from '#common/enums/index.js'
 import { LOCATION_KEYS } from '#common/validation/validation-issues.js'
 
+const MAX_LOGGED_ISSUES = 50
+
 /** @import {IndexedLogProperties, TypedLogger} from '#common/helpers/logging/logger.js' */
 /** @import {ValidationIssue, ValidationIssueContext, ValidationIssueCounts, ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {StoredFile, SummaryLog} from '#domain/summary-logs/model.js' */
@@ -66,6 +68,7 @@ const buildIssueLogPayload = (issue, summaryLogId) => {
 /**
  * @param {{
  *   counts: ValidationIssueCounts,
+ *   logged: number,
  *   summaryLogId: string,
  *   organisationId: string,
  *   registrationId: string
@@ -74,11 +77,12 @@ const buildIssueLogPayload = (issue, summaryLogId) => {
  */
 const buildSummaryLogPayload = ({
   counts,
+  logged,
   summaryLogId,
   organisationId,
   registrationId
 }) => ({
-  message: `Summary log validation completed: fatal=${counts.fatal} error=${counts.error} warning=${counts.warning} org=${organisationId} reg=${registrationId}`,
+  message: `Summary log validation completed: fatal=${counts.fatal} error=${counts.error} warning=${counts.warning} total=${counts.total} logged=${logged} org=${organisationId} reg=${registrationId}`,
   event: {
     kind: 'event',
     category: LOGGING_EVENT_CATEGORIES.SERVER,
@@ -110,12 +114,14 @@ export const logValidationIssues = ({
   if (!issues.hasIssues()) {
     return
   }
-  issues.getAllIssues().forEach((issue) => {
+  const issuesToLog = issues.getAllIssues().slice(0, MAX_LOGGED_ISSUES)
+  issuesToLog.forEach((issue) => {
     logger.warn(buildIssueLogPayload(issue, summaryLogId))
   })
   logger.warn(
     buildSummaryLogPayload({
       counts: issues.getCounts(),
+      logged: issuesToLog.length,
       summaryLogId,
       organisationId: summaryLog.organisationId,
       registrationId: summaryLog.registrationId

--- a/src/application/summary-logs/validate-issue-logging.js
+++ b/src/application/summary-logs/validate-issue-logging.js
@@ -58,18 +58,20 @@ const buildIssueLogPayload = (issue, summaryLogId) => {
 }
 
 /**
- * @param {ReturnType<ReturnType<typeof createValidationIssues>['getCounts']>} counts
- * @param {string} summaryLogId
- * @param {string} organisationId
- * @param {string} registrationId
+ * @param {{
+ *   counts: ReturnType<ReturnType<typeof createValidationIssues>['getCounts']>,
+ *   summaryLogId: string,
+ *   organisationId: string,
+ *   registrationId: string
+ * }} params
  * @returns {IndexedLogProperties}
  */
-const buildSummaryLogPayload = (
+const buildSummaryLogPayload = ({
   counts,
   summaryLogId,
   organisationId,
   registrationId
-) => ({
+}) => ({
   message: `Summary log validation completed: fatal=${counts.fatal} error=${counts.error} warning=${counts.warning} org=${organisationId} reg=${registrationId}`,
   event: {
     kind: 'event',
@@ -106,11 +108,11 @@ export const logValidationIssues = ({
     logger.warn(buildIssueLogPayload(issue, summaryLogId))
   })
   logger.warn(
-    buildSummaryLogPayload(
-      issues.getCounts(),
+    buildSummaryLogPayload({
+      counts: issues.getCounts(),
       summaryLogId,
-      summaryLog.organisationId,
-      summaryLog.registrationId
-    )
+      organisationId: summaryLog.organisationId,
+      registrationId: summaryLog.registrationId
+    })
   )
 }

--- a/src/application/summary-logs/validate-issue-logging.js
+++ b/src/application/summary-logs/validate-issue-logging.js
@@ -4,7 +4,7 @@ import {
 } from '#common/enums/index.js'
 import { LOCATION_KEYS } from '#common/validation/validation-issues.js'
 
-const MAX_LOGGED_ISSUES = 50
+export const MAX_VALIDATION_ISSUES = 100
 
 /** @import {IndexedLogProperties, TypedLogger} from '#common/helpers/logging/logger.js' */
 /** @import {ValidationIssue, ValidationIssueContext, ValidationIssueCounts, ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
@@ -114,7 +114,7 @@ export const logValidationIssues = ({
   if (!issues.hasIssues()) {
     return
   }
-  const issuesToLog = issues.getAllIssues().slice(0, MAX_LOGGED_ISSUES)
+  const issuesToLog = issues.getAllIssues().slice(0, MAX_VALIDATION_ISSUES)
   issuesToLog.forEach((issue) => {
     logger.warn(buildIssueLogPayload(issue, summaryLogId))
   })

--- a/src/application/summary-logs/validate-issue-logging.js
+++ b/src/application/summary-logs/validate-issue-logging.js
@@ -5,7 +5,7 @@ import {
 import { LOCATION_KEYS } from '#common/validation/validation-issues.js'
 
 /** @import {IndexedLogProperties, TypedLogger} from '#common/helpers/logging/logger.js' */
-/** @import {ValidationIssue, ValidationIssueContext, createValidationIssues} from '#common/validation/validation-issues.js' */
+/** @import {ValidationIssue, ValidationIssueContext, ValidationIssueCounts, ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {SummaryLog} from '#domain/summary-logs/model.js' */
 
 /**
@@ -59,7 +59,7 @@ const buildIssueLogPayload = (issue, summaryLogId) => {
 
 /**
  * @param {{
- *   counts: ReturnType<ReturnType<typeof createValidationIssues>['getCounts']>,
+ *   counts: ValidationIssueCounts,
  *   summaryLogId: string,
  *   organisationId: string,
  *   registrationId: string
@@ -91,7 +91,7 @@ const buildSummaryLogPayload = ({
  * @param {{
  *   summaryLogId: string,
  *   summaryLog: SubmittedSummaryLog,
- *   issues: ReturnType<typeof createValidationIssues>,
+ *   issues: ValidationIssuesCollector,
  *   logger: TypedLogger
  * }} params
  */

--- a/src/application/summary-logs/validate-issue-logging.test.js
+++ b/src/application/summary-logs/validate-issue-logging.test.js
@@ -35,9 +35,9 @@ describe('logValidationIssues', () => {
   })
 
   describe('issue-log cap', () => {
-    it('should cap per-issue logs at 50 and report total + logged in the summary', () => {
+    it('should cap per-issue logs at MAX_VALIDATION_ISSUES and report total + logged in the summary', () => {
       const issues = createValidationIssues()
-      for (let i = 0; i < 75; i++) {
+      for (let i = 0; i < 150; i++) {
         issues.addError(
           VALIDATION_CATEGORY.TECHNICAL,
           `issue ${i}`,
@@ -66,9 +66,9 @@ describe('logValidationIssues', () => {
         )
         .map(([payload]) => payload)
 
-      expect(issueLogs).toHaveLength(50)
-      expect(summaryPayload.message).toContain('total=75')
-      expect(summaryPayload.message).toContain('logged=50')
+      expect(issueLogs).toHaveLength(100)
+      expect(summaryPayload.message).toContain('total=150')
+      expect(summaryPayload.message).toContain('logged=100')
     })
 
     it('should report total === logged when issues fit under the cap', () => {

--- a/src/application/summary-logs/validate-issue-logging.test.js
+++ b/src/application/summary-logs/validate-issue-logging.test.js
@@ -37,13 +37,13 @@ describe('logValidationIssues', () => {
   describe('issue-log cap', () => {
     it('should cap per-issue logs at MAX_VALIDATION_ISSUES and report total + logged in the summary', () => {
       const issues = createValidationIssues()
-      for (let i = 0; i < 150; i++) {
+      Array.from({ length: 150 }).forEach(() =>
         issues.addError(
           VALIDATION_CATEGORY.TECHNICAL,
-          `issue ${i}`,
+          'issue',
           VALIDATION_CODE.FIELD_REQUIRED
         )
-      }
+      )
 
       logValidationIssues({
         summaryLogId: 'summary-1',

--- a/src/application/summary-logs/validate-issue-logging.test.js
+++ b/src/application/summary-logs/validate-issue-logging.test.js
@@ -1,0 +1,103 @@
+import { createValidationIssues } from '#common/validation/validation-issues.js'
+import { VALIDATION_CATEGORY, VALIDATION_CODE } from '#common/enums/index.js'
+
+import { logValidationIssues } from './validate-issue-logging.js'
+
+/** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
+/** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
+
+describe('logValidationIssues', () => {
+  /** @type {TypedLogger} */
+  let logger
+
+  beforeEach(() => {
+    logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      fatal: vi.fn(),
+      child: () => logger
+    }
+  })
+
+  const summaryLog = /** @type {SubmittedSummaryLog} */ ({
+    organisationId: 'org-123',
+    registrationId: 'reg-456',
+    file: {
+      id: 'file-1',
+      name: 'test.xlsx',
+      status: 'complete',
+      uri: 's3://x'
+    },
+    status: 'validating'
+  })
+
+  describe('issue-log cap', () => {
+    it('should cap per-issue logs at 50 and report total + logged in the summary', () => {
+      const issues = createValidationIssues()
+      for (let i = 0; i < 75; i++) {
+        issues.addError(
+          VALIDATION_CATEGORY.TECHNICAL,
+          `issue ${i}`,
+          VALIDATION_CODE.FIELD_REQUIRED
+        )
+      }
+
+      logValidationIssues({
+        summaryLogId: 'summary-1',
+        summaryLog,
+        issues,
+        logger
+      })
+
+      const warnCalls = /** @type {{ mock: { calls: any[][] } }} */ (
+        /** @type {unknown} */ (logger.warn)
+      ).mock.calls
+
+      const issueLogs = warnCalls.filter(
+        ([payload]) => payload?.event?.action === 'summary_log_validation_issue'
+      )
+      const [summaryPayload] = warnCalls
+        .filter(
+          ([payload]) =>
+            payload?.event?.action === 'summary_log_validation_completed'
+        )
+        .map(([payload]) => payload)
+
+      expect(issueLogs).toHaveLength(50)
+      expect(summaryPayload.message).toContain('total=75')
+      expect(summaryPayload.message).toContain('logged=50')
+    })
+
+    it('should report total === logged when issues fit under the cap', () => {
+      const issues = createValidationIssues()
+      issues.addError(
+        VALIDATION_CATEGORY.TECHNICAL,
+        'lonely issue',
+        VALIDATION_CODE.FIELD_REQUIRED
+      )
+
+      logValidationIssues({
+        summaryLogId: 'summary-1',
+        summaryLog,
+        issues,
+        logger
+      })
+
+      const warnCalls = /** @type {{ mock: { calls: any[][] } }} */ (
+        /** @type {unknown} */ (logger.warn)
+      ).mock.calls
+      const [summaryPayload] = warnCalls
+        .filter(
+          ([payload]) =>
+            payload?.event?.action === 'summary_log_validation_completed'
+        )
+        .map(([payload]) => payload)
+
+      expect(summaryPayload.message).toContain('total=1')
+      expect(summaryPayload.message).toContain('logged=1')
+    })
+  })
+})

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -10,8 +10,8 @@ import {
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import { buildOrganisation } from '#repositories/organisations/contract/test-data.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
-import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
+import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
 
@@ -178,25 +178,30 @@ describe('SummaryLogsValidator integration', () => {
     expect(updated.summaryLog.validation.issues).toEqual([])
   })
 
-  it('should fail validation when extraction throws error', async () => {
-    const errorMessage = 'Test extraction error'
-    const { updated } = await runValidation({
-      registrationType: 'reprocessor',
-      registrationWRN: 'REG-123',
-      summaryLogExtractor: {
-        extract: async () => {
-          throw new Error(errorMessage)
+  it.each([
+    { description: 'an Error instance', thrown: new Error('extraction error') },
+    { description: 'a non-Error value', thrown: { message: 'plain object' } }
+  ])(
+    'should fail validation when extraction throws $description',
+    async ({ thrown }) => {
+      const { updated } = await runValidation({
+        registrationType: 'reprocessor',
+        registrationWRN: 'REG-123',
+        summaryLogExtractor: {
+          extract: async () => {
+            throw thrown
+          }
         }
-      }
-    })
+      })
 
-    expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.INVALID)
-    expect(updated.summaryLog.validation.issues).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ code: 'VALIDATION_SYSTEM_ERROR' })
-      ])
-    )
-  })
+      expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.INVALID)
+      expect(updated.summaryLog.validation.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: 'VALIDATION_SYSTEM_ERROR' })
+        ])
+      )
+    }
+  )
 
   describe('successful type matching', () => {
     describe.each([

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -1,12 +1,12 @@
-/** @import {SummaryLogExtractor} from '#domain/summary-logs/extractor/port.js' */
-/** @import {MetadataEntry} from '#domain/summary-logs/extractor/port.js' */
-/** @import {WasteProcessingTypeValue} from '#domain/organisations/model.js' */
-
 import { randomUUID } from 'crypto'
 
 import { createInMemorySummaryLogExtractor } from '#application/summary-logs/extractor-inmemory.js'
 import { createSummaryLogsValidator } from '#application/summary-logs/validate.js'
 import { logger } from '#common/helpers/logging/logger.js'
+import {
+  ORGANISATION_STATUS,
+  WASTE_PROCESSING_TYPE
+} from '#domain/organisations/model.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import { buildOrganisation } from '#repositories/organisations/contract/test-data.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
@@ -14,6 +14,9 @@ import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
+
+/** @import {DataSection, MetadataEntry, SummaryLogExtractor} from '#domain/summary-logs/extractor/port.js' */
+/** @import {WasteProcessingTypeValue} from '#domain/organisations/model.js' */
 
 describe('SummaryLogsValidator integration', () => {
   let summaryLogsRepository
@@ -54,10 +57,13 @@ describe('SummaryLogsValidator integration', () => {
       ...(accreditation && { accreditationId: accreditation.id })
     }
 
-    return buildOrganisation({
-      registrations: [registration],
-      accreditations: accreditation ? [accreditation] : []
-    })
+    return {
+      ...buildOrganisation({
+        registrations: [registration],
+        accreditations: accreditation ? [accreditation] : []
+      }),
+      status: ORGANISATION_STATUS.ACTIVE
+    }
   }
 
   const createExtractor = (fileId, metadata, data = {}) => {
@@ -77,12 +83,13 @@ describe('SummaryLogsValidator integration', () => {
 
   /**
    * @typedef {{
-   *  registrationType: WasteProcessingTypeValue;
-   *  registrationWRN: string;
-   *  accreditationNumber?: string;
-   *  reprocessingType?: 'input' | 'output';
-   *  metadata?: Record<string, MetadataEntry>;
-   *  summaryLogExtractor?: SummaryLogExtractor;
+   *   registrationType: WasteProcessingTypeValue;
+   *   registrationWRN: string;
+   *   accreditationNumber?: string;
+   *   reprocessingType?: 'input' | 'output';
+   *   metadata?: Record<string, MetadataEntry>;
+   *   data?: Record<string, DataSection>;
+   *   summaryLogExtractor?: SummaryLogExtractor;
    * }} RunValidationParams
    * @param {RunValidationParams} params
    */
@@ -93,7 +100,7 @@ describe('SummaryLogsValidator integration', () => {
     reprocessingType = 'input',
     metadata,
     data,
-    summaryLogExtractor = null
+    summaryLogExtractor
   }) => {
     const testOrg = createTestOrg(
       registrationType,
@@ -194,13 +201,13 @@ describe('SummaryLogsValidator integration', () => {
   describe('successful type matching', () => {
     describe.each([
       {
-        registrationType: 'reprocessor',
+        registrationType: WASTE_PROCESSING_TYPE.REPROCESSOR,
         registrationWRN: 'REG-123',
         accreditationNumber: 'ACC-001',
         spreadsheetType: 'REPROCESSOR_INPUT'
       },
       {
-        registrationType: 'exporter',
+        registrationType: WASTE_PROCESSING_TYPE.EXPORTER,
         registrationWRN: 'REG-456',
         accreditationNumber: 'ACC-002',
         spreadsheetType: 'EXPORTER'
@@ -254,12 +261,12 @@ describe('SummaryLogsValidator integration', () => {
   describe('type mismatches', () => {
     describe.each([
       {
-        registrationType: 'reprocessor',
+        registrationType: WASTE_PROCESSING_TYPE.REPROCESSOR,
         registrationWRN: 'REG-123',
         spreadsheetType: 'EXPORTER'
       },
       {
-        registrationType: 'exporter',
+        registrationType: WASTE_PROCESSING_TYPE.EXPORTER,
         registrationWRN: 'REG-456',
         spreadsheetType: 'REPROCESSOR_INPUT'
       }

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -127,6 +127,7 @@ describe('SummaryLogsValidator integration', () => {
     const updated = await waitForVersion(summaryLogsRepository, summaryLogId, 2)
 
     return {
+      summaryLogId,
       updated,
       summaryLog,
       testOrg,
@@ -680,6 +681,250 @@ describe('SummaryLogsValidator integration', () => {
 
       expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.VALIDATED)
       expect(updated.summaryLog.validation.issues).toEqual([])
+    })
+  })
+
+  describe('validation issue logging', () => {
+    let warnSpy
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      warnSpy.mockRestore()
+    })
+
+    const filterByAction = (action) =>
+      warnSpy.mock.calls
+        .map(([payload]) => payload)
+        .filter((payload) => payload?.event?.action === action)
+
+    it('should emit a warn log per issue plus a summary log when validation produces issues', async () => {
+      const metadata = {
+        REGISTRATION_NUMBER: {
+          value: 'REG-123',
+          location: { sheet: 'Cover', row: 1, column: 'B' }
+        },
+        MATERIAL: {
+          value: 'Paper_and_board',
+          location: { sheet: 'Cover', row: 3, column: 'B' }
+        },
+        TEMPLATE_VERSION: {
+          value: 5,
+          location: { sheet: 'Cover', row: 4, column: 'B' }
+        }
+      }
+
+      await runValidation({
+        registrationType: 'reprocessor',
+        registrationWRN: 'REG-123',
+        metadata
+      })
+
+      const issueLogs = filterByAction('summary_log_validation_issue')
+      const summaryLogs = filterByAction('summary_log_validation_completed')
+
+      expect(issueLogs).toHaveLength(1)
+      expect(summaryLogs).toHaveLength(1)
+    })
+
+    it('should not emit validation-issue warn logs when validation passes cleanly', async () => {
+      const accreditationNumber = 'ACC-001'
+      const metadata = {
+        REGISTRATION_NUMBER: {
+          value: 'REG-123',
+          location: { sheet: 'Cover', row: 1, column: 'B' }
+        },
+        PROCESSING_TYPE: {
+          value: 'REPROCESSOR_INPUT',
+          location: { sheet: 'Cover', row: 2, column: 'B' }
+        },
+        MATERIAL: {
+          value: 'Paper_and_board',
+          location: { sheet: 'Cover', row: 3, column: 'B' }
+        },
+        TEMPLATE_VERSION: {
+          value: 5,
+          location: { sheet: 'Cover', row: 4, column: 'B' }
+        },
+        ACCREDITATION_NUMBER: {
+          value: accreditationNumber,
+          location: { sheet: 'Cover', row: 5, column: 'B' }
+        }
+      }
+
+      await runValidation({
+        registrationType: 'reprocessor',
+        registrationWRN: 'REG-123',
+        accreditationNumber,
+        metadata
+      })
+
+      const issueLogs = filterByAction('summary_log_validation_issue')
+      const summaryLogs = filterByAction('summary_log_validation_completed')
+
+      expect(issueLogs).toEqual([])
+      expect(summaryLogs).toEqual([])
+    })
+
+    it('should structure the per-issue log with CDP-indexed fields and no PII', async () => {
+      const metadata = {
+        REGISTRATION_NUMBER: {
+          value: 'REG-123',
+          location: { sheet: 'Cover', row: 1, column: 'B' }
+        },
+        MATERIAL: {
+          value: 'Paper_and_board',
+          location: { sheet: 'Cover', row: 3, column: 'B' }
+        },
+        TEMPLATE_VERSION: {
+          value: 5,
+          location: { sheet: 'Cover', row: 4, column: 'B' }
+        }
+      }
+
+      const { summaryLogId } = await runValidation({
+        registrationType: 'reprocessor',
+        registrationWRN: 'REG-123',
+        metadata
+      })
+
+      const [issueLog] = filterByAction('summary_log_validation_issue')
+
+      expect(issueLog).toEqual({
+        message: expect.stringContaining(
+          'Summary log validation issue: PROCESSING_TYPE_REQUIRED'
+        ),
+        event: {
+          kind: 'event',
+          category: 'server',
+          action: 'summary_log_validation_issue',
+          outcome: 'failure',
+          type: 'error',
+          reference: summaryLogId,
+          reason: 'PROCESSING_TYPE_REQUIRED'
+        },
+        error: {
+          code: 'PROCESSING_TYPE_REQUIRED',
+          type: 'fatal',
+          message: expect.stringContaining(
+            "Invalid meta field 'PROCESSING_TYPE'"
+          ),
+          id: 'field=PROCESSING_TYPE'
+        }
+      })
+    })
+
+    it('should encode location as a semicolon-delimited composite in error.id', async () => {
+      const metadata = {
+        REGISTRATION_NUMBER: {
+          value: 'REG-123',
+          location: { sheet: 'Cover', row: 1, column: 'B' }
+        },
+        PROCESSING_TYPE: {
+          value: 'REPROCESSOR_INPUT',
+          location: { sheet: 'Cover', row: 2, column: 'B' }
+        },
+        MATERIAL: {
+          value: 'Paper_and_board',
+          location: { sheet: 'Cover', row: 3, column: 'B' }
+        },
+        TEMPLATE_VERSION: {
+          value: 5,
+          location: { sheet: 'Cover', row: 4, column: 'B' }
+        },
+        ACCREDITATION_NUMBER: {
+          value: '99999999',
+          location: { sheet: 'Cover', row: 5, column: 'B' }
+        }
+      }
+
+      await runValidation({
+        registrationType: 'reprocessor',
+        registrationWRN: 'REG-123',
+        accreditationNumber: '87654321',
+        metadata
+      })
+
+      const [issueLog] = filterByAction('summary_log_validation_issue')
+
+      expect(issueLog.error.id).toBe(
+        'sheet=Cover;row=5;column=B;field=ACCREDITATION_NUMBER'
+      )
+    })
+
+    it('should structure the summary log with counts and org/reg in message', async () => {
+      const metadata = {
+        REGISTRATION_NUMBER: {
+          value: 'REG-123',
+          location: { sheet: 'Cover', row: 1, column: 'B' }
+        },
+        MATERIAL: {
+          value: 'Paper_and_board',
+          location: { sheet: 'Cover', row: 3, column: 'B' }
+        },
+        TEMPLATE_VERSION: {
+          value: 5,
+          location: { sheet: 'Cover', row: 4, column: 'B' }
+        }
+      }
+
+      const { summaryLogId, testOrg } = await runValidation({
+        registrationType: 'reprocessor',
+        registrationWRN: 'REG-123',
+        metadata
+      })
+
+      const [summaryLogPayload] = filterByAction(
+        'summary_log_validation_completed'
+      )
+
+      expect(summaryLogPayload).toEqual({
+        message: `Summary log validation completed: fatal=1 error=0 warning=0 org=${testOrg.id} reg=${testOrg.registrations[0].id}`,
+        event: {
+          kind: 'event',
+          category: 'server',
+          action: 'summary_log_validation_completed',
+          outcome: 'failure',
+          reference: summaryLogId
+        }
+      })
+    })
+
+    it('should never include the actual value, organisationId or registrationId in per-issue logs', async () => {
+      const piiValue = 'sensitive-operator-data-value'
+      const metadata = {
+        REGISTRATION_NUMBER: {
+          value: 'REG-123',
+          location: { sheet: 'Cover', row: 1, column: 'B' }
+        },
+        PROCESSING_TYPE: {
+          value: piiValue,
+          location: { sheet: 'Cover', row: 2, column: 'B' }
+        },
+        MATERIAL: {
+          value: 'Paper_and_board',
+          location: { sheet: 'Cover', row: 3, column: 'B' }
+        },
+        TEMPLATE_VERSION: {
+          value: 5,
+          location: { sheet: 'Cover', row: 4, column: 'B' }
+        }
+      }
+
+      const { testOrg } = await runValidation({
+        registrationType: 'reprocessor',
+        registrationWRN: 'REG-123',
+        metadata
+      })
+
+      const issueLogs = filterByAction('summary_log_validation_issue')
+      const serialised = JSON.stringify(issueLogs)
+
+      expect(serialised).not.toContain(piiValue)
+      expect(serialised).not.toContain(testOrg.id)
+      expect(serialised).not.toContain(testOrg.registrations[0].id)
     })
   })
 })

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -178,30 +178,24 @@ describe('SummaryLogsValidator integration', () => {
     expect(updated.summaryLog.validation.issues).toEqual([])
   })
 
-  it.each([
-    { description: 'an Error instance', thrown: new Error('extraction error') },
-    { description: 'a non-Error value', thrown: { message: 'plain object' } }
-  ])(
-    'should fail validation when extraction throws $description',
-    async ({ thrown }) => {
-      const { updated } = await runValidation({
-        registrationType: 'reprocessor',
-        registrationWRN: 'REG-123',
-        summaryLogExtractor: {
-          extract: async () => {
-            throw thrown
-          }
+  it('should fail validation when extraction throws an error', async () => {
+    const { updated } = await runValidation({
+      registrationType: 'reprocessor',
+      registrationWRN: 'REG-123',
+      summaryLogExtractor: {
+        extract: async () => {
+          throw new Error('extraction error')
         }
-      })
+      }
+    })
 
-      expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.INVALID)
-      expect(updated.summaryLog.validation.issues).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ code: 'VALIDATION_SYSTEM_ERROR' })
-        ])
-      )
-    }
-  )
+    expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.INVALID)
+    expect(updated.summaryLog.validation.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'VALIDATION_SYSTEM_ERROR' })
+      ])
+    )
+  })
 
   describe('successful type matching', () => {
     describe.each([

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -921,7 +921,7 @@ describe('SummaryLogsValidator integration', () => {
       )
 
       expect(summaryLogPayload).toStrictEqual({
-        message: `Summary log validation completed: fatal=1 error=0 warning=0 org=${testOrg.id} reg=${testOrg.registrations[0].id}`,
+        message: `Summary log validation completed: fatal=1 error=0 warning=0 total=1 logged=1 org=${testOrg.id} reg=${testOrg.registrations[0].id}`,
         event: {
           kind: 'event',
           category: 'server',

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -771,8 +771,8 @@ describe('SummaryLogsValidator integration', () => {
       const issueLogs = filterByAction('summary_log_validation_issue')
       const summaryLogs = filterByAction('summary_log_validation_completed')
 
-      expect(issueLogs).toEqual([])
-      expect(summaryLogs).toEqual([])
+      expect(issueLogs).toStrictEqual([])
+      expect(summaryLogs).toStrictEqual([])
     })
 
     it('should structure the per-issue log with CDP-indexed fields and no PII', async () => {
@@ -799,7 +799,7 @@ describe('SummaryLogsValidator integration', () => {
 
       const [issueLog] = filterByAction('summary_log_validation_issue')
 
-      expect(issueLog).toEqual({
+      expect(issueLog).toStrictEqual({
         message: expect.stringContaining(
           'Summary log validation issue: PROCESSING_TYPE_REQUIRED'
         ),
@@ -861,6 +861,39 @@ describe('SummaryLogsValidator integration', () => {
       )
     })
 
+    it('should omit error.id when the issue has no location context', async () => {
+      const errorMessage = 'Test extraction error'
+      const { summaryLogId } = await runValidation({
+        registrationType: 'reprocessor',
+        registrationWRN: 'REG-123',
+        summaryLogExtractor: {
+          extract: async () => {
+            throw new Error(errorMessage)
+          }
+        }
+      })
+
+      const [issueLog] = filterByAction('summary_log_validation_issue')
+
+      expect(issueLog).toStrictEqual({
+        message: 'Summary log validation issue: VALIDATION_SYSTEM_ERROR',
+        event: {
+          kind: 'event',
+          category: 'server',
+          action: 'summary_log_validation_issue',
+          outcome: 'failure',
+          type: 'error',
+          reference: summaryLogId,
+          reason: 'VALIDATION_SYSTEM_ERROR'
+        },
+        error: {
+          code: 'VALIDATION_SYSTEM_ERROR',
+          type: 'fatal',
+          message: errorMessage
+        }
+      })
+    })
+
     it('should structure the summary log with counts and org/reg in message', async () => {
       const metadata = {
         REGISTRATION_NUMBER: {
@@ -887,7 +920,7 @@ describe('SummaryLogsValidator integration', () => {
         'summary_log_validation_completed'
       )
 
-      expect(summaryLogPayload).toEqual({
+      expect(summaryLogPayload).toStrictEqual({
         message: `Summary log validation completed: fatal=1 error=0 warning=0 org=${testOrg.id} reg=${testOrg.registrations[0].id}`,
         event: {
           kind: 'event',

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -39,7 +39,7 @@ export const MAX_VALIDATION_ISSUES = 100
 export const MAX_ACTUAL_LENGTH = 200
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
-/** @import {ValidationIssue} from '#common/validation/validation-issues.js' */
+/** @import {ValidationIssue, ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {SummaryLog} from '#domain/summary-logs/model.js' */
 /** @import {SummaryLogStatus} from '#domain/summary-logs/status.js' */
@@ -142,7 +142,7 @@ const fetchRegistration = async ({
 
 /**
  * @typedef {Object} ValidationResult
- * @property {ReturnType<typeof createValidationIssues>} issues - Validation issues object with methods like getAllIssues(), isFatal()
+ * @property {ValidationIssuesCollector} issues - Validation issues object with methods like getAllIssues(), isFatal()
  * @property {ValidatedWasteRecord[]|null} wasteRecords - Waste records with validation issues (null if transformation not reached)
  * @property {ExtractedMeta} [meta] - Extracted metadata values (only present after successful extraction)
  */
@@ -334,7 +334,7 @@ const performValidationChecks = async ({
 /**
  * Records validation issue metrics grouped by severity × category
  *
- * @param {ReturnType<typeof createValidationIssues>} issues - Validation issues object
+ * @param {ValidationIssuesCollector} issues - Validation issues object
  * @param {string} processingType - The processing type for the metric dimension
  */
 const recordValidationIssueMetrics = async (issues, processingType) => {
@@ -443,7 +443,7 @@ const assertValidatingStatus = (result, summaryLogId) => {
  * Records all validation-related metrics.
  *
  * @param {Object} params
- * @param {ReturnType<typeof createValidationIssues>} params.issues
+ * @param {ValidationIssuesCollector} params.issues
  * @param {import('#common/helpers/metrics/summary-logs.js').ProcessingType} params.processingType
  * @param {SummaryLogStatus} params.status
  * @param {number} params.validationDurationMs
@@ -469,7 +469,7 @@ const recordValidationMetrics = async ({
  * Persists the validation result to the summary log document.
  *
  * @param {Object} params
- * @param {ReturnType<typeof createValidationIssues>} params.issues
+ * @param {ValidationIssuesCollector} params.issues
  * @param {Loads | null} params.loads
  * @param {import('./load-counts.js').LoadsByWasteRecordType | null} params.loadsByWasteRecordType
  * @param {ExtractedMeta | undefined} params.meta

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -404,7 +404,7 @@ const recordValidationIssueMetrics = async (issues, processingType) => {
             category
           ),
         processingType:
-          /** @type {import('#common/helpers/metrics/summary-logs.js').ProcessingType} */ (
+          /** @type {ProcessingType} */ (
             processingType
           )
       },
@@ -446,7 +446,7 @@ const recordRowOutcomeMetrics = async (wasteRecords, processingType) => {
               outcome
             ),
           processingType:
-            /** @type {import('#common/helpers/metrics/summary-logs.js').ProcessingType} */ (
+            /** @type {ProcessingType} */ (
               processingType
             )
         },
@@ -479,7 +479,7 @@ const assertValidatingStatus = (result, summaryLogId) => {
  *
  * @param {Object} params
  * @param {ValidationIssuesCollector} params.issues
- * @param {import('#common/helpers/metrics/summary-logs.js').ProcessingType} params.processingType
+ * @param {ProcessingType} params.processingType
  * @param {SummaryLogStatus} params.status
  * @param {number} params.validationDurationMs
  * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -29,13 +29,17 @@ import {
   countByWasteRecordType,
   mergeLoads
 } from './load-counts.js'
-import { logValidationIssues } from './validate-issue-logging.js'
+import {
+  logValidationIssues,
+  MAX_VALIDATION_ISSUES
+} from './validate-issue-logging.js'
 import { validateDataBusiness } from './validations/data-business.js'
 import { createDataSyntaxValidator } from './validations/data-syntax.js'
 import { validateMetaBusiness } from './validations/meta-business.js'
 import { validateMetaSyntax } from './validations/meta-syntax.js'
 
-export const MAX_VALIDATION_ISSUES = 100
+export { MAX_VALIDATION_ISSUES }
+
 export const MAX_ACTUAL_LENGTH = 200
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -37,18 +37,25 @@ import {
 export const MAX_VALIDATION_ISSUES = 100
 export const MAX_ACTUAL_LENGTH = 200
 
+/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {IndexedLogProperties, TypedLogger} from '#common/helpers/logging/logger.js' */
+/** @import {ValidationIssue, ValidationIssueContext, ValidationIssueLocation} from '#common/validation/validation-issues.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
-/** @typedef {import('#domain/summary-logs/model.js').SummaryLog} SummaryLog */
-/** @typedef {import('#domain/summary-logs/status.js').SummaryLogStatus} SummaryLogStatus */
-/** @typedef {import('#repositories/summary-logs/port.js').SummaryLogsRepository} SummaryLogsRepository */
-/** @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository */
-/** @typedef {import('#repositories/waste-records/port.js').WasteRecordsRepository} WasteRecordsRepository */
-/** @typedef {import('./extractor.js').SummaryLogExtractor} SummaryLogExtractor */
-/** @typedef {import('#domain/waste-records/model.js').WasteRecord} WasteRecord */
-/** @typedef {import('#common/validation/validation-issues.js').ValidationIssue} ValidationIssue */
-/** @typedef {import('./load-counts.js').Loads} Loads */
+/** @import {SummaryLog} from '#domain/summary-logs/model.js' */
+/** @import {SummaryLogStatus} from '#domain/summary-logs/status.js' */
+/** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
+/** @import {SummaryLogsRepository} from '#repositories/summary-logs/port.js' */
+/** @import {WasteRecordsRepository} from '#repositories/waste-records/port.js' */
+/** @import {SummaryLogExtractor} from './extractor.js' */
+/** @import {Loads} from './load-counts.js' */
 
-/** @typedef {import('#application/waste-records/transform-from-summary-log.js').ValidatedWasteRecord} ValidatedWasteRecord */
+/**
+ * SummaryLog after assertValidatingStatus has confirmed it's past PREPROCESSING
+ * (org/reg guaranteed by upstream business logic but the SummaryLog typedef
+ * leaves them optional to cover the PREPROCESSING state too).
+ *
+ * @typedef {SummaryLog & { organisationId: string, registrationId: string }} SubmittedSummaryLog
+ */
 
 const extractSummaryLog = async ({
   summaryLogExtractor,
@@ -416,6 +423,114 @@ const recordRowOutcomeMetrics = async (wasteRecords, processingType) => {
   }
 }
 
+/** @type {readonly (keyof ValidationIssueLocation)[]} */
+const LOCATION_KEY_ORDER = [
+  'sheet',
+  'table',
+  'row',
+  'column',
+  'header',
+  'field'
+]
+
+/**
+ * @param {ValidationIssueContext} [context]
+ * @returns {string} Semicolon-delimited composite, empty parts omitted
+ */
+const buildLocationId = (context) => {
+  const location = context?.location
+  if (!location) {
+    return ''
+  }
+  return LOCATION_KEY_ORDER.filter((key) => location[key] !== undefined)
+    .map((key) => `${key}=${location[key]}`)
+    .join(';')
+}
+
+/**
+ * @param {ValidationIssue} issue
+ * @param {string} summaryLogId
+ * @returns {IndexedLogProperties}
+ */
+const buildIssueLogPayload = (issue, summaryLogId) => ({
+  message: `Summary log validation issue: ${issue.code}`,
+  event: {
+    kind: 'event',
+    category: LOGGING_EVENT_CATEGORIES.SERVER,
+    action: LOGGING_EVENT_ACTIONS.SUMMARY_LOG_VALIDATION_ISSUE,
+    outcome: 'failure',
+    type: 'error',
+    reference: summaryLogId,
+    reason: issue.code
+  },
+  error: {
+    code: issue.code,
+    type: issue.severity,
+    message: issue.message,
+    id: buildLocationId(issue.context)
+  }
+})
+
+/**
+ * @param {ValidationIssue[]} allIssues
+ * @param {string} summaryLogId
+ * @param {string} organisationId
+ * @param {string} registrationId
+ * @returns {IndexedLogProperties}
+ */
+const buildSummaryLogPayload = (
+  allIssues,
+  summaryLogId,
+  organisationId,
+  registrationId
+) => {
+  const counts = { fatal: 0, error: 0, warning: 0 }
+  allIssues.forEach((issue) => {
+    counts[issue.severity]++
+  })
+  return {
+    message: `Summary log validation completed: fatal=${counts.fatal} error=${counts.error} warning=${counts.warning} org=${organisationId} reg=${registrationId}`,
+    event: {
+      kind: 'event',
+      category: LOGGING_EVENT_CATEGORIES.SERVER,
+      action: LOGGING_EVENT_ACTIONS.SUMMARY_LOG_VALIDATION_COMPLETED,
+      outcome: 'failure',
+      reference: summaryLogId
+    }
+  }
+}
+
+/**
+ * Emits a warn-level log per validation issue plus a single summary log so
+ * support can investigate failures via OpenSearch DQL. No-op when there are
+ * no issues. PII (issue.context.actual) and org/reg are never included in
+ * per-issue logs; org/reg appear only in the run-level summary log.
+ *
+ * @param {{
+ *   summaryLogId: string,
+ *   summaryLog: SubmittedSummaryLog,
+ *   issues: ReturnType<typeof createValidationIssues>,
+ *   logger: TypedLogger
+ * }} params
+ */
+const logValidationIssues = ({ summaryLogId, summaryLog, issues, logger }) => {
+  const allIssues = issues.getAllIssues()
+  if (allIssues.length === 0) {
+    return
+  }
+  allIssues.forEach((issue) => {
+    logger.warn(buildIssueLogPayload(issue, summaryLogId))
+  })
+  logger.warn(
+    buildSummaryLogPayload(
+      allIssues,
+      summaryLogId,
+      summaryLog.organisationId,
+      summaryLog.registrationId
+    )
+  )
+}
+
 /**
  * Creates a summary logs validator function
  *
@@ -572,8 +687,10 @@ export const createSummaryLogsValidator = ({
   return async (summaryLogId) => {
     const result = await summaryLogsRepository.findById(summaryLogId)
     assertValidatingStatus(result, summaryLogId)
-
-    const { version, summaryLog } = result
+    const { version, summaryLog } =
+      /** @type {{ version: number, summaryLog: SubmittedSummaryLog }} */ (
+        result
+      )
     const {
       file: { id: fileId, name: filename }
     } = summaryLog
@@ -600,6 +717,8 @@ export const createSummaryLogsValidator = ({
       validateDataSyntax
     })
     const validationDurationMs = Date.now() - validationStart
+
+    logValidationIssues({ summaryLogId, summaryLog, issues, logger })
 
     const processingType = meta?.[SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]
 

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -199,7 +199,7 @@ const extractMetaValues = (parsedMeta) => {
 }
 
 /**
- * @param {Error & { code?: string }} error
+ * @param {unknown} error
  * @param {ValidationIssuesCollector} issues
  * @param {string} loggingContext
  * @param {TypedLogger} logger
@@ -216,8 +216,9 @@ const handleValidationFailure = (error, issues, loggingContext, logger) => {
     })
     issues.addFatal(VALIDATION_CATEGORY.TECHNICAL, error.message, error.code)
   } else {
+    const err = error instanceof Error ? error : new Error(String(error))
     logger.error({
-      err: error,
+      err,
       message: `Failed to validate summary log file: ${loggingContext}`,
       event: {
         category: LOGGING_EVENT_CATEGORIES.SERVER,
@@ -226,7 +227,7 @@ const handleValidationFailure = (error, issues, loggingContext, logger) => {
     })
     issues.addFatal(
       VALIDATION_CATEGORY.TECHNICAL,
-      error.message,
+      err.message,
       VALIDATION_CODE.VALIDATION_SYSTEM_ERROR
     )
   }

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -39,8 +39,10 @@ export const MAX_VALIDATION_ISSUES = 100
 export const MAX_ACTUAL_LENGTH = 200
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
 /** @import {ValidationIssue, ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {ParsedSummaryLog} from '#domain/summary-logs/extractor/port.js' */
 /** @import {SummaryLog} from '#domain/summary-logs/model.js' */
 /** @import {SummaryLogStatus} from '#domain/summary-logs/status.js' */
 /** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
@@ -50,6 +52,15 @@ export const MAX_ACTUAL_LENGTH = 200
 /** @import {SummaryLogExtractor} from './extractor.js' */
 /** @import {Loads} from './load-counts.js' */
 
+/**
+ * @param {{
+ *   summaryLogExtractor: SummaryLogExtractor,
+ *   summaryLog: SummaryLog,
+ *   loggingContext: string,
+ *   logger: TypedLogger
+ * }} params
+ * @returns {Promise<ParsedSummaryLog>}
+ */
 const extractSummaryLog = async ({
   summaryLogExtractor,
   summaryLog,
@@ -69,6 +80,18 @@ const extractSummaryLog = async ({
   return parsed
 }
 
+/**
+ * @param {{
+ *   summaryLogId: string,
+ *   summaryLog: SubmittedSummaryLog,
+ *   validatedData: object,
+ *   wasteRecordsRepository: WasteRecordsRepository
+ * }} params
+ * @returns {Promise<{
+ *   wasteRecords: ValidatedWasteRecord[],
+ *   issues: ValidationIssuesCollector
+ * }>}
+ */
 const transformAndValidateData = async ({
   summaryLogId,
   summaryLog,
@@ -112,6 +135,16 @@ const transformAndValidateData = async ({
   return { wasteRecords, issues }
 }
 
+/**
+ * @param {{
+ *   organisationsRepository: OrganisationsRepository,
+ *   organisationId: string,
+ *   registrationId: string,
+ *   loggingContext: string,
+ *   logger: TypedLogger
+ * }} params
+ * @returns {Promise<Registration>}
+ */
 const fetchRegistration = async ({
   organisationsRepository,
   organisationId,
@@ -202,6 +235,12 @@ const extractMetaValues = (parsedMeta) => {
   )
 }
 
+/**
+ * @param {Error & { code?: string }} error
+ * @param {ValidationIssuesCollector} issues
+ * @param {string} loggingContext
+ * @param {TypedLogger} logger
+ */
 const handleValidationFailure = (error, issues, loggingContext, logger) => {
   if (error instanceof SpreadsheetValidationError) {
     logger.warn({
@@ -417,13 +456,8 @@ const recordRowOutcomeMetrics = async (wasteRecords, processingType) => {
 }
 
 /**
- * Creates a summary logs validator function
- *
- * @param {Object} params
- * @param {SummaryLogsRepository} params.summaryLogsRepository
- * @param {OrganisationsRepository} params.organisationsRepository
- * @param {WasteRecordsRepository} params.wasteRecordsRepository
- * @param {SummaryLogExtractor} params.summaryLogExtractor
+ * @param {{ summaryLog: SummaryLog, version: number } | null | undefined} result
+ * @param {string} summaryLogId
  */
 const assertValidatingStatus = (result, summaryLogId) => {
   if (!result) {
@@ -560,6 +594,18 @@ const classifyLoads = ({
   return { loads, loadsByWasteRecordType }
 }
 
+/**
+ * Creates a summary logs validator function.
+ *
+ * @param {{
+ *   logger: TypedLogger,
+ *   summaryLogsRepository: SummaryLogsRepository,
+ *   organisationsRepository: OrganisationsRepository,
+ *   wasteRecordsRepository: WasteRecordsRepository,
+ *   summaryLogExtractor: SummaryLogExtractor
+ * }} params
+ * @returns {(summaryLogId: string) => Promise<void>}
+ */
 export const createSummaryLogsValidator = ({
   logger,
   summaryLogsRepository,

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -1,4 +1,4 @@
-import { isNil } from '#common/helpers/is-nil.js'
+import { SpreadsheetValidationError } from '#adapters/parsers/summary-logs/exceljs-parser.js'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES,
@@ -6,56 +6,49 @@ import {
   VALIDATION_CODE,
   VALIDATION_SEVERITY
 } from '#common/enums/index.js'
+import { isNil } from '#common/helpers/is-nil.js'
 import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
+import { createValidationIssues } from '#common/validation/validation-issues.js'
 import {
   SUMMARY_LOG_STATUS,
   transitionStatus
 } from '#domain/summary-logs/status.js'
-import { createValidationIssues } from '#common/validation/validation-issues.js'
-import { SpreadsheetValidationError } from '#adapters/parsers/summary-logs/exceljs-parser.js'
 import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 
-import { validateMetaSyntax } from './validations/meta-syntax.js'
-import { validateMetaBusiness } from './validations/meta-business.js'
-import { createDataSyntaxValidator } from './validations/data-syntax.js'
+import { transformFromSummaryLog } from '#application/waste-records/transform-from-summary-log.js'
 import { SUMMARY_LOG_META_FIELDS } from '#domain/summary-logs/meta-fields.js'
 import {
   PROCESSING_TYPE_TABLES,
   findSchemaForProcessingType
 } from '#domain/summary-logs/table-schemas/index.js'
-import { validateDataBusiness } from './validations/data-business.js'
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
-import { transformFromSummaryLog } from '#application/waste-records/transform-from-summary-log.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import {
-  countByWasteBalanceInclusion,
   countByValidity,
+  countByWasteBalanceInclusion,
   countByWasteRecordType,
   mergeLoads
 } from './load-counts.js'
+import { logValidationIssues } from './validate-issue-logging.js'
+import { validateDataBusiness } from './validations/data-business.js'
+import { createDataSyntaxValidator } from './validations/data-syntax.js'
+import { validateMetaBusiness } from './validations/meta-business.js'
+import { validateMetaSyntax } from './validations/meta-syntax.js'
 
 export const MAX_VALIDATION_ISSUES = 100
 export const MAX_ACTUAL_LENGTH = 200
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
-/** @import {IndexedLogProperties, TypedLogger} from '#common/helpers/logging/logger.js' */
-/** @import {ValidationIssue, ValidationIssueContext, ValidationIssueLocation} from '#common/validation/validation-issues.js' */
+/** @import {ValidationIssue} from '#common/validation/validation-issues.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {SummaryLog} from '#domain/summary-logs/model.js' */
 /** @import {SummaryLogStatus} from '#domain/summary-logs/status.js' */
 /** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
 /** @import {SummaryLogsRepository} from '#repositories/summary-logs/port.js' */
 /** @import {WasteRecordsRepository} from '#repositories/waste-records/port.js' */
+/** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 /** @import {SummaryLogExtractor} from './extractor.js' */
 /** @import {Loads} from './load-counts.js' */
-
-/**
- * SummaryLog after assertValidatingStatus has confirmed it's past PREPROCESSING
- * (org/reg guaranteed by upstream business logic but the SummaryLog typedef
- * leaves them optional to cover the PREPROCESSING state too).
- *
- * @typedef {SummaryLog & { organisationId: string, registrationId: string }} SubmittedSummaryLog
- */
 
 const extractSummaryLog = async ({
   summaryLogExtractor,
@@ -421,114 +414,6 @@ const recordRowOutcomeMetrics = async (wasteRecords, processingType) => {
       )
     }
   }
-}
-
-/** @type {readonly (keyof ValidationIssueLocation)[]} */
-const LOCATION_KEY_ORDER = [
-  'sheet',
-  'table',
-  'row',
-  'column',
-  'header',
-  'field'
-]
-
-/**
- * @param {ValidationIssueContext} [context]
- * @returns {string} Semicolon-delimited composite, empty parts omitted
- */
-const buildLocationId = (context) => {
-  const location = context?.location
-  if (!location) {
-    return ''
-  }
-  return LOCATION_KEY_ORDER.filter((key) => location[key] !== undefined)
-    .map((key) => `${key}=${location[key]}`)
-    .join(';')
-}
-
-/**
- * @param {ValidationIssue} issue
- * @param {string} summaryLogId
- * @returns {IndexedLogProperties}
- */
-const buildIssueLogPayload = (issue, summaryLogId) => ({
-  message: `Summary log validation issue: ${issue.code}`,
-  event: {
-    kind: 'event',
-    category: LOGGING_EVENT_CATEGORIES.SERVER,
-    action: LOGGING_EVENT_ACTIONS.SUMMARY_LOG_VALIDATION_ISSUE,
-    outcome: 'failure',
-    type: 'error',
-    reference: summaryLogId,
-    reason: issue.code
-  },
-  error: {
-    code: issue.code,
-    type: issue.severity,
-    message: issue.message,
-    id: buildLocationId(issue.context)
-  }
-})
-
-/**
- * @param {ValidationIssue[]} allIssues
- * @param {string} summaryLogId
- * @param {string} organisationId
- * @param {string} registrationId
- * @returns {IndexedLogProperties}
- */
-const buildSummaryLogPayload = (
-  allIssues,
-  summaryLogId,
-  organisationId,
-  registrationId
-) => {
-  const counts = { fatal: 0, error: 0, warning: 0 }
-  allIssues.forEach((issue) => {
-    counts[issue.severity]++
-  })
-  return {
-    message: `Summary log validation completed: fatal=${counts.fatal} error=${counts.error} warning=${counts.warning} org=${organisationId} reg=${registrationId}`,
-    event: {
-      kind: 'event',
-      category: LOGGING_EVENT_CATEGORIES.SERVER,
-      action: LOGGING_EVENT_ACTIONS.SUMMARY_LOG_VALIDATION_COMPLETED,
-      outcome: 'failure',
-      reference: summaryLogId
-    }
-  }
-}
-
-/**
- * Emits a warn-level log per validation issue plus a single summary log so
- * support can investigate failures via OpenSearch DQL. No-op when there are
- * no issues. PII (issue.context.actual) and org/reg are never included in
- * per-issue logs; org/reg appear only in the run-level summary log.
- *
- * @param {{
- *   summaryLogId: string,
- *   summaryLog: SubmittedSummaryLog,
- *   issues: ReturnType<typeof createValidationIssues>,
- *   logger: TypedLogger
- * }} params
- */
-const logValidationIssues = ({ summaryLogId, summaryLog, issues, logger }) => {
-  const allIssues = issues.getAllIssues()
-  if (allIssues.length === 0) {
-    return
-  }
-  allIssues.forEach((issue) => {
-    logger.warn(buildIssueLogPayload(issue, summaryLogId))
-  })
-  logger.warn(
-    buildSummaryLogPayload(
-      allIssues,
-      summaryLogId,
-      summaryLog.organisationId,
-      summaryLog.registrationId
-    )
-  )
 }
 
 /**

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -507,7 +507,7 @@ const recordValidationMetrics = async ({
  * @param {Loads | null} params.loads
  * @param {import('./load-counts.js').LoadsByWasteRecordType | null} params.loadsByWasteRecordType
  * @param {ExtractedMeta | undefined} params.meta
- * @param {string} params.status
+ * @param {SummaryLogStatus} params.status
  * @param {SummaryLog} params.summaryLog
  * @param {string} params.summaryLogId
  * @param {SummaryLogsRepository} params.summaryLogsRepository

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -403,10 +403,7 @@ const recordValidationIssueMetrics = async (issues, processingType) => {
           /** @type {import('#common/helpers/metrics/summary-logs.js').ValidationCategory} */ (
             category
           ),
-        processingType:
-          /** @type {ProcessingType} */ (
-            processingType
-          )
+        processingType: /** @type {ProcessingType} */ (processingType)
       },
       count
     )
@@ -445,10 +442,7 @@ const recordRowOutcomeMetrics = async (wasteRecords, processingType) => {
             /** @type {import('#common/helpers/metrics/summary-logs.js').RowOutcome} */ (
               outcome
             ),
-          processingType:
-            /** @type {ProcessingType} */ (
-              processingType
-            )
+          processingType: /** @type {ProcessingType} */ (processingType)
         },
         count
       )

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -199,7 +199,7 @@ const extractMetaValues = (parsedMeta) => {
 }
 
 /**
- * @param {unknown} error
+ * @param {Error & { code?: string }} error
  * @param {ValidationIssuesCollector} issues
  * @param {string} loggingContext
  * @param {TypedLogger} logger
@@ -216,9 +216,8 @@ const handleValidationFailure = (error, issues, loggingContext, logger) => {
     })
     issues.addFatal(VALIDATION_CATEGORY.TECHNICAL, error.message, error.code)
   } else {
-    const err = error instanceof Error ? error : new Error(String(error))
     logger.error({
-      err,
+      err: error,
       message: `Failed to validate summary log file: ${loggingContext}`,
       event: {
         category: LOGGING_EVENT_CATEGORIES.SERVER,
@@ -227,7 +226,7 @@ const handleValidationFailure = (error, issues, loggingContext, logger) => {
     })
     issues.addFatal(
       VALIDATION_CATEGORY.TECHNICAL,
-      err.message,
+      error.message,
       VALIDATION_CODE.VALIDATION_SYSTEM_ERROR
     )
   }
@@ -365,7 +364,12 @@ const performValidationChecks = async ({
 
     issues.merge(dataResult.issues)
   } catch (error) {
-    handleValidationFailure(error, issues, loggingContext, logger)
+    handleValidationFailure(
+      /** @type {Error & { code?: string }} */ (error),
+      issues,
+      loggingContext,
+      logger
+    )
   }
 
   return { issues, wasteRecords, meta }

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -42,11 +42,12 @@ export { MAX_VALIDATION_ISSUES }
 
 export const MAX_ACTUAL_LENGTH = 200
 
-/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {ValidatedSummaryLog, ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
 /** @import {ValidationIssue, ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {ParsedSummaryLog} from '#domain/summary-logs/extractor/port.js' */
+/** @import {ProcessingType} from '#domain/summary-logs/meta-fields.js' */
 /** @import {SummaryLog} from '#domain/summary-logs/model.js' */
 /** @import {SummaryLogStatus} from '#domain/summary-logs/status.js' */
 /** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
@@ -88,7 +89,7 @@ const extractSummaryLog = async ({
  * @param {{
  *   summaryLogId: string,
  *   summaryLog: SubmittedSummaryLog,
- *   validatedData: object,
+ *   validatedData: ValidatedSummaryLog,
  *   wasteRecordsRepository: WasteRecordsRepository
  * }} params
  * @returns {Promise<{
@@ -185,48 +186,6 @@ const fetchRegistration = async ({
  */
 
 /**
- * Performs all validation checks on a summary log
- *
- * Implements a four-level short-circuit validation strategy:
- *
- * Level 1: Meta Syntax (FATAL)
- *   - Validates structural correctness of meta fields
- *   - Stops on fatal errors
- *
- * Level 2: Meta Business (FATAL/ERROR)
- *   - Validates meta fields against registration business rules
- *   - Stops on fatal errors
- *
- * Level 3: Data Syntax (ERROR/WARNING)
- *   - Validates structural correctness of data table rows
- *   - Attaches issues directly to rows for downstream processing
- *   - Continues even with errors (non-fatal)
- *
- * Level 4: Transform & Data Business (FATAL/ERROR/WARNING)
- *   - Transforms validated rows into waste records with issues attached
- *   - Sequential row validation: ensures no rows removed from previous uploads
- *   - Stops on fatal errors
- *
- * This approach provides:
- * - Better performance (stops early on fatal errors)
- * - Clearer user feedback (fixes meta issues before seeing data errors)
- * - Reduced noise in validation output
- * - Logical separation between meta and data validation phases
- * - Issues flow with data through transformation (no re-correlation needed)
- *
- * Converts any exceptions to fatal technical issues.
- *
- * @param {Object} params
- * @param {string} params.summaryLogId - The summary log ID
- * @param {SummaryLog} params.summaryLog - The summary log to validate
- * @param {string} params.loggingContext - Context string for logging (e.g., "summaryLogId=123, fileId=456")
- * @param {SummaryLogExtractor} params.summaryLogExtractor - Extractor service for parsing the file
- * @param {OrganisationsRepository} params.organisationsRepository - Organisation repository for fetching registration data
- * @param {WasteRecordsRepository} params.wasteRecordsRepository - Waste records repository for fetching existing records
- * @param {Function} params.validateDataSyntax - Data syntax validator function
- * @returns {Promise<ValidationResult>} Validation result with issues and transformed records
- */
-/**
  * Extracts just the values from parsed metadata entries
  * @param {Object<string, {value: *}>} parsedMeta - Parsed metadata with value/location objects
  * @returns {ExtractedMeta} Object with field names mapped to their values
@@ -296,6 +255,43 @@ const markIgnoredByDateRange = (
   }
 }
 
+/**
+ * Performs all validation checks on a summary log
+ *
+ * Implements a four-level short-circuit validation strategy:
+ *
+ * Level 1: Meta Syntax (FATAL)
+ *   - Validates structural correctness of meta fields
+ *   - Stops on fatal errors
+ *
+ * Level 2: Meta Business (FATAL/ERROR)
+ *   - Validates meta fields against registration business rules
+ *   - Stops on fatal errors
+ *
+ * Level 3: Data Syntax (ERROR/WARNING)
+ *   - Validates structural correctness of data table rows
+ *   - Attaches issues directly to rows for downstream processing
+ *   - Continues even with errors (non-fatal)
+ *
+ * Level 4: Transform & Data Business (FATAL/ERROR/WARNING)
+ *   - Transforms validated rows into waste records with issues attached
+ *   - Sequential row validation: ensures no rows removed from previous uploads
+ *   - Stops on fatal errors
+ *
+ * Converts any exceptions to fatal technical issues.
+ *
+ * @param {{
+ *   summaryLogId: string,
+ *   summaryLog: SubmittedSummaryLog,
+ *   loggingContext: string,
+ *   logger: TypedLogger,
+ *   summaryLogExtractor: SummaryLogExtractor,
+ *   organisationsRepository: OrganisationsRepository,
+ *   wasteRecordsRepository: WasteRecordsRepository,
+ *   validateDataSyntax: (parsed: ParsedSummaryLog) => { issues: ValidationIssuesCollector, validatedData: ValidatedSummaryLog }
+ * }} params
+ * @returns {Promise<ValidationResult>}
+ */
 const performValidationChecks = async ({
   summaryLogId,
   summaryLog,
@@ -564,7 +560,7 @@ const filterWasteBalanceRecords = (wasteRecords, processingType) =>
  * @param {ValidatedWasteRecord[] | null} params.wasteRecords - All waste records
  * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords - Waste-balance-eligible records
  * @param {string} params.summaryLogId
- * @param {string} params.processingType
+ * @param {ProcessingType} params.processingType
  * @returns {{ loads: Loads | null, loadsByWasteRecordType: import('./load-counts.js').LoadsByWasteRecordType | null }}
  */
 const classifyLoads = ({

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -43,6 +43,7 @@ export { MAX_VALIDATION_ISSUES }
 export const MAX_ACTUAL_LENGTH = 200
 
 /** @import {ValidatedSummaryLog, ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {RowOutcome} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
 /** @import {ValidationIssue, ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
@@ -56,6 +57,12 @@ export const MAX_ACTUAL_LENGTH = 200
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 /** @import {SummaryLogExtractor} from './extractor.js' */
 /** @import {Loads} from './load-counts.js' */
+
+/**
+ * A waste record from the validation pipeline (outcome guaranteed).
+ *
+ * @typedef {ValidatedWasteRecord & { outcome: RowOutcome }} ClassifiedWasteRecord
+ */
 
 /**
  * @param {{
@@ -413,7 +420,7 @@ const recordValidationIssueMetrics = async (issues, processingType) => {
 /**
  * Records row outcome metrics grouped by outcome
  *
- * @param {ValidatedWasteRecord[] | null} wasteRecords - Waste records with outcomes
+ * @param {ClassifiedWasteRecord[] | null} wasteRecords - Waste records with outcomes
  * @param {string} processingType - The processing type for the metric dimension
  */
 const recordRowOutcomeMetrics = async (wasteRecords, processingType) => {
@@ -476,7 +483,7 @@ const assertValidatingStatus = (result, summaryLogId) => {
  * @param {ProcessingType} params.processingType
  * @param {SummaryLogStatus} params.status
  * @param {number} params.validationDurationMs
- * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords
+ * @param {ClassifiedWasteRecord[]} params.wasteBalanceRecords
  */
 const recordValidationMetrics = async ({
   issues,
@@ -537,9 +544,9 @@ const persistValidationResult = async ({
 /**
  * Filters waste records to only those from tables that participate in waste balance.
  *
- * @param {ValidatedWasteRecord[] | null} wasteRecords
+ * @param {ClassifiedWasteRecord[] | null} wasteRecords
  * @param {string} processingType
- * @returns {ValidatedWasteRecord[]}
+ * @returns {ClassifiedWasteRecord[]}
  */
 const filterWasteBalanceRecords = (wasteRecords, processingType) =>
   wasteRecords?.filter((wr) => {
@@ -652,8 +659,9 @@ export const createSummaryLogsValidator = ({
       ? SUMMARY_LOG_STATUS.INVALID
       : SUMMARY_LOG_STATUS.VALIDATED
 
+    // wasteRecords come from the validate pipeline, where outcome is guaranteed.
     const wasteBalanceRecords = filterWasteBalanceRecords(
-      wasteRecords,
+      /** @type {ClassifiedWasteRecord[] | null} */ (wasteRecords),
       processingType
     )
 

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -43,7 +43,6 @@ export { MAX_VALIDATION_ISSUES }
 export const MAX_ACTUAL_LENGTH = 200
 
 /** @import {ValidatedSummaryLog, ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
-/** @import {RowOutcome} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
 /** @import {ValidationIssue, ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
@@ -57,12 +56,6 @@ export const MAX_ACTUAL_LENGTH = 200
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 /** @import {SummaryLogExtractor} from './extractor.js' */
 /** @import {Loads} from './load-counts.js' */
-
-/**
- * A waste record from the validation pipeline (outcome guaranteed).
- *
- * @typedef {ValidatedWasteRecord & { outcome: RowOutcome }} ClassifiedWasteRecord
- */
 
 /**
  * @param {{
@@ -420,7 +413,7 @@ const recordValidationIssueMetrics = async (issues, processingType) => {
 /**
  * Records row outcome metrics grouped by outcome
  *
- * @param {ClassifiedWasteRecord[] | null} wasteRecords - Waste records with outcomes
+ * @param {ValidatedWasteRecord[] | null} wasteRecords - Waste records with outcomes
  * @param {string} processingType - The processing type for the metric dimension
  */
 const recordRowOutcomeMetrics = async (wasteRecords, processingType) => {
@@ -483,7 +476,7 @@ const assertValidatingStatus = (result, summaryLogId) => {
  * @param {ProcessingType} params.processingType
  * @param {SummaryLogStatus} params.status
  * @param {number} params.validationDurationMs
- * @param {ClassifiedWasteRecord[]} params.wasteBalanceRecords
+ * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords
  */
 const recordValidationMetrics = async ({
   issues,
@@ -544,9 +537,9 @@ const persistValidationResult = async ({
 /**
  * Filters waste records to only those from tables that participate in waste balance.
  *
- * @param {ClassifiedWasteRecord[] | null} wasteRecords
+ * @param {ValidatedWasteRecord[] | null} wasteRecords
  * @param {string} processingType
- * @returns {ClassifiedWasteRecord[]}
+ * @returns {ValidatedWasteRecord[]}
  */
 const filterWasteBalanceRecords = (wasteRecords, processingType) =>
   wasteRecords?.filter((wr) => {
@@ -659,9 +652,8 @@ export const createSummaryLogsValidator = ({
       ? SUMMARY_LOG_STATUS.INVALID
       : SUMMARY_LOG_STATUS.VALIDATED
 
-    // wasteRecords come from the validate pipeline, where outcome is guaranteed.
     const wasteBalanceRecords = filterWasteBalanceRecords(
-      /** @type {ClassifiedWasteRecord[] | null} */ (wasteRecords),
+      wasteRecords,
       processingType
     )
 

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -1,4 +1,3 @@
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import {
   SUMMARY_LOG_STATUS,
   UPLOAD_STATUS
@@ -1816,26 +1815,6 @@ describe('SummaryLogsValidator', () => {
         { processingType: 'REPROCESSOR_INPUT' },
         expect.any(Number)
       )
-    })
-
-    it('should record row outcome metrics with a defined outcome value for every call', async () => {
-      summaryLogExtractor.extract.mockResolvedValue(
-        buildExtractedData({
-          data: {
-            RECEIVED_LOADS_FOR_REPROCESSING: buildReceivedLoadsTable({
-              rows: [buildReceivedLoadRow({ ROW_ID: 10000 })]
-            })
-          }
-        })
-      )
-
-      await validateSummaryLog(summaryLogId)
-
-      expect(mockRecordRowOutcome).toHaveBeenCalled()
-      const validOutcomes = Object.values(ROW_OUTCOME)
-      for (const [{ outcome }] of mockRecordRowOutcome.mock.calls) {
-        expect(validOutcomes).toContain(outcome)
-      }
     })
 
     it('should not record row outcome metrics for non-waste-balance table rows', async () => {

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -15,6 +15,8 @@ import {
   createEmptyLoadValidity
 } from './load-counts.js'
 
+/** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
+
 // ============================================================================
 // Test Builders
 // ============================================================================
@@ -148,10 +150,15 @@ const mockLoggerInfo = vi.fn()
 const mockLoggerWarn = vi.fn()
 const mockLoggerError = vi.fn()
 
+/** @type {TypedLogger} */
 const logger = {
   info: (...args) => mockLoggerInfo(...args),
   warn: (...args) => mockLoggerWarn(...args),
-  error: (...args) => mockLoggerError(...args)
+  error: (...args) => mockLoggerError(...args),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  fatal: vi.fn(),
+  child: () => logger
 }
 
 const mockRecordStatusTransition = vi.fn()

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -1,3 +1,4 @@
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import {
   SUMMARY_LOG_STATUS,
   UPLOAD_STATUS
@@ -1815,6 +1816,26 @@ describe('SummaryLogsValidator', () => {
         { processingType: 'REPROCESSOR_INPUT' },
         expect.any(Number)
       )
+    })
+
+    it('should record row outcome metrics with a defined outcome value for every call', async () => {
+      summaryLogExtractor.extract.mockResolvedValue(
+        buildExtractedData({
+          data: {
+            RECEIVED_LOADS_FOR_REPROCESSING: buildReceivedLoadsTable({
+              rows: [buildReceivedLoadRow({ ROW_ID: 10000 })]
+            })
+          }
+        })
+      )
+
+      await validateSummaryLog(summaryLogId)
+
+      expect(mockRecordRowOutcome).toHaveBeenCalled()
+      const validOutcomes = Object.values(ROW_OUTCOME)
+      for (const [{ outcome }] of mockRecordRowOutcome.mock.calls) {
+        expect(validOutcomes).toContain(outcome)
+      }
     })
 
     it('should not record row outcome metrics for non-waste-balance table rows', async () => {

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -92,6 +92,12 @@ const buildReceivedLoadRow = (overrides = {}) => ({
 const rowToArray = (rowObject) =>
   RECEIVED_LOADS_HEADERS.map((header) => rowObject[header])
 
+/**
+ * @param {{
+ *   rows?: Array<unknown[] | Record<string, unknown>>,
+ *   headers?: string[]
+ * }} [options]
+ */
 const buildReceivedLoadsTable = ({
   rows = [],
   headers = RECEIVED_LOADS_HEADERS

--- a/src/application/summary-logs/validations/accreditation-number.js
+++ b/src/application/summary-logs/validations/accreditation-number.js
@@ -14,6 +14,8 @@ import {
   logValidationSuccess
 } from './helpers.js'
 
+/** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
+
 /**
  * Validates that the accreditation number in the spreadsheet matches the registration's accreditation number
  *
@@ -21,7 +23,7 @@ import {
  * @param {Object} params.parsed - The parsed summary log structure from the parser
  * @param {Object} params.registration - The registration object from the organisations repository
  * @param {string} params.loggingContext - Logging context message
- * @returns {Object} validation issues with any issues found
+ * @returns {ValidationIssuesCollector} validation issues with any issues found
  */
 export const validateAccreditationNumber = ({
   parsed,

--- a/src/application/summary-logs/validations/data-business.js
+++ b/src/application/summary-logs/validations/data-business.js
@@ -2,6 +2,7 @@ import { createValidationIssues } from '#common/validation/validation-issues.js'
 import { validateRowContinuity } from './row-continuity.js'
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
 
 /**
@@ -22,7 +23,7 @@ import { validateRowContinuity } from './row-continuity.js'
  * @param {Object} params
  * @param {ValidatedWasteRecord[]} params.wasteRecords - Waste records from the current upload
  * @param {WasteRecord[]} params.existingWasteRecords - Existing waste records from previous uploads
- * @returns {Object} Validation issues object
+ * @returns {ValidationIssuesCollector} Validation issues object
  */
 export const validateDataBusiness = ({
   wasteRecords,

--- a/src/application/summary-logs/validations/data-business.js
+++ b/src/application/summary-logs/validations/data-business.js
@@ -1,10 +1,8 @@
 import { createValidationIssues } from '#common/validation/validation-issues.js'
 import { validateRowContinuity } from './row-continuity.js'
 
-/**
- * @typedef {import('#domain/waste-records/model.js').WasteRecord} WasteRecord
- * @typedef {import('../validate.js').ValidatedWasteRecord} ValidatedWasteRecord
- */
+/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {WasteRecord} from '#domain/waste-records/model.js' */
 
 /**
  * Validates data business rules

--- a/src/application/summary-logs/validations/data-syntax.js
+++ b/src/application/summary-logs/validations/data-syntax.js
@@ -1,22 +1,22 @@
-import { createValidationIssues } from '#common/validation/validation-issues.js'
 import {
   VALIDATION_CATEGORY,
   VALIDATION_CODE
 } from '#common/enums/validation.js'
 import { offsetColumn } from '#common/helpers/spreadsheet/columns.js'
+import { createValidationIssues } from '#common/validation/validation-issues.js'
 import {
   isEprMarker,
   SKIP_HEADER_ROW_TEXT
 } from '#domain/summary-logs/markers.js'
+import { TONNAGE_EXPORT_MESSAGES } from '#domain/summary-logs/table-schemas/exporter/validators/tonnage-export-validator.js'
+import { createTableSchemaGetter } from '#domain/summary-logs/table-schemas/index.js'
+import { UK_PACKAGING_WEIGHT_PROPORTION_MESSAGES } from '#domain/summary-logs/table-schemas/reprocessor-output/validators/uk-packaging-weight-proportion-validator.js'
+import { MESSAGES } from '#domain/summary-logs/table-schemas/shared/joi-messages.js'
+import { NET_WEIGHT_MESSAGES } from '#domain/summary-logs/table-schemas/shared/validators/net-weight-validator.js'
 import {
   classifyRow,
   ROW_OUTCOME
 } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
-import { createTableSchemaGetter } from '#domain/summary-logs/table-schemas/index.js'
-import { MESSAGES } from '#domain/summary-logs/table-schemas/shared/joi-messages.js'
-import { NET_WEIGHT_MESSAGES } from '#domain/summary-logs/table-schemas/shared/validators/net-weight-validator.js'
-import { TONNAGE_EXPORT_MESSAGES } from '#domain/summary-logs/table-schemas/exporter/validators/tonnage-export-validator.js'
-import { UK_PACKAGING_WEIGHT_PROPORTION_MESSAGES } from '#domain/summary-logs/table-schemas/reprocessor-output/validators/uk-packaging-weight-proportion-validator.js'
 
 /**
  * @typedef {import('#common/validation/validation-issues.js').ValidationIssue} ValidationIssue
@@ -24,7 +24,7 @@ import { UK_PACKAGING_WEIGHT_PROPORTION_MESSAGES } from '#domain/summary-logs/ta
  * @typedef {import('#domain/summary-logs/table-schemas/validation-pipeline.js').RowOutcome} RowOutcome
  */
 
-/** @import {ValidatedSummaryLog} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {ValidatedSummaryLog, ValidatedTableSection} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {ParsedSummaryLog} from '#domain/summary-logs/extractor/port.js' */
 
 /**
@@ -395,7 +395,7 @@ const validateRows = ({
  * @param {Object} params.tableData - The table data with headers, rows, and location
  * @param {Object} params.schema - The adapted validation schema for this table
  * @param {Object} params.issues - Validation issues collector
- * @returns {Object} Validated table data with rows converted to ValidatedRow[]
+ * @returns {ValidatedTableSection} Validated table data with rows converted to ValidatedRow[]
  */
 const validateTable = ({ tableName, tableData, schema, issues }) => {
   const { headers, rows, location } = tableData
@@ -464,6 +464,7 @@ export const createDataSyntaxValidator = (schemaRegistry) => (parsed) => {
   const data = parsed?.data || {}
   const processingType = parsed?.meta?.PROCESSING_TYPE?.value
   const getTableSchema = createTableSchemaGetter(processingType, schemaRegistry)
+  /** @type {ValidatedSummaryLog['data']} */
   const validatedTables = {}
 
   for (const [tableName, tableData] of Object.entries(data)) {
@@ -481,8 +482,10 @@ export const createDataSyntaxValidator = (schemaRegistry) => (parsed) => {
         { location }
       )
 
-      // Keep unvalidated tables as-is for downstream processing
-      validatedTables[tableName] = tableData
+      // Keep unvalidated tables as-is for downstream processing.
+      validatedTables[tableName] = /** @type {ValidatedTableSection} */ (
+        /** @type {unknown} */ (tableData)
+      )
       continue
     }
 

--- a/src/application/summary-logs/validations/data-syntax.js
+++ b/src/application/summary-logs/validations/data-syntax.js
@@ -20,8 +20,12 @@ import { UK_PACKAGING_WEIGHT_PROPORTION_MESSAGES } from '#domain/summary-logs/ta
 
 /**
  * @typedef {import('#common/validation/validation-issues.js').ValidationIssue} ValidationIssue
+ * @typedef {import('#common/validation/validation-issues.js').ValidationIssuesCollector} ValidationIssuesCollector
  * @typedef {import('#domain/summary-logs/table-schemas/validation-pipeline.js').RowOutcome} RowOutcome
  */
+
+/** @import {ValidatedSummaryLog} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {ParsedSummaryLog} from '#domain/summary-logs/extractor/port.js' */
 
 /**
  * A validated row from the data syntax validation pipeline
@@ -432,8 +436,8 @@ const validateTable = ({ tableName, tableData, schema, issues }) => {
 
 /**
  * @typedef {Object} DataSyntaxValidationResult
- * @property {ReturnType<typeof createValidationIssues>} issues - Validation issues
- * @property {Object} validatedData - Parsed data with rows converted to ValidatedRow[]
+ * @property {ValidationIssuesCollector} issues - Validation issues
+ * @property {ValidatedSummaryLog} validatedData - Parsed data with rows converted to ValidatedRow[]
  */
 
 /**
@@ -452,7 +456,7 @@ const validateTable = ({ tableName, tableData, schema, issues }) => {
  * - FATAL: Invalid row values on REJECTED rows block submission entirely
  *
  * @param {Object} schemaRegistry - Schema registry mapping processing types to table schemas
- * @returns {function(Object): DataSyntaxValidationResult} Validator function that takes parsed summary log
+ * @returns {(parsed: ParsedSummaryLog) => DataSyntaxValidationResult} Validator function that takes parsed summary log
  */
 export const createDataSyntaxValidator = (schemaRegistry) => (parsed) => {
   const issues = createValidationIssues()

--- a/src/application/summary-logs/validations/material-type.js
+++ b/src/application/summary-logs/validations/material-type.js
@@ -10,6 +10,8 @@ import {
   logValidationSuccess
 } from './helpers.js'
 
+/** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
+
 /**
  * Mapping between spreadsheet material values and registration material types
  */
@@ -71,7 +73,7 @@ const validateGlassRecyclingProcess = ({
  * @param {Object} params.parsed - The parsed summary log structure from the parser
  * @param {Object} params.registration - The registration object from the organisations repository
  * @param {string} params.loggingContext - Logging context message
- * @returns {Object} validation issues with any issues found
+ * @returns {ValidationIssuesCollector} validation issues with any issues found
  */
 export const validateMaterialType = ({
   parsed,

--- a/src/application/summary-logs/validations/meta-business.js
+++ b/src/application/summary-logs/validations/meta-business.js
@@ -4,6 +4,8 @@ import { validateProcessingType } from './processing-type.js'
 import { validateAccreditationNumber } from './accreditation-number.js'
 import { validateMaterialType } from './material-type.js'
 
+/** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
+
 /**
  * Validates meta fields against registration business rules
  *
@@ -17,7 +19,7 @@ import { validateMaterialType } from './material-type.js'
  * @param {Object} params.parsed - The parsed summary log data
  * @param {Object} params.registration - The registration from the database
  * @param {string} params.loggingContext - Context string for logging
- * @returns {Object} Validation issues object
+ * @returns {ValidationIssuesCollector} Validation issues object
  */
 export const validateMetaBusiness = ({
   parsed,

--- a/src/application/summary-logs/validations/meta-syntax.js
+++ b/src/application/summary-logs/validations/meta-syntax.js
@@ -6,6 +6,8 @@ import {
 import { MIN_TEMPLATE_VERSIONS } from '#domain/summary-logs/table-schemas/index.js'
 import { createMetaSchema } from './meta-syntax.schema.js'
 
+/** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
+
 /**
  * Maps Joi error types to validation codes based on field name
  * @param {string} fieldName - The meta field name
@@ -46,7 +48,7 @@ const mapJoiErrorToCode = (fieldName, joiType) => {
  * @param {Object} params.parsed - The parsed summary log structure from the parser
  * @param {Object} [params.registration] - Unused, for signature compatibility
  * @param {string} [params.loggingContext] - Unused, for signature compatibility
- * @returns {Object} validation issues with any issues found
+ * @returns {ValidationIssuesCollector} validation issues with any issues found
  */
 export const validateMetaSyntax = ({ parsed }) => {
   const issues = createValidationIssues()

--- a/src/application/summary-logs/validations/registration-number.js
+++ b/src/application/summary-logs/validations/registration-number.js
@@ -11,6 +11,8 @@ import {
   logValidationSuccess
 } from './helpers.js'
 
+/** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
+
 /**
  * Validates that the registration number in the spreadsheet matches the registration's registration number
  *
@@ -18,7 +20,7 @@ import {
  * @param {Object} params.parsed - The parsed summary log structure from the parser
  * @param {Object} params.registration - The registration object from the organisations repository
  * @param {string} params.loggingContext - Logging context message
- * @returns {Object} validation issues with any issues found
+ * @returns {ValidationIssuesCollector} validation issues with any issues found
  */
 export const validateRegistrationNumber = ({
   parsed,

--- a/src/application/summary-logs/validations/row-continuity.js
+++ b/src/application/summary-logs/validations/row-continuity.js
@@ -8,10 +8,8 @@ import {
   PROCESSING_TYPE_TABLES
 } from '#domain/summary-logs/table-schemas/index.js'
 
-/**
- * @typedef {import('#domain/waste-records/model.js').WasteRecord} WasteRecord
- * @typedef {import('../validate.js').ValidatedWasteRecord} ValidatedWasteRecord
- */
+/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {WasteRecord} from '#domain/waste-records/model.js' */
 
 /**
  * Validates that no rows from previous uploads have been removed

--- a/src/application/summary-logs/validations/row-continuity.js
+++ b/src/application/summary-logs/validations/row-continuity.js
@@ -9,6 +9,7 @@ import {
 } from '#domain/summary-logs/table-schemas/index.js'
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
 
 /**
@@ -27,7 +28,7 @@ import {
  * @param {Object} params
  * @param {ValidatedWasteRecord[]} params.wasteRecords - Waste records from the current upload
  * @param {WasteRecord[]} params.existingWasteRecords - Existing waste records from previous uploads
- * @returns {Object} Validation issues object
+ * @returns {ValidationIssuesCollector} Validation issues object
  */
 export const validateRowContinuity = ({
   wasteRecords,

--- a/src/application/waste-records/sync-from-summary-log.js
+++ b/src/application/waste-records/sync-from-summary-log.js
@@ -11,6 +11,7 @@ import {
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { WASTE_RECORD_CHANGE } from '#domain/waste-records/model.js'
 import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 
 /**
  * @import { TypedLogger } from '#common/helpers/logging/logger.js'
@@ -75,7 +76,8 @@ const prepareRows = (headers, rows, rowIdField) => {
       data[headerName] = values[colIndex]
     }
 
-    return [{ data }]
+    // Sync re-syncs already-validated records; outcome required by type, unread here.
+    return [{ data, outcome: ROW_OUTCOME.INCLUDED }]
   })
 }
 

--- a/src/application/waste-records/transform-from-summary-log.js
+++ b/src/application/waste-records/transform-from-summary-log.js
@@ -19,7 +19,7 @@ import { PROCESSING_TYPE_TABLES } from '#domain/summary-logs/table-schemas/index
  * @typedef {Object} TransformableRow
  * @property {Record<string, any>} data - Row data as object keyed by header name
  * @property {ValidationIssue[]} [issues] - Validation issues (present from validation pipeline)
- * @property {RowOutcome} [outcome] - Classification outcome (present from validation pipeline, absent on sync path)
+ * @property {RowOutcome} outcome - Classification outcome from validation pipeline
  */
 
 /**
@@ -50,7 +50,7 @@ import { PROCESSING_TYPE_TABLES } from '#domain/summary-logs/table-schemas/index
  * @typedef {Object} ValidatedWasteRecord
  * @property {WasteRecord} record - The waste record
  * @property {ValidationIssue[]} [issues] - Validation issues (present from validation pipeline)
- * @property {RowOutcome} [outcome] - Classification outcome (present from validation pipeline, absent on sync path)
+ * @property {RowOutcome} outcome - Classification outcome from validation pipeline
  * @property {WasteRecordChange} change - What happened to this record: created, updated, or unchanged
  * @property {string} tableName - The table schema key (e.g. RECEIVED_LOADS_FOR_EXPORT)
  * @property {string} wasteRecordType - The waste record type (e.g. received, exported, sentOn)

--- a/src/application/waste-records/transform-from-summary-log.js
+++ b/src/application/waste-records/transform-from-summary-log.js
@@ -19,7 +19,7 @@ import { PROCESSING_TYPE_TABLES } from '#domain/summary-logs/table-schemas/index
  * @typedef {Object} TransformableRow
  * @property {Record<string, any>} data - Row data as object keyed by header name
  * @property {ValidationIssue[]} [issues] - Validation issues (present from validation pipeline)
- * @property {RowOutcome} [outcome] - Classification outcome (present from validation pipeline)
+ * @property {RowOutcome} outcome - Classification outcome from validation pipeline
  */
 
 /**
@@ -50,7 +50,7 @@ import { PROCESSING_TYPE_TABLES } from '#domain/summary-logs/table-schemas/index
  * @typedef {Object} ValidatedWasteRecord
  * @property {WasteRecord} record - The waste record
  * @property {ValidationIssue[]} [issues] - Validation issues (present from validation pipeline)
- * @property {RowOutcome} [outcome] - Classification outcome (present from validation pipeline)
+ * @property {RowOutcome} outcome - Classification outcome from validation pipeline
  * @property {WasteRecordChange} change - What happened to this record: created, updated, or unchanged
  * @property {string} tableName - The table schema key (e.g. RECEIVED_LOADS_FOR_EXPORT)
  * @property {string} wasteRecordType - The waste record type (e.g. received, exported, sentOn)

--- a/src/application/waste-records/transform-from-summary-log.js
+++ b/src/application/waste-records/transform-from-summary-log.js
@@ -19,7 +19,7 @@ import { PROCESSING_TYPE_TABLES } from '#domain/summary-logs/table-schemas/index
  * @typedef {Object} TransformableRow
  * @property {Record<string, any>} data - Row data as object keyed by header name
  * @property {ValidationIssue[]} [issues] - Validation issues (present from validation pipeline)
- * @property {RowOutcome} outcome - Classification outcome from validation pipeline
+ * @property {RowOutcome} [outcome] - Classification outcome (present from validation pipeline, absent on sync path)
  */
 
 /**
@@ -50,7 +50,7 @@ import { PROCESSING_TYPE_TABLES } from '#domain/summary-logs/table-schemas/index
  * @typedef {Object} ValidatedWasteRecord
  * @property {WasteRecord} record - The waste record
  * @property {ValidationIssue[]} [issues] - Validation issues (present from validation pipeline)
- * @property {RowOutcome} outcome - Classification outcome from validation pipeline
+ * @property {RowOutcome} [outcome] - Classification outcome (present from validation pipeline, absent on sync path)
  * @property {WasteRecordChange} change - What happened to this record: created, updated, or unchanged
  * @property {string} tableName - The table schema key (e.g. RECEIVED_LOADS_FOR_EXPORT)
  * @property {string} wasteRecordType - The waste record type (e.g. received, exported, sentOn)

--- a/src/common/enums/event.js
+++ b/src/common/enums/event.js
@@ -32,6 +32,8 @@ export const LOGGING_EVENT_ACTIONS = {
   VERSION_CONFLICT_DETECTED: 'version_conflict_detected',
   DATA_MIGRATION_FAILURE: 'data_migration_failure',
   SUMMARY_LOG_SUPERSEDED: 'summary_log_superseded',
+  SUMMARY_LOG_VALIDATION_ISSUE: 'summary_log_validation_issue',
+  SUMMARY_LOG_VALIDATION_COMPLETED: 'summary_log_validation_completed',
   COMPENSATION_FAILURE: 'compensation_failure',
   COMPENSATION_SUCCESS: 'compensation_success',
   WASTE_BALANCE_UPDATED: 'waste_balance_updated'

--- a/src/common/enums/validation.js
+++ b/src/common/enums/validation.js
@@ -1,11 +1,15 @@
 /**
  * Severity levels for validation issues
  */
-export const VALIDATION_SEVERITY = Object.freeze({
-  FATAL: 'fatal',
-  ERROR: 'error',
-  WARNING: 'warning'
-})
+export const VALIDATION_SEVERITY = Object.freeze(
+  /** @type {const} */ ({
+    FATAL: 'fatal',
+    ERROR: 'error',
+    WARNING: 'warning'
+  })
+)
+
+/** @typedef {(typeof VALIDATION_SEVERITY)[keyof typeof VALIDATION_SEVERITY]} ValidationSeverity */
 
 /**
  * Categories of validation issues

--- a/src/common/helpers/metrics/summary-logs.js
+++ b/src/common/helpers/metrics/summary-logs.js
@@ -4,8 +4,9 @@ import {
   timed
 } from '#common/helpers/metrics.js'
 
+/** @import {ProcessingType} from '#domain/summary-logs/meta-fields.js' */
+
 /**
- * @typedef {'REPROCESSOR_INPUT'|'REPROCESSOR_OUTPUT'|'EXPORTER'} ProcessingType
  * @typedef {string} SummaryLogStatus
  * @typedef {'fatal'|'error'|'warning'} ValidationSeverity
  * @typedef {'technical'|'business'} ValidationCategory

--- a/src/common/validation/validation-issues.js
+++ b/src/common/validation/validation-issues.js
@@ -11,6 +11,7 @@ export const LOCATION_KEYS = /** @type {const} */ ([
   'sheet',
   'table',
   'row',
+  'rowId',
   'column',
   'header',
   'field'
@@ -26,15 +27,16 @@ export const LOCATION_KEYS = /** @type {const} */ ([
  */
 
 /**
- * Additional context attached to a validation issue.
- *
- * Note: All other context fields are preserved and copied to HTTP response
- * meta. See ADR 0020 for HTTP response format mapping.
+ * Additional context attached to a validation issue. Open by design — all
+ * known fields are listed but the index signature permits arbitrary extras,
+ * which `issueToErrorObject` copies through to the HTTP response meta. See
+ * ADR 0020 for the HTTP response format mapping.
  *
  * @typedef {{
  *   location?: ValidationIssueLocation,
  *   expected?: unknown,
- *   actual?: unknown
+ *   actual?: unknown,
+ *   [key: string]: unknown
  * }} ValidationIssueContext
  */
 
@@ -56,12 +58,78 @@ export const LOCATION_KEYS = /** @type {const} */ ([
  */
 
 /**
+ * Issue counts grouped by severity, plus the total.
+ *
+ * @typedef {{
+ *   fatal: number,
+ *   error: number,
+ *   warning: number,
+ *   total: number
+ * }} ValidationIssueCounts
+ */
+
+/**
+ * HTTP error object produced by issueToErrorObject (ADR 0020 format).
+ *
+ * @typedef {{
+ *   type: string,
+ *   meta?: Record<string, unknown>
+ * }} HttpValidationError
+ */
+
+/**
+ * Collector returned by createValidationIssues. Accumulates issues and exposes
+ * helpers for adding, querying, and transforming them. The add* methods return
+ * the collector to support chaining.
+ *
+ * @typedef {{
+ *   addIssue: (
+ *     severity: ValidationSeverity,
+ *     category: string,
+ *     message: string,
+ *     code: string,
+ *     context?: ValidationIssueContext
+ *   ) => ValidationIssuesCollector,
+ *   addFatal: (
+ *     category: string,
+ *     message: string,
+ *     code: string,
+ *     context?: ValidationIssueContext
+ *   ) => ValidationIssuesCollector,
+ *   addError: (
+ *     category: string,
+ *     message: string,
+ *     code: string,
+ *     context?: ValidationIssueContext
+ *   ) => ValidationIssuesCollector,
+ *   addWarning: (
+ *     category: string,
+ *     message: string,
+ *     code: string,
+ *     context?: ValidationIssueContext
+ *   ) => ValidationIssuesCollector,
+ *   isFatal: () => boolean,
+ *   isValid: () => boolean,
+ *   hasIssues: () => boolean,
+ *   getIssuesBySeverity: (severity: ValidationSeverity) => ValidationIssue[],
+ *   getIssuesByCategory: (category: string) => ValidationIssue[],
+ *   getIssuesByRow: () => Map<number, ValidationIssue[]>,
+ *   groupBySeverity: () => Record<ValidationSeverity, ValidationIssue[]>,
+ *   getAllIssues: () => ValidationIssue[],
+ *   merge: (other: ValidationIssuesCollector) => ValidationIssuesCollector,
+ *   getCounts: () => ValidationIssueCounts,
+ *   getSummary: () => string,
+ *   toErrorResponse: () => { issues: HttpValidationError[] }
+ * }} ValidationIssuesCollector
+ */
+
+/**
  * Converts a validation issue to an error object suitable for HTTP responses
  *
  * Follows the format defined in ADR 0020: Summary Log Validation Output Formats
  *
  * @param {ValidationIssue} issue - The validation issue
- * @returns {Object} Error object with type and meta
+ * @returns {HttpValidationError} Error object with type and meta
  *
  * @example
  * const httpIssues = summaryLog.validation.issues.map(issueToErrorObject)
@@ -273,7 +341,7 @@ const createIssueTransformers = (
  * Collects and manages validation issues with support for different
  * severity levels and categorization
  *
- * @returns {Object} A validation issues object with methods for managing issues
+ * @returns {ValidationIssuesCollector}
  *
  * @example
  * const issues = createValidationIssues()
@@ -283,8 +351,9 @@ const createIssueTransformers = (
  * }
  */
 export const createValidationIssues = () => {
+  /** @type {ValidationIssue[]} */
   const issues = []
-  const result = {}
+  const result = /** @type {ValidationIssuesCollector} */ ({})
 
   const adders = createIssueAdders(issues, result)
   const queries = createIssueQueries(issues)

--- a/src/common/validation/validation-issues.js
+++ b/src/common/validation/validation-issues.js
@@ -1,16 +1,25 @@
 import { VALIDATION_SEVERITY } from '#common/enums/index.js'
 
 /**
+ * Ordered list of spreadsheet-location keys. Single source of truth — the
+ * ValidationIssueLocation type below is derived from this array, so adding or
+ * removing a key updates both the type and the iteration order.
+ */
+export const LOCATION_KEYS = /** @type {const} */ ([
+  'sheet',
+  'table',
+  'row',
+  'column',
+  'header',
+  'field'
+])
+
+/**
  * Spreadsheet location for a validation issue. All fields optional because
  * meta-level issues have no row/column and table-level issues have no field.
  *
  * @typedef {{
- *   sheet?: string,
- *   table?: string,
- *   row?: number,
- *   column?: string,
- *   field?: string,
- *   header?: string
+ *   [K in typeof LOCATION_KEYS[number]]?: K extends 'row' ? number : string
  * }} ValidationIssueLocation
  */
 

--- a/src/common/validation/validation-issues.js
+++ b/src/common/validation/validation-issues.js
@@ -1,5 +1,7 @@
 import { VALIDATION_SEVERITY } from '#common/enums/index.js'
 
+/** @import {ValidationSeverity} from '#common/enums/validation.js' */
+
 /**
  * Ordered list of spreadsheet-location keys. Single source of truth — the
  * ValidationIssueLocation type below is derived from this array, so adding or
@@ -40,7 +42,7 @@ export const LOCATION_KEYS = /** @type {const} */ ([
  * Represents a single validation issue.
  *
  * @typedef {{
- *   severity: string,
+ *   severity: ValidationSeverity,
  *   category: string,
  *   message: string,
  *   code: string,

--- a/src/common/validation/validation-issues.js
+++ b/src/common/validation/validation-issues.js
@@ -1,26 +1,47 @@
 import { VALIDATION_SEVERITY } from '#common/enums/index.js'
 
 /**
- * Represents a single validation issue
+ * Spreadsheet location for a validation issue. All fields optional because
+ * meta-level issues have no row/column and table-level issues have no field.
  *
- * @typedef {Object} ValidationIssue
- * @property {string} severity - One of VALIDATION_SEVERITY (fatal, error, warning)
- * @property {string} category - One of VALIDATION_CATEGORY (technical, business, parsing)
- * @property {string} message - Human-readable description for developers/logging (not sent to clients)
- * @property {string} code - Specific error code for i18n/translation (e.g., 'HEADER_REQUIRED')
- * @property {Object} [context] - Additional context about the issue
- * @property {Object} [context.location] - Spreadsheet location information
- * @property {string} [context.location.sheet] - Sheet name (e.g., 'Cover', 'Received')
- * @property {string} [context.location.table] - Data table name (e.g., 'RECEIVED_LOADS_FOR_REPROCESSING')
- * @property {number} [context.location.row] - Spreadsheet row number (1-based)
- * @property {string} [context.location.column] - Excel column letter (e.g., 'B', 'AA')
- * @property {string} [context.location.field] - Meta field name (e.g., 'REGISTRATION_NUMBER', 'MATERIAL')
- * @property {string} [context.location.header] - Data table column header (e.g., 'DATE_RECEIVED', 'TONNAGE')
- * @property {*} [context.expected] - The expected value (for mismatch errors)
- * @property {*} [context.actual] - The actual value that was provided (for validation errors)
+ * @typedef {{
+ *   sheet?: string,
+ *   table?: string,
+ *   row?: number,
+ *   column?: string,
+ *   field?: string,
+ *   header?: string
+ * }} ValidationIssueLocation
+ */
+
+/**
+ * Additional context attached to a validation issue.
  *
- * Note: All other context fields are preserved and copied to HTTP response meta.
- * See ADR 0020 for HTTP response format mapping.
+ * Note: All other context fields are preserved and copied to HTTP response
+ * meta. See ADR 0020 for HTTP response format mapping.
+ *
+ * @typedef {{
+ *   location?: ValidationIssueLocation,
+ *   expected?: unknown,
+ *   actual?: unknown
+ * }} ValidationIssueContext
+ */
+
+/**
+ * Represents a single validation issue.
+ *
+ * @typedef {{
+ *   severity: string,
+ *   category: string,
+ *   message: string,
+ *   code: string,
+ *   context?: ValidationIssueContext
+ * }} ValidationIssue
+ *
+ * - severity: One of VALIDATION_SEVERITY (fatal, error, warning)
+ * - category: One of VALIDATION_CATEGORY (technical, business, parsing)
+ * - message: Human-readable description for developers/logging (not sent to clients)
+ * - code: Specific error code for i18n/translation (e.g., 'HEADER_REQUIRED')
  */
 
 /**

--- a/src/domain/summary-logs/extractor/port.js
+++ b/src/domain/summary-logs/extractor/port.js
@@ -18,10 +18,19 @@
  */
 
 /**
- * @typedef {Object} DataSection
- * @property {CellLocation} location - Starting location of the data section
- * @property {Array<string|null>} headers - Column headers (null for skipped columns)
- * @property {Array<Array<*>>} rows - Data rows
+ * @typedef {{ rowNumber: number, values: Array<unknown> }} DataRow
+ */
+
+/**
+ * @typedef {{
+ *   location: CellLocation,
+ *   headers: Array<string | null>,
+ *   rows: DataRow[]
+ * }} DataSection
+ *
+ * - location: Starting location of the data section
+ * - headers: Column headers (null for skipped columns)
+ * - rows: Parsed data rows in the section
  */
 
 /**
@@ -43,7 +52,7 @@
  * @example
  * const result = await parse(excelBuffer)
  * // result.meta.PROCESSING_TYPE = { value: 'REPROCESSOR_INPUT', location: { sheet: 'Sheet1', row: 1, column: 'B' } }
- * // result.data.RECEIVED_LOADS_FOR_REPROCESSING = { location: {...}, headers: ['REF', 'DATE'], rows: [[123, '2025-01-01']] }
+ * // result.data.RECEIVED_LOADS_FOR_REPROCESSING = { location: {...}, headers: ['REF', 'DATE'], rows: [{ rowNumber: 3, values: [123, '2025-01-01'] }] }
  *
  * @typedef {(buffer: any) => Promise<ParsedSummaryLog>} SummaryLogParser
  */

--- a/src/domain/summary-logs/meta-fields.js
+++ b/src/domain/summary-logs/meta-fields.js
@@ -21,6 +21,8 @@ export const PROCESSING_TYPES = Object.freeze({
   EXPORTER_REGISTERED_ONLY: 'EXPORTER_REGISTERED_ONLY'
 })
 
+/** @typedef {typeof PROCESSING_TYPES[keyof typeof PROCESSING_TYPES]} ProcessingType */
+
 /**
  * Mapping from spreadsheet PROCESSING_TYPE values to registration wasteProcessingType values
  */

--- a/src/domain/summary-logs/model.js
+++ b/src/domain/summary-logs/model.js
@@ -29,6 +29,7 @@
 /**
  * @typedef {Object} Validation
  * @property {ValidationIssue[]} [issues] - Validation issues found during processing
+ * @property {Array<{code: string, [k: string]: unknown}>} [failures] - Failure codes from upload rejection
  * @property {number} [totalIssuesCount] - Total number of validation issues found (may exceed issues.length when capped for storage)
  */
 

--- a/src/domain/summary-logs/model.js
+++ b/src/domain/summary-logs/model.js
@@ -29,6 +29,7 @@
 /**
  * @typedef {Object} Validation
  * @property {ValidationIssue[]} [issues] - Validation issues found during processing
+ * @property {number} [totalIssuesCount] - Total number of validation issues found (may exceed issues.length when capped for storage)
  */
 
 /**
@@ -44,6 +45,8 @@
  * @property {string} [organisationId]
  * @property {string} [registrationId]
  * @property {SummaryLogMeta} [meta]
+ * @property {import('#application/summary-logs/load-counts.js').Loads} [loads]
+ * @property {import('#application/summary-logs/load-counts.js').LoadsByWasteRecordType} [loadsByWasteRecordType]
  */
 
 /**
@@ -54,6 +57,8 @@
  * @property {string} [organisationId]
  * @property {string} [registrationId]
  * @property {SummaryLogMeta} [meta]
+ * @property {import('#application/summary-logs/load-counts.js').Loads} [loads]
+ * @property {import('#application/summary-logs/load-counts.js').LoadsByWasteRecordType} [loadsByWasteRecordType]
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/domain/summary-logs/model.js
+++ b/src/domain/summary-logs/model.js
@@ -32,9 +32,20 @@
  * @property {number} [totalIssuesCount] - Total number of validation issues found (may exceed issues.length when capped for storage)
  */
 
+/** @import {ProcessingType} from './meta-fields.js' */
+
 /**
- * @typedef {Object.<string, string>} SummaryLogMeta
- * Metadata extracted from the summary log spreadsheet (e.g. PROCESSING_TYPE, MATERIAL)
+ * Metadata extracted from the summary log spreadsheet's Cover sheet.
+ * All fields are optional because extraction emits only the keys that were
+ * present in the parsed file — a missing cell yields a missing field.
+ *
+ * @typedef {{
+ *   PROCESSING_TYPE?: ProcessingType,
+ *   TEMPLATE_VERSION?: number,
+ *   MATERIAL?: string,
+ *   ACCREDITATION_NUMBER?: string,
+ *   REGISTRATION_NUMBER?: string
+ * }} SummaryLogMeta
  */
 
 /**

--- a/src/domain/summary-logs/model.js
+++ b/src/domain/summary-logs/model.js
@@ -32,7 +32,9 @@
  * @property {number} [totalIssuesCount] - Total number of validation issues found (may exceed issues.length when capped for storage)
  */
 
+/** @import {Loads, LoadsByWasteRecordType} from '#application/summary-logs/load-counts.js' */
 /** @import {ProcessingType} from './meta-fields.js' */
+/** @import {SummaryLogStatus} from './status.js' */
 
 /**
  * Metadata extracted from the summary log spreadsheet's Cover sheet.
@@ -49,27 +51,21 @@
  */
 
 /**
- * @typedef {Object} SummaryLog
- * @property {import('./status.js').SummaryLogStatus} status
- * @property {SummaryLogFile} file
- * @property {Validation} [validation]
- * @property {string} [organisationId]
- * @property {string} [registrationId]
- * @property {SummaryLogMeta} [meta]
- * @property {import('#application/summary-logs/load-counts.js').Loads} [loads]
- * @property {import('#application/summary-logs/load-counts.js').LoadsByWasteRecordType} [loadsByWasteRecordType]
+ * @typedef {{
+ *   createdAt?: string,
+ *   expiresAt?: Date | null,
+ *   file: SummaryLogFile,
+ *   loads?: Loads,
+ *   loadsByWasteRecordType?: LoadsByWasteRecordType,
+ *   meta?: SummaryLogMeta,
+ *   organisationId?: string,
+ *   registrationId?: string,
+ *   status: SummaryLogStatus,
+ *   submittedAt?: string,
+ *   validation?: Validation
+ * }} SummaryLog
  */
 
-/**
- * @typedef {Object} StoredSummaryLog
- * @property {import('./status.js').SummaryLogStatus} status
- * @property {StoredFile} file
- * @property {Validation} [validation]
- * @property {string} [organisationId]
- * @property {string} [registrationId]
- * @property {SummaryLogMeta} [meta]
- * @property {import('#application/summary-logs/load-counts.js').Loads} [loads]
- * @property {import('#application/summary-logs/load-counts.js').LoadsByWasteRecordType} [loadsByWasteRecordType]
- */
+/** @typedef {Omit<SummaryLog, 'file'> & { file: StoredFile }} StoredSummaryLog */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/domain/summary-logs/status.js
+++ b/src/domain/summary-logs/status.js
@@ -174,9 +174,9 @@ export const determineStatusFromUpload = (uploadStatus) => {
 /**
  * Validates a status transition and returns an update object with the new
  * status and calculated expiresAt value.
- * @param {{status?: string}} summaryLog - The current summary log (only status is read)
- * @param {string} newStatus - The status to transition to
- * @returns {{status: string, expiresAt: Date|null}} Update object for repository
+ * @param {{status?: SummaryLogStatus}} summaryLog - The current summary log (only status is read)
+ * @param {SummaryLogStatus} newStatus - The status to transition to
+ * @returns {{status: SummaryLogStatus, expiresAt: Date|null}} Update object for repository
  * @throws {InvalidTransitionError} If the transition is not allowed
  */
 export const transitionStatus = (summaryLog, newStatus) => {

--- a/src/domain/summary-logs/status.js
+++ b/src/domain/summary-logs/status.js
@@ -89,6 +89,8 @@ export const SUMMARY_LOG_COMMAND = Object.freeze({
  * Statuses that indicate a summary log is still being validated.
  * Used by the timeout tracker to determine if a failed/timed-out task
  * should be marked as validation_failed.
+ *
+ * @type {readonly SummaryLogStatus[]}
  */
 export const PROCESSING_STATUSES = Object.freeze([
   SUMMARY_LOG_STATUS.PREPROCESSING,
@@ -99,6 +101,8 @@ export const PROCESSING_STATUSES = Object.freeze([
  * Statuses that indicate a summary log is still being submitted.
  * Used by the timeout tracker to determine if a failed/timed-out task
  * should be marked as submission_failed.
+ *
+ * @type {readonly SummaryLogStatus[]}
  */
 export const SUBMISSION_PROCESSING_STATUSES = Object.freeze([
   SUMMARY_LOG_STATUS.SUBMITTING

--- a/src/domain/summary-logs/status.js
+++ b/src/domain/summary-logs/status.js
@@ -124,6 +124,7 @@ const UploadStatusToSummaryLogStatusMap = {
   [UPLOAD_STATUS.COMPLETE]: SUMMARY_LOG_STATUS.VALIDATING
 }
 
+/** @type {Record<SummaryLogStatus, SummaryLogStatus[]>} */
 const VALID_TRANSITIONS = {
   [SUMMARY_LOG_STATUS.PREPROCESSING]: [
     SUMMARY_LOG_STATUS.PREPROCESSING,

--- a/src/domain/summary-logs/status.js
+++ b/src/domain/summary-logs/status.js
@@ -166,7 +166,7 @@ class InvalidTransitionError extends Error {
 
 /**
  * @param {string} uploadStatus
- * @returns {string}
+ * @returns {SummaryLogStatus}
  */
 export const determineStatusFromUpload = (uploadStatus) => {
   const status = UploadStatusToSummaryLogStatusMap[uploadStatus]

--- a/src/domain/summary-logs/table-schemas/shared/sent-on-loads-schema.js
+++ b/src/domain/summary-logs/table-schemas/shared/sent-on-loads-schema.js
@@ -41,7 +41,6 @@ const SUPPLEMENTARY_FIELDS = [
  *
  * @param {number} rowIdMinimum - Minimum ROW_ID value for this variant
  * @param {Function} rowTransformer - Function to transform a row into waste record metadata
- * @returns {object} Table schema for SENT_ON_LOADS
  */
 export const createSentOnLoadsSchema = (rowIdMinimum, rowTransformer) => ({
   rowIdField: FIELDS.ROW_ID,

--- a/src/domain/summary-logs/table-schemas/validation-pipeline.js
+++ b/src/domain/summary-logs/table-schemas/validation-pipeline.js
@@ -20,12 +20,6 @@ import {
  */
 
 /**
- * Row classification outcome type
- *
- * @typedef {'REJECTED'|'EXCLUDED'|'INCLUDED'|'IGNORED'} RowOutcome
- */
-
-/**
  * Result of classifying a row for waste balance calculation.
  *
  * - INCLUDED: row contributes to waste balance with a transaction amount
@@ -59,8 +53,6 @@ import {
 
 /**
  * Row classification outcomes
- *
- * @type {Readonly<{REJECTED: 'REJECTED', EXCLUDED: 'EXCLUDED', INCLUDED: 'INCLUDED', IGNORED: 'IGNORED'}>}
  */
 export const ROW_OUTCOME = Object.freeze({
   REJECTED: 'REJECTED',
@@ -68,6 +60,8 @@ export const ROW_OUTCOME = Object.freeze({
   INCLUDED: 'INCLUDED',
   IGNORED: 'IGNORED'
 })
+
+/** @typedef {typeof ROW_OUTCOME[keyof typeof ROW_OUTCOME]} RowOutcome */
 
 /**
  * Checks if a value is considered "filled"

--- a/src/repositories/summary-logs/port.js
+++ b/src/repositories/summary-logs/port.js
@@ -1,7 +1,9 @@
+/** @import {SummaryLog} from '#domain/summary-logs/model.js' */
+
 /**
  * @typedef {Object} SummaryLogVersion
  * @property {number} version
- * @property {Object} summaryLog
+ * @property {SummaryLog} summaryLog
  */
 
 /**

--- a/src/repositories/summary-logs/port.js
+++ b/src/repositories/summary-logs/port.js
@@ -15,10 +15,10 @@
  */
 
 /**
- * @typedef {Object} TransitionResult
- * @property {boolean} success
- * @property {SummaryLog} [summaryLog]
- * @property {number} [version]
+ * @typedef {
+ *   | { success: false }
+ *   | { success: true, summaryLog: SummaryLog, version: number }
+ * } TransitionResult
  */
 
 /**

--- a/src/repositories/summary-logs/port.js
+++ b/src/repositories/summary-logs/port.js
@@ -1,3 +1,4 @@
+/** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
 /** @import {SummaryLog} from '#domain/summary-logs/model.js' */
 
 /**
@@ -10,13 +11,13 @@
  * @typedef {Object} SummaryLogWithId
  * @property {string} id
  * @property {number} version
- * @property {Object} summaryLog
+ * @property {SummaryLog} summaryLog
  */
 
 /**
  * @typedef {Object} TransitionResult
  * @property {boolean} success
- * @property {Object} [summaryLog]
+ * @property {SummaryLog} [summaryLog]
  * @property {number} [version]
  */
 
@@ -38,8 +39,8 @@
 
 /**
  * @typedef {Object} SummaryLogsRepository
- * @property {(id: string, summaryLog: Object) => Promise<void>} insert
- * @property {(id: string, version: number, summaryLog: Object) => Promise<void>} update
+ * @property {(id: string, summaryLog: SummaryLog) => Promise<void>} insert
+ * @property {(id: string, version: number, summaryLog: Partial<SummaryLog>) => Promise<void>} update
  * @property {(id: string) => Promise<SummaryLogVersion|null>} findById
  * @property {(organisationId: string, registrationId: string) => Promise<SummaryLogWithId|null>} findLatestSubmittedForOrgReg
  * @property {(organisationId: string, registrationId: string) => Promise<SummaryLogWithId[]>} findAllByOrgReg
@@ -49,7 +50,7 @@
  */
 
 /**
- * @typedef {(logger: import('#common/helpers/logging/logger.js').TypedLogger) => SummaryLogsRepository} SummaryLogsRepositoryFactory
+ * @typedef {(logger: TypedLogger) => SummaryLogsRepository} SummaryLogsRepositoryFactory
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/routes/v1/organisations/registrations/summary-logs/submit/post.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/submit/post.js
@@ -96,7 +96,7 @@ export const summaryLogsSubmit = {
           summaryLogId
         )
 
-      if (!result.success || result.version === undefined) {
+      if (!result.success) {
         throw Boom.conflict(
           'Another submission is in progress. Please try again.'
         )

--- a/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.js
@@ -1,5 +1,7 @@
 import { VALIDATION_SEVERITY } from '#common/enums/validation.js'
 
+/** @import {Validation} from '#domain/summary-logs/model.js' */
+
 /**
  * Transforms a fatal validation issue to HTTP response format
  *
@@ -117,10 +119,7 @@ const groupAndTransformRowIssues = (issues) => {
  * - `failures`: Array of fatal meta-level errors (XOR with concerns)
  * - `concerns`: Object with table-keyed row-level errors and warnings
  *
- * @param {Object} [validation] - The validation object from database
- * @param {Array} [validation.issues] - Array of validation issues (from validation pipeline)
- * @param {Array} [validation.failures] - Array of failure codes (from upload rejection)
- * @param {number} [validation.totalIssuesCount] - Total issue count when issues were truncated
+ * @param {Validation} [validation] - The validation object from database
  * @returns {Object} Transformed validation for HTTP response
  */
 export const transformValidationResponse = (validation) => {

--- a/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.js
@@ -117,7 +117,7 @@ const groupAndTransformRowIssues = (issues) => {
  * - `failures`: Array of fatal meta-level errors (XOR with concerns)
  * - `concerns`: Object with table-keyed row-level errors and warnings
  *
- * @param {Object} validation - The validation object from database
+ * @param {Object} [validation] - The validation object from database
  * @param {Array} [validation.issues] - Array of validation issues (from validation pipeline)
  * @param {Array} [validation.failures] - Array of failure codes (from upload rejection)
  * @param {number} [validation.totalIssuesCount] - Total issue count when issues were truncated
@@ -125,7 +125,7 @@ const groupAndTransformRowIssues = (issues) => {
  */
 export const transformValidationResponse = (validation) => {
   // Handle direct failures (e.g., from upload rejection)
-  if ((validation?.failures?.length ?? 0) > 0) {
+  if (validation?.failures && validation.failures.length > 0) {
     const failures =
       /** @type {Array<{errorCode?: string, code?: string, [key: string]: unknown}>} */ (
         validation.failures

--- a/src/server/queue-consumer/ors-import-commands.js
+++ b/src/server/queue-consumer/ors-import-commands.js
@@ -11,13 +11,15 @@ import {
 import { processOrsImport } from '#overseas-sites/application/process-import.js'
 import { orsImportMetrics } from '#overseas-sites/metrics/ors-imports.js'
 
+/** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
+/** @import {SystemLogsRepository} from '#repositories/system-logs/port.js' */
+/** @import {CommandHandler} from './summary-log-commands.js' */
+
 const userSchema = Joi.object({
   id: Joi.string().required(),
   email: Joi.string().required(),
   scope: Joi.array().items(Joi.string()).required()
 })
-
-/** @typedef {import('#common/helpers/logging/logger.js').TypedLogger} TypedLogger */
 
 /**
  * @typedef {object} OrsImportHandlerDeps
@@ -26,10 +28,10 @@ const userSchema = Joi.object({
  * @property {object} uploadsRepository
  * @property {object} overseasSitesRepository
  * @property {object} organisationsRepository
- * @property {import('#repositories/system-logs/port.js').SystemLogsRepository} systemLogsRepository
+ * @property {SystemLogsRepository} systemLogsRepository
  */
 
-/** @type {import('./summary-log-commands.js').CommandHandler[]} */
+/** @type {CommandHandler[]} */
 export const orsImportCommandHandlers = [
   {
     command: ORS_IMPORT_COMMAND.IMPORT_OVERSEAS_SITES,


### PR DESCRIPTION
Ticket: [PAE-1536](https://eaflood.atlassian.net/browse/PAE-1536)

emit warn-level logs per validation issue plus a run-level summary so support can investigate failures via opensearch dql.

- maps issue data onto cdp's indexed ecs fields (`event.*`, `error.*`)
- location encoded as composite string in `error.id` (`sheet=...;table=...;row=...;column=...;header=...;field=...`)

[PAE-1536]: https://eaflood.atlassian.net/browse/PAE-1536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ