### PR TITLE
PAE-1382: Add event-sourced history replay for waste balance migration

### DIFF
--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -136,39 +136,57 @@ const compareForEmbedded = async (embedded, deps) => {
     wasteRecords,
     prns,
     overseasSites,
-    summaryLogs
+    summaryLogs: /** @type {any} */ (summaryLogs)
   })
 
-  return {
-    organisationId: embedded.organisationId,
-    registrationNumber: registration.registrationNumber,
-    accreditationNumber: accreditation.accreditationNumber ?? '<none>',
-    currentAmount: embedded.amount,
-    rebuiltAmount: rebuilt.amount,
-    deltaAmount: formatDelta(embedded.amount, rebuilt.amount),
-    currentAvailableAmount: embedded.availableAmount,
-    rebuiltAvailableAmount: rebuilt.availableAmount,
-    deltaAvailableAmount: formatDelta(
-      embedded.availableAmount,
-      rebuilt.availableAmount
-    ),
-    registrationStatus: registration.status,
-    accreditationStatus: accreditation.status,
-    wasteRecordCount: wasteRecords.length,
-    wasteRecordContribution: rebuilt.wasteRecordContribution,
-    prnCount: prns.length,
-    prnAmountContribution: rebuilt.prnAmountContribution,
-    prnAvailableAmountContribution: rebuilt.prnAvailableAmountContribution,
-    streamAmount: stream.amount,
-    streamAvailableAmount: stream.availableAmount,
-    streamDeltaAmount: formatDelta(rebuilt.amount, stream.amount),
-    streamDeltaAvailableAmount: formatDelta(
-      rebuilt.availableAmount,
-      stream.availableAmount
-    ),
-    streamEventCount: stream.events.length
-  }
+  return buildComparison(
+    embedded,
+    registration,
+    accreditation,
+    rebuilt,
+    stream,
+    wasteRecords,
+    prns
+  )
 }
+
+const buildComparison = (
+  embedded,
+  registration,
+  accreditation,
+  rebuilt,
+  stream,
+  wasteRecords,
+  prns
+) => ({
+  organisationId: embedded.organisationId,
+  registrationNumber: registration.registrationNumber,
+  accreditationNumber: accreditation.accreditationNumber ?? '<none>',
+  currentAmount: embedded.amount,
+  rebuiltAmount: rebuilt.amount,
+  deltaAmount: formatDelta(embedded.amount, rebuilt.amount),
+  currentAvailableAmount: embedded.availableAmount,
+  rebuiltAvailableAmount: rebuilt.availableAmount,
+  deltaAvailableAmount: formatDelta(
+    embedded.availableAmount,
+    rebuilt.availableAmount
+  ),
+  registrationStatus: registration.status,
+  accreditationStatus: accreditation.status,
+  wasteRecordCount: wasteRecords.length,
+  wasteRecordContribution: rebuilt.wasteRecordContribution,
+  prnCount: prns.length,
+  prnAmountContribution: rebuilt.prnAmountContribution,
+  prnAvailableAmountContribution: rebuilt.prnAvailableAmountContribution,
+  streamAmount: stream.amount,
+  streamAvailableAmount: stream.availableAmount,
+  streamDeltaAmount: formatDelta(rebuilt.amount, stream.amount),
+  streamDeltaAvailableAmount: formatDelta(
+    rebuilt.availableAmount,
+    stream.availableAmount
+  ),
+  streamEventCount: stream.events.length
+})
 
 const isDivergent = (comparison) =>
   comparison.deltaAmount !== 0 ||
@@ -264,7 +282,7 @@ const buildDependencies = async (server) => {
     await createOverseasSitesRepository(server.db)
   )()
   const summaryLogsRepository = (
-    await createSummaryLogsRepository(server.db, {})
+    await createSummaryLogsRepository(server.db, /** @type {any} */ ({}))
   )(logger)
 
   return /** @type {DiagnosticDependencies} */ ({

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -3,8 +3,10 @@ import { resolveOverseasSites } from '#application/waste-records/resolve-oversea
 import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
 import { createOverseasSitesRepository } from '#overseas-sites/repository/mongodb.js'
 import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/mongodb.js'
+import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.js'
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
 import { computeRebuiltTotals } from '#waste-balances/application/compute-rebuilt-totals.js'
+import { computeRebuiltStream } from '#waste-balances/application/compute-rebuilt-stream.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 
@@ -32,6 +34,7 @@ const LOCK_NAME = 'balance-divergence-diagnostic'
  * @property {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} prnRepository
  * @property {import('#repositories/waste-records/port.js').WasteRecordsRepository} wasteRecordsRepository
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
+ * @property {import('#repositories/summary-logs/port.js').SummaryLogsRepository} summaryLogsRepository
  */
 
 /**
@@ -77,7 +80,8 @@ const compareForEmbedded = async (embedded, deps) => {
     organisationsRepository,
     prnRepository,
     wasteRecordsRepository,
-    overseasSitesRepository
+    overseasSitesRepository,
+    summaryLogsRepository
   } = deps
 
   const organisation = await organisationsRepository.findById(
@@ -122,6 +126,19 @@ const compareForEmbedded = async (embedded, deps) => {
     overseasSites
   })
 
+  const summaryLogs = await summaryLogsRepository.findAllByOrgReg(
+    embedded.organisationId,
+    registration.id
+  )
+
+  const stream = computeRebuiltStream({
+    accreditation,
+    wasteRecords,
+    prns,
+    overseasSites,
+    summaryLogs
+  })
+
   return {
     organisationId: embedded.organisationId,
     registrationNumber: registration.registrationNumber,
@@ -141,12 +158,23 @@ const compareForEmbedded = async (embedded, deps) => {
     wasteRecordContribution: rebuilt.wasteRecordContribution,
     prnCount: prns.length,
     prnAmountContribution: rebuilt.prnAmountContribution,
-    prnAvailableAmountContribution: rebuilt.prnAvailableAmountContribution
+    prnAvailableAmountContribution: rebuilt.prnAvailableAmountContribution,
+    streamAmount: stream.amount,
+    streamAvailableAmount: stream.availableAmount,
+    streamDeltaAmount: formatDelta(rebuilt.amount, stream.amount),
+    streamDeltaAvailableAmount: formatDelta(
+      rebuilt.availableAmount,
+      stream.availableAmount
+    ),
+    streamEventCount: stream.events.length
   }
 }
 
 const isDivergent = (comparison) =>
-  comparison.deltaAmount !== 0 || comparison.deltaAvailableAmount !== 0
+  comparison.deltaAmount !== 0 ||
+  comparison.deltaAvailableAmount !== 0 ||
+  comparison.streamDeltaAmount !== 0 ||
+  comparison.streamDeltaAvailableAmount !== 0
 
 const formatDivergenceLine = (comparison) =>
   [
@@ -166,7 +194,12 @@ const formatDivergenceLine = (comparison) =>
     `wasteRecordContribution=${comparison.wasteRecordContribution}`,
     `prnCount=${comparison.prnCount}`,
     `prnAmountContribution=${comparison.prnAmountContribution}`,
-    `prnAvailableAmountContribution=${comparison.prnAvailableAmountContribution}`
+    `prnAvailableAmountContribution=${comparison.prnAvailableAmountContribution}`,
+    `streamAmount=${comparison.streamAmount}`,
+    `streamAvailableAmount=${comparison.streamAvailableAmount}`,
+    `streamDeltaAmount=${comparison.streamDeltaAmount}`,
+    `streamDeltaAvailableAmount=${comparison.streamDeltaAvailableAmount}`,
+    `streamEventCount=${comparison.streamEventCount}`
   ].join(' ')
 
 const formatErrorLine = (embedded, error) =>
@@ -230,12 +263,16 @@ const buildDependencies = async (server) => {
   const overseasSitesRepository = (
     await createOverseasSitesRepository(server.db)
   )()
+  const summaryLogsRepository = (
+    await createSummaryLogsRepository(server.db, {})
+  )(logger)
 
   return /** @type {DiagnosticDependencies} */ ({
     organisationsRepository,
     wasteRecordsRepository,
     prnRepository,
-    overseasSitesRepository
+    overseasSitesRepository,
+    summaryLogsRepository
   })
 }
 

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -126,7 +126,7 @@ const compareForEmbedded = async (embedded, deps) => {
     overseasSites
   })
 
-  const summaryLogs = await summaryLogsRepository.findAllByOrgReg(
+  const summaryLogDocs = await summaryLogsRepository.findAllByOrgReg(
     embedded.organisationId,
     registration.id
   )
@@ -136,7 +136,11 @@ const compareForEmbedded = async (embedded, deps) => {
     wasteRecords,
     prns,
     overseasSites,
-    summaryLogs: /** @type {any} */ (summaryLogs)
+    summaryLogs: summaryLogDocs.map(({ id, summaryLog }) => ({
+      id,
+      status: summaryLog.status,
+      submittedAt: summaryLog.submittedAt
+    }))
   })
 
   return buildComparison(

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -133,10 +133,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 0,
-      availableAmount: 0,
-      wasteRecordContribution: 0,
-      prnAmountContribution: 0,
-      prnAvailableAmountContribution: 0
+      availableAmount: 0
     })
     vi.mocked(resolveOverseasSites).mockResolvedValue({})
   })
@@ -216,10 +213,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 7,
-      availableAmount: 5,
-      wasteRecordContribution: 7,
-      prnAmountContribution: 0,
-      prnAvailableAmountContribution: 0
+      availableAmount: 5
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -268,10 +262,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 95,
-      availableAmount: 80,
-      wasteRecordContribution: 95,
-      prnAmountContribution: 0,
-      prnAvailableAmountContribution: -15
+      availableAmount: 80
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -395,10 +386,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 7,
-      availableAmount: 7,
-      wasteRecordContribution: 7,
-      prnAmountContribution: 0,
-      prnAvailableAmountContribution: 0
+      availableAmount: 7
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -546,10 +534,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 5,
-      availableAmount: 5,
-      wasteRecordContribution: 5,
-      prnAmountContribution: 0,
-      prnAvailableAmountContribution: 0
+      availableAmount: 5
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -672,10 +657,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 95,
-      availableAmount: 75,
-      wasteRecordContribution: 95,
-      prnAmountContribution: 0,
-      prnAvailableAmountContribution: -20
+      availableAmount: 75
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -613,10 +613,13 @@ describe('runBalanceDivergenceDiagnostic', () => {
       }
     ]
     accreditations['org-1'] = [accreditation]
-    const summaryLogs = [
-      { id: 'sl-1', status: 'submitted', submittedAt: '2025-01-01T00:00:00Z' }
-    ]
-    summaryLogsRepository.findAllByOrgReg.mockResolvedValue(summaryLogs)
+    summaryLogsRepository.findAllByOrgReg.mockResolvedValue([
+      {
+        id: 'sl-1',
+        version: 1,
+        summaryLog: { status: 'submitted', submittedAt: '2025-01-01T00:00:00Z' }
+      }
+    ])
     const wasteRecords = [{ rowId: 'r-1', type: 'received' }]
     wasteRecordsRepository.findByRegistration.mockResolvedValue(wasteRecords)
     const prns = [{ id: 'prn-1' }]
@@ -633,7 +636,9 @@ describe('runBalanceDivergenceDiagnostic', () => {
       wasteRecords,
       prns,
       overseasSites: {},
-      summaryLogs
+      summaryLogs: [
+        { id: 'sl-1', status: 'submitted', submittedAt: '2025-01-01T00:00:00Z' }
+      ]
     })
   })
 

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -95,36 +95,42 @@ describe('runBalanceDivergenceDiagnostic', () => {
         accreditations: accreditations[orgId] ?? []
       }))
     }
-    createOrganisationsRepository.mockResolvedValue(
+    vi.mocked(createOrganisationsRepository).mockResolvedValue(
       () => organisationsRepository
     )
 
     wasteRecordsRepository = {
       findByRegistration: vi.fn().mockResolvedValue([])
     }
-    createWasteRecordsRepository.mockResolvedValue(() => wasteRecordsRepository)
+    vi.mocked(createWasteRecordsRepository).mockResolvedValue(
+      () => wasteRecordsRepository
+    )
 
     prnRepository = {
       findByAccreditation: vi.fn().mockResolvedValue([])
     }
-    createPackagingRecyclingNotesRepository.mockResolvedValue(
+    vi.mocked(createPackagingRecyclingNotesRepository).mockResolvedValue(
       () => prnRepository
     )
 
     overseasSitesRepository = {
       findByIds: vi.fn().mockResolvedValue([])
     }
-    createOverseasSitesRepository.mockResolvedValue(
+    vi.mocked(createOverseasSitesRepository).mockResolvedValue(
       () => overseasSitesRepository
     )
 
     summaryLogsRepository = {
       findAllByOrgReg: vi.fn().mockResolvedValue([])
     }
-    createSummaryLogsRepository.mockResolvedValue(() => summaryLogsRepository)
+    vi.mocked(createSummaryLogsRepository).mockResolvedValue(
+      () => summaryLogsRepository
+    )
 
-    computeRebuiltTotals.mockReturnValue({ amount: 0, availableAmount: 0 })
-    computeRebuiltStream.mockReturnValue({
+    vi.mocked(computeRebuiltTotals).mockReturnValue(
+      /** @type {any} */ ({ amount: 0, availableAmount: 0 })
+    )
+    vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 0,
       availableAmount: 0,
@@ -132,7 +138,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
       prnAmountContribution: 0,
       prnAvailableAmountContribution: 0
     })
-    resolveOverseasSites.mockResolvedValue({})
+    vi.mocked(resolveOverseasSites).mockResolvedValue({})
   })
 
   it('acquires a lock scoped to the diagnostic and releases it afterwards', async () => {
@@ -204,8 +210,10 @@ describe('runBalanceDivergenceDiagnostic', () => {
     accreditations['org-1'] = [
       { id: 'acc-1', accreditationNumber: 'ACC-acc-1' }
     ]
-    computeRebuiltTotals.mockReturnValue({ amount: 7, availableAmount: 5 })
-    computeRebuiltStream.mockReturnValue({
+    vi.mocked(computeRebuiltTotals).mockReturnValue(
+      /** @type {any} */ ({ amount: 7, availableAmount: 5 })
+    )
+    vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 7,
       availableAmount: 5,
@@ -216,9 +224,13 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
-    const perAccreditationLines = logger.info.mock.calls.filter(([arg]) =>
-      arg.message.startsWith('Waste-balance divergence affected accreditation:')
-    )
+    const perAccreditationLines = vi
+      .mocked(logger.info)
+      .mock.calls.filter(([arg]) =>
+        /** @type {any} */ (arg).message?.startsWith(
+          'Waste-balance divergence affected accreditation:'
+        )
+      )
     expect(perAccreditationLines).toHaveLength(0)
     expect(logger.info).toHaveBeenCalledWith({
       message:
@@ -246,14 +258,14 @@ describe('runBalanceDivergenceDiagnostic', () => {
     accreditations['org-1'] = [
       { id: 'acc-1', accreditationNumber: 'ACC-acc-1', status: 'approved' }
     ]
-    computeRebuiltTotals.mockReturnValue({
+    vi.mocked(computeRebuiltTotals).mockReturnValue({
       amount: 95,
       availableAmount: 80,
       wasteRecordContribution: 95,
       prnAmountContribution: 0,
       prnAvailableAmountContribution: -15
     })
-    computeRebuiltStream.mockReturnValue({
+    vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 95,
       availableAmount: 80,
@@ -336,7 +348,9 @@ describe('runBalanceDivergenceDiagnostic', () => {
     accreditations['org-1'] = [
       { id: 'acc-1', accreditationNumber: 'ACC-acc-1' }
     ]
-    resolveOverseasSites.mockResolvedValue({ '099': { validFrom: null } })
+    vi.mocked(resolveOverseasSites).mockResolvedValue({
+      '099': { validFrom: null }
+    })
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
@@ -371,14 +385,14 @@ describe('runBalanceDivergenceDiagnostic', () => {
       }
     ]
     accreditations['org-1'] = [{ id: 'acc-pending', status: 'created' }]
-    computeRebuiltTotals.mockReturnValue({
+    vi.mocked(computeRebuiltTotals).mockReturnValue({
       amount: 7,
       availableAmount: 7,
       wasteRecordContribution: 7,
       prnAmountContribution: 0,
       prnAvailableAmountContribution: 0
     })
-    computeRebuiltStream.mockReturnValue({
+    vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 7,
       availableAmount: 7,
@@ -417,7 +431,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     ]
     wasteRecordsRepository.findByRegistration.mockResolvedValue([{}, {}, {}])
     prnRepository.findByAccreditation.mockResolvedValue([{}, {}])
-    computeRebuiltTotals.mockReturnValue({
+    vi.mocked(computeRebuiltTotals).mockReturnValue({
       amount: 0,
       availableAmount: 0,
       wasteRecordContribution: 0,
@@ -526,8 +540,10 @@ describe('runBalanceDivergenceDiagnostic', () => {
     accreditations['org-2'] = [
       { id: 'acc-good', accreditationNumber: 'ACC-good' }
     ]
-    computeRebuiltTotals.mockReturnValue({ amount: 5, availableAmount: 5 })
-    computeRebuiltStream.mockReturnValue({
+    vi.mocked(computeRebuiltTotals).mockReturnValue(
+      /** @type {any} */ ({ amount: 5, availableAmount: 5 })
+    )
+    vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 5,
       availableAmount: 5,
@@ -641,14 +657,14 @@ describe('runBalanceDivergenceDiagnostic', () => {
     accreditations['org-1'] = [
       { id: 'acc-1', accreditationNumber: 'ACC-1', status: 'approved' }
     ]
-    computeRebuiltTotals.mockReturnValue({
+    vi.mocked(computeRebuiltTotals).mockReturnValue({
       amount: 100,
       availableAmount: 80,
       wasteRecordContribution: 100,
       prnAmountContribution: 0,
       prnAvailableAmountContribution: -20
     })
-    computeRebuiltStream.mockReturnValue({
+    vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 95,
       availableAmount: 75,
@@ -659,9 +675,13 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
-    const divergenceLines = logger.info.mock.calls.filter(([arg]) =>
-      arg.message.startsWith('Waste-balance divergence affected accreditation:')
-    )
+    const divergenceLines = vi
+      .mocked(logger.info)
+      .mock.calls.filter(([arg]) =>
+        /** @type {any} */ (arg).message?.startsWith(
+          'Waste-balance divergence affected accreditation:'
+        )
+      )
     expect(divergenceLines).toHaveLength(1)
     expect(divergenceLines[0][0].message).toContain('streamAmount=95')
     expect(divergenceLines[0][0].message).toContain('streamAvailableAmount=75')

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -6,7 +6,9 @@ import { createOverseasSitesRepository } from '#overseas-sites/repository/mongod
 import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/mongodb.js'
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
 import { computeRebuiltTotals } from '#waste-balances/application/compute-rebuilt-totals.js'
+import { computeRebuiltStream } from '#waste-balances/application/compute-rebuilt-stream.js'
 import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
+import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.js'
 
 import { runBalanceDivergenceDiagnostic } from './run-balance-divergence-diagnostic.js'
 
@@ -31,8 +33,14 @@ vi.mock('#overseas-sites/repository/mongodb.js', () => ({
 vi.mock('#waste-balances/application/compute-rebuilt-totals.js', () => ({
   computeRebuiltTotals: vi.fn()
 }))
+vi.mock('#waste-balances/application/compute-rebuilt-stream.js', () => ({
+  computeRebuiltStream: vi.fn()
+}))
 vi.mock('#application/waste-records/resolve-overseas-sites.js', () => ({
   resolveOverseasSites: vi.fn()
+}))
+vi.mock('#repositories/summary-logs/mongodb.js', () => ({
+  createSummaryLogsRepository: vi.fn()
 }))
 
 describe('runBalanceDivergenceDiagnostic', () => {
@@ -42,6 +50,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
   let wasteRecordsRepository
   let prnRepository
   let overseasSitesRepository
+  let summaryLogsRepository
   let mockToArray
   let mockFind
   let collectionByName
@@ -109,7 +118,20 @@ describe('runBalanceDivergenceDiagnostic', () => {
       () => overseasSitesRepository
     )
 
+    summaryLogsRepository = {
+      findAllByOrgReg: vi.fn().mockResolvedValue([])
+    }
+    createSummaryLogsRepository.mockResolvedValue(() => summaryLogsRepository)
+
     computeRebuiltTotals.mockReturnValue({ amount: 0, availableAmount: 0 })
+    computeRebuiltStream.mockReturnValue({
+      events: [],
+      amount: 0,
+      availableAmount: 0,
+      wasteRecordContribution: 0,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
     resolveOverseasSites.mockResolvedValue({})
   })
 
@@ -183,6 +205,14 @@ describe('runBalanceDivergenceDiagnostic', () => {
       { id: 'acc-1', accreditationNumber: 'ACC-acc-1' }
     ]
     computeRebuiltTotals.mockReturnValue({ amount: 7, availableAmount: 5 })
+    computeRebuiltStream.mockReturnValue({
+      events: [],
+      amount: 7,
+      availableAmount: 5,
+      wasteRecordContribution: 7,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
@@ -223,12 +253,20 @@ describe('runBalanceDivergenceDiagnostic', () => {
       prnAmountContribution: 0,
       prnAvailableAmountContribution: -15
     })
+    computeRebuiltStream.mockReturnValue({
+      events: [],
+      amount: 95,
+      availableAmount: 80,
+      wasteRecordContribution: 95,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: -15
+    })
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-acc-1 currentAmount=100 rebuiltAmount=95 deltaAmount=-5 currentAvailableAmount=80 rebuiltAvailableAmount=80 deltaAvailableAmount=0 registrationStatus=approved accreditationStatus=approved wasteRecordCount=0 wasteRecordContribution=95 prnCount=0 prnAmountContribution=0 prnAvailableAmountContribution=-15'
+        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-acc-1 currentAmount=100 rebuiltAmount=95 deltaAmount=-5 currentAvailableAmount=80 rebuiltAvailableAmount=80 deltaAvailableAmount=0 registrationStatus=approved accreditationStatus=approved wasteRecordCount=0 wasteRecordContribution=95 prnCount=0 prnAmountContribution=0 prnAvailableAmountContribution=-15 streamAmount=95 streamAvailableAmount=80 streamDeltaAmount=0 streamDeltaAvailableAmount=0 streamEventCount=0'
     })
     expect(logger.info).toHaveBeenCalledWith({
       message:
@@ -340,12 +378,20 @@ describe('runBalanceDivergenceDiagnostic', () => {
       prnAmountContribution: 0,
       prnAvailableAmountContribution: 0
     })
+    computeRebuiltStream.mockReturnValue({
+      events: [],
+      amount: 7,
+      availableAmount: 7,
+      wasteRecordContribution: 7,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=<none> currentAmount=10 rebuiltAmount=7 deltaAmount=-3 currentAvailableAmount=10 rebuiltAvailableAmount=7 deltaAvailableAmount=-3 registrationStatus=approved accreditationStatus=created wasteRecordCount=0 wasteRecordContribution=7 prnCount=0 prnAmountContribution=0 prnAvailableAmountContribution=0'
+        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=<none> currentAmount=10 rebuiltAmount=7 deltaAmount=-3 currentAvailableAmount=10 rebuiltAvailableAmount=7 deltaAvailableAmount=-3 registrationStatus=approved accreditationStatus=created wasteRecordCount=0 wasteRecordContribution=7 prnCount=0 prnAmountContribution=0 prnAvailableAmountContribution=0 streamAmount=7 streamAvailableAmount=7 streamDeltaAmount=0 streamDeltaAvailableAmount=0 streamEventCount=0'
     })
   })
 
@@ -383,7 +429,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=null accreditationNumber=ACC-1 currentAmount=2084.27 rebuiltAmount=0 deltaAmount=-2084.27 currentAvailableAmount=2084.27 rebuiltAvailableAmount=0 deltaAvailableAmount=-2084.27 registrationStatus=cancelled accreditationStatus=cancelled wasteRecordCount=3 wasteRecordContribution=0 prnCount=2 prnAmountContribution=0 prnAvailableAmountContribution=0'
+        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=null accreditationNumber=ACC-1 currentAmount=2084.27 rebuiltAmount=0 deltaAmount=-2084.27 currentAvailableAmount=2084.27 rebuiltAvailableAmount=0 deltaAvailableAmount=-2084.27 registrationStatus=cancelled accreditationStatus=cancelled wasteRecordCount=3 wasteRecordContribution=0 prnCount=2 prnAmountContribution=0 prnAvailableAmountContribution=0 streamAmount=0 streamAvailableAmount=0 streamDeltaAmount=0 streamDeltaAvailableAmount=0 streamEventCount=0'
     })
   })
 
@@ -481,6 +527,14 @@ describe('runBalanceDivergenceDiagnostic', () => {
       { id: 'acc-good', accreditationNumber: 'ACC-good' }
     ]
     computeRebuiltTotals.mockReturnValue({ amount: 5, availableAmount: 5 })
+    computeRebuiltStream.mockReturnValue({
+      events: [],
+      amount: 5,
+      availableAmount: 5,
+      wasteRecordContribution: 5,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
@@ -522,5 +576,95 @@ describe('runBalanceDivergenceDiagnostic', () => {
       err: error,
       message: 'Failed to run waste-balance divergence diagnostic'
     })
+  })
+
+  it('fetches summary logs and passes them to computeRebuiltStream', async () => {
+    const accreditation = { id: 'acc-1', accreditationNumber: 'ACC-001' }
+    setEmbeddedBalances([
+      {
+        accreditationId: 'acc-1',
+        organisationId: 'org-1',
+        amount: 0,
+        availableAmount: 0
+      }
+    ])
+    registrations['org-1'] = [
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: 'REG-1',
+        status: 'approved'
+      }
+    ]
+    accreditations['org-1'] = [accreditation]
+    const summaryLogs = [
+      { id: 'sl-1', status: 'submitted', submittedAt: '2025-01-01T00:00:00Z' }
+    ]
+    summaryLogsRepository.findAllByOrgReg.mockResolvedValue(summaryLogs)
+    const wasteRecords = [{ rowId: 'r-1', type: 'received' }]
+    wasteRecordsRepository.findByRegistration.mockResolvedValue(wasteRecords)
+    const prns = [{ id: 'prn-1' }]
+    prnRepository.findByAccreditation.mockResolvedValue(prns)
+
+    await runBalanceDivergenceDiagnostic(mockServer)
+
+    expect(summaryLogsRepository.findAllByOrgReg).toHaveBeenCalledWith(
+      'org-1',
+      'reg-1'
+    )
+    expect(computeRebuiltStream).toHaveBeenCalledWith({
+      accreditation,
+      wasteRecords,
+      prns,
+      overseasSites: {},
+      summaryLogs
+    })
+  })
+
+  it('includes stream replay figures in the divergence log when stream disagrees', async () => {
+    setEmbeddedBalances([
+      {
+        accreditationId: 'acc-1',
+        organisationId: 'org-1',
+        amount: 100,
+        availableAmount: 80
+      }
+    ])
+    registrations['org-1'] = [
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: 'REG-1',
+        status: 'approved'
+      }
+    ]
+    accreditations['org-1'] = [
+      { id: 'acc-1', accreditationNumber: 'ACC-1', status: 'approved' }
+    ]
+    computeRebuiltTotals.mockReturnValue({
+      amount: 100,
+      availableAmount: 80,
+      wasteRecordContribution: 100,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: -20
+    })
+    computeRebuiltStream.mockReturnValue({
+      events: [],
+      amount: 95,
+      availableAmount: 75,
+      wasteRecordContribution: 95,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: -20
+    })
+
+    await runBalanceDivergenceDiagnostic(mockServer)
+
+    const divergenceLines = logger.info.mock.calls.filter(([arg]) =>
+      arg.message.startsWith('Waste-balance divergence affected accreditation:')
+    )
+    expect(divergenceLines).toHaveLength(1)
+    expect(divergenceLines[0][0].message).toContain('streamAmount=95')
+    expect(divergenceLines[0][0].message).toContain('streamAvailableAmount=75')
+    expect(divergenceLines[0][0].message).toContain('streamEventCount=0')
   })
 })

--- a/src/waste-balances/application/append-to-stream.js
+++ b/src/waste-balances/application/append-to-stream.js
@@ -1,6 +1,8 @@
-import { add, subtract, toNumber } from '#common/helpers/decimal-utils.js'
-
 import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import {
+  closingForSummaryLogSubmitted,
+  closingForPrn
+} from './stream-closing-balance.js'
 
 const ZERO_BALANCE = Object.freeze({ amount: 0, availableAmount: 0 })
 
@@ -14,66 +16,6 @@ const openingBalanceFrom = (latest) =>
  * @param {import('../repository/stream-port.js').StreamEvent | null} latest
  */
 const nextNumberFrom = (latest) => (latest === null ? 1 : latest.number + 1)
-
-/**
- * Compute closing balance for a summary-log-submitted event.
- *
- * The caller supplies the aggregate `creditTotal` for this submission.
- * We read the previous summary-log-submitted event (if any) and compute
- * `delta = creditTotal - previousCreditTotal`. Both `amount` and
- * `availableAmount` shift by delta.
- *
- * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} opening
- * @param {number} creditTotal
- * @param {number} previousCreditTotal
- * @returns {import('../repository/stream-schema.js').StreamBalanceSnapshot}
- */
-const closingForSummaryLogSubmitted = (
-  opening,
-  creditTotal,
-  previousCreditTotal
-) => {
-  const delta = subtract(creditTotal, previousCreditTotal)
-  return {
-    amount: toNumber(add(opening.amount, delta)),
-    availableAmount: toNumber(add(opening.availableAmount, delta))
-  }
-}
-
-/**
- * Compute closing balance for a PRN event.
- *
- * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} opening
- * @param {import('../repository/stream-schema.js').StreamEventKind} kind
- * @param {number} prnAmount
- * @returns {import('../repository/stream-schema.js').StreamBalanceSnapshot}
- */
-const closingForPrn = (opening, kind, prnAmount) => {
-  switch (kind) {
-    case STREAM_EVENT_KIND.PRN_CREATED:
-      return {
-        amount: opening.amount,
-        availableAmount: toNumber(subtract(opening.availableAmount, prnAmount))
-      }
-    case STREAM_EVENT_KIND.PRN_ISSUED:
-      return {
-        amount: toNumber(subtract(opening.amount, prnAmount)),
-        availableAmount: opening.availableAmount
-      }
-    case STREAM_EVENT_KIND.PRN_CREATION_CANCELLED:
-      return {
-        amount: opening.amount,
-        availableAmount: toNumber(add(opening.availableAmount, prnAmount))
-      }
-    case STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE:
-      return {
-        amount: toNumber(add(opening.amount, prnAmount)),
-        availableAmount: toNumber(add(opening.availableAmount, prnAmount))
-      }
-    default:
-      throw new Error(`Unknown PRN event kind: ${kind}`)
-  }
-}
 
 /**
  * Append a single event to the waste balance stream.

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -254,7 +254,7 @@ export const computeRebuiltStream = ({
     }
   }
 
-  const finalBalance = events[events.length - 1].closingBalance
+  const finalBalance = events.at(-1).closingBalance
 
   let wasteRecordContribution = 0
   let prnAmountContribution = 0

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -254,7 +254,10 @@ export const computeRebuiltStream = ({
     }
   }
 
-  const finalBalance = events.at(-1).closingBalance
+  const finalBalance =
+    /** @type {import('../repository/stream-schema.js').StreamEventInsert} */ (
+      events.at(-1)
+    ).closingBalance
 
   let wasteRecordContribution = 0
   let prnAmountContribution = 0

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -1,0 +1,279 @@
+import { add, toNumber } from '#common/helpers/decimal-utils.js'
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
+
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import {
+  closingForSummaryLogSubmitted,
+  closingForPrn
+} from './stream-closing-balance.js'
+import { getTargetAmount } from './target-amount.js'
+
+/**
+ * Reconstruct a waste record's data as it existed at a given submission
+ * point. Layers version data objects via shallow merge, stopping at the
+ * latest version whose summaryLog.id appears in the seen set.
+ *
+ * @param {Array<{ summaryLog: { id: string }, data: Object }>} versions
+ * @param {Set<string>} seenSummaryLogIds
+ * @returns {Object | null}
+ */
+export const reconstructDataAtSubmission = (versions, seenSummaryLogIds) => {
+  let lastMatchIndex = -1
+
+  for (let i = 0; i < versions.length; i++) {
+    if (seenSummaryLogIds.has(versions[i].summaryLog.id)) {
+      lastMatchIndex = i
+    }
+  }
+
+  if (lastMatchIndex === -1) {
+    return null
+  }
+
+  let data = {}
+  for (let i = 0; i <= lastMatchIndex; i++) {
+    data = { ...data, ...versions[i].data }
+  }
+
+  return data
+}
+
+/**
+ * Map a PRN status transition to a stream event kind.
+ *
+ * @param {string | null} prevStatus
+ * @param {string} newStatus
+ * @returns {import('../repository/stream-schema.js').StreamEventKind | null}
+ */
+const prnTransitionToStreamKind = (prevStatus, newStatus) => {
+  if (newStatus === PRN_STATUS.AWAITING_AUTHORISATION) {
+    return STREAM_EVENT_KIND.PRN_CREATED
+  }
+  if (
+    newStatus === PRN_STATUS.AWAITING_ACCEPTANCE &&
+    prevStatus === PRN_STATUS.AWAITING_AUTHORISATION
+  ) {
+    return STREAM_EVENT_KIND.PRN_ISSUED
+  }
+  if (
+    (newStatus === PRN_STATUS.CANCELLED || newStatus === PRN_STATUS.DELETED) &&
+    prevStatus === PRN_STATUS.AWAITING_AUTHORISATION
+  ) {
+    return STREAM_EVENT_KIND.PRN_CREATION_CANCELLED
+  }
+  if (
+    newStatus === PRN_STATUS.CANCELLED &&
+    prevStatus === PRN_STATUS.AWAITING_CANCELLATION
+  ) {
+    return STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE
+  }
+  return null
+}
+
+/**
+ * Build an unsorted list of chronologically timestamped event tuples
+ * from summary log submissions and PRN status transitions.
+ *
+ * @param {Object} params
+ * @param {{ id: string }} params.accreditation
+ * @param {Array} params.wasteRecords
+ * @param {Array} params.prns
+ * @param {Object} params.overseasSites
+ * @param {Array<{ id: string, status: string, submittedAt: string }>} params.summaryLogs
+ */
+export const buildChronologicalEvents = ({
+  accreditation,
+  wasteRecords,
+  prns,
+  overseasSites,
+  summaryLogs
+}) => {
+  const events = []
+
+  const submitted = summaryLogs
+    .filter((sl) => sl.status === SUMMARY_LOG_STATUS.SUBMITTED)
+    .sort((a, b) => new Date(a.submittedAt) - new Date(b.submittedAt))
+
+  const seenSummaryLogIds = new Set()
+
+  for (const summaryLog of submitted) {
+    seenSummaryLogIds.add(summaryLog.id)
+
+    let creditTotal = 0
+    for (const record of wasteRecords) {
+      const data = reconstructDataAtSubmission(
+        record.versions,
+        seenSummaryLogIds
+      )
+      if (data === null) {
+        continue
+      }
+      const amount = getTargetAmount(
+        { data, excludedFromWasteBalance: record.excludedFromWasteBalance },
+        accreditation,
+        overseasSites
+      )
+      creditTotal = toNumber(add(creditTotal, amount))
+    }
+
+    events.push({
+      timestamp: new Date(summaryLog.submittedAt),
+      kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+      payload: { summaryLogId: summaryLog.id, creditTotal },
+      registrationId: wasteRecords[0]?.registrationId,
+      accreditationId: accreditation.id,
+      organisationId: wasteRecords[0]?.organisationId
+    })
+  }
+
+  for (const prn of prns) {
+    const history = prn.status.history
+    for (let i = 0; i < history.length; i++) {
+      const prevStatus = i === 0 ? null : history[i - 1].status
+      const kind = prnTransitionToStreamKind(prevStatus, history[i].status)
+      if (kind === null) {
+        continue
+      }
+      events.push({
+        timestamp: history[i].at,
+        kind,
+        payload: { prnId: prn.id, amount: prn.tonnage },
+        registrationId: wasteRecords[0]?.registrationId,
+        accreditationId: accreditation.id,
+        organisationId: wasteRecords[0]?.organisationId
+      })
+    }
+  }
+
+  return events
+}
+
+/**
+ * Replay a chronologically sorted list of events, threading opening and
+ * closing balances through each event. Assigns sequential slot numbers.
+ *
+ * @param {Array<{
+ *   timestamp: Date,
+ *   kind: import('../repository/stream-schema.js').StreamEventKind,
+ *   payload: Object,
+ *   registrationId: string,
+ *   accreditationId: string | null,
+ *   organisationId: string
+ * }>} events
+ * @returns {import('../repository/stream-schema.js').StreamEventInsert[]}
+ */
+export const replayStream = (events) => {
+  const result = []
+  let previousBalance = { amount: 0, availableAmount: 0 }
+  let previousCreditTotal = 0
+
+  for (let i = 0; i < events.length; i++) {
+    const { timestamp, kind, payload, ...context } = events[i]
+    const openingBalance = { ...previousBalance }
+
+    let closingBalance
+    if (kind === STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED) {
+      const { creditTotal } = payload
+      closingBalance = closingForSummaryLogSubmitted(
+        openingBalance,
+        creditTotal,
+        previousCreditTotal
+      )
+      previousCreditTotal = creditTotal
+    } else {
+      closingBalance = closingForPrn(openingBalance, kind, payload.amount)
+    }
+
+    result.push({
+      ...context,
+      number: i + 1,
+      kind,
+      payload,
+      openingBalance,
+      closingBalance,
+      createdAt: timestamp,
+      createdBy: { id: 'system', name: 'replay' }
+    })
+
+    previousBalance = closingBalance
+  }
+
+  return result
+}
+
+/**
+ * Reconstruct the full historical event stream for an accreditation and
+ * derive balance totals from it. The event list is suitable for seeding
+ * a stream store; the totals match the shape of `computeRebuiltTotals`
+ * for 3-way diagnostic comparison.
+ *
+ * @param {Object} params
+ * @param {{ id: string }} params.accreditation
+ * @param {Array} params.wasteRecords
+ * @param {Array} params.prns
+ * @param {Object} params.overseasSites
+ * @param {Array<{ id: string, status: string, submittedAt: string }>} params.summaryLogs
+ */
+export const computeRebuiltStream = ({
+  accreditation,
+  wasteRecords,
+  prns,
+  overseasSites,
+  summaryLogs
+}) => {
+  const unsorted = buildChronologicalEvents({
+    accreditation,
+    wasteRecords,
+    prns,
+    overseasSites,
+    summaryLogs
+  })
+
+  unsorted.sort((a, b) => a.timestamp - b.timestamp)
+
+  const events = replayStream(unsorted)
+
+  if (events.length === 0) {
+    return {
+      events,
+      amount: 0,
+      availableAmount: 0,
+      wasteRecordContribution: 0,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    }
+  }
+
+  const finalBalance = events[events.length - 1].closingBalance
+
+  let wasteRecordContribution = 0
+  let prnAmountContribution = 0
+  let prnAvailableAmountContribution = 0
+
+  for (const event of events) {
+    if (event.kind === STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED) {
+      wasteRecordContribution = event.payload.creditTotal
+    } else {
+      const delta = {
+        amount: event.closingBalance.amount - event.openingBalance.amount,
+        availableAmount:
+          event.closingBalance.availableAmount -
+          event.openingBalance.availableAmount
+      }
+      prnAmountContribution = toNumber(add(prnAmountContribution, delta.amount))
+      prnAvailableAmountContribution = toNumber(
+        add(prnAvailableAmountContribution, delta.availableAmount)
+      )
+    }
+  }
+
+  return {
+    events,
+    amount: finalBalance.amount,
+    availableAmount: finalBalance.availableAmount,
+    wasteRecordContribution,
+    prnAmountContribution,
+    prnAvailableAmountContribution
+  }
+}

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -46,7 +46,7 @@ export const reconstructDataAtSubmission = (versions, seenSummaryLogIds) => {
  * @param {string} newStatus
  * @returns {import('../repository/stream-schema.js').StreamEventKind | null}
  */
-const prnTransitionToStreamKind = (prevStatus, newStatus) => {
+export const prnTransitionToStreamKind = (prevStatus, newStatus) => {
   if (newStatus === PRN_STATUS.AWAITING_AUTHORISATION) {
     return STREAM_EVENT_KIND.PRN_CREATED
   }

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -18,7 +18,7 @@ import { getTargetAmount } from './target-amount.js'
  * @param {Set<string>} seenSummaryLogIds
  * @returns {Object | null}
  */
-export const reconstructDataAtSubmission = (versions, seenSummaryLogIds) => {
+const reconstructDataAtSubmission = (versions, seenSummaryLogIds) => {
   let lastMatchIndex = -1
 
   for (let i = 0; i < versions.length; i++) {
@@ -82,7 +82,7 @@ export const prnTransitionToStreamKind = (prevStatus, newStatus) => {
  * @param {Object} params.overseasSites
  * @param {Array<{ id: string, status: string, submittedAt?: string }>} params.summaryLogs
  */
-export const buildChronologicalEvents = ({
+const buildChronologicalEvents = ({
   accreditation,
   wasteRecords,
   prns,
@@ -169,7 +169,7 @@ export const buildChronologicalEvents = ({
  * }>} events
  * @returns {import('../repository/stream-schema.js').StreamEventInsert[]}
  */
-export const replayStream = (events) => {
+const replayStream = (events) => {
   const result = []
   let previousBalance = { amount: 0, availableAmount: 0 }
   let previousCreditTotal = 0

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -210,9 +210,10 @@ const replayStream = (events) => {
 
 /**
  * Reconstruct the full historical event stream for an accreditation and
- * derive balance totals from it. The event list is suitable for seeding
- * a stream store; the totals match the shape of `computeRebuiltTotals`
- * for 3-way diagnostic comparison.
+ * derive balance totals from it. The event list validates the stream
+ * replay logic against authoritative sources; seeding these events into
+ * a store requires further work (deterministic tiebreaks, partition
+ * shape, createdBy attribution) tracked separately under PAE-1382.
  *
  * @param {Object} params
  * @param {{ id: string }} params.accreditation
@@ -241,14 +242,7 @@ export const computeRebuiltStream = ({
   const events = replayStream(unsorted)
 
   if (events.length === 0) {
-    return {
-      events,
-      amount: 0,
-      availableAmount: 0,
-      wasteRecordContribution: 0,
-      prnAmountContribution: 0,
-      prnAvailableAmountContribution: 0
-    }
+    return { events, amount: 0, availableAmount: 0 }
   }
 
   const finalBalance =
@@ -256,36 +250,9 @@ export const computeRebuiltStream = ({
       events.at(-1)
     ).closingBalance
 
-  let wasteRecordContribution = 0
-  let prnAmountContribution = 0
-  let prnAvailableAmountContribution = 0
-
-  for (const event of events) {
-    if (event.kind === STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED) {
-      wasteRecordContribution =
-        /** @type {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} */ (
-          event.payload
-        ).creditTotal
-    } else {
-      const delta = {
-        amount: event.closingBalance.amount - event.openingBalance.amount,
-        availableAmount:
-          event.closingBalance.availableAmount -
-          event.openingBalance.availableAmount
-      }
-      prnAmountContribution = toNumber(add(prnAmountContribution, delta.amount))
-      prnAvailableAmountContribution = toNumber(
-        add(prnAvailableAmountContribution, delta.availableAmount)
-      )
-    }
-  }
-
   return {
     events,
     amount: finalBalance.amount,
-    availableAmount: finalBalance.availableAmount,
-    wasteRecordContribution,
-    prnAmountContribution,
-    prnAvailableAmountContribution
+    availableAmount: finalBalance.availableAmount
   }
 }

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -116,10 +116,7 @@ export const buildChronologicalEvents = ({
         continue
       }
       const amount = getTargetAmount(
-        /** @type {any} */ ({
-          data,
-          excludedFromWasteBalance: record.excludedFromWasteBalance
-        }),
+        { ...record, data },
         accreditation,
         overseasSites
       )

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -80,7 +80,7 @@ const prnTransitionToStreamKind = (prevStatus, newStatus) => {
  * @param {Array} params.wasteRecords
  * @param {Array} params.prns
  * @param {Object} params.overseasSites
- * @param {Array<{ id: string, status: string, submittedAt: string }>} params.summaryLogs
+ * @param {Array<{ id: string, status: string, submittedAt?: string }>} params.summaryLogs
  */
 export const buildChronologicalEvents = ({
   accreditation,
@@ -92,8 +92,14 @@ export const buildChronologicalEvents = ({
   const events = []
 
   const submitted = summaryLogs
-    .filter((sl) => sl.status === SUMMARY_LOG_STATUS.SUBMITTED)
-    .sort((a, b) => new Date(a.submittedAt) - new Date(b.submittedAt))
+    .filter(
+      /** @returns {sl is { id: string, status: string, submittedAt: string }} */
+      (sl) => sl.status === SUMMARY_LOG_STATUS.SUBMITTED
+    )
+    .sort(
+      (a, b) =>
+        new Date(a.submittedAt).getTime() - new Date(b.submittedAt).getTime()
+    )
 
   const seenSummaryLogIds = new Set()
 
@@ -110,7 +116,10 @@ export const buildChronologicalEvents = ({
         continue
       }
       const amount = getTargetAmount(
-        { data, excludedFromWasteBalance: record.excludedFromWasteBalance },
+        /** @type {any} */ ({
+          data,
+          excludedFromWasteBalance: record.excludedFromWasteBalance
+        }),
         accreditation,
         overseasSites
       )
@@ -213,7 +222,7 @@ export const replayStream = (events) => {
  * @param {Array} params.wasteRecords
  * @param {Array} params.prns
  * @param {Object} params.overseasSites
- * @param {Array<{ id: string, status: string, submittedAt: string }>} params.summaryLogs
+ * @param {Array<{ id: string, status: string, submittedAt?: string }>} params.summaryLogs
  */
 export const computeRebuiltStream = ({
   accreditation,
@@ -253,7 +262,10 @@ export const computeRebuiltStream = ({
 
   for (const event of events) {
     if (event.kind === STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED) {
-      wasteRecordContribution = event.payload.creditTotal
+      wasteRecordContribution =
+        /** @type {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} */ (
+          event.payload
+        ).creditTotal
     } else {
       const delta = {
         amount: event.closingBalance.amount - event.openingBalance.amount,

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -212,12 +212,14 @@ describe('buildChronologicalEvents', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    findSchemaForProcessingType.mockReturnValue({
-      classifyForWasteBalance: (data) =>
-        data.tonnage === undefined
-          ? { outcome: ROW_OUTCOME.EXCLUDED, transactionAmount: 0 }
-          : includedAt(data.tonnage)
-    })
+    vi.mocked(findSchemaForProcessingType).mockReturnValue(
+      /** @type {any} */ ({
+        classifyForWasteBalance: (data) =>
+          data.tonnage === undefined
+            ? { outcome: ROW_OUTCOME.EXCLUDED, transactionAmount: 0 }
+            : includedAt(data.tonnage)
+      })
+    )
   })
 
   it('returns empty array when no summary logs and no PRNs', () => {
@@ -337,8 +339,7 @@ describe('buildChronologicalEvents', () => {
       },
       {
         id: 'sl-draft',
-        status: SUMMARY_LOG_STATUS.VALIDATED,
-        submittedAt: undefined
+        status: SUMMARY_LOG_STATUS.VALIDATED
       }
     ]
     const wasteRecords = [
@@ -457,12 +458,14 @@ describe('computeRebuiltStream', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    findSchemaForProcessingType.mockReturnValue({
-      classifyForWasteBalance: (data) =>
-        data.tonnage === undefined
-          ? { outcome: ROW_OUTCOME.EXCLUDED, transactionAmount: 0 }
-          : includedAt(data.tonnage)
-    })
+    vi.mocked(findSchemaForProcessingType).mockReturnValue(
+      /** @type {any} */ ({
+        classifyForWasteBalance: (data) =>
+          data.tonnage === undefined
+            ? { outcome: ROW_OUTCOME.EXCLUDED, transactionAmount: 0 }
+            : includedAt(data.tonnage)
+      })
+    )
   })
 
   it('returns zero totals and empty events when given no inputs', () => {
@@ -609,10 +612,18 @@ describe('computeRebuiltStream', () => {
     expect(result.events).toHaveLength(3)
     // Chronological: sl-1 (Jan 10), prn-created (Jan 15), sl-2 (Jan 20)
     expect(result.events[0].kind).toBe(STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
-    expect(result.events[0].payload.creditTotal).toBe(40)
+    expect(
+      /** @type {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} */ (
+        result.events[0].payload
+      ).creditTotal
+    ).toBe(40)
     expect(result.events[1].kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
     expect(result.events[2].kind).toBe(STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
-    expect(result.events[2].payload.creditTotal).toBe(60)
+    expect(
+      /** @type {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} */ (
+        result.events[2].payload
+      ).creditTotal
+    ).toBe(60)
 
     // Final balance: 60 (waste) - 10 (PRN created, availableAmount only)
     expect(result.amount).toBe(60)

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -5,12 +5,7 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 
 import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
-import {
-  reconstructDataAtSubmission,
-  replayStream,
-  buildChronologicalEvents,
-  computeRebuiltStream
-} from './compute-rebuilt-stream.js'
+import { computeRebuiltStream } from './compute-rebuilt-stream.js'
 
 vi.mock('#domain/summary-logs/table-schemas/index.js', () => ({
   findSchemaForProcessingType: vi.fn()
@@ -22,562 +17,6 @@ const { findSchemaForProcessingType } =
 const includedAt = (amount) => ({
   outcome: ROW_OUTCOME.INCLUDED,
   transactionAmount: amount
-})
-
-describe('reconstructDataAtSubmission', () => {
-  it('returns null when no versions match the seen summary logs', () => {
-    const versions = [{ summaryLog: { id: 'sl-2' }, data: { tonnage: 10 } }]
-
-    const result = reconstructDataAtSubmission(versions, new Set(['sl-1']))
-
-    expect(result).toBeNull()
-  })
-
-  it('returns the created version data when its summary log has been seen', () => {
-    const versions = [
-      {
-        status: 'created',
-        summaryLog: { id: 'sl-1' },
-        data: { tonnage: 10, material: 'plastic', processingType: 'INPUT' }
-      }
-    ]
-
-    const result = reconstructDataAtSubmission(versions, new Set(['sl-1']))
-
-    expect(result).toEqual({
-      tonnage: 10,
-      material: 'plastic',
-      processingType: 'INPUT'
-    })
-  })
-
-  it('layers updated version data onto the created version', () => {
-    const versions = [
-      {
-        status: 'created',
-        summaryLog: { id: 'sl-1' },
-        data: { tonnage: 10, material: 'plastic', processingType: 'INPUT' }
-      },
-      {
-        status: 'updated',
-        summaryLog: { id: 'sl-2' },
-        data: { tonnage: 15 }
-      }
-    ]
-
-    const result = reconstructDataAtSubmission(
-      versions,
-      new Set(['sl-1', 'sl-2'])
-    )
-
-    expect(result).toEqual({
-      tonnage: 15,
-      material: 'plastic',
-      processingType: 'INPUT'
-    })
-  })
-
-  it('stops at the latest version whose summary log has been seen', () => {
-    const versions = [
-      {
-        status: 'created',
-        summaryLog: { id: 'sl-1' },
-        data: { tonnage: 10, material: 'plastic', processingType: 'INPUT' }
-      },
-      {
-        status: 'updated',
-        summaryLog: { id: 'sl-2' },
-        data: { tonnage: 15 }
-      },
-      {
-        status: 'updated',
-        summaryLog: { id: 'sl-3' },
-        data: { tonnage: 20 }
-      }
-    ]
-
-    const result = reconstructDataAtSubmission(
-      versions,
-      new Set(['sl-1', 'sl-2'])
-    )
-
-    expect(result).toEqual({
-      tonnage: 15,
-      material: 'plastic',
-      processingType: 'INPUT'
-    })
-  })
-})
-
-describe('replayStream', () => {
-  it('returns empty array when given no events', () => {
-    const result = replayStream([])
-
-    expect(result).toEqual([])
-  })
-
-  it('replays a single summary-log-submitted event from zero balance', () => {
-    const events = [
-      {
-        timestamp: new Date('2025-01-01T00:00:00.000Z'),
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'sl-1', creditTotal: 100 },
-        registrationId: 'reg-1',
-        accreditationId: 'acc-1',
-        organisationId: 'org-1'
-      }
-    ]
-
-    const result = replayStream(events)
-
-    expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      number: 1,
-      kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-      openingBalance: { amount: 0, availableAmount: 0 },
-      closingBalance: { amount: 100, availableAmount: 100 }
-    })
-  })
-
-  it('threads balances across multiple events', () => {
-    const events = [
-      {
-        timestamp: new Date('2025-01-01T00:00:00.000Z'),
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'sl-1', creditTotal: 100 },
-        registrationId: 'reg-1',
-        accreditationId: 'acc-1',
-        organisationId: 'org-1'
-      },
-      {
-        timestamp: new Date('2025-01-02T00:00:00.000Z'),
-        kind: STREAM_EVENT_KIND.PRN_CREATED,
-        payload: { prnId: 'prn-1', amount: 30 },
-        registrationId: 'reg-1',
-        accreditationId: 'acc-1',
-        organisationId: 'org-1'
-      }
-    ]
-
-    const result = replayStream(events)
-
-    expect(result).toHaveLength(2)
-    expect(result[0].closingBalance).toEqual({
-      amount: 100,
-      availableAmount: 100
-    })
-    expect(result[1]).toMatchObject({
-      number: 2,
-      openingBalance: { amount: 100, availableAmount: 100 },
-      closingBalance: { amount: 100, availableAmount: 70 }
-    })
-  })
-
-  it('tracks previousCreditTotal across summary-log events', () => {
-    const events = [
-      {
-        timestamp: new Date('2025-01-01T00:00:00.000Z'),
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'sl-1', creditTotal: 100 },
-        registrationId: 'reg-1',
-        accreditationId: 'acc-1',
-        organisationId: 'org-1'
-      },
-      {
-        timestamp: new Date('2025-01-02T00:00:00.000Z'),
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'sl-2', creditTotal: 150 },
-        registrationId: 'reg-1',
-        accreditationId: 'acc-1',
-        organisationId: 'org-1'
-      }
-    ]
-
-    const result = replayStream(events)
-
-    expect(result[0].closingBalance).toEqual({
-      amount: 100,
-      availableAmount: 100
-    })
-    expect(result[1]).toMatchObject({
-      openingBalance: { amount: 100, availableAmount: 100 },
-      closingBalance: { amount: 150, availableAmount: 150 }
-    })
-  })
-})
-
-describe('buildChronologicalEvents', () => {
-  const accreditation = { id: 'acc-1' }
-  const overseasSites = {}
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-    vi.mocked(findSchemaForProcessingType).mockReturnValue(
-      /** @type {any} */ ({
-        classifyForWasteBalance: (data) =>
-          data.tonnage === undefined
-            ? { outcome: ROW_OUTCOME.EXCLUDED, transactionAmount: 0 }
-            : includedAt(data.tonnage)
-      })
-    )
-  })
-
-  it('returns empty array when no summary logs and no PRNs', () => {
-    const result = buildChronologicalEvents({
-      accreditation,
-      wasteRecords: [],
-      prns: [],
-      overseasSites,
-      summaryLogs: []
-    })
-
-    expect(result).toEqual([])
-  })
-
-  it('emits a summary-log-submitted event with creditTotal from waste records', () => {
-    const summaryLogs = [
-      {
-        id: 'sl-1',
-        status: SUMMARY_LOG_STATUS.SUBMITTED,
-        submittedAt: '2025-01-15T10:00:00.000Z'
-      }
-    ]
-    const wasteRecords = [
-      {
-        organisationId: 'org-1',
-        registrationId: 'reg-1',
-        type: 'received',
-        data: { processingType: 'INPUT', tonnage: 40 },
-        versions: [
-          {
-            summaryLog: { id: 'sl-1' },
-            data: { processingType: 'INPUT', tonnage: 40 }
-          }
-        ],
-        excludedFromWasteBalance: false
-      },
-      {
-        organisationId: 'org-1',
-        registrationId: 'reg-1',
-        type: 'received',
-        data: { processingType: 'INPUT', tonnage: 60 },
-        versions: [
-          {
-            summaryLog: { id: 'sl-1' },
-            data: { processingType: 'INPUT', tonnage: 60 }
-          }
-        ],
-        excludedFromWasteBalance: false
-      }
-    ]
-
-    const result = buildChronologicalEvents({
-      accreditation,
-      wasteRecords,
-      prns: [],
-      overseasSites,
-      summaryLogs
-    })
-
-    expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-      payload: { summaryLogId: 'sl-1', creditTotal: 100 },
-      timestamp: new Date('2025-01-15T10:00:00.000Z')
-    })
-  })
-
-  it('accumulates creditTotal across summary log submissions using version history', () => {
-    const summaryLogs = [
-      {
-        id: 'sl-1',
-        status: SUMMARY_LOG_STATUS.SUBMITTED,
-        submittedAt: '2025-01-15T10:00:00.000Z'
-      },
-      {
-        id: 'sl-2',
-        status: SUMMARY_LOG_STATUS.SUBMITTED,
-        submittedAt: '2025-02-15T10:00:00.000Z'
-      }
-    ]
-    const wasteRecords = [
-      {
-        organisationId: 'org-1',
-        registrationId: 'reg-1',
-        type: 'received',
-        data: { processingType: 'INPUT', tonnage: 50 },
-        versions: [
-          {
-            summaryLog: { id: 'sl-1' },
-            data: { processingType: 'INPUT', tonnage: 40 }
-          },
-          { summaryLog: { id: 'sl-2' }, data: { tonnage: 50 } }
-        ],
-        excludedFromWasteBalance: false
-      }
-    ]
-
-    const result = buildChronologicalEvents({
-      accreditation,
-      wasteRecords,
-      prns: [],
-      overseasSites,
-      summaryLogs
-    })
-
-    expect(result).toHaveLength(2)
-    expect(result[0].payload).toEqual({ summaryLogId: 'sl-1', creditTotal: 40 })
-    expect(result[1].payload).toEqual({ summaryLogId: 'sl-2', creditTotal: 50 })
-  })
-
-  it('filters out non-submitted summary logs', () => {
-    const summaryLogs = [
-      {
-        id: 'sl-1',
-        status: SUMMARY_LOG_STATUS.SUBMITTED,
-        submittedAt: '2025-01-15T10:00:00.000Z'
-      },
-      {
-        id: 'sl-draft',
-        status: SUMMARY_LOG_STATUS.VALIDATED
-      }
-    ]
-    const wasteRecords = [
-      {
-        organisationId: 'org-1',
-        registrationId: 'reg-1',
-        type: 'received',
-        data: { processingType: 'INPUT', tonnage: 10 },
-        versions: [
-          {
-            summaryLog: { id: 'sl-1' },
-            data: { processingType: 'INPUT', tonnage: 10 }
-          }
-        ],
-        excludedFromWasteBalance: false
-      }
-    ]
-
-    const result = buildChronologicalEvents({
-      accreditation,
-      wasteRecords,
-      prns: [],
-      overseasSites,
-      summaryLogs
-    })
-
-    expect(result).toHaveLength(1)
-    expect(result[0].payload.summaryLogId).toBe('sl-1')
-  })
-
-  it('emits PRN events from status history transitions', () => {
-    const prns = [
-      {
-        id: 'prn-1',
-        tonnage: 25,
-        status: {
-          history: [
-            {
-              status: PRN_STATUS.DRAFT,
-              at: new Date('2025-01-10T00:00:00.000Z')
-            },
-            {
-              status: PRN_STATUS.AWAITING_AUTHORISATION,
-              at: new Date('2025-01-11T00:00:00.000Z')
-            },
-            {
-              status: PRN_STATUS.AWAITING_ACCEPTANCE,
-              at: new Date('2025-01-12T00:00:00.000Z')
-            }
-          ]
-        }
-      }
-    ]
-
-    const result = buildChronologicalEvents({
-      accreditation,
-      wasteRecords: [],
-      prns,
-      overseasSites,
-      summaryLogs: []
-    })
-
-    expect(result).toHaveLength(2)
-    expect(result[0]).toMatchObject({
-      kind: STREAM_EVENT_KIND.PRN_CREATED,
-      payload: { prnId: 'prn-1', amount: 25 },
-      timestamp: new Date('2025-01-11T00:00:00.000Z')
-    })
-    expect(result[1]).toMatchObject({
-      kind: STREAM_EVENT_KIND.PRN_ISSUED,
-      payload: { prnId: 'prn-1', amount: 25 },
-      timestamp: new Date('2025-01-12T00:00:00.000Z')
-    })
-  })
-
-  it('emits PRN_CREATION_CANCELLED for a deleted PRN', () => {
-    const prns = [
-      {
-        id: 'prn-1',
-        tonnage: 25,
-        status: {
-          history: [
-            {
-              status: PRN_STATUS.DRAFT,
-              at: new Date('2025-01-10T00:00:00.000Z')
-            },
-            {
-              status: PRN_STATUS.AWAITING_AUTHORISATION,
-              at: new Date('2025-01-11T00:00:00.000Z')
-            },
-            {
-              status: PRN_STATUS.CANCELLED,
-              at: new Date('2025-01-12T00:00:00.000Z')
-            }
-          ]
-        }
-      }
-    ]
-
-    const result = buildChronologicalEvents({
-      accreditation,
-      wasteRecords: [],
-      prns,
-      overseasSites,
-      summaryLogs: []
-    })
-
-    expect(result).toHaveLength(2)
-    expect(result[0].kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
-    expect(result[1].kind).toBe(STREAM_EVENT_KIND.PRN_CREATION_CANCELLED)
-  })
-
-  it('emits PRN_CANCELLED_AFTER_ISSUE for a post-issue cancellation', () => {
-    const prns = [
-      {
-        id: 'prn-1',
-        tonnage: 25,
-        status: {
-          history: [
-            {
-              status: PRN_STATUS.DRAFT,
-              at: new Date('2025-01-10T00:00:00.000Z')
-            },
-            {
-              status: PRN_STATUS.AWAITING_AUTHORISATION,
-              at: new Date('2025-01-11T00:00:00.000Z')
-            },
-            {
-              status: PRN_STATUS.AWAITING_ACCEPTANCE,
-              at: new Date('2025-01-12T00:00:00.000Z')
-            },
-            {
-              status: PRN_STATUS.AWAITING_CANCELLATION,
-              at: new Date('2025-01-13T00:00:00.000Z')
-            },
-            {
-              status: PRN_STATUS.CANCELLED,
-              at: new Date('2025-01-14T00:00:00.000Z')
-            }
-          ]
-        }
-      }
-    ]
-
-    const result = buildChronologicalEvents({
-      accreditation,
-      wasteRecords: [],
-      prns,
-      overseasSites,
-      summaryLogs: []
-    })
-
-    expect(result).toHaveLength(3)
-    expect(result[0].kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
-    expect(result[1].kind).toBe(STREAM_EVENT_KIND.PRN_ISSUED)
-    expect(result[2].kind).toBe(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE)
-  })
-
-  it('skips waste records not yet created at a submission point', () => {
-    const summaryLogs = [
-      {
-        id: 'sl-1',
-        status: SUMMARY_LOG_STATUS.SUBMITTED,
-        submittedAt: '2025-01-10T00:00:00.000Z'
-      },
-      {
-        id: 'sl-2',
-        status: SUMMARY_LOG_STATUS.SUBMITTED,
-        submittedAt: '2025-01-20T00:00:00.000Z'
-      }
-    ]
-    const wasteRecords = [
-      {
-        organisationId: 'org-1',
-        registrationId: 'reg-1',
-        type: 'received',
-        data: { processingType: 'INPUT', tonnage: 50 },
-        versions: [
-          {
-            summaryLog: { id: 'sl-2' },
-            data: { processingType: 'INPUT', tonnage: 50 }
-          }
-        ],
-        excludedFromWasteBalance: false
-      }
-    ]
-
-    const result = buildChronologicalEvents({
-      accreditation,
-      wasteRecords,
-      prns: [],
-      overseasSites,
-      summaryLogs
-    })
-
-    expect(result).toHaveLength(2)
-    expect(result[0].payload).toEqual({ summaryLogId: 'sl-1', creditTotal: 0 })
-    expect(result[1].payload).toEqual({
-      summaryLogId: 'sl-2',
-      creditTotal: 50
-    })
-  })
-
-  it('skips PRN transitions that do not produce stream events', () => {
-    const prns = [
-      {
-        id: 'prn-1',
-        tonnage: 25,
-        status: {
-          history: [
-            {
-              status: PRN_STATUS.DRAFT,
-              at: new Date('2025-01-10T00:00:00.000Z')
-            },
-            {
-              status: PRN_STATUS.AWAITING_AUTHORISATION,
-              at: new Date('2025-01-11T00:00:00.000Z')
-            },
-            {
-              status: PRN_STATUS.ACCEPTED,
-              at: new Date('2025-01-13T00:00:00.000Z')
-            }
-          ]
-        }
-      }
-    ]
-
-    const result = buildChronologicalEvents({
-      accreditation,
-      wasteRecords: [],
-      prns,
-      overseasSites,
-      summaryLogs: []
-    })
-
-    expect(result).toHaveLength(1)
-    expect(result[0].kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
-  })
 })
 
 describe('computeRebuiltStream', () => {
@@ -759,5 +198,205 @@ describe('computeRebuiltStream', () => {
     expect(result.wasteRecordContribution).toBe(60)
     expect(result.prnAmountContribution).toBe(0)
     expect(result.prnAvailableAmountContribution).toBe(-10)
+  })
+
+  it('ignores non-submitted summary logs', () => {
+    const result = computeRebuiltStream({
+      accreditation,
+      wasteRecords: [
+        {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          type: 'received',
+          data: { processingType: 'INPUT', tonnage: 10 },
+          versions: [
+            {
+              summaryLog: { id: 'sl-1' },
+              data: { processingType: 'INPUT', tonnage: 10 }
+            }
+          ],
+          excludedFromWasteBalance: false
+        }
+      ],
+      prns: [],
+      overseasSites,
+      summaryLogs: [
+        {
+          id: 'sl-1',
+          status: SUMMARY_LOG_STATUS.SUBMITTED,
+          submittedAt: '2025-01-15T10:00:00.000Z'
+        },
+        { id: 'sl-draft', status: SUMMARY_LOG_STATUS.VALIDATED }
+      ]
+    })
+
+    expect(result.events).toHaveLength(1)
+    expect(result.wasteRecordContribution).toBe(10)
+  })
+
+  it('excludes waste records not yet created at a submission point', () => {
+    const result = computeRebuiltStream({
+      accreditation,
+      wasteRecords: [
+        {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          type: 'received',
+          data: { processingType: 'INPUT', tonnage: 50 },
+          versions: [
+            {
+              summaryLog: { id: 'sl-2' },
+              data: { processingType: 'INPUT', tonnage: 50 }
+            }
+          ],
+          excludedFromWasteBalance: false
+        }
+      ],
+      prns: [],
+      overseasSites,
+      summaryLogs: [
+        {
+          id: 'sl-1',
+          status: SUMMARY_LOG_STATUS.SUBMITTED,
+          submittedAt: '2025-01-10T00:00:00.000Z'
+        },
+        {
+          id: 'sl-2',
+          status: SUMMARY_LOG_STATUS.SUBMITTED,
+          submittedAt: '2025-01-20T00:00:00.000Z'
+        }
+      ]
+    })
+
+    expect(result.events).toHaveLength(2)
+    // First submission: record does not exist yet, creditTotal = 0
+    expect(result.events[0].closingBalance).toEqual({
+      amount: 0,
+      availableAmount: 0
+    })
+    // Second submission: record appears, creditTotal = 50
+    expect(result.wasteRecordContribution).toBe(50)
+    expect(result.amount).toBe(50)
+  })
+
+  it('reverses availableAmount for a pre-issue PRN cancellation', () => {
+    const result = computeRebuiltStream({
+      accreditation,
+      wasteRecords: [
+        {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          type: 'received',
+          data: { processingType: 'INPUT', tonnage: 100 },
+          versions: [
+            {
+              summaryLog: { id: 'sl-1' },
+              data: { processingType: 'INPUT', tonnage: 100 }
+            }
+          ],
+          excludedFromWasteBalance: false
+        }
+      ],
+      prns: [
+        {
+          id: 'prn-1',
+          tonnage: 25,
+          status: {
+            history: [
+              {
+                status: PRN_STATUS.DRAFT,
+                at: new Date('2025-01-20T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.AWAITING_AUTHORISATION,
+                at: new Date('2025-01-21T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.CANCELLED,
+                at: new Date('2025-01-22T00:00:00.000Z')
+              }
+            ]
+          }
+        }
+      ],
+      overseasSites,
+      summaryLogs: [
+        {
+          id: 'sl-1',
+          status: SUMMARY_LOG_STATUS.SUBMITTED,
+          submittedAt: '2025-01-15T10:00:00.000Z'
+        }
+      ]
+    })
+
+    // PRN created then cancelled pre-issue: net zero effect on availableAmount
+    expect(result.amount).toBe(100)
+    expect(result.availableAmount).toBe(100)
+    expect(result.prnAvailableAmountContribution).toBe(0)
+  })
+
+  it('reverses both amount and availableAmount for a post-issue cancellation', () => {
+    const result = computeRebuiltStream({
+      accreditation,
+      wasteRecords: [
+        {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          type: 'received',
+          data: { processingType: 'INPUT', tonnage: 100 },
+          versions: [
+            {
+              summaryLog: { id: 'sl-1' },
+              data: { processingType: 'INPUT', tonnage: 100 }
+            }
+          ],
+          excludedFromWasteBalance: false
+        }
+      ],
+      prns: [
+        {
+          id: 'prn-1',
+          tonnage: 25,
+          status: {
+            history: [
+              {
+                status: PRN_STATUS.DRAFT,
+                at: new Date('2025-01-20T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.AWAITING_AUTHORISATION,
+                at: new Date('2025-01-21T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                at: new Date('2025-01-22T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.AWAITING_CANCELLATION,
+                at: new Date('2025-01-23T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.CANCELLED,
+                at: new Date('2025-01-24T00:00:00.000Z')
+              }
+            ]
+          }
+        }
+      ],
+      overseasSites,
+      summaryLogs: [
+        {
+          id: 'sl-1',
+          status: SUMMARY_LOG_STATUS.SUBMITTED,
+          submittedAt: '2025-01-15T10:00:00.000Z'
+        }
+      ]
+    })
+
+    // PRN created, issued, then cancelled: net zero effect
+    expect(result.amount).toBe(100)
+    expect(result.availableAmount).toBe(100)
+    expect(result.prnAmountContribution).toBe(0)
+    expect(result.prnAvailableAmountContribution).toBe(0)
   })
 })

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -47,10 +47,7 @@ describe('computeRebuiltStream', () => {
     expect(result).toEqual({
       events: [],
       amount: 0,
-      availableAmount: 0,
-      wasteRecordContribution: 0,
-      prnAmountContribution: 0,
-      prnAvailableAmountContribution: 0
+      availableAmount: 0
     })
   })
 
@@ -115,9 +112,6 @@ describe('computeRebuiltStream', () => {
 
     expect(result.amount).toBe(70)
     expect(result.availableAmount).toBe(70)
-    expect(result.wasteRecordContribution).toBe(100)
-    expect(result.prnAmountContribution).toBe(-30)
-    expect(result.prnAvailableAmountContribution).toBe(-30)
   })
 
   it('handles multiple summary logs with version history and interleaved PRNs', () => {
@@ -195,9 +189,6 @@ describe('computeRebuiltStream', () => {
     // Final balance: 60 (waste) - 10 (PRN created, availableAmount only)
     expect(result.amount).toBe(60)
     expect(result.availableAmount).toBe(50)
-    expect(result.wasteRecordContribution).toBe(60)
-    expect(result.prnAmountContribution).toBe(0)
-    expect(result.prnAvailableAmountContribution).toBe(-10)
   })
 
   it('ignores non-submitted summary logs', () => {
@@ -231,7 +222,7 @@ describe('computeRebuiltStream', () => {
     })
 
     expect(result.events).toHaveLength(1)
-    expect(result.wasteRecordContribution).toBe(10)
+    expect(result.amount).toBe(10)
   })
 
   it('excludes waste records not yet created at a submission point', () => {
@@ -274,8 +265,7 @@ describe('computeRebuiltStream', () => {
       amount: 0,
       availableAmount: 0
     })
-    // Second submission: record appears, creditTotal = 50
-    expect(result.wasteRecordContribution).toBe(50)
+    // Second submission: record appears, balance reflects it
     expect(result.amount).toBe(50)
   })
 
@@ -329,10 +319,9 @@ describe('computeRebuiltStream', () => {
       ]
     })
 
-    // PRN created then cancelled pre-issue: net zero effect on availableAmount
+    // PRN created then cancelled pre-issue: net zero effect on balance
     expect(result.amount).toBe(100)
     expect(result.availableAmount).toBe(100)
-    expect(result.prnAvailableAmountContribution).toBe(0)
   })
 
   it('reverses both amount and availableAmount for a post-issue cancellation', () => {
@@ -396,7 +385,5 @@ describe('computeRebuiltStream', () => {
     // PRN created, issued, then cancelled: net zero effect
     expect(result.amount).toBe(100)
     expect(result.availableAmount).toBe(100)
-    expect(result.prnAmountContribution).toBe(0)
-    expect(result.prnAvailableAmountContribution).toBe(0)
   })
 })

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -415,6 +415,134 @@ describe('buildChronologicalEvents', () => {
     })
   })
 
+  it('emits PRN_CREATION_CANCELLED for a deleted PRN', () => {
+    const prns = [
+      {
+        id: 'prn-1',
+        tonnage: 25,
+        status: {
+          history: [
+            {
+              status: PRN_STATUS.DRAFT,
+              at: new Date('2025-01-10T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.AWAITING_AUTHORISATION,
+              at: new Date('2025-01-11T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.CANCELLED,
+              at: new Date('2025-01-12T00:00:00.000Z')
+            }
+          ]
+        }
+      }
+    ]
+
+    const result = buildChronologicalEvents({
+      accreditation,
+      wasteRecords: [],
+      prns,
+      overseasSites,
+      summaryLogs: []
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0].kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+    expect(result[1].kind).toBe(STREAM_EVENT_KIND.PRN_CREATION_CANCELLED)
+  })
+
+  it('emits PRN_CANCELLED_AFTER_ISSUE for a post-issue cancellation', () => {
+    const prns = [
+      {
+        id: 'prn-1',
+        tonnage: 25,
+        status: {
+          history: [
+            {
+              status: PRN_STATUS.DRAFT,
+              at: new Date('2025-01-10T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.AWAITING_AUTHORISATION,
+              at: new Date('2025-01-11T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.AWAITING_ACCEPTANCE,
+              at: new Date('2025-01-12T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.AWAITING_CANCELLATION,
+              at: new Date('2025-01-13T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.CANCELLED,
+              at: new Date('2025-01-14T00:00:00.000Z')
+            }
+          ]
+        }
+      }
+    ]
+
+    const result = buildChronologicalEvents({
+      accreditation,
+      wasteRecords: [],
+      prns,
+      overseasSites,
+      summaryLogs: []
+    })
+
+    expect(result).toHaveLength(3)
+    expect(result[0].kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+    expect(result[1].kind).toBe(STREAM_EVENT_KIND.PRN_ISSUED)
+    expect(result[2].kind).toBe(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE)
+  })
+
+  it('skips waste records not yet created at a submission point', () => {
+    const summaryLogs = [
+      {
+        id: 'sl-1',
+        status: SUMMARY_LOG_STATUS.SUBMITTED,
+        submittedAt: '2025-01-10T00:00:00.000Z'
+      },
+      {
+        id: 'sl-2',
+        status: SUMMARY_LOG_STATUS.SUBMITTED,
+        submittedAt: '2025-01-20T00:00:00.000Z'
+      }
+    ]
+    const wasteRecords = [
+      {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        type: 'received',
+        data: { processingType: 'INPUT', tonnage: 50 },
+        versions: [
+          {
+            summaryLog: { id: 'sl-2' },
+            data: { processingType: 'INPUT', tonnage: 50 }
+          }
+        ],
+        excludedFromWasteBalance: false
+      }
+    ]
+
+    const result = buildChronologicalEvents({
+      accreditation,
+      wasteRecords,
+      prns: [],
+      overseasSites,
+      summaryLogs
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0].payload).toEqual({ summaryLogId: 'sl-1', creditTotal: 0 })
+    expect(result[1].payload).toEqual({
+      summaryLogId: 'sl-2',
+      creditTotal: 50
+    })
+  })
+
   it('skips PRN transitions that do not produce stream events', () => {
     const prns = [
       {

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -1,0 +1,624 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
+
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import {
+  reconstructDataAtSubmission,
+  replayStream,
+  buildChronologicalEvents,
+  computeRebuiltStream
+} from './compute-rebuilt-stream.js'
+
+vi.mock('#domain/summary-logs/table-schemas/index.js', () => ({
+  findSchemaForProcessingType: vi.fn()
+}))
+
+const { findSchemaForProcessingType } =
+  await import('#domain/summary-logs/table-schemas/index.js')
+
+const includedAt = (amount) => ({
+  outcome: ROW_OUTCOME.INCLUDED,
+  transactionAmount: amount
+})
+
+describe('reconstructDataAtSubmission', () => {
+  it('returns null when no versions match the seen summary logs', () => {
+    const versions = [{ summaryLog: { id: 'sl-2' }, data: { tonnage: 10 } }]
+
+    const result = reconstructDataAtSubmission(versions, new Set(['sl-1']))
+
+    expect(result).toBeNull()
+  })
+
+  it('returns the created version data when its summary log has been seen', () => {
+    const versions = [
+      {
+        status: 'created',
+        summaryLog: { id: 'sl-1' },
+        data: { tonnage: 10, material: 'plastic', processingType: 'INPUT' }
+      }
+    ]
+
+    const result = reconstructDataAtSubmission(versions, new Set(['sl-1']))
+
+    expect(result).toEqual({
+      tonnage: 10,
+      material: 'plastic',
+      processingType: 'INPUT'
+    })
+  })
+
+  it('layers updated version data onto the created version', () => {
+    const versions = [
+      {
+        status: 'created',
+        summaryLog: { id: 'sl-1' },
+        data: { tonnage: 10, material: 'plastic', processingType: 'INPUT' }
+      },
+      {
+        status: 'updated',
+        summaryLog: { id: 'sl-2' },
+        data: { tonnage: 15 }
+      }
+    ]
+
+    const result = reconstructDataAtSubmission(
+      versions,
+      new Set(['sl-1', 'sl-2'])
+    )
+
+    expect(result).toEqual({
+      tonnage: 15,
+      material: 'plastic',
+      processingType: 'INPUT'
+    })
+  })
+
+  it('stops at the latest version whose summary log has been seen', () => {
+    const versions = [
+      {
+        status: 'created',
+        summaryLog: { id: 'sl-1' },
+        data: { tonnage: 10, material: 'plastic', processingType: 'INPUT' }
+      },
+      {
+        status: 'updated',
+        summaryLog: { id: 'sl-2' },
+        data: { tonnage: 15 }
+      },
+      {
+        status: 'updated',
+        summaryLog: { id: 'sl-3' },
+        data: { tonnage: 20 }
+      }
+    ]
+
+    const result = reconstructDataAtSubmission(
+      versions,
+      new Set(['sl-1', 'sl-2'])
+    )
+
+    expect(result).toEqual({
+      tonnage: 15,
+      material: 'plastic',
+      processingType: 'INPUT'
+    })
+  })
+})
+
+describe('replayStream', () => {
+  it('returns empty array when given no events', () => {
+    const result = replayStream([])
+
+    expect(result).toEqual([])
+  })
+
+  it('replays a single summary-log-submitted event from zero balance', () => {
+    const events = [
+      {
+        timestamp: new Date('2025-01-01T00:00:00.000Z'),
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'sl-1', creditTotal: 100 },
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1',
+        organisationId: 'org-1'
+      }
+    ]
+
+    const result = replayStream(events)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      number: 1,
+      kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+      openingBalance: { amount: 0, availableAmount: 0 },
+      closingBalance: { amount: 100, availableAmount: 100 }
+    })
+  })
+
+  it('threads balances across multiple events', () => {
+    const events = [
+      {
+        timestamp: new Date('2025-01-01T00:00:00.000Z'),
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'sl-1', creditTotal: 100 },
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1',
+        organisationId: 'org-1'
+      },
+      {
+        timestamp: new Date('2025-01-02T00:00:00.000Z'),
+        kind: STREAM_EVENT_KIND.PRN_CREATED,
+        payload: { prnId: 'prn-1', amount: 30 },
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1',
+        organisationId: 'org-1'
+      }
+    ]
+
+    const result = replayStream(events)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].closingBalance).toEqual({
+      amount: 100,
+      availableAmount: 100
+    })
+    expect(result[1]).toMatchObject({
+      number: 2,
+      openingBalance: { amount: 100, availableAmount: 100 },
+      closingBalance: { amount: 100, availableAmount: 70 }
+    })
+  })
+
+  it('tracks previousCreditTotal across summary-log events', () => {
+    const events = [
+      {
+        timestamp: new Date('2025-01-01T00:00:00.000Z'),
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'sl-1', creditTotal: 100 },
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1',
+        organisationId: 'org-1'
+      },
+      {
+        timestamp: new Date('2025-01-02T00:00:00.000Z'),
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'sl-2', creditTotal: 150 },
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1',
+        organisationId: 'org-1'
+      }
+    ]
+
+    const result = replayStream(events)
+
+    expect(result[0].closingBalance).toEqual({
+      amount: 100,
+      availableAmount: 100
+    })
+    expect(result[1]).toMatchObject({
+      openingBalance: { amount: 100, availableAmount: 100 },
+      closingBalance: { amount: 150, availableAmount: 150 }
+    })
+  })
+})
+
+describe('buildChronologicalEvents', () => {
+  const accreditation = { id: 'acc-1' }
+  const overseasSites = {}
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    findSchemaForProcessingType.mockReturnValue({
+      classifyForWasteBalance: (data) =>
+        data.tonnage === undefined
+          ? { outcome: ROW_OUTCOME.EXCLUDED, transactionAmount: 0 }
+          : includedAt(data.tonnage)
+    })
+  })
+
+  it('returns empty array when no summary logs and no PRNs', () => {
+    const result = buildChronologicalEvents({
+      accreditation,
+      wasteRecords: [],
+      prns: [],
+      overseasSites,
+      summaryLogs: []
+    })
+
+    expect(result).toEqual([])
+  })
+
+  it('emits a summary-log-submitted event with creditTotal from waste records', () => {
+    const summaryLogs = [
+      {
+        id: 'sl-1',
+        status: SUMMARY_LOG_STATUS.SUBMITTED,
+        submittedAt: '2025-01-15T10:00:00.000Z'
+      }
+    ]
+    const wasteRecords = [
+      {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        type: 'received',
+        data: { processingType: 'INPUT', tonnage: 40 },
+        versions: [
+          {
+            summaryLog: { id: 'sl-1' },
+            data: { processingType: 'INPUT', tonnage: 40 }
+          }
+        ],
+        excludedFromWasteBalance: false
+      },
+      {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        type: 'received',
+        data: { processingType: 'INPUT', tonnage: 60 },
+        versions: [
+          {
+            summaryLog: { id: 'sl-1' },
+            data: { processingType: 'INPUT', tonnage: 60 }
+          }
+        ],
+        excludedFromWasteBalance: false
+      }
+    ]
+
+    const result = buildChronologicalEvents({
+      accreditation,
+      wasteRecords,
+      prns: [],
+      overseasSites,
+      summaryLogs
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+      payload: { summaryLogId: 'sl-1', creditTotal: 100 },
+      timestamp: new Date('2025-01-15T10:00:00.000Z')
+    })
+  })
+
+  it('accumulates creditTotal across summary log submissions using version history', () => {
+    const summaryLogs = [
+      {
+        id: 'sl-1',
+        status: SUMMARY_LOG_STATUS.SUBMITTED,
+        submittedAt: '2025-01-15T10:00:00.000Z'
+      },
+      {
+        id: 'sl-2',
+        status: SUMMARY_LOG_STATUS.SUBMITTED,
+        submittedAt: '2025-02-15T10:00:00.000Z'
+      }
+    ]
+    const wasteRecords = [
+      {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        type: 'received',
+        data: { processingType: 'INPUT', tonnage: 50 },
+        versions: [
+          {
+            summaryLog: { id: 'sl-1' },
+            data: { processingType: 'INPUT', tonnage: 40 }
+          },
+          { summaryLog: { id: 'sl-2' }, data: { tonnage: 50 } }
+        ],
+        excludedFromWasteBalance: false
+      }
+    ]
+
+    const result = buildChronologicalEvents({
+      accreditation,
+      wasteRecords,
+      prns: [],
+      overseasSites,
+      summaryLogs
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0].payload).toEqual({ summaryLogId: 'sl-1', creditTotal: 40 })
+    expect(result[1].payload).toEqual({ summaryLogId: 'sl-2', creditTotal: 50 })
+  })
+
+  it('filters out non-submitted summary logs', () => {
+    const summaryLogs = [
+      {
+        id: 'sl-1',
+        status: SUMMARY_LOG_STATUS.SUBMITTED,
+        submittedAt: '2025-01-15T10:00:00.000Z'
+      },
+      {
+        id: 'sl-draft',
+        status: SUMMARY_LOG_STATUS.VALIDATED,
+        submittedAt: undefined
+      }
+    ]
+    const wasteRecords = [
+      {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        type: 'received',
+        data: { processingType: 'INPUT', tonnage: 10 },
+        versions: [
+          {
+            summaryLog: { id: 'sl-1' },
+            data: { processingType: 'INPUT', tonnage: 10 }
+          }
+        ],
+        excludedFromWasteBalance: false
+      }
+    ]
+
+    const result = buildChronologicalEvents({
+      accreditation,
+      wasteRecords,
+      prns: [],
+      overseasSites,
+      summaryLogs
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].payload.summaryLogId).toBe('sl-1')
+  })
+
+  it('emits PRN events from status history transitions', () => {
+    const prns = [
+      {
+        id: 'prn-1',
+        tonnage: 25,
+        status: {
+          history: [
+            {
+              status: PRN_STATUS.DRAFT,
+              at: new Date('2025-01-10T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.AWAITING_AUTHORISATION,
+              at: new Date('2025-01-11T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.AWAITING_ACCEPTANCE,
+              at: new Date('2025-01-12T00:00:00.000Z')
+            }
+          ]
+        }
+      }
+    ]
+
+    const result = buildChronologicalEvents({
+      accreditation,
+      wasteRecords: [],
+      prns,
+      overseasSites,
+      summaryLogs: []
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({
+      kind: STREAM_EVENT_KIND.PRN_CREATED,
+      payload: { prnId: 'prn-1', amount: 25 },
+      timestamp: new Date('2025-01-11T00:00:00.000Z')
+    })
+    expect(result[1]).toMatchObject({
+      kind: STREAM_EVENT_KIND.PRN_ISSUED,
+      payload: { prnId: 'prn-1', amount: 25 },
+      timestamp: new Date('2025-01-12T00:00:00.000Z')
+    })
+  })
+
+  it('skips PRN transitions that do not produce stream events', () => {
+    const prns = [
+      {
+        id: 'prn-1',
+        tonnage: 25,
+        status: {
+          history: [
+            {
+              status: PRN_STATUS.DRAFT,
+              at: new Date('2025-01-10T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.AWAITING_AUTHORISATION,
+              at: new Date('2025-01-11T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.ACCEPTED,
+              at: new Date('2025-01-13T00:00:00.000Z')
+            }
+          ]
+        }
+      }
+    ]
+
+    const result = buildChronologicalEvents({
+      accreditation,
+      wasteRecords: [],
+      prns,
+      overseasSites,
+      summaryLogs: []
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+  })
+})
+
+describe('computeRebuiltStream', () => {
+  const accreditation = { id: 'acc-1' }
+  const overseasSites = {}
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    findSchemaForProcessingType.mockReturnValue({
+      classifyForWasteBalance: (data) =>
+        data.tonnage === undefined
+          ? { outcome: ROW_OUTCOME.EXCLUDED, transactionAmount: 0 }
+          : includedAt(data.tonnage)
+    })
+  })
+
+  it('returns zero totals and empty events when given no inputs', () => {
+    const result = computeRebuiltStream({
+      accreditation,
+      wasteRecords: [],
+      prns: [],
+      overseasSites,
+      summaryLogs: []
+    })
+
+    expect(result).toEqual({
+      events: [],
+      amount: 0,
+      availableAmount: 0,
+      wasteRecordContribution: 0,
+      prnAmountContribution: 0,
+      prnAvailableAmountContribution: 0
+    })
+  })
+
+  it('produces events sorted chronologically and derives correct totals', () => {
+    const summaryLogs = [
+      {
+        id: 'sl-1',
+        status: SUMMARY_LOG_STATUS.SUBMITTED,
+        submittedAt: '2025-01-15T10:00:00.000Z'
+      }
+    ]
+    const wasteRecords = [
+      {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        type: 'received',
+        data: { processingType: 'INPUT', tonnage: 100 },
+        versions: [
+          {
+            summaryLog: { id: 'sl-1' },
+            data: { processingType: 'INPUT', tonnage: 100 }
+          }
+        ],
+        excludedFromWasteBalance: false
+      }
+    ]
+    const prns = [
+      {
+        id: 'prn-1',
+        tonnage: 30,
+        status: {
+          history: [
+            {
+              status: PRN_STATUS.DRAFT,
+              at: new Date('2025-01-20T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.AWAITING_AUTHORISATION,
+              at: new Date('2025-01-21T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.AWAITING_ACCEPTANCE,
+              at: new Date('2025-01-22T00:00:00.000Z')
+            }
+          ]
+        }
+      }
+    ]
+
+    const result = computeRebuiltStream({
+      accreditation,
+      wasteRecords,
+      prns,
+      overseasSites,
+      summaryLogs
+    })
+
+    expect(result.events).toHaveLength(3)
+    expect(result.events[0].kind).toBe(STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
+    expect(result.events[1].kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+    expect(result.events[2].kind).toBe(STREAM_EVENT_KIND.PRN_ISSUED)
+
+    expect(result.amount).toBe(70)
+    expect(result.availableAmount).toBe(70)
+    expect(result.wasteRecordContribution).toBe(100)
+    expect(result.prnAmountContribution).toBe(-30)
+    expect(result.prnAvailableAmountContribution).toBe(-30)
+  })
+
+  it('handles multiple summary logs with version history and interleaved PRNs', () => {
+    const summaryLogs = [
+      {
+        id: 'sl-1',
+        status: SUMMARY_LOG_STATUS.SUBMITTED,
+        submittedAt: '2025-01-10T00:00:00.000Z'
+      },
+      {
+        id: 'sl-2',
+        status: SUMMARY_LOG_STATUS.SUBMITTED,
+        submittedAt: '2025-01-20T00:00:00.000Z'
+      }
+    ]
+    const wasteRecords = [
+      {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        type: 'received',
+        data: { processingType: 'INPUT', tonnage: 60 },
+        versions: [
+          {
+            summaryLog: { id: 'sl-1' },
+            data: { processingType: 'INPUT', tonnage: 40 }
+          },
+          { summaryLog: { id: 'sl-2' }, data: { tonnage: 60 } }
+        ],
+        excludedFromWasteBalance: false
+      }
+    ]
+    const prns = [
+      {
+        id: 'prn-1',
+        tonnage: 10,
+        status: {
+          history: [
+            {
+              status: PRN_STATUS.DRAFT,
+              at: new Date('2025-01-14T00:00:00.000Z')
+            },
+            {
+              status: PRN_STATUS.AWAITING_AUTHORISATION,
+              at: new Date('2025-01-15T00:00:00.000Z')
+            }
+          ]
+        }
+      }
+    ]
+
+    const result = computeRebuiltStream({
+      accreditation,
+      wasteRecords,
+      prns,
+      overseasSites,
+      summaryLogs
+    })
+
+    expect(result.events).toHaveLength(3)
+    // Chronological: sl-1 (Jan 10), prn-created (Jan 15), sl-2 (Jan 20)
+    expect(result.events[0].kind).toBe(STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
+    expect(result.events[0].payload.creditTotal).toBe(40)
+    expect(result.events[1].kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+    expect(result.events[2].kind).toBe(STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
+    expect(result.events[2].payload.creditTotal).toBe(60)
+
+    // Final balance: 60 (waste) - 10 (PRN created, availableAmount only)
+    expect(result.amount).toBe(60)
+    expect(result.availableAmount).toBe(50)
+    expect(result.wasteRecordContribution).toBe(60)
+    expect(result.prnAmountContribution).toBe(0)
+    expect(result.prnAvailableAmountContribution).toBe(-10)
+  })
+})

--- a/src/waste-balances/application/compute-rebuilt-totals.js
+++ b/src/waste-balances/application/compute-rebuilt-totals.js
@@ -1,6 +1,8 @@
 import { add, toNumber } from '#common/helpers/decimal-utils.js'
-import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { getTargetAmount } from './target-amount.js'
+import { prnTransitionToStreamKind } from './compute-rebuilt-stream.js'
+
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
 
 /**
  * @typedef {import('#domain/waste-records/model.js').WasteRecord} WasteRecord
@@ -9,56 +11,24 @@ import { getTargetAmount } from './target-amount.js'
  * @typedef {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} OverseasSitesContext
  */
 
-const REBUILT_TRANSACTION_KIND = Object.freeze({
-  PRN_CREATED: 'prn-created',
-  PRN_ISSUED: 'prn-issued',
-  PRN_CANCELLED_PRE_ISSUE: 'prn-cancelled-pre-issue',
-  PRN_CANCELLED_POST_ISSUE: 'prn-cancelled-post-issue'
-})
-
 const PRN_DELTAS = Object.freeze({
-  [REBUILT_TRANSACTION_KIND.PRN_CREATED]: (tonnage) => ({
+  [STREAM_EVENT_KIND.PRN_CREATED]: (tonnage) => ({
     amount: 0,
     availableAmount: -tonnage
   }),
-  [REBUILT_TRANSACTION_KIND.PRN_ISSUED]: (tonnage) => ({
+  [STREAM_EVENT_KIND.PRN_ISSUED]: (tonnage) => ({
     amount: -tonnage,
     availableAmount: 0
   }),
-  [REBUILT_TRANSACTION_KIND.PRN_CANCELLED_PRE_ISSUE]: (tonnage) => ({
+  [STREAM_EVENT_KIND.PRN_CREATION_CANCELLED]: (tonnage) => ({
     amount: 0,
     availableAmount: tonnage
   }),
-  [REBUILT_TRANSACTION_KIND.PRN_CANCELLED_POST_ISSUE]: (tonnage) => ({
+  [STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE]: (tonnage) => ({
     amount: tonnage,
     availableAmount: tonnage
   })
 })
-
-const prnKindFromTransition = (prevStatus, newStatus) => {
-  if (newStatus === PRN_STATUS.AWAITING_AUTHORISATION) {
-    return REBUILT_TRANSACTION_KIND.PRN_CREATED
-  }
-  if (
-    newStatus === PRN_STATUS.AWAITING_ACCEPTANCE &&
-    prevStatus === PRN_STATUS.AWAITING_AUTHORISATION
-  ) {
-    return REBUILT_TRANSACTION_KIND.PRN_ISSUED
-  }
-  if (
-    (newStatus === PRN_STATUS.CANCELLED || newStatus === PRN_STATUS.DELETED) &&
-    prevStatus === PRN_STATUS.AWAITING_AUTHORISATION
-  ) {
-    return REBUILT_TRANSACTION_KIND.PRN_CANCELLED_PRE_ISSUE
-  }
-  if (
-    newStatus === PRN_STATUS.CANCELLED &&
-    prevStatus === PRN_STATUS.AWAITING_CANCELLATION
-  ) {
-    return REBUILT_TRANSACTION_KIND.PRN_CANCELLED_POST_ISSUE
-  }
-  return null
-}
 
 /**
  * Iterate balance-affecting deltas from a PRN's status history without
@@ -70,7 +40,7 @@ function* prnDeltasOf(prn) {
   const history = prn.status.history
   for (let i = 0; i < history.length; i++) {
     const prevStatus = i === 0 ? null : history[i - 1].status
-    const kind = prnKindFromTransition(prevStatus, history[i].status)
+    const kind = prnTransitionToStreamKind(prevStatus, history[i].status)
     if (!kind) {
       continue
     }

--- a/src/waste-balances/application/stream-closing-balance.js
+++ b/src/waste-balances/application/stream-closing-balance.js
@@ -1,0 +1,62 @@
+import { add, subtract, toNumber } from '#common/helpers/decimal-utils.js'
+
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+
+/**
+ * Compute closing balance for a summary-log-submitted event.
+ *
+ * The caller supplies the aggregate `creditTotal` for this submission.
+ * `delta = creditTotal - previousCreditTotal`. Both `amount` and
+ * `availableAmount` shift by delta.
+ *
+ * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} opening
+ * @param {number} creditTotal
+ * @param {number} previousCreditTotal
+ * @returns {import('../repository/stream-schema.js').StreamBalanceSnapshot}
+ */
+export const closingForSummaryLogSubmitted = (
+  opening,
+  creditTotal,
+  previousCreditTotal
+) => {
+  const delta = subtract(creditTotal, previousCreditTotal)
+  return {
+    amount: toNumber(add(opening.amount, delta)),
+    availableAmount: toNumber(add(opening.availableAmount, delta))
+  }
+}
+
+/**
+ * Compute closing balance for a PRN event.
+ *
+ * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} opening
+ * @param {import('../repository/stream-schema.js').StreamEventKind} kind
+ * @param {number} prnAmount
+ * @returns {import('../repository/stream-schema.js').StreamBalanceSnapshot}
+ */
+export const closingForPrn = (opening, kind, prnAmount) => {
+  switch (kind) {
+    case STREAM_EVENT_KIND.PRN_CREATED:
+      return {
+        amount: opening.amount,
+        availableAmount: toNumber(subtract(opening.availableAmount, prnAmount))
+      }
+    case STREAM_EVENT_KIND.PRN_ISSUED:
+      return {
+        amount: toNumber(subtract(opening.amount, prnAmount)),
+        availableAmount: opening.availableAmount
+      }
+    case STREAM_EVENT_KIND.PRN_CREATION_CANCELLED:
+      return {
+        amount: opening.amount,
+        availableAmount: toNumber(add(opening.availableAmount, prnAmount))
+      }
+    case STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE:
+      return {
+        amount: toNumber(add(opening.amount, prnAmount)),
+        availableAmount: toNumber(add(opening.availableAmount, prnAmount))
+      }
+    default:
+      throw new Error(`Unknown PRN event kind: ${kind}`)
+  }
+}


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

- Extract `closingForSummaryLogSubmitted` and `closingForPrn` from `append-to-stream.js` into a shared `stream-closing-balance.js` module, enabling reuse by both the live stream append path and the new replay function
- Add `computeRebuiltStream`, a pure function that reconstructs the full historical event stream for an accreditation from waste records, summary logs, and PRN status history. Reconstructs waste record data at each historical submission point by layering version data (handling partial updates), interleaves PRN status transition events chronologically, and replays stream balance arithmetic to produce a complete `StreamEventInsert[]` plus the same totals shape as `computeRebuiltTotals`
- Wire `computeRebuiltStream` into the startup divergence diagnostic, extending it from a 2-way comparison (embedded vs rebuilt) to a 3-way comparison (embedded vs rebuilt vs stream replay). The diagnostic now also logs `streamAmount`, `streamAvailableAmount`, `streamDeltaAmount`, `streamDeltaAvailableAmount`, and `streamEventCount` for each divergent accreditation
- Deduplicate PRN transition logic: `prnTransitionToStreamKind` is now the single source of truth, shared by both `computeRebuiltTotals` and `computeRebuiltStream`

## Why

This is groundwork for migrating embedded waste balances to the event-sourced stream model. The reconstructed event stream serves two purposes: seeding the stream store with historical events (full audit trail required), and enabling a 3-way divergence diagnostic to validate the stream replay logic against both the embedded balance and the authoritative-sources rebuild before committing to the migration.

## Event loop considerations

`buildChronologicalEvents` has an O(summaryLogs x wasteRecords) loop per accreditation: for each summary log submission, it iterates all waste records to reconstruct the cumulative `creditTotal` at that point in history. For a typical accreditation (tens of summary logs, hundreds of waste records) this completes in single-digit milliseconds.

The diagnostic processes accreditations sequentially with `await` between each one (for the DB reads in `compareForEmbedded`), so the event loop yields between accreditations. The CPU-bound replay work per accreditation is short enough that it won't cause responsiveness issues. Worth revisiting if individual accreditations grow to thousands of summary logs.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ