### PR TITLE
PAE-1382: Return stream watermark from PRN balance methods

### DIFF
--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -33,7 +33,7 @@ async function deductWasteBalanceIfNeeded(wasteBalancesRepository, params) {
       throw Boom.conflict('Insufficient available waste balance')
     }
 
-    await wasteBalancesRepository.deductAvailableBalanceForPrnCreation({
+    return wasteBalancesRepository.deductAvailableBalanceForPrnCreation({
       accreditationId,
       registrationId,
       organisationId,
@@ -71,7 +71,7 @@ async function deductTotalBalanceIfNeeded(wasteBalancesRepository, params) {
       throw Boom.conflict('Insufficient total waste balance')
     }
 
-    await wasteBalancesRepository.deductTotalBalanceForPrnIssue({
+    return wasteBalancesRepository.deductTotalBalanceForPrnIssue({
       accreditationId,
       registrationId,
       organisationId,
@@ -106,7 +106,7 @@ async function creditWasteBalanceIfNeeded(wasteBalancesRepository, params) {
     await wasteBalancesRepository.findByAccreditationId(accreditationId)
 
   if (balance) {
-    await wasteBalancesRepository.creditAvailableBalanceForPrnCancellation({
+    return wasteBalancesRepository.creditAvailableBalanceForPrnCancellation({
       accreditationId,
       registrationId,
       organisationId,
@@ -141,7 +141,7 @@ async function creditFullBalanceIfNeeded(wasteBalancesRepository, params) {
     await wasteBalancesRepository.findByAccreditationId(accreditationId)
 
   if (balance) {
-    await wasteBalancesRepository.creditFullBalanceForIssuedPrnCancellation({
+    return wasteBalancesRepository.creditFullBalanceForIssuedPrnCancellation({
       accreditationId,
       registrationId,
       organisationId,
@@ -191,6 +191,9 @@ function logWasteBalanceUpdate(
  * @param {WasteBalancesRepository} wasteBalancesRepository
  * @param {import('#common/hapi-types.js').TypedLogger} logger
  * @param {Object} params
+ * @returns {Promise<number|null>} The stream event number applied by the firing
+ *   transition (the watermark) on the ledger path, or `null` on the embedded
+ *   path and when no balance effect fires.
  */
 export async function applyWasteBalanceEffects(
   wasteBalancesRepository,
@@ -200,8 +203,13 @@ export async function applyWasteBalanceEffects(
   const { currentStatus, newStatus, ...balanceParams } = params
   const { prnId, tonnage } = balanceParams
 
+  let lastAppliedEventNumber = null
+
   if (newStatus === PRN_STATUS.AWAITING_AUTHORISATION) {
-    await deductWasteBalanceIfNeeded(wasteBalancesRepository, balanceParams)
+    lastAppliedEventNumber = await deductWasteBalanceIfNeeded(
+      wasteBalancesRepository,
+      balanceParams
+    )
     logWasteBalanceUpdate(
       logger,
       'deduct_available',
@@ -219,7 +227,10 @@ export async function applyWasteBalanceEffects(
     (newStatus === PRN_STATUS.CANCELLED || newStatus === PRN_STATUS.DELETED) &&
     currentStatus === PRN_STATUS.AWAITING_AUTHORISATION
   ) {
-    await creditWasteBalanceIfNeeded(wasteBalancesRepository, balanceParams)
+    lastAppliedEventNumber = await creditWasteBalanceIfNeeded(
+      wasteBalancesRepository,
+      balanceParams
+    )
     logWasteBalanceUpdate(
       logger,
       'credit_available',
@@ -234,7 +245,10 @@ export async function applyWasteBalanceEffects(
     newStatus === PRN_STATUS.CANCELLED &&
     currentStatus === PRN_STATUS.AWAITING_CANCELLATION
   ) {
-    await creditFullBalanceIfNeeded(wasteBalancesRepository, balanceParams)
+    lastAppliedEventNumber = await creditFullBalanceIfNeeded(
+      wasteBalancesRepository,
+      balanceParams
+    )
     logWasteBalanceUpdate(
       logger,
       'credit_full',
@@ -246,7 +260,10 @@ export async function applyWasteBalanceEffects(
   }
 
   if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
-    await deductTotalBalanceIfNeeded(wasteBalancesRepository, balanceParams)
+    lastAppliedEventNumber = await deductTotalBalanceIfNeeded(
+      wasteBalancesRepository,
+      balanceParams
+    )
     logWasteBalanceUpdate(
       logger,
       'deduct_total',
@@ -256,4 +273,6 @@ export async function applyWasteBalanceEffects(
       newStatus
     )
   }
+
+  return lastAppliedEventNumber
 }

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { applyWasteBalanceEffects } from './update-status-balance-effects.js'
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { createInMemoryWasteBalancesRepository } from '#waste-balances/repository/inmemory.js'
+import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { buildStreamEvent } from '#waste-balances/repository/stream-test-data.js'
+
+const REGISTRATION_ID = 'reg-1'
+const ACCREDITATION_ID = 'acc-1'
+const ORGANISATION_ID = 'org-1'
+const SEEDED_EVENT_NUMBER = 1
+const APPENDED_EVENT_NUMBER = 2
+
+const buildLogger = () => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn()
+})
+
+/**
+ * A ledger-backed in-memory repository seeded with one stream event so the
+ * marker-aware read resolves a non-zero balance. The next balance effect
+ * appends a second event, so the returned watermark is APPENDED_EVENT_NUMBER.
+ */
+const setupLedgerRepository = async () => {
+  const streamRepository = createInMemoryStreamRepository()()
+  await streamRepository.appendEvent(
+    buildStreamEvent({
+      registrationId: REGISTRATION_ID,
+      accreditationId: ACCREDITATION_ID,
+      number: SEEDED_EVENT_NUMBER,
+      closingBalance: { amount: 100, availableAmount: 100 }
+    })
+  )
+
+  const ledgerBalance = {
+    id: 'bal-1',
+    organisationId: ORGANISATION_ID,
+    registrationId: REGISTRATION_ID,
+    accreditationId: ACCREDITATION_ID,
+    schemaVersion: 1,
+    version: 1,
+    amount: 0,
+    availableAmount: 0,
+    canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+    transactions: []
+  }
+
+  const wasteBalancesRepository = createInMemoryWasteBalancesRepository(
+    [ledgerBalance],
+    { streamRepository }
+  )()
+
+  return { wasteBalancesRepository, streamRepository }
+}
+
+const balanceParamsFor = (overrides) => ({
+  prnId: 'prn-1',
+  tonnage: 10,
+  accreditationId: ACCREDITATION_ID,
+  registrationId: REGISTRATION_ID,
+  organisationId: ORGANISATION_ID,
+  userId: 'user-1',
+  ...overrides
+})
+
+describe('applyWasteBalanceEffects watermark return', () => {
+  it('returns the appended event number from the deduct-available branch', async () => {
+    const { wasteBalancesRepository, streamRepository } =
+      await setupLedgerRepository()
+
+    const watermark = await applyWasteBalanceEffects(
+      wasteBalancesRepository,
+      buildLogger(),
+      balanceParamsFor({
+        currentStatus: PRN_STATUS.DRAFT,
+        newStatus: PRN_STATUS.AWAITING_AUTHORISATION
+      })
+    )
+
+    const latest = await streamRepository.findLatestByPartition(
+      REGISTRATION_ID,
+      ACCREDITATION_ID
+    )
+    expect(watermark).toBe(latest?.number)
+    expect(watermark).toBe(APPENDED_EVENT_NUMBER)
+  })
+
+  it('returns the appended event number from the deduct-total branch', async () => {
+    const { wasteBalancesRepository, streamRepository } =
+      await setupLedgerRepository()
+
+    const watermark = await applyWasteBalanceEffects(
+      wasteBalancesRepository,
+      buildLogger(),
+      balanceParamsFor({
+        currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+        newStatus: PRN_STATUS.AWAITING_ACCEPTANCE
+      })
+    )
+
+    const latest = await streamRepository.findLatestByPartition(
+      REGISTRATION_ID,
+      ACCREDITATION_ID
+    )
+    expect(watermark).toBe(latest?.number)
+    expect(watermark).toBe(APPENDED_EVENT_NUMBER)
+  })
+
+  it('returns the appended event number from the credit-available branch', async () => {
+    const { wasteBalancesRepository, streamRepository } =
+      await setupLedgerRepository()
+
+    const watermark = await applyWasteBalanceEffects(
+      wasteBalancesRepository,
+      buildLogger(),
+      balanceParamsFor({
+        currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+        newStatus: PRN_STATUS.DELETED
+      })
+    )
+
+    const latest = await streamRepository.findLatestByPartition(
+      REGISTRATION_ID,
+      ACCREDITATION_ID
+    )
+    expect(watermark).toBe(latest?.number)
+    expect(watermark).toBe(APPENDED_EVENT_NUMBER)
+  })
+
+  it('returns the appended event number from the credit-full branch', async () => {
+    const { wasteBalancesRepository, streamRepository } =
+      await setupLedgerRepository()
+
+    const watermark = await applyWasteBalanceEffects(
+      wasteBalancesRepository,
+      buildLogger(),
+      balanceParamsFor({
+        currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
+        newStatus: PRN_STATUS.CANCELLED
+      })
+    )
+
+    const latest = await streamRepository.findLatestByPartition(
+      REGISTRATION_ID,
+      ACCREDITATION_ID
+    )
+    expect(watermark).toBe(latest?.number)
+    expect(watermark).toBe(APPENDED_EVENT_NUMBER)
+  })
+
+  it('returns null when the transition has no balance effect', async () => {
+    const { wasteBalancesRepository } = await setupLedgerRepository()
+
+    const watermark = await applyWasteBalanceEffects(
+      wasteBalancesRepository,
+      buildLogger(),
+      balanceParamsFor({
+        currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+        newStatus: PRN_STATUS.AWAITING_CANCELLATION
+      })
+    )
+
+    expect(watermark).toBeNull()
+  })
+})

--- a/src/waste-balances/repository/contract/creditAvailableBalanceForPrnCancellation.contract.js
+++ b/src/waste-balances/repository/contract/creditAvailableBalanceForPrnCancellation.contract.js
@@ -1,7 +1,10 @@
 import Boom from '@hapi/boom'
 import { describe, beforeEach, expect } from 'vitest'
 import { buildWasteBalance } from './test-data.js'
-import { WASTE_BALANCE_TRANSACTION_ENTITY_TYPE } from '../../domain/model.js'
+import {
+  WASTE_BALANCE_CANONICAL_SOURCE,
+  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
+} from '../../domain/model.js'
 
 export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
   describe('creditAvailableBalanceForPrnCancellation', () => {
@@ -78,6 +81,59 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
           userId: 'user-123'
         })
       ).rejects.toThrow(Boom.Boom)
+    })
+
+    it('returns the appended stream event number on the ledger path', async ({
+      insertWasteBalance,
+      streamRepository
+    }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-cancel-ledger',
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      const watermark =
+        await repository.creditAvailableBalanceForPrnCancellation({
+          accreditationId: 'acc-cancel-ledger',
+          registrationId: 'reg-1',
+          organisationId: 'org-1',
+          prnId: 'prn-ledger',
+          tonnage: 10,
+          userId: 'user-abc'
+        })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        'acc-cancel-ledger'
+      )
+      expect(watermark).toBe(latest.number)
+      expect(watermark).toBe(1)
+    })
+
+    it('returns null on the embedded path', async ({ insertWasteBalance }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-cancel-embedded',
+        organisationId: 'org-1',
+        amount: 500,
+        availableAmount: 350
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      const watermark =
+        await repository.creditAvailableBalanceForPrnCancellation({
+          accreditationId: 'acc-cancel-embedded',
+          organisationId: 'org-1',
+          prnId: 'prn-embedded',
+          tonnage: 10,
+          userId: 'user-abc'
+        })
+
+      expect(watermark).toBeNull()
     })
 
     it('increments version number', async ({ insertWasteBalance }) => {

--- a/src/waste-balances/repository/contract/creditFullBalanceForIssuedPrnCancellation.contract.js
+++ b/src/waste-balances/repository/contract/creditFullBalanceForIssuedPrnCancellation.contract.js
@@ -1,7 +1,10 @@
 import Boom from '@hapi/boom'
 import { describe, beforeEach, expect } from 'vitest'
 import { buildWasteBalance } from './test-data.js'
-import { WASTE_BALANCE_TRANSACTION_ENTITY_TYPE } from '../../domain/model.js'
+import {
+  WASTE_BALANCE_CANONICAL_SOURCE,
+  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
+} from '../../domain/model.js'
 
 export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
   describe('creditFullBalanceForIssuedPrnCancellation', () => {
@@ -78,6 +81,59 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
           userId: 'user-123'
         })
       ).rejects.toThrow(Boom.Boom)
+    })
+
+    it('returns the appended stream event number on the ledger path', async ({
+      insertWasteBalance,
+      streamRepository
+    }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-full-cancel-ledger',
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      const watermark =
+        await repository.creditFullBalanceForIssuedPrnCancellation({
+          accreditationId: 'acc-full-cancel-ledger',
+          registrationId: 'reg-1',
+          organisationId: 'org-1',
+          prnId: 'prn-ledger',
+          tonnage: 10,
+          userId: 'user-abc'
+        })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        'acc-full-cancel-ledger'
+      )
+      expect(watermark).toBe(latest.number)
+      expect(watermark).toBe(1)
+    })
+
+    it('returns null on the embedded path', async ({ insertWasteBalance }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-full-cancel-embedded',
+        organisationId: 'org-1',
+        amount: 400,
+        availableAmount: 350
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      const watermark =
+        await repository.creditFullBalanceForIssuedPrnCancellation({
+          accreditationId: 'acc-full-cancel-embedded',
+          organisationId: 'org-1',
+          prnId: 'prn-embedded',
+          tonnage: 10,
+          userId: 'user-abc'
+        })
+
+      expect(watermark).toBeNull()
     })
 
     it('increments version number', async ({ insertWasteBalance }) => {

--- a/src/waste-balances/repository/contract/deductAvailableBalanceForPrnCreation.contract.js
+++ b/src/waste-balances/repository/contract/deductAvailableBalanceForPrnCreation.contract.js
@@ -1,6 +1,9 @@
 import { describe, beforeEach, expect } from 'vitest'
 import { buildWasteBalance } from './test-data.js'
-import { WASTE_BALANCE_TRANSACTION_ENTITY_TYPE } from '../../domain/model.js'
+import {
+  WASTE_BALANCE_CANONICAL_SOURCE,
+  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
+} from '../../domain/model.js'
 
 export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
   describe('deductAvailableBalanceForPrnCreation', () => {
@@ -67,8 +70,8 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
       )
     })
 
-    it('does nothing when no balance exists', async () => {
-      await repository.deductAvailableBalanceForPrnCreation({
+    it('does nothing and returns null when no balance exists', async () => {
+      const watermark = await repository.deductAvailableBalanceForPrnCreation({
         accreditationId: 'acc-nonexistent',
         organisationId: 'org-1',
         prnId: 'prn-789',
@@ -78,6 +81,58 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
 
       const result = await repository.findByAccreditationId('acc-nonexistent')
       expect(result).toBeNull()
+      expect(watermark).toBeNull()
+    })
+
+    it('returns the appended stream event number on the ledger path', async ({
+      insertWasteBalance,
+      streamRepository
+    }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-prn-ledger',
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      const watermark = await repository.deductAvailableBalanceForPrnCreation({
+        accreditationId: 'acc-prn-ledger',
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        prnId: 'prn-ledger',
+        tonnage: 10,
+        userId: 'user-abc'
+      })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        'acc-prn-ledger'
+      )
+      expect(watermark).toBe(latest.number)
+      expect(watermark).toBe(1)
+    })
+
+    it('returns null on the embedded path', async ({ insertWasteBalance }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-prn-embedded',
+        organisationId: 'org-1',
+        amount: 500,
+        availableAmount: 400
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      const watermark = await repository.deductAvailableBalanceForPrnCreation({
+        accreditationId: 'acc-prn-embedded',
+        organisationId: 'org-1',
+        prnId: 'prn-embedded',
+        tonnage: 10,
+        userId: 'user-abc'
+      })
+
+      expect(watermark).toBeNull()
     })
 
     it('increments version number', async ({ insertWasteBalance }) => {

--- a/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
+++ b/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
@@ -103,8 +103,8 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
       expect(transaction.closingAvailableAmount).toBe(270)
     })
 
-    it('does nothing when no balance exists', async () => {
-      await repository.deductTotalBalanceForPrnIssue({
+    it('does nothing and returns null when no balance exists', async () => {
+      const watermark = await repository.deductTotalBalanceForPrnIssue({
         accreditationId: 'acc-nonexistent',
         organisationId: 'org-1',
         prnId: 'prn-999',
@@ -114,6 +114,58 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
 
       const result = await repository.findByAccreditationId('acc-nonexistent')
       expect(result).toBeNull()
+      expect(watermark).toBeNull()
+    })
+
+    it('returns the appended stream event number on the ledger path', async ({
+      insertWasteBalance,
+      streamRepository
+    }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-issue-ledger',
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      const watermark = await repository.deductTotalBalanceForPrnIssue({
+        accreditationId: 'acc-issue-ledger',
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        prnId: 'prn-ledger',
+        tonnage: 10,
+        userId: 'user-abc'
+      })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        'acc-issue-ledger'
+      )
+      expect(watermark).toBe(latest.number)
+      expect(watermark).toBe(1)
+    })
+
+    it('returns null on the embedded path', async ({ insertWasteBalance }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-issue-embedded',
+        organisationId: 'org-1',
+        amount: 500,
+        availableAmount: 450
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      const watermark = await repository.deductTotalBalanceForPrnIssue({
+        accreditationId: 'acc-issue-embedded',
+        organisationId: 'org-1',
+        prnId: 'prn-embedded',
+        tonnage: 10,
+        userId: 'user-abc'
+      })
+
+      expect(watermark).toBeNull()
     })
 
     it('preserves canonicalSource on update — only the flip method may mutate it', async ({

--- a/src/waste-balances/repository/helpers-prn.js
+++ b/src/waste-balances/repository/helpers-prn.js
@@ -61,6 +61,7 @@ export const buildPrnCreationTransaction = ({
  * @param {number} params.tonnage
  * @param {string} params.userId
  * @param {import('./stream-schema.js').StreamEventKind} params.streamKind
+ * @returns {Promise<number>} The event number of the appended event (the watermark).
  */
 const appendPrnStreamEvent = async ({
   streamRepository,
@@ -72,7 +73,7 @@ const appendPrnStreamEvent = async ({
   userId,
   streamKind
 }) => {
-  await appendToStream(
+  const event = await appendToStream(
     {
       repository: streamRepository,
       registrationId,
@@ -85,6 +86,7 @@ const appendPrnStreamEvent = async ({
       createdBy: { id: userId, name: userId }
     }
   )
+  return event.number
 }
 
 /**
@@ -96,6 +98,8 @@ const appendPrnStreamEvent = async ({
  * @param {(balance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>} params.saveBalance
  * @param {Object} [params.dependencies]
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} [params.dependencies.streamRepository]
+ * @returns {Promise<number|null>} The appended event number on the ledger path,
+ *   or `null` on the embedded path and when no balance exists.
  */
 export const performDeductAvailableBalanceForPrnCreation = async ({
   deductParams,
@@ -116,14 +120,14 @@ export const performDeductAvailableBalanceForPrnCreation = async ({
   const wasteBalance = await findBalance(validatedAccreditationId)
 
   if (!wasteBalance) {
-    return
+    return null
   }
 
   if (
     wasteBalance.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER &&
     dependencies?.streamRepository
   ) {
-    await appendPrnStreamEvent({
+    return appendPrnStreamEvent({
       streamRepository: dependencies.streamRepository,
       registrationId,
       accreditationId: validatedAccreditationId,
@@ -133,7 +137,6 @@ export const performDeductAvailableBalanceForPrnCreation = async ({
       userId,
       streamKind: STREAM_EVENT_KIND.PRN_CREATED
     })
-    return
   }
 
   const transaction = buildPrnCreationTransaction({
@@ -151,6 +154,8 @@ export const performDeductAvailableBalanceForPrnCreation = async ({
   }
 
   await saveBalance(updatedBalance, [transaction])
+
+  return null
 }
 
 /**
@@ -198,6 +203,8 @@ export const buildPrnIssuedTransaction = ({
  * @param {(balance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>} params.saveBalance
  * @param {Object} [params.dependencies]
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} [params.dependencies.streamRepository]
+ * @returns {Promise<number|null>} The appended event number on the ledger path,
+ *   or `null` on the embedded path and when no balance exists.
  */
 export const performDeductTotalBalanceForPrnIssue = async ({
   deductParams,
@@ -218,14 +225,14 @@ export const performDeductTotalBalanceForPrnIssue = async ({
   const wasteBalance = await findBalance(validatedAccreditationId)
 
   if (!wasteBalance) {
-    return
+    return null
   }
 
   if (
     wasteBalance.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER &&
     dependencies?.streamRepository
   ) {
-    await appendPrnStreamEvent({
+    return appendPrnStreamEvent({
       streamRepository: dependencies.streamRepository,
       registrationId,
       accreditationId: validatedAccreditationId,
@@ -235,7 +242,6 @@ export const performDeductTotalBalanceForPrnIssue = async ({
       userId,
       streamKind: STREAM_EVENT_KIND.PRN_ISSUED
     })
-    return
   }
 
   const transaction = buildPrnIssuedTransaction({
@@ -253,6 +259,8 @@ export const performDeductTotalBalanceForPrnIssue = async ({
   }
 
   await saveBalance(updatedBalance, [transaction])
+
+  return null
 }
 
 /**
@@ -342,6 +350,8 @@ export const buildIssuedPrnCancellationTransaction = ({
  * @param {(balance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>} params.saveBalance
  * @param {Object} [params.dependencies]
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} [params.dependencies.streamRepository]
+ * @returns {Promise<number|null>} The appended event number on the ledger path,
+ *   or `null` on the embedded path. Throws when no balance exists.
  */
 export const performCreditFullBalanceForIssuedPrnCancellation = async ({
   creditParams,
@@ -371,7 +381,7 @@ export const performCreditFullBalanceForIssuedPrnCancellation = async ({
     wasteBalance.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER &&
     dependencies?.streamRepository
   ) {
-    await appendPrnStreamEvent({
+    return appendPrnStreamEvent({
       streamRepository: dependencies.streamRepository,
       registrationId,
       accreditationId: validatedAccreditationId,
@@ -381,7 +391,6 @@ export const performCreditFullBalanceForIssuedPrnCancellation = async ({
       userId,
       streamKind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE
     })
-    return
   }
 
   const transaction = buildIssuedPrnCancellationTransaction({
@@ -400,6 +409,8 @@ export const performCreditFullBalanceForIssuedPrnCancellation = async ({
   }
 
   await saveBalance(updatedBalance, [transaction])
+
+  return null
 }
 
 /**
@@ -411,6 +422,8 @@ export const performCreditFullBalanceForIssuedPrnCancellation = async ({
  * @param {(balance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>} params.saveBalance
  * @param {Object} [params.dependencies]
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} [params.dependencies.streamRepository]
+ * @returns {Promise<number|null>} The appended event number on the ledger path,
+ *   or `null` on the embedded path. Throws when no balance exists.
  */
 export const performCreditAvailableBalanceForPrnCancellation = async ({
   creditParams,
@@ -440,7 +453,7 @@ export const performCreditAvailableBalanceForPrnCancellation = async ({
     wasteBalance.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER &&
     dependencies?.streamRepository
   ) {
-    await appendPrnStreamEvent({
+    return appendPrnStreamEvent({
       streamRepository: dependencies.streamRepository,
       registrationId,
       accreditationId: validatedAccreditationId,
@@ -450,7 +463,6 @@ export const performCreditAvailableBalanceForPrnCancellation = async ({
       userId,
       streamKind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED
     })
-    return
   }
 
   const transaction = buildPrnCancellationTransaction({
@@ -468,4 +480,6 @@ export const performCreditAvailableBalanceForPrnCancellation = async ({
   }
 
   await saveBalance(updatedBalance, [transaction])
+
+  return null
 }

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -60,7 +60,7 @@ vi.mock('../application/update-via-stream.js', () => ({
 }))
 
 vi.mock('../application/append-to-stream.js', () => ({
-  appendToStream: vi.fn().mockResolvedValue(undefined)
+  appendToStream: vi.fn().mockResolvedValue({ number: 1 })
 }))
 
 describe('src/waste-balances/repository/helpers.js', () => {

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -109,10 +109,18 @@
  * @property {(accreditationId: string) => Promise<import('../domain/model.js').WasteBalance | null>} findByAccreditationId
  * @property {(accreditationIds: string[]) => Promise<import('../domain/model.js').WasteBalance[]>} findByAccreditationIds
  * @property {(wasteRecords: import('#domain/waste-records/model.js').WasteRecord[], options: { user: import('#domain/summary-logs/worker/port.js').SubmitUser, accreditation: import('#domain/organisations/accreditation.js').Accreditation, overseasSites: import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext, summaryLogId: string }) => Promise<void>} updateWasteBalanceTransactions
- * @property {(params: DeductAvailableBalanceParams) => Promise<void>} deductAvailableBalanceForPrnCreation
- * @property {(params: DeductTotalBalanceParams) => Promise<void>} deductTotalBalanceForPrnIssue
- * @property {(params: CreditAvailableBalanceParams) => Promise<void>} creditAvailableBalanceForPrnCancellation
- * @property {(params: CreditFullBalanceParams) => Promise<void>} creditFullBalanceForIssuedPrnCancellation
+ * @property {(params: DeductAvailableBalanceParams) => Promise<number|null>} deductAvailableBalanceForPrnCreation
+ *   Resolves to the appended stream event number on the ledger path, or `null`
+ *   on the embedded path (and when no balance exists).
+ * @property {(params: DeductTotalBalanceParams) => Promise<number|null>} deductTotalBalanceForPrnIssue
+ *   Resolves to the appended stream event number on the ledger path, or `null`
+ *   on the embedded path (and when no balance exists).
+ * @property {(params: CreditAvailableBalanceParams) => Promise<number|null>} creditAvailableBalanceForPrnCancellation
+ *   Resolves to the appended stream event number on the ledger path, or `null`
+ *   on the embedded path.
+ * @property {(params: CreditFullBalanceParams) => Promise<number|null>} creditFullBalanceForIssuedPrnCancellation
+ *   Resolves to the appended stream event number on the ledger path, or `null`
+ *   on the embedded path.
  * @property {(params: FlipCanonicalSourceToMigratingParams) => Promise<FlipCanonicalSourceToMigratingResult>} flipCanonicalSourceToMigrating
  *   Promote an `'embedded'` accreditation to `'migrating'` and stamp
  *   `migratingSince`, gated on `version` matching the captured value. The


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
The waste-balance write path is migrating from an embedded MongoDB document to an event-sourced stream. Each stream event carries a monotonic event number; a later change will stamp that number onto the PRN document as a watermark so the read side can tell when it has caught up to a given write. `appendToStream` already returns the appended event including its number, but the PRN balance methods awaited and discarded it.

This change returns that event number (the watermark) out through the four balance-affecting PRN methods and up through the application layer, giving the forthcoming stamping work a value to stamp.

What changed:

- The four balance-affecting PRN repository methods (`deductAvailableBalanceForPrnCreation`, `deductTotalBalanceForPrnIssue`, `creditAvailableBalanceForPrnCancellation`, `creditFullBalanceForIssuedPrnCancellation`) now return the appended event number on the ledger path and `null` on the embedded path. Their port typedefs change from `Promise<void>` to `Promise<number|null>`.
- `appendPrnStreamEvent` returns the appended event's number rather than discarding it.
- `applyWasteBalanceEffects` returns the watermark from whichever balance effect fires, and `null` when a transition has no balance effect.

This is pure additive plumbing — no caller consumes the return value yet, so observable behaviour is unchanged. Contract tests cover the number-on-ledger and null-on-embedded cases against both repository adapters, and a unit test covers branch selection in the application layer.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ