### PR TITLE
PAE-1382: Write PRN balance events first on the ledger path

### DIFF
--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -196,13 +196,21 @@ function logWasteBalanceUpdate(
  * @returns {boolean}
  */
 export function affectsWasteBalance(currentStatus, newStatus) {
+  const deductsAvailableOnCreation =
+    newStatus === PRN_STATUS.AWAITING_AUTHORISATION
+  const deductsTotalOnIssue = newStatus === PRN_STATUS.AWAITING_ACCEPTANCE
+  const creditsAvailableOnPreIssueCancellation =
+    (newStatus === PRN_STATUS.CANCELLED || newStatus === PRN_STATUS.DELETED) &&
+    currentStatus === PRN_STATUS.AWAITING_AUTHORISATION
+  const creditsFullOnIssuedCancellation =
+    newStatus === PRN_STATUS.CANCELLED &&
+    currentStatus === PRN_STATUS.AWAITING_CANCELLATION
+
   return (
-    newStatus === PRN_STATUS.AWAITING_AUTHORISATION ||
-    newStatus === PRN_STATUS.AWAITING_ACCEPTANCE ||
-    ((newStatus === PRN_STATUS.CANCELLED || newStatus === PRN_STATUS.DELETED) &&
-      currentStatus === PRN_STATUS.AWAITING_AUTHORISATION) ||
-    (newStatus === PRN_STATUS.CANCELLED &&
-      currentStatus === PRN_STATUS.AWAITING_CANCELLATION)
+    deductsAvailableOnCreation ||
+    deductsTotalOnIssue ||
+    creditsAvailableOnPreIssueCancellation ||
+    creditsFullOnIssuedCancellation
   )
 }
 

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -185,6 +185,28 @@ function logWasteBalanceUpdate(
 }
 
 /**
+ * Whether a status transition fires a waste balance effect. The four cases
+ * mirror the firing branches in {@link applyWasteBalanceEffects} exactly: a
+ * caller that needs to know whether a balance write will happen (to choose the
+ * write ordering before any side effect runs) must agree with what the effects
+ * actually do.
+ *
+ * @param {import('#packaging-recycling-notes/domain/model.js').PrnStatus} currentStatus
+ * @param {import('#packaging-recycling-notes/domain/model.js').PrnStatus} newStatus
+ * @returns {boolean}
+ */
+export function affectsWasteBalance(currentStatus, newStatus) {
+  return (
+    newStatus === PRN_STATUS.AWAITING_AUTHORISATION ||
+    newStatus === PRN_STATUS.AWAITING_ACCEPTANCE ||
+    ((newStatus === PRN_STATUS.CANCELLED || newStatus === PRN_STATUS.DELETED) &&
+      currentStatus === PRN_STATUS.AWAITING_AUTHORISATION) ||
+    (newStatus === PRN_STATUS.CANCELLED &&
+      currentStatus === PRN_STATUS.AWAITING_CANCELLATION)
+  )
+}
+
+/**
  * Applies waste balance side effects for a status transition.
  * Each transition type is mutually exclusive based on newStatus.
  *

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -5,9 +5,35 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/event.js'
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
 
 /**
  * @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository
+ * @typedef {import('#packaging-recycling-notes/domain/model.js').PrnStatus} PrnStatus
+ * @typedef {import('#waste-balances/repository/stream-schema.js').StreamEventKind} StreamEventKind
+ */
+
+/**
+ * Payload carried by a balance event — what the embedded path needs to mutate
+ * the balance, what the stream path needs to append, and what the logger needs
+ * for ops correlation. `currentStatus`/`newStatus` are transition metadata
+ * preserved for logging only.
+ *
+ * @typedef {Object} BalanceEventParams
+ * @property {PrnStatus} currentStatus
+ * @property {PrnStatus} newStatus
+ * @property {string} accreditationId
+ * @property {string} registrationId
+ * @property {string} organisationId
+ * @property {string} prnId
+ * @property {number} tonnage
+ * @property {string} userId
+ */
+
+/**
+ * @typedef {Object} BalanceEvent
+ * @property {StreamEventKind} kind
+ * @property {BalanceEventParams} params
  */
 
 /**
@@ -185,124 +211,93 @@ function logWasteBalanceUpdate(
 }
 
 /**
- * Whether a status transition fires a waste balance effect. The four cases
- * mirror the firing branches in {@link applyWasteBalanceEffects} exactly: a
- * caller that needs to know whether a balance write will happen (to choose the
- * write ordering before any side effect runs) must agree with what the effects
- * actually do.
+ * Derives the balance events a status transition would write. An empty array
+ * means the transition has no balance effect — callers use that to skip the
+ * stream-write decision read entirely. The kinds align with `STREAM_EVENT_KIND`
+ * so the live-write path, backfill, and the stream itself share one vocabulary.
  *
- * @param {import('#packaging-recycling-notes/domain/model.js').PrnStatus} currentStatus
- * @param {import('#packaging-recycling-notes/domain/model.js').PrnStatus} newStatus
- * @returns {boolean}
+ * @param {PrnStatus} currentStatus
+ * @param {PrnStatus} newStatus
+ * @param {BalanceEventParams} params
+ * @returns {BalanceEvent[]}
  */
-export function affectsWasteBalance(currentStatus, newStatus) {
-  const deductsAvailableOnCreation =
-    newStatus === PRN_STATUS.AWAITING_AUTHORISATION
-  const deductsTotalOnIssue = newStatus === PRN_STATUS.AWAITING_ACCEPTANCE
-  const creditsAvailableOnPreIssueCancellation =
+export function balanceEventsFor(currentStatus, newStatus, params) {
+  if (newStatus === PRN_STATUS.AWAITING_AUTHORISATION) {
+    return [{ kind: STREAM_EVENT_KIND.PRN_CREATED, params }]
+  }
+  if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
+    return [{ kind: STREAM_EVENT_KIND.PRN_ISSUED, params }]
+  }
+  if (
     (newStatus === PRN_STATUS.CANCELLED || newStatus === PRN_STATUS.DELETED) &&
     currentStatus === PRN_STATUS.AWAITING_AUTHORISATION
-  const creditsFullOnIssuedCancellation =
+  ) {
+    return [{ kind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED, params }]
+  }
+  if (
     newStatus === PRN_STATUS.CANCELLED &&
     currentStatus === PRN_STATUS.AWAITING_CANCELLATION
-
-  return (
-    deductsAvailableOnCreation ||
-    deductsTotalOnIssue ||
-    creditsAvailableOnPreIssueCancellation ||
-    creditsFullOnIssuedCancellation
-  )
+  ) {
+    return [{ kind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE, params }]
+  }
+  return []
 }
 
 /**
- * Applies waste balance side effects for a status transition.
- * Each transition type is mutually exclusive based on newStatus.
+ * Per-kind dispatch: each kind pairs an effect handler with its log-operation
+ * label. The handlers are the same primitives the embedded path has always
+ * used; on the ledger path they append a stream event and return its number.
+ */
+const EFFECT_HANDLERS = Object.freeze({
+  [STREAM_EVENT_KIND.PRN_CREATED]: {
+    apply: deductWasteBalanceIfNeeded,
+    logOperation: 'deduct_available'
+  },
+  [STREAM_EVENT_KIND.PRN_ISSUED]: {
+    apply: deductTotalBalanceIfNeeded,
+    logOperation: 'deduct_total'
+  },
+  [STREAM_EVENT_KIND.PRN_CREATION_CANCELLED]: {
+    apply: creditWasteBalanceIfNeeded,
+    logOperation: 'credit_available'
+  },
+  [STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE]: {
+    apply: creditFullBalanceIfNeeded,
+    logOperation: 'credit_full'
+  }
+})
+
+/**
+ * Applies the balance events for a status transition. Returns the last applied
+ * event's number (the watermark) on the ledger path, or `null` on the embedded
+ * path and when the events array is empty.
  *
  * @param {WasteBalancesRepository} wasteBalancesRepository
  * @param {import('#common/hapi-types.js').TypedLogger} logger
- * @param {Object} params
- * @returns {Promise<number|null>} The stream event number applied by the firing
- *   transition (the watermark) on the ledger path, or `null` on the embedded
- *   path and when no balance effect fires.
+ * @param {BalanceEvent[]} events
+ * @returns {Promise<number|null>}
  */
 export async function applyWasteBalanceEffects(
   wasteBalancesRepository,
   logger,
-  params
+  events
 ) {
-  const { currentStatus, newStatus, ...balanceParams } = params
-  const { prnId, tonnage } = balanceParams
-
   let lastAppliedEventNumber = null
-
-  if (newStatus === PRN_STATUS.AWAITING_AUTHORISATION) {
-    lastAppliedEventNumber = await deductWasteBalanceIfNeeded(
+  for (const event of events) {
+    const handler = EFFECT_HANDLERS[event.kind]
+    const { currentStatus, newStatus, ...balanceParams } = event.params
+    lastAppliedEventNumber = await handler.apply(
       wasteBalancesRepository,
       balanceParams
     )
     logWasteBalanceUpdate(
       logger,
-      'deduct_available',
-      prnId,
-      tonnage,
+      handler.logOperation,
+      balanceParams.prnId,
+      balanceParams.tonnage,
       currentStatus,
       newStatus
     )
   }
-
-  // AWAITING_AUTHORISATION -> CANCELLED is rejected by validateTransition; only the
-  // DELETED leg is reachable here, but the OR is kept defensively as the credit
-  // semantics are identical for both targets.
-  if (
-    (newStatus === PRN_STATUS.CANCELLED || newStatus === PRN_STATUS.DELETED) &&
-    currentStatus === PRN_STATUS.AWAITING_AUTHORISATION
-  ) {
-    lastAppliedEventNumber = await creditWasteBalanceIfNeeded(
-      wasteBalancesRepository,
-      balanceParams
-    )
-    logWasteBalanceUpdate(
-      logger,
-      'credit_available',
-      prnId,
-      tonnage,
-      currentStatus,
-      newStatus
-    )
-  }
-
-  if (
-    newStatus === PRN_STATUS.CANCELLED &&
-    currentStatus === PRN_STATUS.AWAITING_CANCELLATION
-  ) {
-    lastAppliedEventNumber = await creditFullBalanceIfNeeded(
-      wasteBalancesRepository,
-      balanceParams
-    )
-    logWasteBalanceUpdate(
-      logger,
-      'credit_full',
-      prnId,
-      tonnage,
-      currentStatus,
-      newStatus
-    )
-  }
-
-  if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
-    lastAppliedEventNumber = await deductTotalBalanceIfNeeded(
-      wasteBalancesRepository,
-      balanceParams
-    )
-    logWasteBalanceUpdate(
-      logger,
-      'deduct_total',
-      prnId,
-      tonnage,
-      currentStatus,
-      newStatus
-    )
-  }
-
   return lastAppliedEventNumber
 }

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
@@ -2,12 +2,13 @@ import { describe, it, expect, vi } from 'vitest'
 
 import {
   applyWasteBalanceEffects,
-  affectsWasteBalance
+  balanceEventsFor
 } from './update-status-balance-effects.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { createInMemoryWasteBalancesRepository } from '#waste-balances/repository/inmemory.js'
 import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
 import { buildStreamEvent } from '#waste-balances/repository/stream-test-data.js'
 
 const REGISTRATION_ID = 'reg-1'
@@ -73,6 +74,13 @@ const balanceParamsFor = (overrides) => ({
   ...overrides
 })
 
+const eventsForTransition = (currentStatus, newStatus) =>
+  balanceEventsFor(
+    currentStatus,
+    newStatus,
+    balanceParamsFor({ currentStatus, newStatus })
+  )
+
 describe('applyWasteBalanceEffects watermark return', () => {
   it('returns the appended event number from the deduct-available branch', async () => {
     const { wasteBalancesRepository, streamRepository } =
@@ -81,10 +89,7 @@ describe('applyWasteBalanceEffects watermark return', () => {
     const watermark = await applyWasteBalanceEffects(
       wasteBalancesRepository,
       buildLogger(),
-      balanceParamsFor({
-        currentStatus: PRN_STATUS.DRAFT,
-        newStatus: PRN_STATUS.AWAITING_AUTHORISATION
-      })
+      eventsForTransition(PRN_STATUS.DRAFT, PRN_STATUS.AWAITING_AUTHORISATION)
     )
 
     const latest = await streamRepository.findLatestByPartition(
@@ -102,10 +107,10 @@ describe('applyWasteBalanceEffects watermark return', () => {
     const watermark = await applyWasteBalanceEffects(
       wasteBalancesRepository,
       buildLogger(),
-      balanceParamsFor({
-        currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
-        newStatus: PRN_STATUS.AWAITING_ACCEPTANCE
-      })
+      eventsForTransition(
+        PRN_STATUS.AWAITING_AUTHORISATION,
+        PRN_STATUS.AWAITING_ACCEPTANCE
+      )
     )
 
     const latest = await streamRepository.findLatestByPartition(
@@ -123,10 +128,7 @@ describe('applyWasteBalanceEffects watermark return', () => {
     const watermark = await applyWasteBalanceEffects(
       wasteBalancesRepository,
       buildLogger(),
-      balanceParamsFor({
-        currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
-        newStatus: PRN_STATUS.DELETED
-      })
+      eventsForTransition(PRN_STATUS.AWAITING_AUTHORISATION, PRN_STATUS.DELETED)
     )
 
     const latest = await streamRepository.findLatestByPartition(
@@ -144,10 +146,10 @@ describe('applyWasteBalanceEffects watermark return', () => {
     const watermark = await applyWasteBalanceEffects(
       wasteBalancesRepository,
       buildLogger(),
-      balanceParamsFor({
-        currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
-        newStatus: PRN_STATUS.CANCELLED
-      })
+      eventsForTransition(
+        PRN_STATUS.AWAITING_CANCELLATION,
+        PRN_STATUS.CANCELLED
+      )
     )
 
     const latest = await streamRepository.findLatestByPartition(
@@ -158,71 +160,88 @@ describe('applyWasteBalanceEffects watermark return', () => {
     expect(watermark).toBe(APPENDED_EVENT_NUMBER)
   })
 
-  it('returns null when the transition has no balance effect', async () => {
+  it('returns null when the events array is empty', async () => {
     const { wasteBalancesRepository } = await setupLedgerRepository()
 
     const watermark = await applyWasteBalanceEffects(
       wasteBalancesRepository,
       buildLogger(),
-      balanceParamsFor({
-        currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
-        newStatus: PRN_STATUS.AWAITING_CANCELLATION
-      })
+      []
     )
 
     expect(watermark).toBeNull()
   })
 })
 
-describe('affectsWasteBalance', () => {
-  it('is true for PRN creation', () => {
-    expect(
-      affectsWasteBalance(PRN_STATUS.DRAFT, PRN_STATUS.AWAITING_AUTHORISATION)
-    ).toBe(true)
+describe('balanceEventsFor', () => {
+  const params = balanceParamsFor({
+    currentStatus: PRN_STATUS.DRAFT,
+    newStatus: PRN_STATUS.AWAITING_AUTHORISATION
   })
 
-  it('is true for PRN issuance', () => {
+  it('emits a prn-created event for PRN creation', () => {
     expect(
-      affectsWasteBalance(
+      balanceEventsFor(
+        PRN_STATUS.DRAFT,
         PRN_STATUS.AWAITING_AUTHORISATION,
-        PRN_STATUS.AWAITING_ACCEPTANCE
+        params
       )
-    ).toBe(true)
+    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_CREATED, params }])
   })
 
-  it('is true for deleting a PRN awaiting authorisation', () => {
+  it('emits a prn-issued event for PRN issuance', () => {
     expect(
-      affectsWasteBalance(PRN_STATUS.AWAITING_AUTHORISATION, PRN_STATUS.DELETED)
-    ).toBe(true)
-  })
-
-  it('is true for cancelling an issued PRN', () => {
-    expect(
-      affectsWasteBalance(
-        PRN_STATUS.AWAITING_CANCELLATION,
-        PRN_STATUS.CANCELLED
-      )
-    ).toBe(true)
-  })
-
-  it('is false for accepting an issued PRN', () => {
-    expect(
-      affectsWasteBalance(PRN_STATUS.AWAITING_ACCEPTANCE, PRN_STATUS.ACCEPTED)
-    ).toBe(false)
-  })
-
-  it('is false for requesting cancellation of an issued PRN', () => {
-    expect(
-      affectsWasteBalance(
+      balanceEventsFor(
+        PRN_STATUS.AWAITING_AUTHORISATION,
         PRN_STATUS.AWAITING_ACCEPTANCE,
-        PRN_STATUS.AWAITING_CANCELLATION
+        params
       )
-    ).toBe(false)
+    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_ISSUED, params }])
   })
 
-  it('is false for discarding a draft PRN', () => {
-    expect(affectsWasteBalance(PRN_STATUS.DRAFT, PRN_STATUS.DISCARDED)).toBe(
-      false
-    )
+  it('emits a prn-creation-cancelled event for deleting a PRN awaiting authorisation', () => {
+    expect(
+      balanceEventsFor(
+        PRN_STATUS.AWAITING_AUTHORISATION,
+        PRN_STATUS.DELETED,
+        params
+      )
+    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED, params }])
+  })
+
+  it('emits a prn-cancelled-after-issue event for cancelling an issued PRN', () => {
+    expect(
+      balanceEventsFor(
+        PRN_STATUS.AWAITING_CANCELLATION,
+        PRN_STATUS.CANCELLED,
+        params
+      )
+    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE, params }])
+  })
+
+  it('emits no events when accepting an issued PRN', () => {
+    expect(
+      balanceEventsFor(
+        PRN_STATUS.AWAITING_ACCEPTANCE,
+        PRN_STATUS.ACCEPTED,
+        params
+      )
+    ).toEqual([])
+  })
+
+  it('emits no events when requesting cancellation of an issued PRN', () => {
+    expect(
+      balanceEventsFor(
+        PRN_STATUS.AWAITING_ACCEPTANCE,
+        PRN_STATUS.AWAITING_CANCELLATION,
+        params
+      )
+    ).toEqual([])
+  })
+
+  it('emits no events when discarding a draft PRN', () => {
+    expect(
+      balanceEventsFor(PRN_STATUS.DRAFT, PRN_STATUS.DISCARDED, params)
+    ).toEqual([])
   })
 })

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from 'vitest'
 
-import { applyWasteBalanceEffects } from './update-status-balance-effects.js'
+import {
+  applyWasteBalanceEffects,
+  affectsWasteBalance
+} from './update-status-balance-effects.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { createInMemoryWasteBalancesRepository } from '#waste-balances/repository/inmemory.js'
 import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
@@ -168,5 +171,58 @@ describe('applyWasteBalanceEffects watermark return', () => {
     )
 
     expect(watermark).toBeNull()
+  })
+})
+
+describe('affectsWasteBalance', () => {
+  it('is true for PRN creation', () => {
+    expect(
+      affectsWasteBalance(PRN_STATUS.DRAFT, PRN_STATUS.AWAITING_AUTHORISATION)
+    ).toBe(true)
+  })
+
+  it('is true for PRN issuance', () => {
+    expect(
+      affectsWasteBalance(
+        PRN_STATUS.AWAITING_AUTHORISATION,
+        PRN_STATUS.AWAITING_ACCEPTANCE
+      )
+    ).toBe(true)
+  })
+
+  it('is true for deleting a PRN awaiting authorisation', () => {
+    expect(
+      affectsWasteBalance(PRN_STATUS.AWAITING_AUTHORISATION, PRN_STATUS.DELETED)
+    ).toBe(true)
+  })
+
+  it('is true for cancelling an issued PRN', () => {
+    expect(
+      affectsWasteBalance(
+        PRN_STATUS.AWAITING_CANCELLATION,
+        PRN_STATUS.CANCELLED
+      )
+    ).toBe(true)
+  })
+
+  it('is false for accepting an issued PRN', () => {
+    expect(
+      affectsWasteBalance(PRN_STATUS.AWAITING_ACCEPTANCE, PRN_STATUS.ACCEPTED)
+    ).toBe(false)
+  })
+
+  it('is false for requesting cancellation of an issued PRN', () => {
+    expect(
+      affectsWasteBalance(
+        PRN_STATUS.AWAITING_ACCEPTANCE,
+        PRN_STATUS.AWAITING_CANCELLATION
+      )
+    ).toBe(false)
+  })
+
+  it('is false for discarding a draft PRN', () => {
+    expect(affectsWasteBalance(PRN_STATUS.DRAFT, PRN_STATUS.DISCARDED)).toBe(
+      false
+    )
   })
 })

--- a/src/packaging-recycling-notes/application/update-status-stream.test.js
+++ b/src/packaging-recycling-notes/application/update-status-stream.test.js
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import {
+  PRN_STATUS,
+  PRN_ACTOR,
+  SuspendedAccreditationError
+} from '#packaging-recycling-notes/domain/model.js'
+import { REGULATOR } from '#domain/organisations/model.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+
+vi.mock('./metrics.js', () => ({
+  prnMetrics: {
+    recordStatusTransition: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+const { updatePrnStatus } = await import('./update-status.js')
+
+const ORG_ID = 'org-123'
+const ACC_ID = 'acc-456'
+const REG_ID = 'reg-789'
+const PRN_ID = '507f1f77bcf86cd799439011'
+const TONNAGE = 50
+const APPENDED_WATERMARK = 5
+
+const buildLogger = () => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  fatal: vi.fn()
+})
+
+const buildLedgerBalance = (overrides = {}) => ({
+  accreditationId: ACC_ID,
+  amount: 1000,
+  availableAmount: 1000,
+  canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+  ...overrides
+})
+
+const buildPrn = (overrides = {}) => ({
+  id: PRN_ID,
+  organisation: { id: ORG_ID },
+  accreditation: { id: ACC_ID, accreditationYear: 2026, material: 'plastic' },
+  isExport: false,
+  tonnage: TONNAGE,
+  version: 3,
+  status: { currentStatus: PRN_STATUS.DRAFT },
+  ...overrides
+})
+
+const buildOrganisationsRepository = (accreditation = {}) => ({
+  findAccreditationById: vi.fn().mockResolvedValue({
+    submittedToRegulator: REGULATOR.EA,
+    ...accreditation
+  })
+})
+
+const callUpdate = (overrides) =>
+  updatePrnStatus({
+    logger: buildLogger(),
+    id: PRN_ID,
+    organisationId: ORG_ID,
+    registrationId: REG_ID,
+    accreditationId: ACC_ID,
+    user: { id: 'user-789', name: 'Test User' },
+    ...overrides
+  })
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('updatePrnStatus on the ledger (event-first) path', () => {
+  it('stamps the appended watermark onto the PRN document when creating', async () => {
+    const updateStatus = vi.fn().mockResolvedValue(buildPrn())
+    const prnRepository = { findById: vi.fn(), updateStatus }
+    const wasteBalancesRepository = {
+      findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
+      deductAvailableBalanceForPrnCreation: vi
+        .fn()
+        .mockResolvedValue(APPENDED_WATERMARK)
+    }
+
+    await callUpdate({
+      prnRepository,
+      wasteBalancesRepository,
+      organisationsRepository: buildOrganisationsRepository(),
+      providedPrn: buildPrn({ status: { currentStatus: PRN_STATUS.DRAFT } }),
+      newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+      actor: PRN_ACTOR.REPROCESSOR_EXPORTER
+    })
+
+    expect(updateStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ lastAppliedEventNumber: APPENDED_WATERMARK })
+    )
+  })
+
+  it('appends the balance event before writing the PRN document when issuing', async () => {
+    const updateStatus = vi.fn().mockResolvedValue(buildPrn())
+    const prnRepository = { findById: vi.fn(), updateStatus }
+    const deductTotalBalanceForPrnIssue = vi
+      .fn()
+      .mockResolvedValue(APPENDED_WATERMARK)
+    const wasteBalancesRepository = {
+      findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
+      deductTotalBalanceForPrnIssue
+    }
+
+    await callUpdate({
+      prnRepository,
+      wasteBalancesRepository,
+      organisationsRepository: buildOrganisationsRepository(),
+      providedPrn: buildPrn({
+        status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+      }),
+      newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+      actor: PRN_ACTOR.SIGNATORY
+    })
+
+    expect(
+      deductTotalBalanceForPrnIssue.mock.invocationCallOrder[0]
+    ).toBeLessThan(updateStatus.mock.invocationCallOrder[0])
+    expect(updateStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ lastAppliedEventNumber: APPENDED_WATERMARK })
+    )
+  })
+
+  it('rejects issuance on a suspended accreditation before appending any event', async () => {
+    const updateStatus = vi.fn().mockResolvedValue(buildPrn())
+    const prnRepository = { findById: vi.fn(), updateStatus }
+    const deductTotalBalanceForPrnIssue = vi.fn()
+    const wasteBalancesRepository = {
+      findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
+      deductTotalBalanceForPrnIssue
+    }
+
+    await expect(
+      callUpdate({
+        prnRepository,
+        wasteBalancesRepository,
+        organisationsRepository: buildOrganisationsRepository({
+          status: 'suspended'
+        }),
+        providedPrn: buildPrn({
+          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+        }),
+        newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+        actor: PRN_ACTOR.SIGNATORY
+      })
+    ).rejects.toThrow(SuspendedAccreditationError)
+
+    expect(deductTotalBalanceForPrnIssue).not.toHaveBeenCalled()
+    expect(updateStatus).not.toHaveBeenCalled()
+  })
+
+  it('appends the credit event before writing the PRN document when cancelling an issued PRN', async () => {
+    const updateStatus = vi.fn().mockResolvedValue(buildPrn())
+    const prnRepository = { findById: vi.fn(), updateStatus }
+    const creditFullBalanceForIssuedPrnCancellation = vi
+      .fn()
+      .mockResolvedValue(APPENDED_WATERMARK)
+    const wasteBalancesRepository = {
+      findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
+      creditFullBalanceForIssuedPrnCancellation
+    }
+
+    await callUpdate({
+      prnRepository,
+      wasteBalancesRepository,
+      organisationsRepository: buildOrganisationsRepository(),
+      providedPrn: buildPrn({
+        status: { currentStatus: PRN_STATUS.AWAITING_CANCELLATION },
+        lastAppliedEventNumber: 2
+      }),
+      newStatus: PRN_STATUS.CANCELLED,
+      actor: PRN_ACTOR.SIGNATORY
+    })
+
+    expect(
+      creditFullBalanceForIssuedPrnCancellation.mock.invocationCallOrder[0]
+    ).toBeLessThan(updateStatus.mock.invocationCallOrder[0])
+    expect(updateStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ lastAppliedEventNumber: APPENDED_WATERMARK })
+    )
+  })
+
+  it('carries the existing watermark forward on a lifecycle-only transition', async () => {
+    const updateStatus = vi.fn().mockResolvedValue(buildPrn())
+    const prnRepository = { findById: vi.fn(), updateStatus }
+
+    await callUpdate({
+      prnRepository,
+      wasteBalancesRepository: {},
+      organisationsRepository: buildOrganisationsRepository(),
+      providedPrn: buildPrn({
+        status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE },
+        lastAppliedEventNumber: 7
+      }),
+      newStatus: PRN_STATUS.ACCEPTED,
+      actor: PRN_ACTOR.PRODUCER
+    })
+
+    expect(updateStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ lastAppliedEventNumber: 7 })
+    )
+  })
+
+  it('does not credit the balance back when the PRN document write fails on creation', async () => {
+    const updateStatus = vi
+      .fn()
+      .mockRejectedValue(new Error('doc write failed'))
+    const prnRepository = { findById: vi.fn(), updateStatus }
+    const creditAvailableBalanceForPrnCancellation = vi.fn()
+    const wasteBalancesRepository = {
+      findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
+      deductAvailableBalanceForPrnCreation: vi
+        .fn()
+        .mockResolvedValue(APPENDED_WATERMARK),
+      creditAvailableBalanceForPrnCancellation
+    }
+
+    await expect(
+      callUpdate({
+        prnRepository,
+        wasteBalancesRepository,
+        organisationsRepository: buildOrganisationsRepository(),
+        providedPrn: buildPrn({ status: { currentStatus: PRN_STATUS.DRAFT } }),
+        newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+        actor: PRN_ACTOR.REPROCESSOR_EXPORTER
+      })
+    ).rejects.toThrow('doc write failed')
+
+    expect(creditAvailableBalanceForPrnCancellation).not.toHaveBeenCalled()
+  })
+})

--- a/src/packaging-recycling-notes/application/update-status-stream.test.js
+++ b/src/packaging-recycling-notes/application/update-status-stream.test.js
@@ -235,4 +235,34 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
 
     expect(creditAvailableBalanceForPrnCancellation).not.toHaveBeenCalled()
   })
+
+  it('does not roll back the balance when the PRN document write fails on issuance', async () => {
+    const updateStatus = vi
+      .fn()
+      .mockRejectedValue(new Error('doc write failed'))
+    const prnRepository = { findById: vi.fn(), updateStatus }
+    const creditFullBalanceForIssuedPrnCancellation = vi.fn()
+    const wasteBalancesRepository = {
+      findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
+      deductTotalBalanceForPrnIssue: vi
+        .fn()
+        .mockResolvedValue(APPENDED_WATERMARK),
+      creditFullBalanceForIssuedPrnCancellation
+    }
+
+    await expect(
+      callUpdate({
+        prnRepository,
+        wasteBalancesRepository,
+        organisationsRepository: buildOrganisationsRepository(),
+        providedPrn: buildPrn({
+          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+        }),
+        newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+        actor: PRN_ACTOR.SIGNATORY
+      })
+    ).rejects.toThrow('doc write failed')
+
+    expect(creditFullBalanceForIssuedPrnCancellation).not.toHaveBeenCalled()
+  })
 })

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -434,12 +434,12 @@ async function performStreamWrite({
   user,
   now
 }) {
-  // On the embedded path the suspension check lives inside applyStatusUpdate,
-  // which runs after the doc CAS. Event-first ordering would otherwise append
-  // the debit before that check, so the check is hoisted ahead of the append
-  // here to guarantee a suspended accreditation is never debited. The fetched
-  // accreditation is handed to applyStatusUpdate so the issuance write reuses
-  // it rather than reading it twice.
+  // The suspension check lives inside applyStatusUpdate, gating the document
+  // write. On the stream path the balance event is appended before that write,
+  // so the check is hoisted ahead of the append here to guarantee a suspended
+  // accreditation is never debited. The fetched accreditation is handed to
+  // applyStatusUpdate so the issuance write reuses it rather than reading it
+  // twice.
   let accreditation
   if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
     accreditation = await organisationsRepository.findAccreditationById(

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -1,7 +1,11 @@
 import Boom from '@hapi/boom'
 
 import { prnMetrics } from './metrics.js'
-import { applyWasteBalanceEffects } from './update-status-balance-effects.js'
+import {
+  applyWasteBalanceEffects,
+  affectsWasteBalance
+} from './update-status-balance-effects.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
@@ -66,6 +70,31 @@ const ROLLBACK_METHOD_BY_TRANSITION = {
  * @typedef {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepository
  * @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository
  * @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository
+ * @typedef {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} PackagingRecyclingNote
+ * @typedef {import('#packaging-recycling-notes/domain/model.js').PrnStatus} PrnStatus
+ */
+
+/**
+ * The shared context every write strategy receives. The three strategies
+ * (create, transition, stream) consume overlapping subsets of it, so the
+ * dispatcher hands all of it to whichever one it selects.
+ *
+ * @typedef {Object} PrnWriteContext
+ * @property {PackagingRecyclingNotesRepository} prnRepository
+ * @property {OrganisationsRepository} organisationsRepository
+ * @property {WasteBalancesRepository} wasteBalancesRepository
+ * @property {import('#common/hapi-types.js').TypedLogger} logger
+ * @property {PackagingRecyclingNote} prn
+ * @property {import('#packaging-recycling-notes/repository/port.js').UpdateStatusParams} updateParams
+ * @property {Object} balanceEffectsParams
+ * @property {PrnStatus} newStatus
+ * @property {string} organisationId
+ * @property {string} registrationId
+ * @property {string} accreditationId
+ * @property {{ id: string; name: string }} user
+ * @property {PrnStatus} currentStatus
+ * @property {Date} now
+ * @property {string} id
  */
 
 /**
@@ -121,7 +150,8 @@ async function applyStatusUpdate({
   organisationId,
   accreditationId,
   user,
-  now
+  now,
+  accreditation: providedAccreditation
 }) {
   if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
     updateParams.operation = {
@@ -130,10 +160,12 @@ async function applyStatusUpdate({
       by: { id: user.id, name: user.name }
     }
 
-    const accreditation = await organisationsRepository.findAccreditationById(
-      organisationId,
-      accreditationId
-    )
+    const accreditation =
+      providedAccreditation ??
+      (await organisationsRepository.findAccreditationById(
+        organisationId,
+        accreditationId
+      ))
 
     assertAccreditationNotSuspended(accreditation)
 
@@ -381,6 +413,96 @@ async function performTransition({
 }
 
 /**
+ * Event-first write for a migrated accreditation (canonicalSource 'ledger').
+ * The balance-affecting event is appended before the PRN document is
+ * projected, and the returned event number is stamped onto the document as its
+ * watermark. There is no compensation: a partial failure (event appended, doc
+ * not written) is recovered by the read-side catch-up, which folds events
+ * after the watermark on the next read.
+ */
+async function performStreamWrite({
+  prnRepository,
+  organisationsRepository,
+  wasteBalancesRepository,
+  logger,
+  prn,
+  updateParams,
+  balanceEffectsParams,
+  newStatus,
+  organisationId,
+  accreditationId,
+  user,
+  now
+}) {
+  // On the embedded path the suspension check lives inside applyStatusUpdate,
+  // which runs after the doc CAS. Event-first ordering would otherwise append
+  // the debit before that check, so the check is hoisted ahead of the append
+  // here to guarantee a suspended accreditation is never debited. The fetched
+  // accreditation is handed to applyStatusUpdate so the issuance write reuses
+  // it rather than reading it twice.
+  let accreditation
+  if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
+    accreditation = await organisationsRepository.findAccreditationById(
+      organisationId,
+      accreditationId
+    )
+    assertAccreditationNotSuspended(accreditation)
+  }
+
+  updateParams.lastAppliedEventNumber = await applyWasteBalanceEffects(
+    wasteBalancesRepository,
+    logger,
+    balanceEffectsParams
+  )
+
+  return applyStatusUpdate({
+    prnRepository,
+    organisationsRepository,
+    prn,
+    updateParams,
+    newStatus,
+    organisationId,
+    accreditationId,
+    user,
+    now,
+    accreditation
+  })
+}
+
+/**
+ * Whether the accreditation's balance has migrated to the event-sourced stream
+ * (canonicalSource 'ledger'). Read up front so the write ordering is chosen
+ * before any side effect runs.
+ *
+ * @param {WasteBalancesRepository} wasteBalancesRepository
+ * @param {string} accreditationId
+ * @returns {Promise<boolean>}
+ */
+async function isOnLedger(wasteBalancesRepository, accreditationId) {
+  const balance =
+    await wasteBalancesRepository.findByAccreditationId(accreditationId)
+  return balance?.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+}
+
+/**
+ * Selects the write strategy. A migrated accreditation uses the event-first
+ * stream write; everything else keeps the embedded create/transition paths
+ * with their compensation, byte-for-byte as before.
+ *
+ * @param {boolean} onLedger
+ * @param {PrnStatus} newStatus
+ * @returns {(context: PrnWriteContext) => Promise<PackagingRecyclingNote>}
+ */
+function selectWriteStrategy(onLedger, newStatus) {
+  if (onLedger) {
+    return performStreamWrite
+  }
+  return newStatus === PRN_STATUS.AWAITING_AUTHORISATION
+    ? performCreation
+    : performTransition
+}
+
+/**
  * Updates PRN status with all business logic
  *
  * @param {Object} params
@@ -444,13 +566,15 @@ export async function updatePrnStatus({
     version: prn.version,
     status: newStatus,
     updatedBy: user,
-    updatedAt: now
+    updatedAt: now,
+    lastAppliedEventNumber: prn.lastAppliedEventNumber
   }
 
-  const perform =
-    newStatus === PRN_STATUS.AWAITING_AUTHORISATION
-      ? performCreation
-      : performTransition
+  const onLedger =
+    affectsWasteBalance(currentStatus, newStatus) &&
+    (await isOnLedger(wasteBalancesRepository, accreditationId))
+
+  const perform = selectWriteStrategy(onLedger, newStatus)
 
   const updatedPrn = await perform({
     prnRepository,

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -3,7 +3,7 @@ import Boom from '@hapi/boom'
 import { prnMetrics } from './metrics.js'
 import {
   applyWasteBalanceEffects,
-  affectsWasteBalance
+  balanceEventsFor
 } from './update-status-balance-effects.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import {
@@ -86,7 +86,7 @@ const ROLLBACK_METHOD_BY_TRANSITION = {
  * @property {import('#common/hapi-types.js').TypedLogger} logger
  * @property {PackagingRecyclingNote} prn
  * @property {import('#packaging-recycling-notes/repository/port.js').UpdateStatusParams} updateParams
- * @property {Object} balanceEffectsParams
+ * @property {import('./update-status-balance-effects.js').BalanceEvent[]} events
  * @property {PrnStatus} newStatus
  * @property {string} organisationId
  * @property {string} registrationId
@@ -293,7 +293,7 @@ async function performCreation({
   logger,
   prn,
   updateParams,
-  balanceEffectsParams,
+  events,
   newStatus,
   organisationId,
   registrationId,
@@ -303,11 +303,7 @@ async function performCreation({
   now,
   id
 }) {
-  await applyWasteBalanceEffects(
-    wasteBalancesRepository,
-    logger,
-    balanceEffectsParams
-  )
+  await applyWasteBalanceEffects(wasteBalancesRepository, logger, events)
 
   try {
     return await applyStatusUpdate({
@@ -357,7 +353,7 @@ async function performTransition({
   logger,
   prn,
   updateParams,
-  balanceEffectsParams,
+  events,
   newStatus,
   organisationId,
   accreditationId,
@@ -379,11 +375,7 @@ async function performTransition({
   })
 
   try {
-    await applyWasteBalanceEffects(
-      wasteBalancesRepository,
-      logger,
-      balanceEffectsParams
-    )
+    await applyWasteBalanceEffects(wasteBalancesRepository, logger, events)
   } catch (forwardError) {
     const transitionKey = /** @type {PostCasRollbackTransition} */ (
       `${currentStatus}|${newStatus}`
@@ -427,7 +419,7 @@ async function performStreamWrite({
   logger,
   prn,
   updateParams,
-  balanceEffectsParams,
+  events,
   newStatus,
   organisationId,
   accreditationId,
@@ -452,7 +444,7 @@ async function performStreamWrite({
   updateParams.lastAppliedEventNumber = await applyWasteBalanceEffects(
     wasteBalancesRepository,
     logger,
-    balanceEffectsParams
+    events
   )
 
   return applyStatusUpdate({
@@ -489,12 +481,12 @@ async function isOnLedger(wasteBalancesRepository, accreditationId) {
  * stream write; everything else keeps the embedded create/transition paths
  * with their compensation, byte-for-byte as before.
  *
- * @param {boolean} onLedger
+ * @param {boolean} useStreamWrite
  * @param {PrnStatus} newStatus
  * @returns {(context: PrnWriteContext) => Promise<PackagingRecyclingNote>}
  */
-function selectWriteStrategy(onLedger, newStatus) {
-  if (onLedger) {
+function selectWriteStrategy(useStreamWrite, newStatus) {
+  if (useStreamWrite) {
     return performStreamWrite
   }
   return newStatus === PRN_STATUS.AWAITING_AUTHORISATION
@@ -549,7 +541,7 @@ export async function updatePrnStatus({
   const currentStatus = prn.status.currentStatus
   validateTransition(currentStatus, newStatus, actor)
 
-  const balanceEffectsParams = {
+  const events = balanceEventsFor(currentStatus, newStatus, {
     currentStatus,
     newStatus,
     accreditationId,
@@ -558,7 +550,7 @@ export async function updatePrnStatus({
     prnId: id,
     tonnage: prn.tonnage,
     userId: user.id
-  }
+  })
 
   const now = updatedAt ?? new Date()
   const updateParams = {
@@ -570,11 +562,11 @@ export async function updatePrnStatus({
     lastAppliedEventNumber: prn.lastAppliedEventNumber
   }
 
-  const onLedger =
-    affectsWasteBalance(currentStatus, newStatus) &&
+  const useStreamWrite =
+    events.length > 0 &&
     (await isOnLedger(wasteBalancesRepository, accreditationId))
 
-  const perform = selectWriteStrategy(onLedger, newStatus)
+  const perform = selectWriteStrategy(useStreamWrite, newStatus)
 
   const updatedPrn = await perform({
     prnRepository,
@@ -583,7 +575,7 @@ export async function updatePrnStatus({
     logger,
     prn,
     updateParams,
-    balanceEffectsParams,
+    events,
     newStatus,
     organisationId,
     registrationId,

--- a/src/packaging-recycling-notes/routes/status.test.js
+++ b/src/packaging-recycling-notes/routes/status.test.js
@@ -984,7 +984,11 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
     })
 
     it('returns 400 when no waste balance exists', async () => {
-      wasteBalancesRepository.findByAccreditationId.mockResolvedValueOnce(null)
+      // An accreditation with no balance returns null on every lookup: both
+      // the up-front canonical-source check and the balance-effect read.
+      wasteBalancesRepository.findByAccreditationId
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
       packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
         createMockPrn()
       )

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
@@ -1,3 +1,4 @@
+import { ObjectId } from 'mongodb'
 import { http, HttpResponse } from 'msw'
 import { describe, it, expect, beforeEach } from 'vitest'
 
@@ -7,7 +8,10 @@ import {
 } from '#domain/summary-logs/status.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
-import { WASTE_BALANCE_TRANSACTION_ENTITY_TYPE } from '#waste-balances/domain/model.js'
+import {
+  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE,
+  WASTE_BALANCE_CANONICAL_SOURCE
+} from '#waste-balances/domain/model.js'
 
 import {
   asStandardUser,
@@ -1234,6 +1238,138 @@ describe('Waste balance arithmetic integration tests', () => {
       const balanceAfterB =
         await wasteBalancesRepository.findByAccreditationId(accreditationId)
       expect(balanceAfterB.amount).toBe(100)
+    })
+  })
+
+  describe('on the event-sourced ledger path', () => {
+    const setupLedgerEnv = () => {
+      const organisationId = new ObjectId().toString()
+      const registrationId = new ObjectId().toString()
+      /** @type {import('#waste-balances/domain/model.js').WasteBalance[]} */
+      const existingWasteBalances = [
+        {
+          id: 'seeded-ledger-balance',
+          accreditationId: 'ACC-123',
+          registrationId,
+          organisationId,
+          schemaVersion: 1,
+          version: 0,
+          amount: 0,
+          availableAmount: 0,
+          transactions: [],
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+        }
+      ]
+      return setupWasteBalanceIntegrationEnvironment({
+        processingType: 'exporter',
+        organisationId,
+        registrationId,
+        featureFlagOverrides: { wasteBalanceLedger: true },
+        // @ts-expect-error -- existingWasteBalances defaults to never[]; WasteBalance[] is correct at runtime
+        existingWasteBalances
+      })
+    }
+
+    it('ringfences available balance and stamps the PRN watermark when raising', async () => {
+      const env = await setupLedgerEnv()
+      const { wasteBalancesRepository, packagingRecyclingNotesRepository } = env
+
+      await performSummaryLogSubmission(
+        env,
+        'log-ledger-raise',
+        'file-ledger-raise',
+        'waste-ledger-raise.xlsx',
+        createUploadData([{ rowId: 1001, exportTonnage: 300 }])
+      )
+
+      let balance =
+        await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      expect(balance.amount).toBe(300)
+      expect(balance.availableAmount).toBe(300)
+
+      const prn = await createPrn(env, 50)
+      await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION)
+
+      balance = await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      expect(balance.amount).toBe(300) // total unchanged
+      expect(balance.availableAmount).toBe(250) // 300 - 50 ringfenced
+
+      const stored = await packagingRecyclingNotesRepository.findById(prn.id)
+      expect(stored.lastAppliedEventNumber).toEqual(expect.any(Number))
+    })
+
+    it('deducts from total balance when issuing', async () => {
+      const env = await setupLedgerEnv()
+      const { wasteBalancesRepository } = env
+
+      await performSummaryLogSubmission(
+        env,
+        'log-ledger-issue',
+        'file-ledger-issue',
+        'waste-ledger-issue.xlsx',
+        createUploadData([{ rowId: 1001, exportTonnage: 200 }])
+      )
+
+      const prn = await createPrn(env, 50)
+      await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION)
+      await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_ACCEPTANCE)
+
+      const balance =
+        await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      expect(balance.amount).toBe(150) // 200 - 50 finalised
+      expect(balance.availableAmount).toBe(150)
+    })
+
+    it('restores available balance when deleting a raised PRN', async () => {
+      const env = await setupLedgerEnv()
+      const { wasteBalancesRepository } = env
+
+      await performSummaryLogSubmission(
+        env,
+        'log-ledger-delete',
+        'file-ledger-delete',
+        'waste-ledger-delete.xlsx',
+        createUploadData([{ rowId: 1001, exportTonnage: 100 }])
+      )
+
+      const prn = await createPrn(env, 40)
+      await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION)
+
+      let balance =
+        await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      expect(balance.availableAmount).toBe(60)
+
+      await transitionPrnStatus(env, prn.id, PRN_STATUS.DELETED)
+
+      balance = await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      expect(balance.amount).toBe(100)
+      expect(balance.availableAmount).toBe(100) // ringfence released
+    })
+
+    it('debits available balance once per PRN when two raises race on the same accreditation', async () => {
+      const env = await setupLedgerEnv()
+      const { wasteBalancesRepository } = env
+
+      await performSummaryLogSubmission(
+        env,
+        'log-ledger-race',
+        'file-ledger-race',
+        'waste-ledger-race.xlsx',
+        createUploadData([{ rowId: 1001, exportTonnage: 200 }])
+      )
+
+      const prnA = await createPrn(env, 30)
+      const prnB = await createPrn(env, 30)
+
+      await Promise.allSettled([
+        transitionPrnStatus(env, prnA.id, PRN_STATUS.AWAITING_AUTHORISATION),
+        transitionPrnStatus(env, prnB.id, PRN_STATUS.AWAITING_AUTHORISATION)
+      ])
+
+      const balance =
+        await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      expect(balance.amount).toBe(200)
+      expect(balance.availableAmount).toBe(140) // 200 - 30 - 30
     })
   })
 })

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict'
+
 import { ObjectId } from 'mongodb'
 import { http, HttpResponse } from 'msw'
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -25,6 +27,20 @@ import {
   createExporterRowValues,
   EXPORTER_HEADERS
 } from './integration-test-helpers.js'
+
+/**
+ * Reads an accreditation's waste balance and asserts it is present, so callers
+ * can read its fields without a null guard at every assertion site.
+ *
+ * @param {{ findByAccreditationId: (accreditationId: string) => Promise<import('#waste-balances/domain/model.js').WasteBalance | null> }} wasteBalancesRepository
+ * @param {string} accreditationId
+ */
+const getWasteBalance = async (wasteBalancesRepository, accreditationId) => {
+  const balance =
+    await wasteBalancesRepository.findByAccreditationId(accreditationId)
+  assert(balance)
+  return balance
+}
 
 /**
  * Integration tests for waste balance arithmetic across multiple operations.
@@ -187,8 +203,10 @@ describe('Waste balance arithmetic integration tests', () => {
         ])
       )
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(300) // 100 + 200 = 300
       expect(balance.availableAmount).toBe(300)
 
@@ -196,8 +214,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn1 = await createPrn(env, 50)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(300) // Total unchanged
       expect(balance.availableAmount).toBe(250) // 300 - 50 = 250
 
@@ -215,8 +232,7 @@ describe('Waste balance arithmetic integration tests', () => {
         ])
       )
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(450) // 100 + 200 + 150 = 450
       expect(balance.availableAmount).toBe(400) // 450 - 50 = 400
 
@@ -224,8 +240,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn2 = await createPrn(env, 75)
       await transitionPrnStatus(env, prn2.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(450) // Total unchanged
       expect(balance.availableAmount).toBe(325) // 400 - 75 = 325
 
@@ -233,8 +248,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn3 = await createPrn(env, 100)
       await transitionPrnStatus(env, prn3.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(450) // Total unchanged
       expect(balance.availableAmount).toBe(225) // 325 - 100 = 225
     })
@@ -255,8 +269,10 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 100 }])
       )
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(100)
       expect(balance.availableAmount).toBe(100)
 
@@ -264,8 +280,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn1 = await createPrn(env, 30)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(100)
       expect(balance.availableAmount).toBe(70) // 100 - 30 = 70
 
@@ -281,8 +296,7 @@ describe('Waste balance arithmetic integration tests', () => {
         ])
       )
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(150) // 100 + 50 = 150
       expect(balance.availableAmount).toBe(120) // 70 + 50 = 120
 
@@ -290,8 +304,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn2 = await createPrn(env, 45)
       await transitionPrnStatus(env, prn2.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(150) // Total unchanged
       expect(balance.availableAmount).toBe(75) // 120 - 45 = 75
 
@@ -308,8 +321,7 @@ describe('Waste balance arithmetic integration tests', () => {
         ])
       )
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(350) // 100 + 50 + 200 = 350
       expect(balance.availableAmount).toBe(275) // 75 + 200 = 275
 
@@ -317,8 +329,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn3 = await createPrn(env, 125)
       await transitionPrnStatus(env, prn3.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(350) // Total unchanged
       expect(balance.availableAmount).toBe(150) // 275 - 125 = 150
 
@@ -341,8 +352,10 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 200 }])
       )
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(200)
       expect(balance.availableAmount).toBe(200)
 
@@ -350,8 +363,7 @@ describe('Waste balance arithmetic integration tests', () => {
       await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION)
       await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_ACCEPTANCE)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(150)
       expect(balance.availableAmount).toBe(150)
 
@@ -363,8 +375,7 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 200 }])
       )
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(150)
       expect(balance.availableAmount).toBe(150)
     })
@@ -385,8 +396,10 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: firstCredit }])
       )
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(firstCredit)
       expect(balance.availableAmount).toBe(firstCredit)
 
@@ -396,8 +409,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn1 = await createPrn(env, debit1)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(firstCredit) // Total unchanged
       expect(balance.availableAmount).toBe(expectedAvailable1) // 100.5 - 33 = 67.5
 
@@ -416,8 +428,7 @@ describe('Waste balance arithmetic integration tests', () => {
         ])
       )
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(expectedTotal2) // 100.5 + 50.25 = 150.75
       expect(balance.availableAmount).toBe(expectedAvailable2) // 150.75 - 33 = 117.75
 
@@ -427,8 +438,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn2 = await createPrn(env, debit2)
       await transitionPrnStatus(env, prn2.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(expectedTotal2) // Total unchanged
       expect(balance.availableAmount).toBe(expectedAvailable3) // 117.75 - 17 = 100.75
     })
@@ -449,8 +459,10 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: creditAmount }])
       )
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(creditAmount)
       expect(balance.availableAmount).toBe(creditAmount)
 
@@ -466,8 +478,7 @@ describe('Waste balance arithmetic integration tests', () => {
       expect(result.message).toBe('Insufficient available waste balance')
 
       // Balance should be unchanged
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(100)
       expect(balance.availableAmount).toBe(100)
     })
@@ -487,8 +498,10 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 100 }])
       )
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(100)
       expect(balance.availableAmount).toBe(100)
 
@@ -496,22 +509,21 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn1 = await createPrn(env, 50)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(100)
       expect(balance.availableAmount).toBe(50)
 
       // Manually reduce total balance to simulate concurrent deduction
       await wasteBalancesRepository.deductTotalBalanceForPrnIssue({
         accreditationId,
+        registrationId: env.registrationId,
         organisationId: env.organisationId,
         prnId: 'other-prn',
         tonnage: 80,
         userId: 'test-user'
       })
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(20) // 100 - 80
 
       // Attempt to issue PRN for 50 (more than remaining total of 20) - should be rejected
@@ -524,8 +536,7 @@ describe('Waste balance arithmetic integration tests', () => {
       expect(result.message).toBe('Insufficient total waste balance')
 
       // Balance should be unchanged
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(20)
     })
 
@@ -544,8 +555,10 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 200 }])
       )
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(200)
       expect(balance.availableAmount).toBe(200)
 
@@ -555,16 +568,14 @@ describe('Waste balance arithmetic integration tests', () => {
       // Raise PRN (deduct from available only)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(200) // Total unchanged
       expect(balance.availableAmount).toBe(150) // 200 - 50 = 150
 
       // Issue PRN (deduct from total only)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_ACCEPTANCE)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(150) // 200 - 50 = 150 (now deducted)
       expect(balance.availableAmount).toBe(150) // Unchanged from issue
     })
@@ -584,8 +595,10 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 500 }])
       )
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(500)
       expect(balance.availableAmount).toBe(500)
 
@@ -593,8 +606,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn1 = await createPrn(env, 100)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(500)
       expect(balance.availableAmount).toBe(400) // 500 - 100
 
@@ -602,16 +614,14 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn2 = await createPrn(env, 75)
       await transitionPrnStatus(env, prn2.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(500)
       expect(balance.availableAmount).toBe(325) // 400 - 75
 
       // Issue PRN 1 (total deducted, available unchanged)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_ACCEPTANCE)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(400) // 500 - 100
       expect(balance.availableAmount).toBe(325) // Unchanged
 
@@ -619,24 +629,21 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn3 = await createPrn(env, 50)
       await transitionPrnStatus(env, prn3.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(400) // Unchanged
       expect(balance.availableAmount).toBe(275) // 325 - 50
 
       // Issue PRN 2 (total deducted, available unchanged)
       await transitionPrnStatus(env, prn2.id, PRN_STATUS.AWAITING_ACCEPTANCE)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(325) // 400 - 75
       expect(balance.availableAmount).toBe(275) // Unchanged
 
       // Issue PRN 3 (total deducted, available unchanged)
       await transitionPrnStatus(env, prn3.id, PRN_STATUS.AWAITING_ACCEPTANCE)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(275) // 325 - 50
       expect(balance.availableAmount).toBe(275) // Now matches total
 
@@ -658,8 +665,10 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 100 }])
       )
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(100)
       expect(balance.availableAmount).toBe(100)
 
@@ -667,8 +676,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn1 = await createPrn(env, 30)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(100)
       expect(balance.availableAmount).toBe(70)
 
@@ -681,8 +689,7 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 80 }])
       )
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(80) // Revised down
       expect(balance.availableAmount).toBe(50) // 80 - 30 = 50
 
@@ -690,8 +697,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn2 = await createPrn(env, 25)
       await transitionPrnStatus(env, prn2.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(80)
       expect(balance.availableAmount).toBe(25) // 50 - 25 = 25
 
@@ -704,8 +710,7 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 120 }])
       )
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(120) // Revised up
       expect(balance.availableAmount).toBe(65) // 120 - 30 - 25 = 65
     })
@@ -727,8 +732,10 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 200 }])
       )
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(200)
       expect(balance.availableAmount).toBe(200)
 
@@ -736,16 +743,14 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn1 = await createPrn(env, 50)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(200)
       expect(balance.availableAmount).toBe(150)
 
       // Delete the PRN (restores available)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.DELETED)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(200) // Total unchanged
       expect(balance.availableAmount).toBe(200) // Restored: 150 + 50
     })
@@ -768,16 +773,17 @@ describe('Waste balance arithmetic integration tests', () => {
       // Create PRN (stays in draft, no balance deduction)
       const prn1 = await createPrn(env, 50)
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(200)
       expect(balance.availableAmount).toBe(200)
 
       // Discard from draft (no balance change)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.DISCARDED)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(200) // Unchanged
       expect(balance.availableAmount).toBe(200) // Unchanged
     })
@@ -807,16 +813,17 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn3 = await createPrn(env, 50)
       await transitionPrnStatus(env, prn3.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(500)
       expect(balance.availableAmount).toBe(275) // 500 - 100 - 75 - 50
 
       // Delete only the 75-tonne PRN
       await transitionPrnStatus(env, prn2.id, PRN_STATUS.DELETED)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(500) // Total unchanged
       expect(balance.availableAmount).toBe(350) // 275 + 75
     })
@@ -840,23 +847,23 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn1 = await createPrn(env, 80)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.availableAmount).toBe(20)
 
       // Delete it (available restored to 100)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.DELETED)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.availableAmount).toBe(100)
 
       // Raise a new PRN for 90 using the restored balance
       const prn2 = await createPrn(env, 90)
       await transitionPrnStatus(env, prn2.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(100) // Total unchanged throughout
       expect(balance.availableAmount).toBe(10) // 100 - 90
     })
@@ -886,32 +893,31 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn3 = await createPrn(env, 50)
       await transitionPrnStatus(env, prn3.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      let balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(500)
       expect(balance.availableAmount).toBe(275) // 500 - 100 - 75 - 50
 
       // Issue PRN 1 (total deducted, available unchanged)
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.AWAITING_ACCEPTANCE)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(400) // 500 - 100
       expect(balance.availableAmount).toBe(275) // Unchanged
 
       // Delete PRN 2 (available credited, total unchanged)
       await transitionPrnStatus(env, prn2.id, PRN_STATUS.DELETED)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(400) // Unchanged
       expect(balance.availableAmount).toBe(350) // 275 + 75
 
       // Issue PRN 3 (total deducted, available unchanged)
       await transitionPrnStatus(env, prn3.id, PRN_STATUS.AWAITING_ACCEPTANCE)
 
-      balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
       expect(balance.amount).toBe(350) // 400 - 50
       expect(balance.availableAmount).toBe(350) // Now matches total
     })
@@ -953,8 +959,10 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn2 = await createPrn(env, 25)
       await transitionPrnStatus(env, prn2.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      const balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      const balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
 
       // Verify final amounts
       expect(balance.amount).toBe(160) // 100 + 60
@@ -1003,8 +1011,10 @@ describe('Waste balance arithmetic integration tests', () => {
       // Delete it
       await transitionPrnStatus(env, prn1.id, PRN_STATUS.DELETED)
 
-      const balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      const balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
 
       // Find the cancellation credit transaction
       const cancellationTransactions = balance.transactions.filter((t) =>
@@ -1045,6 +1055,7 @@ describe('Waste balance arithmetic integration tests', () => {
 
       await wasteBalancesRepository.deductTotalBalanceForPrnIssue({
         accreditationId,
+        registrationId: env.registrationId,
         organisationId,
         prnId: 'other-prn',
         tonnage: 80,
@@ -1059,6 +1070,7 @@ describe('Waste balance arithmetic integration tests', () => {
       expect(result.statusCode).toBe(409)
 
       const refetched = await packagingRecyclingNotesRepository.findById(prn.id)
+      assert(refetched)
 
       expect(refetched.status.currentStatus).toBe(
         PRN_STATUS.AWAITING_AUTHORISATION
@@ -1094,6 +1106,7 @@ describe('Waste balance arithmetic integration tests', () => {
 
       await wasteBalancesRepository.deductTotalBalanceForPrnIssue({
         accreditationId,
+        registrationId: env.registrationId,
         organisationId,
         prnId: 'other-prn',
         tonnage: 20,
@@ -1108,17 +1121,21 @@ describe('Waste balance arithmetic integration tests', () => {
       const refetchedA = await packagingRecyclingNotesRepository.findById(
         prnA.id
       )
+      assert(refetchedA)
       const refetchedB = await packagingRecyclingNotesRepository.findById(
         prnB.id
       )
+      assert(refetchedB)
 
       const issuedCount = [refetchedA, refetchedB].filter(
         (p) => p.status.currentStatus === PRN_STATUS.AWAITING_ACCEPTANCE
       ).length
       expect(issuedCount).toBe(1)
 
-      const balance =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      const balance = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balance.amount).toBe(30)
     })
   })
@@ -1148,8 +1165,10 @@ describe('Waste balance arithmetic integration tests', () => {
         transitionPrnStatus(env, prnB.id, PRN_STATUS.DELETED)
       ])
 
-      const balanceAfter =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      const balanceAfter = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balanceAfter.amount).toBe(200)
       expect(balanceAfter.availableAmount).toBe(200)
     })
@@ -1175,8 +1194,10 @@ describe('Waste balance arithmetic integration tests', () => {
         transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION)
       ])
 
-      const balanceAfter =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      const balanceAfter = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balanceAfter.amount).toBe(100)
       expect(balanceAfter.availableAmount).toBe(50)
     })
@@ -1203,8 +1224,10 @@ describe('Waste balance arithmetic integration tests', () => {
         transitionPrnStatus(env, prnB.id, PRN_STATUS.AWAITING_AUTHORISATION)
       ])
 
-      const balanceAfter =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      const balanceAfter = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balanceAfter.amount).toBe(200)
       expect(balanceAfter.availableAmount).toBe(140)
     })
@@ -1223,8 +1246,10 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 100 }])
       )
 
-      const balanceAfterA =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      const balanceAfterA = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balanceAfterA.amount).toBe(100)
 
       await performSummaryLogSubmission(
@@ -1235,8 +1260,10 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 100 }])
       )
 
-      const balanceAfterB =
-        await wasteBalancesRepository.findByAccreditationId(accreditationId)
+      const balanceAfterB = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId
+      )
       expect(balanceAfterB.amount).toBe(100)
     })
   })
@@ -1287,15 +1314,14 @@ describe('Waste balance arithmetic integration tests', () => {
         createUploadData([{ rowId: 1001, exportTonnage: 300 }])
       )
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      let balance = await getWasteBalance(wasteBalancesRepository, 'ACC-123')
       expect(balance.amount).toBe(300)
       expect(balance.availableAmount).toBe(300)
 
       const prn = await createPrn(env, 50)
       await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      balance = await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      balance = await getWasteBalance(wasteBalancesRepository, 'ACC-123')
       expect(balance.amount).toBe(300) // total unchanged
       expect(balance.availableAmount).toBe(250) // 300 - 50 ringfenced
 
@@ -1305,6 +1331,7 @@ describe('Waste balance arithmetic integration tests', () => {
         'ACC-123'
       )
       const stored = await packagingRecyclingNotesRepository.findById(prn.id)
+      assert(stored)
       expect(stored.lastAppliedEventNumber).toBe(latest?.number)
     })
 
@@ -1324,8 +1351,7 @@ describe('Waste balance arithmetic integration tests', () => {
       await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION)
       await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_ACCEPTANCE)
 
-      const balance =
-        await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      const balance = await getWasteBalance(wasteBalancesRepository, 'ACC-123')
       expect(balance.amount).toBe(150) // 200 - 50 finalised
       expect(balance.availableAmount).toBe(150)
     })
@@ -1345,13 +1371,12 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn = await createPrn(env, 40)
       await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
-      let balance =
-        await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      let balance = await getWasteBalance(wasteBalancesRepository, 'ACC-123')
       expect(balance.availableAmount).toBe(60)
 
       await transitionPrnStatus(env, prn.id, PRN_STATUS.DELETED)
 
-      balance = await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      balance = await getWasteBalance(wasteBalancesRepository, 'ACC-123')
       expect(balance.amount).toBe(100)
       expect(balance.availableAmount).toBe(100) // ringfence released
     })
@@ -1376,8 +1401,7 @@ describe('Waste balance arithmetic integration tests', () => {
         transitionPrnStatus(env, prnB.id, PRN_STATUS.AWAITING_AUTHORISATION)
       ])
 
-      const balance =
-        await wasteBalancesRepository.findByAccreditationId('ACC-123')
+      const balance = await getWasteBalance(wasteBalancesRepository, 'ACC-123')
       expect(balance.amount).toBe(200)
       expect(balance.availableAmount).toBe(140) // 200 - 30 - 30
     })

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
@@ -1272,7 +1272,12 @@ describe('Waste balance arithmetic integration tests', () => {
 
     it('ringfences available balance and stamps the PRN watermark when raising', async () => {
       const env = await setupLedgerEnv()
-      const { wasteBalancesRepository, packagingRecyclingNotesRepository } = env
+      const {
+        wasteBalancesRepository,
+        packagingRecyclingNotesRepository,
+        streamRepository,
+        registrationId
+      } = env
 
       await performSummaryLogSubmission(
         env,
@@ -1294,8 +1299,13 @@ describe('Waste balance arithmetic integration tests', () => {
       expect(balance.amount).toBe(300) // total unchanged
       expect(balance.availableAmount).toBe(250) // 300 - 50 ringfenced
 
+      // The document watermark is the event the raise appended, not just any number.
+      const latest = await streamRepository.findLatestByPartition(
+        registrationId,
+        'ACC-123'
+      )
       const stored = await packagingRecyclingNotesRepository.findById(prn.id)
-      expect(stored.lastAppliedEventNumber).toEqual(expect.any(Number))
+      expect(stored.lastAppliedEventNumber).toBe(latest?.number)
     })
 
     it('deducts from total balance when issuing', async () => {
@@ -1346,7 +1356,7 @@ describe('Waste balance arithmetic integration tests', () => {
       expect(balance.availableAmount).toBe(100) // ringfence released
     })
 
-    it('debits available balance once per PRN when two raises race on the same accreditation', async () => {
+    it('debits available balance once per PRN when two raises are submitted together on the same accreditation', async () => {
       const env = await setupLedgerEnv()
       const { wasteBalancesRepository } = env
 


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
When an accreditation's waste balance has migrated to the event-sourced stream (`canonicalSource === 'ledger'`), balance-affecting PRN status transitions are now written event-first: the balance event is appended to the stream *before* the PRN document is projected, and the document is stamped with the appended event number as a monotonic watermark (`lastAppliedEventNumber`). There is no compensation on this path — a partial failure where the event commits but the document write fails is left in place, to be reconciled by the read-side catch-up that folds the stream forward on the next read, rather than rolled back. This is the inverse of the embedded path, where the document is the source of truth and a failed balance write is compensated.

The write strategy is chosen up front from the accreditation's canonical-source marker, and only for transitions that actually move the balance (create, issue, delete-from-awaiting-authorisation, cancel-an-issued-PRN). Lifecycle-only transitions — and every transition on a non-migrated accreditation — carry the PRN's existing watermark forward unchanged, which keeps the repository's monotonic watermark guard satisfied without a marker read. On issuance the suspended-accreditation check is hoisted ahead of the append, so a suspended accreditation is rejected before any balance event is written.

The embedded (non-migrated) create and transition paths, including their credit-back and full-credit compensation, are unchanged. Every production accreditation is still `embedded` today, so the ledger path added here is dormant until balances are migrated; the change is exercised end-to-end by the waste-balance arithmetic integration tests under a seeded ledger-backed accreditation, confirming the PRN events fold into the resolved balance and the stamped watermark tracks the latest stream event.

Part of PAE-1382 — moving the waste balance from the embedded document onto the event-sourced stream.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ