### PR TITLE
PAE-1382: Add monotonic lastAppliedEventNumber watermark to PRNs

### DIFF
--- a/src/common/enums/event.js
+++ b/src/common/enums/event.js
@@ -30,6 +30,7 @@ export const LOGGING_EVENT_ACTIONS = {
   PROCESS_FAILURE: 'process_failure',
   PROCESS_SUCCESS: 'process_success',
   VERSION_CONFLICT_DETECTED: 'version_conflict_detected',
+  WATERMARK_REGRESSION_DETECTED: 'watermark_regression_detected',
   DATA_MIGRATION_FAILURE: 'data_migration_failure',
   SUMMARY_LOG_SUPERSEDED: 'summary_log_superseded',
   COMPENSATION_FAILURE: 'compensation_failure',

--- a/src/packaging-recycling-notes/application/external-prn-mapper.test.js
+++ b/src/packaging-recycling-notes/application/external-prn-mapper.test.js
@@ -3,6 +3,10 @@ import { describe, it, expect } from 'vitest'
 import { mapToExternalPrn } from './external-prn-mapper.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 
+/**
+ * @typedef {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} PackagingRecyclingNote
+ */
+
 const draftDate = new Date('2026-01-10T10:00:00Z')
 const authorisedDate = new Date('2026-01-12T10:00:00Z')
 const issuedDate = new Date('2026-01-15T10:00:00Z')
@@ -14,9 +18,14 @@ const creator = { id: 'user-123', name: 'Test User' }
 const issuer = { id: 'user-issuer', name: 'Issuer User', position: 'Manager' }
 const producer = { id: 'user-producer', name: 'Producer User' }
 
+/**
+ * @param {Partial<PackagingRecyclingNote>} overrides
+ * @returns {PackagingRecyclingNote}
+ */
 const buildAwaitingAcceptancePrn = (overrides = {}) => ({
   id: '507f1f77bcf86cd799439011',
   schemaVersion: 2,
+  version: 1,
   prnNumber: 'ER2600001',
   organisation: {
     id: 'org-123',
@@ -42,6 +51,7 @@ const buildAwaitingAcceptancePrn = (overrides = {}) => ({
   notes: 'T2E Reference 9201234',
   status: {
     currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+    currentStatusAt: issuedDate,
     created: { at: authorisedDate, by: creator },
     issued: { at: issuedDate, by: issuer },
     history: [
@@ -103,6 +113,7 @@ describe('mapToExternalPrn', () => {
     const prn = buildAwaitingAcceptancePrn({
       status: {
         currentStatus: PRN_STATUS.ACCEPTED,
+        currentStatusAt: acceptedDate,
         created: { at: authorisedDate, by: creator },
         issued: { at: issuedDate, by: issuer },
         accepted: { at: acceptedDate, by: producer },
@@ -119,6 +130,7 @@ describe('mapToExternalPrn', () => {
     const prn = buildAwaitingAcceptancePrn({
       status: {
         currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
+        currentStatusAt: rejectedDate,
         created: { at: authorisedDate, by: creator },
         issued: { at: issuedDate, by: issuer },
         rejected: { at: rejectedDate, by: producer },
@@ -135,6 +147,7 @@ describe('mapToExternalPrn', () => {
     const prn = buildAwaitingAcceptancePrn({
       status: {
         currentStatus: PRN_STATUS.CANCELLED,
+        currentStatusAt: cancelledDate,
         created: { at: authorisedDate, by: creator },
         issued: { at: issuedDate, by: issuer },
         rejected: { at: rejectedDate, by: producer },
@@ -152,6 +165,7 @@ describe('mapToExternalPrn', () => {
     const prn = buildAwaitingAcceptancePrn({
       status: {
         currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+        currentStatusAt: authorisedDate,
         created: { at: authorisedDate, by: creator },
         history: []
       }
@@ -169,6 +183,7 @@ describe('mapToExternalPrn', () => {
     const prn = buildAwaitingAcceptancePrn({
       status: {
         currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+        currentStatusAt: issuedDate,
         created: { at: authorisedDate, by: creator },
         issued: { at: issuedDate, by: issuerWithoutPosition },
         history: []
@@ -229,6 +244,7 @@ describe('mapToExternalPrn', () => {
       prnNumber: undefined,
       status: {
         currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+        currentStatusAt: authorisedDate,
         created: { at: authorisedDate, by: creator },
         history: []
       }

--- a/src/packaging-recycling-notes/application/external-prn-mapper.test.js
+++ b/src/packaging-recycling-notes/application/external-prn-mapper.test.js
@@ -296,4 +296,12 @@ describe('mapToExternalPrn', () => {
 
     expect(result.isExport).toBe(true)
   })
+
+  it('omits the internal lastAppliedEventNumber watermark', () => {
+    const prn = buildAwaitingAcceptancePrn({ lastAppliedEventNumber: 7 })
+
+    const result = mapToExternalPrn(prn)
+
+    expect(result).not.toHaveProperty('lastAppliedEventNumber')
+  })
 })

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -363,7 +363,8 @@ async function performTransition({
           id,
           expectedVersion: updatedPrn.version,
           updatedBy: user,
-          updatedAt: now
+          updatedAt: now,
+          lastAppliedEventNumber: updatedPrn.lastAppliedEventNumber
         }),
       {
         forwardError,

--- a/src/packaging-recycling-notes/domain/model.js
+++ b/src/packaging-recycling-notes/domain/model.js
@@ -197,6 +197,7 @@ export function validateTransition(currentStatus, newStatus, actor) {
  *   id: string;
  *   schemaVersion: number;
  *   version: number;
+ *   lastAppliedEventNumber?: number;
  *   prnNumber?: string | null;
  *   organisation: OrganisationNameAndId;
  *   registrationId: string;

--- a/src/packaging-recycling-notes/repository/contract/rollback.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/rollback.contract.js
@@ -191,6 +191,69 @@ export const testRollbackBehaviour = (it) => {
         })
       )
     })
+
+    describe('lastAppliedEventNumber watermark', () => {
+      const seedWatermarked = (lastAppliedEventNumber) =>
+        repository.create(
+          buildAwaitingAcceptancePrn({ lastAppliedEventNumber })
+        )
+
+      const rollback = (prn, lastAppliedEventNumber) =>
+        repository.rollbackIssuance({
+          id: prn.id,
+          expectedVersion: prn.version,
+          updatedBy: compensator,
+          updatedAt: new Date(),
+          lastAppliedEventNumber
+        })
+
+      it('carries an equal watermark forward', async () => {
+        const created = await seedWatermarked(5)
+
+        const rolledBack = await rollback(created, 5)
+
+        expect(rolledBack.lastAppliedEventNumber).toBe(5)
+      })
+
+      it('advances to a higher watermark', async () => {
+        const created = await seedWatermarked(5)
+
+        const rolledBack = await rollback(created, 9)
+
+        expect(rolledBack.lastAppliedEventNumber).toBe(9)
+      })
+
+      it('rejects a lower watermark as an internal error', async () => {
+        const created = await seedWatermarked(5)
+
+        await expect(rollback(created, 3)).rejects.toMatchObject({
+          isBoom: true,
+          output: { statusCode: 500 },
+          message: `Watermark regression: PRN ${created.id} has applied event 5 but the update would move it back to 3`
+        })
+      })
+
+      it('rejects a rollback that drops the watermark once one is set', async () => {
+        const created = await seedWatermarked(5)
+
+        await expect(rollback(created, undefined)).rejects.toMatchObject({
+          isBoom: true,
+          output: { statusCode: 500 },
+          message: `Watermark regression: PRN ${created.id} has applied event 5 but the update did not carry a watermark`
+        })
+      })
+
+      it('leaves the watermark untouched when a rollback is rejected', async () => {
+        const created = await seedWatermarked(5)
+
+        await rollback(created, 3).catch(() => {})
+
+        const found = await repository.findById(created.id)
+        expect(found.lastAppliedEventNumber).toBe(5)
+        expect(found.version).toBe(created.version)
+        expect(found.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+      })
+    })
   })
 
   describe('rollbackPendingCancellation', () => {

--- a/src/packaging-recycling-notes/repository/contract/update-status.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/update-status.contract.js
@@ -1,4 +1,4 @@
-import { describe, beforeEach, expect } from 'vitest'
+import { describe, beforeEach, expect, vi } from 'vitest'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { buildDraftPrn, buildAwaitingAuthorisationPrn } from './test-data.js'
 
@@ -171,38 +171,42 @@ export const testUpdateStatusBehaviour = (it) => {
     })
 
     describe('lastAppliedEventNumber watermark', () => {
-      it('sets lastAppliedEventNumber when provided', async () => {
+      const seedWatermarkedPrn = async (lastAppliedEventNumber) => {
         const created = await repository.create(buildDraftPrn())
-
-        const updated = await repository.updateStatus({
+        return repository.updateStatus({
           id: created.id,
           version: created.version,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
           updatedBy: { id: 'user-raiser', name: 'Raiser User' },
           updatedAt: new Date(),
-          lastAppliedEventNumber: 5
+          lastAppliedEventNumber
+        })
+      }
+
+      const reapplyWatermark = (prn, lastAppliedEventNumber) =>
+        repository.updateStatus({
+          id: prn.id,
+          version: prn.version,
+          status: PRN_STATUS.AWAITING_ACCEPTANCE,
+          updatedBy: { id: 'user-issuer', name: 'Issuer User' },
+          updatedAt: new Date(),
+          lastAppliedEventNumber
         })
 
-        expect(updated.lastAppliedEventNumber).toBe(5)
+      it('sets lastAppliedEventNumber when provided', async () => {
+        const watermarked = await seedWatermarkedPrn(5)
+
+        expect(watermarked.lastAppliedEventNumber).toBe(5)
       })
 
       it('persists lastAppliedEventNumber so it can be retrieved', async () => {
-        const created = await repository.create(buildDraftPrn())
+        const watermarked = await seedWatermarkedPrn(7)
 
-        await repository.updateStatus({
-          id: created.id,
-          version: created.version,
-          status: PRN_STATUS.AWAITING_AUTHORISATION,
-          updatedBy: { id: 'user-raiser', name: 'Raiser User' },
-          updatedAt: new Date(),
-          lastAppliedEventNumber: 7
-        })
-
-        const found = await repository.findById(created.id)
+        const found = await repository.findById(watermarked.id)
         expect(found.lastAppliedEventNumber).toBe(7)
       })
 
-      it('does not set lastAppliedEventNumber when not provided', async () => {
+      it('does not set lastAppliedEventNumber when none is stored or provided', async () => {
         const created = await repository.create(buildDraftPrn())
 
         const updated = await repository.updateStatus({
@@ -216,10 +220,83 @@ export const testUpdateStatusBehaviour = (it) => {
         expect(updated.lastAppliedEventNumber).toBeUndefined()
       })
 
-      it('preserves an existing watermark when a later update omits it', async () => {
-        const created = await repository.create(buildDraftPrn())
+      it('re-applies an equal watermark', async () => {
+        const watermarked = await seedWatermarkedPrn(5)
 
-        const watermarked = await repository.updateStatus({
+        const updated = await reapplyWatermark(watermarked, 5)
+
+        expect(updated.lastAppliedEventNumber).toBe(5)
+      })
+
+      it('advances to a higher watermark', async () => {
+        const watermarked = await seedWatermarkedPrn(5)
+
+        const updated = await reapplyWatermark(watermarked, 9)
+
+        expect(updated.lastAppliedEventNumber).toBe(9)
+      })
+
+      it('rejects a lower watermark with a 409 conflict', async () => {
+        const watermarked = await seedWatermarkedPrn(5)
+
+        await expect(reapplyWatermark(watermarked, 3)).rejects.toMatchObject({
+          isBoom: true,
+          output: { statusCode: 409 }
+        })
+      })
+
+      it('rejects an update that omits the watermark once one is set', async () => {
+        const watermarked = await seedWatermarkedPrn(5)
+
+        await expect(
+          reapplyWatermark(watermarked, undefined)
+        ).rejects.toMatchObject({
+          isBoom: true,
+          output: { statusCode: 409 }
+        })
+      })
+
+      it('leaves the PRN untouched when a stale watermark is rejected', async () => {
+        const watermarked = await seedWatermarkedPrn(5)
+
+        await reapplyWatermark(watermarked, 3).catch(() => {})
+
+        const found = await repository.findById(watermarked.id)
+        expect(found.lastAppliedEventNumber).toBe(5)
+        expect(found.version).toBe(watermarked.version)
+        expect(found.status.currentStatus).toBe(
+          PRN_STATUS.AWAITING_AUTHORISATION
+        )
+      })
+
+      it('describes the stored watermark in the conflict message', async () => {
+        const watermarked = await seedWatermarkedPrn(5)
+
+        await expect(reapplyWatermark(watermarked, 3)).rejects.toMatchObject({
+          isBoom: true,
+          output: {
+            statusCode: 409,
+            payload: {
+              message: `Stale watermark: PRN ${watermarked.id} has already applied event 5 but the update did not advance it`
+            }
+          }
+        })
+      })
+    })
+
+    describe('watermark conflict logging', () => {
+      it('logs watermark regression with database/watermark_regression_detected event metadata', async ({
+        prnRepositoryFactory
+      }) => {
+        const logger = {
+          info: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          debug: vi.fn()
+        }
+        const repo = prnRepositoryFactory(logger)
+        const created = await repo.create(buildDraftPrn())
+        const watermarked = await repo.updateStatus({
           id: created.id,
           version: created.version,
           status: PRN_STATUS.AWAITING_AUTHORISATION,
@@ -228,17 +305,31 @@ export const testUpdateStatusBehaviour = (it) => {
           lastAppliedEventNumber: 5
         })
 
-        await repository.updateStatus({
-          id: created.id,
-          version: watermarked.version,
-          status: PRN_STATUS.AWAITING_ACCEPTANCE,
-          updatedBy: { id: 'user-issuer', name: 'Issuer User' },
-          updatedAt: new Date(),
-          prnNumber: `ER26${Date.now().toString().slice(-5)}W`
+        await expect(
+          repo.updateStatus({
+            id: created.id,
+            version: watermarked.version,
+            status: PRN_STATUS.AWAITING_ACCEPTANCE,
+            updatedBy: { id: 'user-issuer', name: 'Issuer User' },
+            updatedAt: new Date(),
+            lastAppliedEventNumber: 3
+          })
+        ).rejects.toMatchObject({
+          isBoom: true,
+          output: { statusCode: 409 }
         })
 
-        const found = await repository.findById(created.id)
-        expect(found.lastAppliedEventNumber).toBe(5)
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            err: expect.any(Error),
+            message: `Stale watermark detected for PRN ${created.id}`,
+            event: {
+              category: 'database',
+              action: 'watermark_regression_detected',
+              reference: created.id
+            }
+          })
+        )
       })
     })
 

--- a/src/packaging-recycling-notes/repository/contract/update-status.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/update-status.contract.js
@@ -170,6 +170,78 @@ export const testUpdateStatusBehaviour = (it) => {
       })
     })
 
+    describe('lastAppliedEventNumber watermark', () => {
+      it('sets lastAppliedEventNumber when provided', async () => {
+        const created = await repository.create(buildDraftPrn())
+
+        const updated = await repository.updateStatus({
+          id: created.id,
+          version: created.version,
+          status: PRN_STATUS.AWAITING_AUTHORISATION,
+          updatedBy: { id: 'user-raiser', name: 'Raiser User' },
+          updatedAt: new Date(),
+          lastAppliedEventNumber: 5
+        })
+
+        expect(updated.lastAppliedEventNumber).toBe(5)
+      })
+
+      it('persists lastAppliedEventNumber so it can be retrieved', async () => {
+        const created = await repository.create(buildDraftPrn())
+
+        await repository.updateStatus({
+          id: created.id,
+          version: created.version,
+          status: PRN_STATUS.AWAITING_AUTHORISATION,
+          updatedBy: { id: 'user-raiser', name: 'Raiser User' },
+          updatedAt: new Date(),
+          lastAppliedEventNumber: 7
+        })
+
+        const found = await repository.findById(created.id)
+        expect(found.lastAppliedEventNumber).toBe(7)
+      })
+
+      it('does not set lastAppliedEventNumber when not provided', async () => {
+        const created = await repository.create(buildDraftPrn())
+
+        const updated = await repository.updateStatus({
+          id: created.id,
+          version: created.version,
+          status: PRN_STATUS.AWAITING_AUTHORISATION,
+          updatedBy: { id: 'user-raiser', name: 'Raiser User' },
+          updatedAt: new Date()
+        })
+
+        expect(updated.lastAppliedEventNumber).toBeUndefined()
+      })
+
+      it('preserves an existing watermark when a later update omits it', async () => {
+        const created = await repository.create(buildDraftPrn())
+
+        const watermarked = await repository.updateStatus({
+          id: created.id,
+          version: created.version,
+          status: PRN_STATUS.AWAITING_AUTHORISATION,
+          updatedBy: { id: 'user-raiser', name: 'Raiser User' },
+          updatedAt: new Date(),
+          lastAppliedEventNumber: 5
+        })
+
+        await repository.updateStatus({
+          id: created.id,
+          version: watermarked.version,
+          status: PRN_STATUS.AWAITING_ACCEPTANCE,
+          updatedBy: { id: 'user-issuer', name: 'Issuer User' },
+          updatedAt: new Date(),
+          prnNumber: `ER26${Date.now().toString().slice(-5)}W`
+        })
+
+        const found = await repository.findById(created.id)
+        expect(found.lastAppliedEventNumber).toBe(5)
+      })
+    })
+
     describe('business operation slots', () => {
       it('sets the named operation slot when provided', async () => {
         const created = await repository.create(buildAwaitingAuthorisationPrn())

--- a/src/packaging-recycling-notes/repository/contract/update-status.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/update-status.contract.js
@@ -242,12 +242,12 @@ export const testUpdateStatusBehaviour = (it) => {
         expect(updated.lastAppliedEventNumber).toBe(9)
       })
 
-      it('rejects a lower watermark with a 409 conflict', async () => {
+      it('rejects a lower watermark as an internal error', async () => {
         const watermarked = await seedWatermarkedPrn(5)
 
         await expect(reapplyWatermark(watermarked, 3)).rejects.toMatchObject({
           isBoom: true,
-          output: { statusCode: 409 }
+          output: { statusCode: 500 }
         })
       })
 
@@ -258,7 +258,7 @@ export const testUpdateStatusBehaviour = (it) => {
           reapplyWatermark(watermarked, undefined)
         ).rejects.toMatchObject({
           isBoom: true,
-          output: { statusCode: 409 }
+          output: { statusCode: 500 }
         })
       })
 
@@ -275,17 +275,13 @@ export const testUpdateStatusBehaviour = (it) => {
         )
       })
 
-      it('describes the stored watermark in the conflict message', async () => {
+      it('describes the stored watermark in the error message', async () => {
         const watermarked = await seedWatermarkedPrn(5)
 
         await expect(reapplyWatermark(watermarked, 3)).rejects.toMatchObject({
           isBoom: true,
-          output: {
-            statusCode: 409,
-            payload: {
-              message: `Stale watermark: PRN ${watermarked.id} has already applied event 5 but the update did not advance it`
-            }
-          }
+          output: { statusCode: 500 },
+          message: `Stale watermark: PRN ${watermarked.id} has already applied event 5 but the update did not advance it`
         })
       })
     })
@@ -322,7 +318,7 @@ export const testUpdateStatusBehaviour = (it) => {
           })
         ).rejects.toMatchObject({
           isBoom: true,
-          output: { statusCode: 409 }
+          output: { statusCode: 500 }
         })
 
         expect(logger.error).toHaveBeenCalledWith(

--- a/src/packaging-recycling-notes/repository/contract/update-status.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/update-status.contract.js
@@ -251,18 +251,19 @@ export const testUpdateStatusBehaviour = (it) => {
         })
       })
 
-      it('rejects an update that omits the watermark once one is set', async () => {
+      it('rejects an update that drops the watermark once one is set', async () => {
         const watermarked = await seedWatermarkedPrn(5)
 
         await expect(
           reapplyWatermark(watermarked, undefined)
         ).rejects.toMatchObject({
           isBoom: true,
-          output: { statusCode: 500 }
+          output: { statusCode: 500 },
+          message: `Watermark regression: PRN ${watermarked.id} has applied event 5 but the update did not carry a watermark`
         })
       })
 
-      it('leaves the PRN untouched when a stale watermark is rejected', async () => {
+      it('leaves the PRN untouched when a watermark regression is rejected', async () => {
         const watermarked = await seedWatermarkedPrn(5)
 
         await reapplyWatermark(watermarked, 3).catch(() => {})
@@ -275,18 +276,18 @@ export const testUpdateStatusBehaviour = (it) => {
         )
       })
 
-      it('describes the stored watermark in the error message', async () => {
+      it('describes the backwards move in the error message', async () => {
         const watermarked = await seedWatermarkedPrn(5)
 
         await expect(reapplyWatermark(watermarked, 3)).rejects.toMatchObject({
           isBoom: true,
           output: { statusCode: 500 },
-          message: `Stale watermark: PRN ${watermarked.id} has already applied event 5 but the update did not advance it`
+          message: `Watermark regression: PRN ${watermarked.id} has applied event 5 but the update would move it back to 3`
         })
       })
     })
 
-    describe('watermark conflict logging', () => {
+    describe('watermark regression logging', () => {
       it('logs watermark regression with database/watermark_regression_detected event metadata', async ({
         prnRepositoryFactory
       }) => {
@@ -324,7 +325,7 @@ export const testUpdateStatusBehaviour = (it) => {
         expect(logger.error).toHaveBeenCalledWith(
           expect.objectContaining({
             err: expect.any(Error),
-            message: `Stale watermark detected for PRN ${created.id}`,
+            message: `Watermark regression detected for PRN ${created.id}`,
             event: {
               category: 'database',
               action: 'watermark_regression_detected',

--- a/src/packaging-recycling-notes/repository/contract/update-status.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/update-status.contract.js
@@ -2,13 +2,19 @@ import { describe, beforeEach, expect, vi } from 'vitest'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { buildDraftPrn, buildAwaitingAuthorisationPrn } from './test-data.js'
 
+/** @typedef {import('../port.js').PackagingRecyclingNotesRepository} PrnRepository */
+
 export const testUpdateStatusBehaviour = (it) => {
   describe('updateStatus', () => {
     let repository
 
-    beforeEach(async ({ prnRepository }) => {
-      repository = prnRepository
-    })
+    beforeEach(
+      async (
+        /** @type {{ prnRepository: PrnRepository }} */ { prnRepository }
+      ) => {
+        repository = prnRepository
+      }
+    )
 
     describe('basic behaviour', () => {
       it('updates the current status', async () => {

--- a/src/packaging-recycling-notes/repository/inmemory.plugin.js
+++ b/src/packaging-recycling-notes/repository/inmemory.plugin.js
@@ -163,7 +163,8 @@ const performUpdateStatus =
     updatedBy,
     updatedAt,
     prnNumber,
-    operation
+    operation,
+    lastAppliedEventNumber
   }) => {
     const prn = storage.get(id)
     if (!prn) {
@@ -213,6 +214,10 @@ const performUpdateStatus =
 
     if (prnNumber) {
       updated.prnNumber = prnNumber
+    }
+
+    if (lastAppliedEventNumber !== undefined) {
+      updated.lastAppliedEventNumber = lastAppliedEventNumber
     }
 
     storage.set(id, structuredClone(updated))

--- a/src/packaging-recycling-notes/repository/inmemory.plugin.js
+++ b/src/packaging-recycling-notes/repository/inmemory.plugin.js
@@ -56,6 +56,12 @@ const buildVersionConflictError = (id, expected, actual) =>
   )
 
 /**
+ * The watermark only ever moves alongside the version, so a stale watermark
+ * here means the caller held the current version yet supplied a lower (or
+ * absent) watermark — it fed an out-of-order event into the projection rather
+ * than losing a race. That is a coding error, not a retryable conflict, so it
+ * surfaces as an internal error.
+ *
  * @param {string} id
  * @param {number | undefined} storedEventNumber
  * @param {number | undefined} incomingEventNumber
@@ -72,11 +78,11 @@ const enforceMonotonicWatermark = (
     (incomingEventNumber === undefined ||
       incomingEventNumber < storedEventNumber)
   ) {
-    const conflictError = new Error(
+    const regressionError = new Error(
       `Stale watermark: PRN ${id} has already applied event ${storedEventNumber} but the update did not advance it`
     )
     logger.error({
-      err: conflictError,
+      err: regressionError,
       message: `Stale watermark detected for PRN ${id}`,
       event: {
         category: LOGGING_EVENT_CATEGORIES.DB,
@@ -84,7 +90,7 @@ const enforceMonotonicWatermark = (
         reference: id
       }
     })
-    throw Boom.conflict(conflictError.message)
+    throw Boom.badImplementation(regressionError.message)
   }
 }
 

--- a/src/packaging-recycling-notes/repository/inmemory.plugin.js
+++ b/src/packaging-recycling-notes/repository/inmemory.plugin.js
@@ -8,6 +8,10 @@ import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 import { PrnNumberConflictError } from './port.js'
 import { validatePrnInsert } from './validation.js'
+import {
+  isWatermarkRegression,
+  throwWatermarkRegression
+} from './watermark-guard.js'
 
 /** @import { TypedLogger } from '#common/hapi-types.js' */
 /** @import { Organisation } from '#domain/organisations/model.js' */
@@ -56,12 +60,6 @@ const buildVersionConflictError = (id, expected, actual) =>
   )
 
 /**
- * The watermark only ever moves alongside the version, so a stale watermark
- * here means the caller held the current version yet supplied a lower (or
- * absent) watermark — it fed an out-of-order event into the projection rather
- * than losing a race. That is a coding error, not a retryable conflict, so it
- * surfaces as an internal error.
- *
  * @param {string} id
  * @param {number | undefined} storedEventNumber
  * @param {number | undefined} incomingEventNumber
@@ -73,24 +71,8 @@ const enforceMonotonicWatermark = (
   incomingEventNumber,
   logger
 ) => {
-  if (
-    storedEventNumber !== undefined &&
-    (incomingEventNumber === undefined ||
-      incomingEventNumber < storedEventNumber)
-  ) {
-    const regressionError = new Error(
-      `Stale watermark: PRN ${id} has already applied event ${storedEventNumber} but the update did not advance it`
-    )
-    logger.error({
-      err: regressionError,
-      message: `Stale watermark detected for PRN ${id}`,
-      event: {
-        category: LOGGING_EVENT_CATEGORIES.DB,
-        action: LOGGING_EVENT_ACTIONS.WATERMARK_REGRESSION_DETECTED,
-        reference: id
-      }
-    })
-    throw Boom.badImplementation(regressionError.message)
+  if (isWatermarkRegression(storedEventNumber, incomingEventNumber)) {
+    throwWatermarkRegression(id, storedEventNumber, incomingEventNumber, logger)
   }
 }
 
@@ -278,7 +260,13 @@ const performUpdateStatus =
  */
 const performRollback =
   (storage, logger, { revertedStatus, slotsToUnset, unsetPrnNumber }) =>
-  async ({ id, expectedVersion, updatedBy, updatedAt }) => {
+  async ({
+    id,
+    expectedVersion,
+    updatedBy,
+    updatedAt,
+    lastAppliedEventNumber
+  }) => {
     const prn = storage.get(id)
     if (!prn) {
       return null
@@ -301,6 +289,13 @@ const performRollback =
       })
       throw Boom.conflict(conflictError.message)
     }
+
+    enforceMonotonicWatermark(
+      id,
+      prn.lastAppliedEventNumber,
+      lastAppliedEventNumber,
+      logger
+    )
 
     const statusUpdate = {
       ...prn.status,
@@ -326,6 +321,10 @@ const performRollback =
 
     if (unsetPrnNumber) {
       delete updated.prnNumber
+    }
+
+    if (lastAppliedEventNumber !== undefined) {
+      updated.lastAppliedEventNumber = lastAppliedEventNumber
     }
 
     storage.set(id, structuredClone(updated))

--- a/src/packaging-recycling-notes/repository/inmemory.plugin.js
+++ b/src/packaging-recycling-notes/repository/inmemory.plugin.js
@@ -185,6 +185,26 @@ const performUpdateStatus =
       throw Boom.conflict(conflictError.message)
     }
 
+    if (
+      prn.lastAppliedEventNumber !== undefined &&
+      (lastAppliedEventNumber === undefined ||
+        lastAppliedEventNumber < prn.lastAppliedEventNumber)
+    ) {
+      const conflictError = new Error(
+        `Stale watermark: PRN ${id} has already applied event ${prn.lastAppliedEventNumber} but the update did not advance it`
+      )
+      logger.error({
+        err: conflictError,
+        message: `Stale watermark detected for PRN ${id}`,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.DB,
+          action: LOGGING_EVENT_ACTIONS.WATERMARK_REGRESSION_DETECTED,
+          reference: id
+        }
+      })
+      throw Boom.conflict(conflictError.message)
+    }
+
     if (prnNumber) {
       for (const existing of storage.values()) {
         if (existing.id !== id && existing.prnNumber === prnNumber) {

--- a/src/packaging-recycling-notes/repository/inmemory.plugin.js
+++ b/src/packaging-recycling-notes/repository/inmemory.plugin.js
@@ -56,6 +56,39 @@ const buildVersionConflictError = (id, expected, actual) =>
   )
 
 /**
+ * @param {string} id
+ * @param {number | undefined} storedEventNumber
+ * @param {number | undefined} incomingEventNumber
+ * @param {TypedLogger} logger
+ */
+const enforceMonotonicWatermark = (
+  id,
+  storedEventNumber,
+  incomingEventNumber,
+  logger
+) => {
+  if (
+    storedEventNumber !== undefined &&
+    (incomingEventNumber === undefined ||
+      incomingEventNumber < storedEventNumber)
+  ) {
+    const conflictError = new Error(
+      `Stale watermark: PRN ${id} has already applied event ${storedEventNumber} but the update did not advance it`
+    )
+    logger.error({
+      err: conflictError,
+      message: `Stale watermark detected for PRN ${id}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.DB,
+        action: LOGGING_EVENT_ACTIONS.WATERMARK_REGRESSION_DETECTED,
+        reference: id
+      }
+    })
+    throw Boom.conflict(conflictError.message)
+  }
+}
+
+/**
  * @param {Storage} storage
  * @returns {(accreditationId: string) => Promise<PackagingRecyclingNote[]>}
  */
@@ -185,25 +218,12 @@ const performUpdateStatus =
       throw Boom.conflict(conflictError.message)
     }
 
-    if (
-      prn.lastAppliedEventNumber !== undefined &&
-      (lastAppliedEventNumber === undefined ||
-        lastAppliedEventNumber < prn.lastAppliedEventNumber)
-    ) {
-      const conflictError = new Error(
-        `Stale watermark: PRN ${id} has already applied event ${prn.lastAppliedEventNumber} but the update did not advance it`
-      )
-      logger.error({
-        err: conflictError,
-        message: `Stale watermark detected for PRN ${id}`,
-        event: {
-          category: LOGGING_EVENT_CATEGORIES.DB,
-          action: LOGGING_EVENT_ACTIONS.WATERMARK_REGRESSION_DETECTED,
-          reference: id
-        }
-      })
-      throw Boom.conflict(conflictError.message)
-    }
+    enforceMonotonicWatermark(
+      id,
+      prn.lastAppliedEventNumber,
+      lastAppliedEventNumber,
+      logger
+    )
 
     if (prnNumber) {
       for (const existing of storage.values()) {

--- a/src/packaging-recycling-notes/repository/mongodb.js
+++ b/src/packaging-recycling-notes/repository/mongodb.js
@@ -351,6 +351,11 @@ const performUpdateStatus = async (
   }
 
   const versionMatches = { $eq: [{ $ifNull: ['$version', 1] }, version] }
+  // A supplied watermark must not go backwards: it has to be >= the stored one,
+  // with a missing stored watermark defaulting to the incoming value so the
+  // first write always passes. An omitted watermark is allowed only while the
+  // PRN carries none (the embedded path); omitting it over a stored watermark
+  // is itself a regression and fails the guard.
   const watermarkAdvances =
     lastAppliedEventNumber === undefined
       ? { $eq: [{ $ifNull: ['$lastAppliedEventNumber', null] }, null] }

--- a/src/packaging-recycling-notes/repository/mongodb.js
+++ b/src/packaging-recycling-notes/repository/mongodb.js
@@ -8,6 +8,7 @@ import {
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { PrnNumberConflictError } from './port.js'
 import { validatePrnInsert, validatePrnRead } from './validation.js'
+import { throwWatermarkRegression } from './watermark-guard.js'
 
 /** @import { Collection, Db, Document, Filter, WithId } from 'mongodb' */
 /** @import { Organisation } from '#domain/organisations/model.js' */
@@ -250,23 +251,46 @@ const performFindByStatus = (db, excludeOrganisationIds) => {
 }
 
 /**
+ * CAS guard that lets a write through only when it does not move the watermark
+ * backwards. An omitted watermark passes only while the PRN carries none (the
+ * pre-migration path); once a PRN has a watermark every write must supply one,
+ * and it must be greater than or equal to the stored value. A missing stored
+ * value defaults to the incoming one so the migrating write always passes.
+ *
+ * @param {number | undefined} lastAppliedEventNumber
+ */
+const watermarkNotRegressing = (lastAppliedEventNumber) =>
+  lastAppliedEventNumber === undefined
+    ? { $eq: [{ $ifNull: ['$lastAppliedEventNumber', null] }, null] }
+    : {
+        $gte: [
+          lastAppliedEventNumber,
+          { $ifNull: ['$lastAppliedEventNumber', lastAppliedEventNumber] }
+        ]
+      }
+
+/**
  * Resolves a missed CAS update into a 404 (PRN missing), a 409 version
- * conflict, or a 500 internal error. When the expected version is still
- * current the monotonic watermark guard is the only thing that could have
- * rejected the write, and since the watermark only ever moves alongside the
- * version, that means the caller held the current version yet supplied a lower
- * lastAppliedEventNumber (or omitted it over a watermarked PRN) — an
- * out-of-order event fed into the projection rather than a lost race. That is
- * a coding error, so it surfaces as an internal error rather than a retryable
- * conflict. Logs the cause for observability before throwing.
+ * conflict, or a 500 internal error. If the stored version still matches the
+ * expected one then the version guard passed and it was the watermark guard
+ * that rejected the write: the caller held the current version yet failed to
+ * carry a migrated PRN's watermark forward. That is a coding error, not a lost
+ * race, so it surfaces as an internal error. Logs the cause before throwing.
  *
  * @param {Db} db
  * @param {string} id
  * @param {number} expectedVersion
+ * @param {number | undefined} incomingEventNumber
  * @param {TypedLogger} logger
  * @returns {Promise<null>}
  */
-const resolveMissedUpdate = async (db, id, expectedVersion, logger) => {
+const resolveMissedUpdate = async (
+  db,
+  id,
+  expectedVersion,
+  incomingEventNumber,
+  logger
+) => {
   const objectId = ObjectId.createFromHexString(id)
   const existing = await db
     .collection(COLLECTION_NAME)
@@ -296,19 +320,12 @@ const resolveMissedUpdate = async (db, id, expectedVersion, logger) => {
     throw Boom.conflict(versionConflictError.message)
   }
 
-  const watermarkRegressionError = new Error(
-    `Stale watermark: PRN ${id} has already applied event ${existing.lastAppliedEventNumber} but the update did not advance it`
+  return throwWatermarkRegression(
+    id,
+    existing.lastAppliedEventNumber,
+    incomingEventNumber,
+    logger
   )
-  logger.error({
-    err: watermarkRegressionError,
-    message: `Stale watermark detected for PRN ${id}`,
-    event: {
-      category: LOGGING_EVENT_CATEGORIES.DB,
-      action: LOGGING_EVENT_ACTIONS.WATERMARK_REGRESSION_DETECTED,
-      reference: id
-    }
-  })
-  throw Boom.badImplementation(watermarkRegressionError.message)
 }
 
 /**
@@ -354,26 +371,14 @@ const performUpdateStatus = async (
   }
 
   const versionMatches = { $eq: [{ $ifNull: ['$version', 1] }, version] }
-  // A supplied watermark must not go backwards: it has to be >= the stored one,
-  // with a missing stored watermark defaulting to the incoming value so the
-  // first write always passes. An omitted watermark is allowed only while the
-  // PRN carries none (the embedded path); omitting it over a stored watermark
-  // is itself a regression and fails the guard.
-  const watermarkAdvances =
-    lastAppliedEventNumber === undefined
-      ? { $eq: [{ $ifNull: ['$lastAppliedEventNumber', null] }, null] }
-      : {
-          $gte: [
-            lastAppliedEventNumber,
-            { $ifNull: ['$lastAppliedEventNumber', lastAppliedEventNumber] }
-          ]
-        }
 
   try {
     const result = await db.collection(COLLECTION_NAME).findOneAndUpdate(
       {
         _id: ObjectId.createFromHexString(id),
-        $expr: { $and: [versionMatches, watermarkAdvances] }
+        $expr: {
+          $and: [versionMatches, watermarkNotRegressing(lastAppliedEventNumber)]
+        }
       },
       {
         $set: { ...setFields, version: version + 1 },
@@ -385,7 +390,13 @@ const performUpdateStatus = async (
     )
 
     if (!result) {
-      return resolveMissedUpdate(db, id, version, logger)
+      return resolveMissedUpdate(
+        db,
+        id,
+        version,
+        lastAppliedEventNumber,
+        logger
+      )
     }
 
     return validatePrnRead({ ...result, id: result._id.toHexString() })
@@ -410,7 +421,7 @@ const performUpdateStatus = async (
 const performRollback = async (
   db,
   logger,
-  { id, expectedVersion, updatedBy, updatedAt },
+  { id, expectedVersion, updatedBy, updatedAt, lastAppliedEventNumber },
   { revertedStatus, slotsToUnset, unsetPrnNumber }
 ) => {
   const setFields = {
@@ -418,6 +429,10 @@ const performRollback = async (
     'status.currentStatusAt': updatedAt,
     updatedAt,
     updatedBy
+  }
+
+  if (lastAppliedEventNumber !== undefined) {
+    setFields.lastAppliedEventNumber = lastAppliedEventNumber
   }
 
   /** @type {Record<string, ''>} */
@@ -429,10 +444,16 @@ const performRollback = async (
     unsetFields.prnNumber = ''
   }
 
+  const versionMatches = {
+    $eq: [{ $ifNull: ['$version', 1] }, expectedVersion]
+  }
+
   const result = await db.collection(COLLECTION_NAME).findOneAndUpdate(
     {
       _id: ObjectId.createFromHexString(id),
-      $expr: { $eq: [{ $ifNull: ['$version', 1] }, expectedVersion] }
+      $expr: {
+        $and: [versionMatches, watermarkNotRegressing(lastAppliedEventNumber)]
+      }
     },
     {
       $set: { ...setFields, version: expectedVersion + 1 },
@@ -449,7 +470,13 @@ const performRollback = async (
   )
 
   if (!result) {
-    return resolveMissedUpdate(db, id, expectedVersion, logger)
+    return resolveMissedUpdate(
+      db,
+      id,
+      expectedVersion,
+      lastAppliedEventNumber,
+      logger
+    )
   }
 
   return validatePrnRead({ ...result, id: result._id.toHexString() })

--- a/src/packaging-recycling-notes/repository/mongodb.js
+++ b/src/packaging-recycling-notes/repository/mongodb.js
@@ -250,8 +250,12 @@ const performFindByStatus = (db, excludeOrganisationIds) => {
 }
 
 /**
- * Resolves a missed CAS update into a 404 (PRN missing) or 409 (version conflict).
- * Logs the version conflict for observability before throwing.
+ * Resolves a missed CAS update into a 404 (PRN missing), a 409 version
+ * conflict, or a 409 stale-watermark conflict. When the expected version is
+ * still current the monotonic watermark guard is what rejected the write — the
+ * update either supplied a lower lastAppliedEventNumber or omitted it over a
+ * PRN that already carries one. Logs the conflict for observability before
+ * throwing.
  *
  * @param {Db} db
  * @param {string} id
@@ -263,22 +267,41 @@ const resolveMissedUpdate = async (db, id, expectedVersion, logger) => {
   const objectId = ObjectId.createFromHexString(id)
   const existing = await db
     .collection(COLLECTION_NAME)
-    .findOne({ _id: objectId }, { projection: { version: 1 } })
+    .findOne(
+      { _id: objectId },
+      { projection: { version: 1, lastAppliedEventNumber: 1 } }
+    )
 
   if (!existing) {
     return null
   }
 
   const actualVersion = existing.version ?? 1
+  if (actualVersion !== expectedVersion) {
+    const conflictError = new Error(
+      `Version conflict: attempted to update PRN ${id} with version ${expectedVersion} but current version is ${actualVersion}`
+    )
+    logger.error({
+      err: conflictError,
+      message: `Version conflict detected for PRN ${id}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.DB,
+        action: LOGGING_EVENT_ACTIONS.VERSION_CONFLICT_DETECTED,
+        reference: id
+      }
+    })
+    throw Boom.conflict(conflictError.message)
+  }
+
   const conflictError = new Error(
-    `Version conflict: attempted to update PRN ${id} with version ${expectedVersion} but current version is ${actualVersion}`
+    `Stale watermark: PRN ${id} has already applied event ${existing.lastAppliedEventNumber} but the update did not advance it`
   )
   logger.error({
     err: conflictError,
-    message: `Version conflict detected for PRN ${id}`,
+    message: `Stale watermark detected for PRN ${id}`,
     event: {
       category: LOGGING_EVENT_CATEGORIES.DB,
-      action: LOGGING_EVENT_ACTIONS.VERSION_CONFLICT_DETECTED,
+      action: LOGGING_EVENT_ACTIONS.WATERMARK_REGRESSION_DETECTED,
       reference: id
     }
   })
@@ -327,11 +350,22 @@ const performUpdateStatus = async (
     }
   }
 
+  const versionMatches = { $eq: [{ $ifNull: ['$version', 1] }, version] }
+  const watermarkAdvances =
+    lastAppliedEventNumber === undefined
+      ? { $eq: [{ $ifNull: ['$lastAppliedEventNumber', null] }, null] }
+      : {
+          $gte: [
+            lastAppliedEventNumber,
+            { $ifNull: ['$lastAppliedEventNumber', lastAppliedEventNumber] }
+          ]
+        }
+
   try {
     const result = await db.collection(COLLECTION_NAME).findOneAndUpdate(
       {
         _id: ObjectId.createFromHexString(id),
-        $expr: { $eq: [{ $ifNull: ['$version', 1] }, version] }
+        $expr: { $and: [versionMatches, watermarkAdvances] }
       },
       {
         $set: { ...setFields, version: version + 1 },

--- a/src/packaging-recycling-notes/repository/mongodb.js
+++ b/src/packaging-recycling-notes/repository/mongodb.js
@@ -278,11 +278,11 @@ const resolveMissedUpdate = async (db, id, expectedVersion, logger) => {
 
   const actualVersion = existing.version ?? 1
   if (actualVersion !== expectedVersion) {
-    const conflictError = new Error(
+    const versionConflictError = new Error(
       `Version conflict: attempted to update PRN ${id} with version ${expectedVersion} but current version is ${actualVersion}`
     )
     logger.error({
-      err: conflictError,
+      err: versionConflictError,
       message: `Version conflict detected for PRN ${id}`,
       event: {
         category: LOGGING_EVENT_CATEGORIES.DB,
@@ -290,14 +290,14 @@ const resolveMissedUpdate = async (db, id, expectedVersion, logger) => {
         reference: id
       }
     })
-    throw Boom.conflict(conflictError.message)
+    throw Boom.conflict(versionConflictError.message)
   }
 
-  const conflictError = new Error(
+  const watermarkConflictError = new Error(
     `Stale watermark: PRN ${id} has already applied event ${existing.lastAppliedEventNumber} but the update did not advance it`
   )
   logger.error({
-    err: conflictError,
+    err: watermarkConflictError,
     message: `Stale watermark detected for PRN ${id}`,
     event: {
       category: LOGGING_EVENT_CATEGORIES.DB,
@@ -305,7 +305,7 @@ const resolveMissedUpdate = async (db, id, expectedVersion, logger) => {
       reference: id
     }
   })
-  throw Boom.conflict(conflictError.message)
+  throw Boom.conflict(watermarkConflictError.message)
 }
 
 /**

--- a/src/packaging-recycling-notes/repository/mongodb.js
+++ b/src/packaging-recycling-notes/repository/mongodb.js
@@ -251,11 +251,14 @@ const performFindByStatus = (db, excludeOrganisationIds) => {
 
 /**
  * Resolves a missed CAS update into a 404 (PRN missing), a 409 version
- * conflict, or a 409 stale-watermark conflict. When the expected version is
- * still current the monotonic watermark guard is what rejected the write — the
- * update either supplied a lower lastAppliedEventNumber or omitted it over a
- * PRN that already carries one. Logs the conflict for observability before
- * throwing.
+ * conflict, or a 500 internal error. When the expected version is still
+ * current the monotonic watermark guard is the only thing that could have
+ * rejected the write, and since the watermark only ever moves alongside the
+ * version, that means the caller held the current version yet supplied a lower
+ * lastAppliedEventNumber (or omitted it over a watermarked PRN) — an
+ * out-of-order event fed into the projection rather than a lost race. That is
+ * a coding error, so it surfaces as an internal error rather than a retryable
+ * conflict. Logs the cause for observability before throwing.
  *
  * @param {Db} db
  * @param {string} id
@@ -293,11 +296,11 @@ const resolveMissedUpdate = async (db, id, expectedVersion, logger) => {
     throw Boom.conflict(versionConflictError.message)
   }
 
-  const watermarkConflictError = new Error(
+  const watermarkRegressionError = new Error(
     `Stale watermark: PRN ${id} has already applied event ${existing.lastAppliedEventNumber} but the update did not advance it`
   )
   logger.error({
-    err: watermarkConflictError,
+    err: watermarkRegressionError,
     message: `Stale watermark detected for PRN ${id}`,
     event: {
       category: LOGGING_EVENT_CATEGORIES.DB,
@@ -305,7 +308,7 @@ const resolveMissedUpdate = async (db, id, expectedVersion, logger) => {
       reference: id
     }
   })
-  throw Boom.conflict(watermarkConflictError.message)
+  throw Boom.badImplementation(watermarkRegressionError.message)
 }
 
 /**

--- a/src/packaging-recycling-notes/repository/mongodb.js
+++ b/src/packaging-recycling-notes/repository/mongodb.js
@@ -294,7 +294,16 @@ const resolveMissedUpdate = async (db, id, expectedVersion, logger) => {
 const performUpdateStatus = async (
   db,
   logger,
-  { id, version, status, updatedBy, updatedAt, prnNumber, operation }
+  {
+    id,
+    version,
+    status,
+    updatedBy,
+    updatedAt,
+    prnNumber,
+    operation,
+    lastAppliedEventNumber
+  }
 ) => {
   const setFields = {
     'status.currentStatus': status,
@@ -305,6 +314,10 @@ const performUpdateStatus = async (
 
   if (prnNumber) {
     setFields.prnNumber = prnNumber
+  }
+
+  if (lastAppliedEventNumber !== undefined) {
+    setFields.lastAppliedEventNumber = lastAppliedEventNumber
   }
 
   if (operation) {

--- a/src/packaging-recycling-notes/repository/port.js
+++ b/src/packaging-recycling-notes/repository/port.js
@@ -19,6 +19,7 @@ export class PrnNumberConflictError extends Error {
  * @property {Date} updatedAt - Timestamp of the change
  * @property {string} [prnNumber] - PRN number to set when issuing (transitioning to awaiting_acceptance)
  * @property {{ slot: import('#packaging-recycling-notes/domain/model.js').BusinessOperationSlot; at: Date; by: import('#packaging-recycling-notes/domain/model.js').Actor }} [operation] - Business operation to record on the status object
+ * @property {number} [lastAppliedEventNumber] - Stream watermark to stamp on the projection; the sequence number of the latest waste-balance event folded into this PRN
  */
 
 /**

--- a/src/packaging-recycling-notes/repository/port.js
+++ b/src/packaging-recycling-notes/repository/port.js
@@ -19,7 +19,7 @@ export class PrnNumberConflictError extends Error {
  * @property {Date} updatedAt - Timestamp of the change
  * @property {string} [prnNumber] - PRN number to set when issuing (transitioning to awaiting_acceptance)
  * @property {{ slot: import('#packaging-recycling-notes/domain/model.js').BusinessOperationSlot; at: Date; by: import('#packaging-recycling-notes/domain/model.js').Actor }} [operation] - Business operation to record on the status object
- * @property {number} [lastAppliedEventNumber] - Stream watermark to stamp on the projection; the sequence number of the latest waste-balance event folded into this PRN. Enforced monotonic: once a PRN carries a watermark, every update must supply one that does not go backwards (equal or higher) — a lower or omitted watermark is rejected with a 409 conflict. The embedded (non-stream) path never sets it.
+ * @property {number} [lastAppliedEventNumber] - Stream watermark to stamp on the projection; the sequence number of the latest waste-balance event folded into this PRN. Enforced monotonic: once a PRN carries a watermark it has migrated to ledger-event status tracking, so every write must carry one forward (equal or higher). A lower or dropped watermark cannot be a lost race, only a coding error, so it is rejected as a 500 internal error. A PRN that has never carried a watermark may omit it (the pre-migration path).
  */
 
 /**
@@ -48,6 +48,7 @@ export class PrnNumberConflictError extends Error {
  * @property {number} expectedVersion - Document version after the forward write (CAS gate)
  * @property {{ id: string; name: string }} updatedBy - Actor recorded against the rollback history entry
  * @property {Date} updatedAt - Timestamp of the rollback
+ * @property {number} [lastAppliedEventNumber] - Stream watermark to carry forward; subject to the same monotonic guard as updateStatus. A migrated PRN (one that already carries a watermark) must carry one on its rollback too; a PRN that has never carried one may omit it.
  */
 
 /**

--- a/src/packaging-recycling-notes/repository/port.js
+++ b/src/packaging-recycling-notes/repository/port.js
@@ -19,7 +19,7 @@ export class PrnNumberConflictError extends Error {
  * @property {Date} updatedAt - Timestamp of the change
  * @property {string} [prnNumber] - PRN number to set when issuing (transitioning to awaiting_acceptance)
  * @property {{ slot: import('#packaging-recycling-notes/domain/model.js').BusinessOperationSlot; at: Date; by: import('#packaging-recycling-notes/domain/model.js').Actor }} [operation] - Business operation to record on the status object
- * @property {number} [lastAppliedEventNumber] - Stream watermark to stamp on the projection; the sequence number of the latest waste-balance event folded into this PRN
+ * @property {number} [lastAppliedEventNumber] - Stream watermark to stamp on the projection; the sequence number of the latest waste-balance event folded into this PRN. Enforced monotonic: once a PRN carries a watermark, every update must supply one that does not go backwards (equal or higher) — a lower or omitted watermark is rejected with a 409 conflict. The embedded (non-stream) path never sets it.
  */
 
 /**

--- a/src/packaging-recycling-notes/repository/schema.js
+++ b/src/packaging-recycling-notes/repository/schema.js
@@ -88,6 +88,7 @@ const statusSchema = Joi.object({
 export const prnInsertSchema = Joi.object({
   schemaVersion: Joi.number().integer().valid(2).required(),
   version: Joi.number().integer().min(1).default(1),
+  lastAppliedEventNumber: Joi.number().integer().min(1).optional(),
   prnNumber: Joi.string().allow(null).optional(),
   organisation: organisationNameAndIdSchema.required(),
   registrationId: Joi.string().required(),

--- a/src/packaging-recycling-notes/repository/schema.test.js
+++ b/src/packaging-recycling-notes/repository/schema.test.js
@@ -490,6 +490,41 @@ describe('PRN insert schema', () => {
       expect(value.bogus).toBeUndefined()
     })
   })
+
+  describe('lastAppliedEventNumber watermark', () => {
+    it('accepts an optional integer lastAppliedEventNumber', () => {
+      const data = buildValidPrnInsert({ lastAppliedEventNumber: 3 })
+      const { error } = prnInsertSchema.validate(data)
+      expect(error).toBeUndefined()
+    })
+
+    it('accepts a document without lastAppliedEventNumber', () => {
+      const data = buildValidPrnInsert()
+      const { error } = prnInsertSchema.validate(data)
+      expect(error).toBeUndefined()
+    })
+
+    it('rejects lastAppliedEventNumber below 1', () => {
+      const data = buildValidPrnInsert({ lastAppliedEventNumber: 0 })
+      const { error } = prnInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('rejects a non-integer lastAppliedEventNumber', () => {
+      const data = buildValidPrnInsert({ lastAppliedEventNumber: 1.5 })
+      const { error } = prnInsertSchema.validate(data)
+      expect(error).toBeDefined()
+    })
+
+    it('does not strip lastAppliedEventNumber when stripUnknown is enabled', () => {
+      const data = buildValidPrnInsert({ lastAppliedEventNumber: 7 })
+      const { error, value } = prnInsertSchema.validate(data, {
+        stripUnknown: true
+      })
+      expect(error).toBeUndefined()
+      expect(value.lastAppliedEventNumber).toBe(7)
+    })
+  })
 })
 
 describe('PRN read schema', () => {
@@ -534,6 +569,15 @@ describe('PRN read schema', () => {
     const { error, value } = prnReadSchema.validate(data)
     expect(error).toBeUndefined()
     expect(value).not.toHaveProperty('notes')
+  })
+
+  it('round-trips a lastAppliedEventNumber watermark under stripUnknown', () => {
+    const data = buildReadDocument({ lastAppliedEventNumber: 12 })
+    const { error, value } = prnReadSchema.validate(data, {
+      stripUnknown: true
+    })
+    expect(error).toBeUndefined()
+    expect(value.lastAppliedEventNumber).toBe(12)
   })
 
   it('rejects when required fields from insert schema are missing', () => {

--- a/src/packaging-recycling-notes/repository/schema.test.js
+++ b/src/packaging-recycling-notes/repository/schema.test.js
@@ -7,6 +7,9 @@ import {
   buildAwaitingAcceptancePrn
 } from './contract/test-data.js'
 
+/** @typedef {import('#packaging-recycling-notes/domain/model.js').AccreditationSnapshot} AccreditationSnapshot */
+/** @typedef {import('#domain/organisations/model.js').Material} Material */
+
 const buildReadDocument = (overrides = {}) => ({
   id: '507f1f77bcf86cd799439011',
   ...buildValidPrnInsert(),
@@ -75,7 +78,7 @@ describe('PRN insert schema', () => {
     })
 
     it('rejects null notes on insert', () => {
-      const data = buildValidPrnInsert({ notes: null })
+      const data = { ...buildValidPrnInsert(), notes: null }
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
@@ -164,131 +167,131 @@ describe('PRN insert schema', () => {
 
   describe('required fields', () => {
     it('rejects when schemaVersion is missing', () => {
-      const data = buildValidPrnInsert()
-      delete data.schemaVersion
+      const { schemaVersion: _schemaVersion, ...data } = buildValidPrnInsert()
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when organisation is missing', () => {
-      const data = buildValidPrnInsert()
-      delete data.organisation
+      const { organisation: _organisation, ...data } = buildValidPrnInsert()
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when organisation.id is missing', () => {
-      const data = buildValidPrnInsert({
+      const data = {
+        ...buildValidPrnInsert(),
         organisation: { name: 'Org' }
-      })
+      }
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when organisation.name is missing', () => {
-      const data = buildValidPrnInsert({
+      const data = {
+        ...buildValidPrnInsert(),
         organisation: { id: 'org-1' }
-      })
+      }
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when registrationId is missing', () => {
-      const data = buildValidPrnInsert()
-      delete data.registrationId
+      const { registrationId: _registrationId, ...data } = buildValidPrnInsert()
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when accreditation is missing', () => {
-      const data = buildValidPrnInsert()
-      delete data.accreditation
+      const { accreditation: _accreditation, ...data } = buildValidPrnInsert()
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when accreditation.id is missing', () => {
-      const data = buildValidPrnInsert({
+      const data = {
+        ...buildValidPrnInsert(),
         accreditation: {
           accreditationNumber: 'ACC-001',
           accreditationYear: 2026,
           material: 'plastic',
           submittedToRegulator: 'ea'
         }
-      })
+      }
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when accreditation.accreditationNumber is missing', () => {
-      const data = buildValidPrnInsert({
+      const data = {
+        ...buildValidPrnInsert(),
         accreditation: {
           id: 'acc-1',
           accreditationYear: 2026,
           material: 'plastic',
           submittedToRegulator: 'ea'
         }
-      })
+      }
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when accreditation.accreditationYear is missing', () => {
-      const data = buildValidPrnInsert({
+      const data = {
+        ...buildValidPrnInsert(),
         accreditation: {
           id: 'acc-1',
           accreditationNumber: 'ACC-001',
           material: 'plastic',
           submittedToRegulator: 'ea'
         }
-      })
+      }
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when accreditation.material is missing', () => {
-      const data = buildValidPrnInsert({
+      const data = {
+        ...buildValidPrnInsert(),
         accreditation: {
           id: 'acc-1',
           accreditationNumber: 'ACC-001',
           accreditationYear: 2026,
           submittedToRegulator: 'ea'
         }
-      })
+      }
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when accreditation.submittedToRegulator is missing', () => {
-      const data = buildValidPrnInsert({
+      const data = {
+        ...buildValidPrnInsert(),
         accreditation: {
           id: 'acc-1',
           accreditationNumber: 'ACC-001',
           accreditationYear: 2026,
           material: 'plastic'
         }
-      })
+      }
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when tonnage is missing', () => {
-      const data = buildValidPrnInsert()
-      delete data.tonnage
+      const { tonnage: _tonnage, ...data } = buildValidPrnInsert()
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when isExport is missing', () => {
-      const data = buildValidPrnInsert()
-      delete data.isExport
+      const { isExport: _isExport, ...data } = buildValidPrnInsert()
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('rejects when status is missing', () => {
-      const data = buildValidPrnInsert()
-      delete data.status
+      const { status: _status, ...data } = buildValidPrnInsert()
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
@@ -299,14 +302,14 @@ describe('PRN insert schema', () => {
       const data = buildValidPrnInsert({ tonnage: 0 })
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
-      expect(error.message).toContain('positive')
+      expect(error?.message).toContain('positive')
     })
 
     it('rejects negative tonnage', () => {
       const data = buildValidPrnInsert({ tonnage: -5 })
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
-      expect(error.message).toContain('positive')
+      expect(error?.message).toContain('positive')
     })
 
     it('accepts positive tonnage', () => {
@@ -318,7 +321,8 @@ describe('PRN insert schema', () => {
 
   describe('material enum validation', () => {
     it('rejects invalid material value', () => {
-      const data = buildValidPrnInsert({
+      const data = {
+        ...buildValidPrnInsert(),
         accreditation: {
           id: 'acc-1',
           accreditationNumber: 'ACC-001',
@@ -326,12 +330,13 @@ describe('PRN insert schema', () => {
           material: 'unobtainium',
           submittedToRegulator: 'ea'
         }
-      })
+      }
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
 
     it('accepts all valid material values', () => {
+      /** @type {Material[]} */
       const materials = [
         'aluminium',
         'fibre',
@@ -342,6 +347,7 @@ describe('PRN insert schema', () => {
         'wood'
       ]
       for (const material of materials) {
+        /** @type {AccreditationSnapshot} */
         const accreditation =
           material === 'glass'
             ? {
@@ -371,7 +377,8 @@ describe('PRN insert schema', () => {
 
   describe('glassRecyclingProcess enum validation', () => {
     it('rejects invalid glassRecyclingProcess value', () => {
-      const data = buildValidPrnInsert({
+      const data = {
+        ...buildValidPrnInsert(),
         accreditation: {
           id: 'acc-1',
           accreditationNumber: 'ACC-001',
@@ -380,7 +387,7 @@ describe('PRN insert schema', () => {
           submittedToRegulator: 'ea',
           glassRecyclingProcess: 'glass_magic'
         }
-      })
+      }
       const { error } = prnInsertSchema.validate(data)
       expect(error).toBeDefined()
     })
@@ -482,7 +489,7 @@ describe('PRN insert schema', () => {
 
   describe('strips unknown fields', () => {
     it('strips unknown top-level fields', () => {
-      const data = buildValidPrnInsert({ bogus: 'field' })
+      const data = { ...buildValidPrnInsert(), bogus: 'field' }
       const { error, value } = prnInsertSchema.validate(data, {
         stripUnknown: true
       })
@@ -535,8 +542,7 @@ describe('PRN read schema', () => {
   })
 
   it('rejects when id is missing', () => {
-    const data = buildReadDocument()
-    delete data.id
+    const { id: _id, ...data } = buildReadDocument()
     const { error } = prnReadSchema.validate(data)
     expect(error).toBeDefined()
   })
@@ -581,8 +587,7 @@ describe('PRN read schema', () => {
   })
 
   it('rejects when required fields from insert schema are missing', () => {
-    const data = buildReadDocument()
-    delete data.organisation
+    const { organisation: _organisation, ...data } = buildReadDocument()
     const { error } = prnReadSchema.validate(data)
     expect(error).toBeDefined()
   })

--- a/src/packaging-recycling-notes/repository/watermark-guard.js
+++ b/src/packaging-recycling-notes/repository/watermark-guard.js
@@ -1,0 +1,62 @@
+import Boom from '@hapi/boom'
+
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/event.js'
+
+/** @import { TypedLogger } from '#common/hapi-types.js' */
+
+/**
+ * Once a PRN carries a watermark it has migrated to ledger-event status
+ * tracking, so every subsequent write must carry the watermark forward and
+ * never move it backwards. A write is a regression when the PRN already has a
+ * watermark and the write either drops it (carries none) or supplies a lower
+ * one. A write that carries an equal or higher watermark, or any write to a
+ * PRN that has never had one, is fine.
+ *
+ * @param {number | undefined} storedEventNumber
+ * @param {number | undefined} incomingEventNumber
+ * @returns {storedEventNumber is number}
+ */
+export const isWatermarkRegression = (storedEventNumber, incomingEventNumber) =>
+  storedEventNumber !== undefined &&
+  (incomingEventNumber === undefined || incomingEventNumber < storedEventNumber)
+
+/**
+ * A watermark regression can only happen when the calling code, holding the
+ * current version, fails to carry a migrated PRN's watermark forward — an
+ * out-of-order or dropped event fed into the projection. That is a coding
+ * error, not a retryable conflict, so it is logged and surfaced as an internal
+ * error. Both repository adapters route through here so their message, log
+ * event and status code stay identical.
+ *
+ * @param {string} id
+ * @param {number} storedEventNumber
+ * @param {number | undefined} incomingEventNumber
+ * @param {TypedLogger} logger
+ * @returns {never}
+ */
+export const throwWatermarkRegression = (
+  id,
+  storedEventNumber,
+  incomingEventNumber,
+  logger
+) => {
+  const message =
+    incomingEventNumber === undefined
+      ? `Watermark regression: PRN ${id} has applied event ${storedEventNumber} but the update did not carry a watermark`
+      : `Watermark regression: PRN ${id} has applied event ${storedEventNumber} but the update would move it back to ${incomingEventNumber}`
+
+  const error = new Error(message)
+  logger.error({
+    err: error,
+    message: `Watermark regression detected for PRN ${id}`,
+    event: {
+      category: LOGGING_EVENT_CATEGORIES.DB,
+      action: LOGGING_EVENT_ACTIONS.WATERMARK_REGRESSION_DETECTED,
+      reference: id
+    }
+  })
+  throw Boom.badImplementation(message)
+}


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)

## What

This installs a repository-level guard that stops a PRN's event-stream watermark from regressing, and adds the field that guard protects. It is enforcement only — there is no business-logic or API change, and nothing populates a watermark yet, so the guard is dormant until the event-first work that follows starts setting one.

- PRN documents gain an optional integer `lastAppliedEventNumber` (minimum 1). `prnInsertSchema` and `prnReadSchema` accept it and it survives Joi's `stripUnknown`; the `PackagingRecyclingNote`, `UpdateStatusParams` and `RollbackParams` typedefs carry it.
- The guarantee the guard enforces: once a PRN carries a watermark it has migrated to event-stream status tracking, and from that point every write must carry it forward — it can never be dropped or rewound. A write may leave the watermark unchanged or advance it (a write needn't move it, only refrain from moving it backwards). A PRN that has never carried a watermark may omit it: that is the pre-migration path, and it is every PRN today.
- A regression here cannot be a lost race. A genuine race bumps the document version and already surfaces as a 409 version conflict, so the only way to drop or rewind a watermark is for the calling code to feed an out-of-order or absent value into the projection — a coding error. It is therefore rejected as a 500 internal error and logged as a `watermark_regression_detected` database event, with a message that distinguishes a dropped watermark from a backwards move.
- The guard runs on every write, not just status updates. The three rollback methods take the same optional watermark, threaded from the loaded PRN, and run through the same monotonic check. Both adapters route the rejection through one shared helper so the message, log event and status code stay identical — the MongoDB adapter folds the check into the same atomic compare-and-set as the optimistic version guard, and the in-memory adapter mirrors it.
- The watermark is internal projection state and never part of the contract with API clients: it is absent from the external PRN schema and the external read mapping, and the external accept/reject handlers read nothing from the request body but the timestamp, so a client can neither see it nor set it.
- The field is optional in storage, so the embedded (non-stream) write path, which never sets a watermark, is unaffected.
- Separately, the PRN repository's schema and contract test files now type-check cleanly: deliberately malformed validation inputs are expressed type-safely — required fields are dropped by rest-destructuring rather than mutated away with `delete`, and invalid overrides are built by spreading so there is no contextual type to violate.

## Why

This is the safety rail for the event-first PRN work that follows. A PRN projection needs to record how far through the waste-balance event stream it has been built, so the read path can later fold any events that landed after the document was last written. Once a PRN is tracked that way, a write that silently dropped or rewound its watermark would corrupt the projection. Installing the guard now — ahead of the change that starts setting watermarks — means the first time anyone introduces such a regression it fails loudly as a coding error rather than quietly as a data bug, and it covers rollbacks as well as forward transitions. `schemaVersion` stays at 2 because the field is additive and optional in storage.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
