### PR TITLE
PAE-1382: Unify PRN status projection across the ledger write and read paths

### DIFF
--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
@@ -2,32 +2,76 @@ import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
 
 /**
- * Stream-event-kind → PRN currentStatus when projected from a balance-affecting
- * event onto the PRN document. Only the four balance-affecting kinds appear
- * here; lifecycle-only transitions (accept, discard, awaiting-cancellation) do
- * not produce stream events and are not part of read-side catch-up.
- *
- * `prn-creation-cancelled` folds to `deleted` because the only transition out
- * of `awaiting_authorisation` that produces a `prn-creation-cancelled` event is
- * the signatory deleting the PRN; the alternative target (`awaiting_acceptance`)
- * issues `prn-issued` instead.
+ * Stream-event-kind → PRN currentStatus the event projects to.
  *
  * @type {Record<string, import('#packaging-recycling-notes/domain/model.js').PrnStatus>}
  */
 const STREAM_EVENT_KIND_TO_PRN_STATUS = Object.freeze({
   [STREAM_EVENT_KIND.PRN_CREATED]: PRN_STATUS.AWAITING_AUTHORISATION,
   [STREAM_EVENT_KIND.PRN_ISSUED]: PRN_STATUS.AWAITING_ACCEPTANCE,
+  [STREAM_EVENT_KIND.PRN_ACCEPTED]: PRN_STATUS.ACCEPTED,
+  [STREAM_EVENT_KIND.PRN_REJECTED]: PRN_STATUS.AWAITING_CANCELLATION,
   [STREAM_EVENT_KIND.PRN_CREATION_CANCELLED]: PRN_STATUS.DELETED,
   [STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE]: PRN_STATUS.CANCELLED
 })
 
 /**
- * Pure projection of stream tail events onto a PRN document. Returns the PRN
- * with `status.currentStatus`, `status.currentStatusAt` and
- * `lastAppliedEventNumber` updated from the last (highest-numbered) event, or
- * the PRN unchanged when no events are supplied.
+ * Stream-event-kind → PRN status slot the event timestamps. Slot names follow
+ * the business operation that occurred (rejected/deleted/cancelled), not the
+ * resulting status — `prn-rejected` records on `status.rejected` even though
+ * the currentStatus moves to `awaiting_cancellation`.
  *
- * Expects `tailEvents` ordered by `number` ascending — the order
+ * @type {Record<string, 'created' | 'issued' | 'accepted' | 'rejected' | 'deleted' | 'cancelled'>}
+ */
+const STREAM_EVENT_KIND_TO_STATUS_SLOT = Object.freeze({
+  [STREAM_EVENT_KIND.PRN_CREATED]: 'created',
+  [STREAM_EVENT_KIND.PRN_ISSUED]: 'issued',
+  [STREAM_EVENT_KIND.PRN_ACCEPTED]: 'accepted',
+  [STREAM_EVENT_KIND.PRN_REJECTED]: 'rejected',
+  [STREAM_EVENT_KIND.PRN_CREATION_CANCELLED]: 'deleted',
+  [STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE]: 'cancelled'
+})
+
+/**
+ * @param {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} prn
+ * @param {import('#waste-balances/repository/stream-schema.js').StreamEvent} event
+ */
+const applyEvent = (prn, event) => {
+  const newStatus = STREAM_EVENT_KIND_TO_PRN_STATUS[event.kind]
+  if (!newStatus) {
+    throw new Error(`Unmappable stream event kind: ${event.kind}`)
+  }
+  const slot = STREAM_EVENT_KIND_TO_STATUS_SLOT[event.kind]
+  const slotValue = { at: event.createdAt, by: event.createdBy }
+
+  return {
+    ...prn,
+    version: (prn.version ?? 0) + 1,
+    updatedAt: event.createdAt,
+    updatedBy: event.createdBy,
+    lastAppliedEventNumber: event.number,
+    status: {
+      ...prn.status,
+      currentStatus: newStatus,
+      currentStatusAt: event.createdAt,
+      [slot]: slotValue,
+      history: [
+        ...prn.status.history,
+        { status: newStatus, at: event.createdAt, by: event.createdBy }
+      ]
+    }
+  }
+}
+
+/**
+ * Left-fold over persisted stream tail events: applies each event in turn,
+ * stamping its slot, appending a history entry, advancing currentStatus,
+ * updatedAt/By, version and the lastAppliedEventNumber watermark.
+ *
+ * Pure: returns a new PRN, does not mutate the input. Returns the input
+ * reference unchanged when no events are supplied.
+ *
+ * Expects events ordered by `number` ascending — the order
  * `WasteBalanceStreamRepository.findEventsByPrnIdAfter` guarantees.
  *
  * @param {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} prn
@@ -35,23 +79,8 @@ const STREAM_EVENT_KIND_TO_PRN_STATUS = Object.freeze({
  * @returns {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote}
  */
 export const foldPrnFromTailEvents = (prn, tailEvents) => {
-  const latest = tailEvents.at(-1)
-  if (!latest) {
+  if (tailEvents.length === 0) {
     return prn
   }
-
-  const newStatus = STREAM_EVENT_KIND_TO_PRN_STATUS[latest.kind]
-  if (!newStatus) {
-    throw new Error(`Unmappable stream event kind: ${latest.kind}`)
-  }
-
-  return {
-    ...prn,
-    status: {
-      ...prn.status,
-      currentStatus: newStatus,
-      currentStatusAt: latest.createdAt
-    },
-    lastAppliedEventNumber: latest.number
-  }
+  return tailEvents.reduce(applyEvent, prn)
 }

--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
@@ -1,0 +1,57 @@
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+
+/**
+ * Stream-event-kind → PRN currentStatus when projected from a balance-affecting
+ * event onto the PRN document. Only the four balance-affecting kinds appear
+ * here; lifecycle-only transitions (accept, discard, awaiting-cancellation) do
+ * not produce stream events and are not part of read-side catch-up.
+ *
+ * `prn-creation-cancelled` folds to `deleted` because the only transition out
+ * of `awaiting_authorisation` that produces a `prn-creation-cancelled` event is
+ * the signatory deleting the PRN; the alternative target (`awaiting_acceptance`)
+ * issues `prn-issued` instead.
+ *
+ * @type {Record<string, import('#packaging-recycling-notes/domain/model.js').PrnStatus>}
+ */
+const STREAM_EVENT_KIND_TO_PRN_STATUS = Object.freeze({
+  [STREAM_EVENT_KIND.PRN_CREATED]: PRN_STATUS.AWAITING_AUTHORISATION,
+  [STREAM_EVENT_KIND.PRN_ISSUED]: PRN_STATUS.AWAITING_ACCEPTANCE,
+  [STREAM_EVENT_KIND.PRN_CREATION_CANCELLED]: PRN_STATUS.DELETED,
+  [STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE]: PRN_STATUS.CANCELLED
+})
+
+/**
+ * Pure projection of stream tail events onto a PRN document. Returns the PRN
+ * with `status.currentStatus`, `status.currentStatusAt` and
+ * `lastAppliedEventNumber` updated from the last (highest-numbered) event, or
+ * the PRN unchanged when no events are supplied.
+ *
+ * Expects `tailEvents` ordered by `number` ascending — the order
+ * `WasteBalanceStreamRepository.findEventsByPrnIdAfter` guarantees.
+ *
+ * @param {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} prn
+ * @param {import('#waste-balances/repository/stream-schema.js').StreamEvent[]} tailEvents
+ * @returns {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote}
+ */
+export const foldPrnFromTailEvents = (prn, tailEvents) => {
+  const latest = tailEvents.at(-1)
+  if (!latest) {
+    return prn
+  }
+
+  const newStatus = STREAM_EVENT_KIND_TO_PRN_STATUS[latest.kind]
+  if (!newStatus) {
+    throw new Error(`Unmappable stream event kind: ${latest.kind}`)
+  }
+
+  return {
+    ...prn,
+    status: {
+      ...prn.status,
+      currentStatus: newStatus,
+      currentStatusAt: latest.createdAt
+    },
+    lastAppliedEventNumber: latest.number
+  }
+}

--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
@@ -82,5 +82,5 @@ export const foldPrnFromTailEvents = (prn, tailEvents) => {
   if (tailEvents.length === 0) {
     return prn
   }
-  return tailEvents.reduce(applyEvent, prn)
+  return tailEvents.reduce((acc, event) => applyEvent(acc, event), prn)
 }

--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
@@ -4,17 +4,26 @@ import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { foldPrnFromTailEvents } from './fold-prn-from-tail-events.js'
 
+const baseUpdatedAt = new Date('2026-01-15T10:00:00.000Z')
+const baseCreator = { id: 'creator', name: 'Original Creator' }
+
 const basePrn = () => ({
   id: 'prn-1',
   registrationId: 'reg-1',
   accreditation: { id: 'acc-1' },
+  version: 1,
+  updatedAt: baseUpdatedAt,
+  updatedBy: baseCreator,
   status: {
     currentStatus: PRN_STATUS.DRAFT,
-    currentStatusAt: new Date('2026-01-15T10:00:00.000Z')
+    currentStatusAt: baseUpdatedAt,
+    history: [{ status: PRN_STATUS.DRAFT, at: baseUpdatedAt, by: baseCreator }]
   }
 })
 
-const buildEvent = (kind, number, createdAt) => ({
+const eventCreator = { id: 'user-1', name: 'Test User' }
+
+const buildEvent = (kind, number, createdAt, createdBy = eventCreator) => ({
   id: `event-${number}`,
   registrationId: 'reg-1',
   accreditationId: 'acc-1',
@@ -25,7 +34,7 @@ const buildEvent = (kind, number, createdAt) => ({
   openingBalance: { amount: 100, availableAmount: 100 },
   closingBalance: { amount: 100, availableAmount: 50 },
   createdAt: new Date(createdAt),
-  createdBy: { id: 'user-1', name: 'Test User' }
+  createdBy
 })
 
 describe('foldPrnFromTailEvents', () => {
@@ -39,8 +48,8 @@ describe('foldPrnFromTailEvents', () => {
     })
   })
 
-  describe('fold map', () => {
-    it('prn-created folds to awaiting_authorisation', () => {
+  describe('per-event projection', () => {
+    it('prn-created sets status, slot, history, version, updatedAt/By and watermark', () => {
       const prn = basePrn()
       const event = buildEvent(
         STREAM_EVENT_KIND.PRN_CREATED,
@@ -54,11 +63,26 @@ describe('foldPrnFromTailEvents', () => {
         PRN_STATUS.AWAITING_AUTHORISATION
       )
       expect(result.status.currentStatusAt).toEqual(event.createdAt)
+      expect(result.status.created).toEqual({
+        at: event.createdAt,
+        by: event.createdBy
+      })
+      expect(result.status.history).toEqual([
+        ...prn.status.history,
+        {
+          status: PRN_STATUS.AWAITING_AUTHORISATION,
+          at: event.createdAt,
+          by: event.createdBy
+        }
+      ])
+      expect(result.version).toBe(2)
+      expect(result.updatedAt).toEqual(event.createdAt)
+      expect(result.updatedBy).toEqual(event.createdBy)
       expect(result.lastAppliedEventNumber).toBe(1)
     })
 
-    it('prn-issued folds to awaiting_acceptance', () => {
-      const prn = { ...basePrn(), lastAppliedEventNumber: 1 }
+    it('prn-issued sets currentStatus awaiting_acceptance and issued slot', () => {
+      const prn = basePrn()
       const event = buildEvent(
         STREAM_EVENT_KIND.PRN_ISSUED,
         2,
@@ -68,40 +92,153 @@ describe('foldPrnFromTailEvents', () => {
       const result = foldPrnFromTailEvents(prn, [event])
 
       expect(result.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
-      expect(result.status.currentStatusAt).toEqual(event.createdAt)
-      expect(result.lastAppliedEventNumber).toBe(2)
+      expect(result.status.issued).toEqual({
+        at: event.createdAt,
+        by: event.createdBy
+      })
+      expect(result.status.history.at(-1)).toEqual({
+        status: PRN_STATUS.AWAITING_ACCEPTANCE,
+        at: event.createdAt,
+        by: event.createdBy
+      })
     })
 
-    it('prn-creation-cancelled folds to deleted', () => {
+    it('prn-accepted sets currentStatus accepted and accepted slot', () => {
       const prn = basePrn()
       const event = buildEvent(
-        STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
+        STREAM_EVENT_KIND.PRN_ACCEPTED,
         3,
         '2026-02-03T12:00:00.000Z'
       )
 
       const result = foldPrnFromTailEvents(prn, [event])
 
-      expect(result.status.currentStatus).toBe(PRN_STATUS.DELETED)
-      expect(result.status.currentStatusAt).toEqual(event.createdAt)
-      expect(result.lastAppliedEventNumber).toBe(3)
+      expect(result.status.currentStatus).toBe(PRN_STATUS.ACCEPTED)
+      expect(result.status.accepted).toEqual({
+        at: event.createdAt,
+        by: event.createdBy
+      })
+      expect(result.status.history.at(-1)).toEqual({
+        status: PRN_STATUS.ACCEPTED,
+        at: event.createdAt,
+        by: event.createdBy
+      })
     })
 
-    it('prn-cancelled-after-issue folds to cancelled', () => {
+    it('prn-rejected sets currentStatus awaiting_cancellation and rejected slot', () => {
       const prn = basePrn()
       const event = buildEvent(
-        STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+        STREAM_EVENT_KIND.PRN_REJECTED,
         4,
         '2026-02-04T12:00:00.000Z'
       )
 
       const result = foldPrnFromTailEvents(prn, [event])
 
-      expect(result.status.currentStatus).toBe(PRN_STATUS.CANCELLED)
-      expect(result.status.currentStatusAt).toEqual(event.createdAt)
-      expect(result.lastAppliedEventNumber).toBe(4)
+      expect(result.status.currentStatus).toBe(PRN_STATUS.AWAITING_CANCELLATION)
+      expect(result.status.rejected).toEqual({
+        at: event.createdAt,
+        by: event.createdBy
+      })
+      expect(result.status.history.at(-1)).toEqual({
+        status: PRN_STATUS.AWAITING_CANCELLATION,
+        at: event.createdAt,
+        by: event.createdBy
+      })
     })
 
+    it('prn-creation-cancelled sets currentStatus deleted and deleted slot', () => {
+      const prn = basePrn()
+      const event = buildEvent(
+        STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
+        5,
+        '2026-02-05T12:00:00.000Z'
+      )
+
+      const result = foldPrnFromTailEvents(prn, [event])
+
+      expect(result.status.currentStatus).toBe(PRN_STATUS.DELETED)
+      expect(result.status.deleted).toEqual({
+        at: event.createdAt,
+        by: event.createdBy
+      })
+      expect(result.status.history.at(-1)).toEqual({
+        status: PRN_STATUS.DELETED,
+        at: event.createdAt,
+        by: event.createdBy
+      })
+    })
+
+    it('prn-cancelled-after-issue sets currentStatus cancelled and cancelled slot', () => {
+      const prn = basePrn()
+      const event = buildEvent(
+        STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+        6,
+        '2026-02-06T12:00:00.000Z'
+      )
+
+      const result = foldPrnFromTailEvents(prn, [event])
+
+      expect(result.status.currentStatus).toBe(PRN_STATUS.CANCELLED)
+      expect(result.status.cancelled).toEqual({
+        at: event.createdAt,
+        by: event.createdBy
+      })
+      expect(result.status.history.at(-1)).toEqual({
+        status: PRN_STATUS.CANCELLED,
+        at: event.createdAt,
+        by: event.createdBy
+      })
+    })
+  })
+
+  describe('multi-event left fold', () => {
+    it('applies every event in order, populating each slot and appending each history entry', () => {
+      const prn = basePrn()
+      const created = buildEvent(
+        STREAM_EVENT_KIND.PRN_CREATED,
+        1,
+        '2026-02-01T12:00:00.000Z'
+      )
+      const issued = buildEvent(
+        STREAM_EVENT_KIND.PRN_ISSUED,
+        2,
+        '2026-02-02T12:00:00.000Z',
+        { id: 'signatory', name: 'Sig Natory' }
+      )
+
+      const result = foldPrnFromTailEvents(prn, [created, issued])
+
+      expect(result.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+      expect(result.status.currentStatusAt).toEqual(issued.createdAt)
+      expect(result.status.created).toEqual({
+        at: created.createdAt,
+        by: created.createdBy
+      })
+      expect(result.status.issued).toEqual({
+        at: issued.createdAt,
+        by: issued.createdBy
+      })
+      expect(result.status.history.slice(-2)).toEqual([
+        {
+          status: PRN_STATUS.AWAITING_AUTHORISATION,
+          at: created.createdAt,
+          by: created.createdBy
+        },
+        {
+          status: PRN_STATUS.AWAITING_ACCEPTANCE,
+          at: issued.createdAt,
+          by: issued.createdBy
+        }
+      ])
+      expect(result.version).toBe(3)
+      expect(result.updatedAt).toEqual(issued.createdAt)
+      expect(result.updatedBy).toEqual(issued.createdBy)
+      expect(result.lastAppliedEventNumber).toBe(2)
+    })
+  })
+
+  describe('error handling', () => {
     it('throws on an unmappable kind (e.g. summary-log-submitted)', () => {
       const prn = basePrn()
       const event = buildEvent(
@@ -116,30 +253,8 @@ describe('foldPrnFromTailEvents', () => {
     })
   })
 
-  describe('with multiple tail events', () => {
-    it('folds from the latest (highest-numbered) event', () => {
-      const prn = basePrn()
-      const earlier = buildEvent(
-        STREAM_EVENT_KIND.PRN_CREATED,
-        1,
-        '2026-02-01T12:00:00.000Z'
-      )
-      const latest = buildEvent(
-        STREAM_EVENT_KIND.PRN_ISSUED,
-        2,
-        '2026-02-02T12:00:00.000Z'
-      )
-
-      const result = foldPrnFromTailEvents(prn, [earlier, latest])
-
-      expect(result.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
-      expect(result.status.currentStatusAt).toEqual(latest.createdAt)
-      expect(result.lastAppliedEventNumber).toBe(2)
-    })
-  })
-
-  describe('preserves the rest of the PRN', () => {
-    it('does not mutate the input', () => {
+  describe('purity', () => {
+    it('does not mutate the input PRN', () => {
       const prn = basePrn()
       const snapshot = structuredClone(prn)
       const event = buildEvent(
@@ -153,16 +268,12 @@ describe('foldPrnFromTailEvents', () => {
       expect(prn).toEqual(snapshot)
     })
 
-    it('keeps other top-level fields and nested status fields', () => {
+    it('keeps other top-level fields untouched', () => {
       const prn = {
         ...basePrn(),
         tonnage: 50,
         prnNumber: 'ER1234567890A',
-        status: {
-          ...basePrn().status,
-          history: [{ status: PRN_STATUS.DRAFT, at: new Date(), by: {} }],
-          issued: { at: new Date('2026-01-16T14:30:00.000Z'), by: { id: 'u' } }
-        }
+        notes: 'leave me alone'
       }
       const event = buildEvent(
         STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
@@ -174,9 +285,7 @@ describe('foldPrnFromTailEvents', () => {
 
       expect(result.tonnage).toBe(50)
       expect(result.prnNumber).toBe('ER1234567890A')
-      expect(result.status.history).toEqual(prn.status.history)
-      expect(result.status.issued).toEqual(prn.status.issued)
-      expect(result.status.currentStatus).toBe(PRN_STATUS.CANCELLED)
+      expect(result.notes).toBe('leave me alone')
     })
   })
 })

--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
@@ -4,22 +4,32 @@ import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { foldPrnFromTailEvents } from './fold-prn-from-tail-events.js'
 
+/**
+ * @typedef {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} PackagingRecyclingNote
+ */
+
 const baseUpdatedAt = new Date('2026-01-15T10:00:00.000Z')
 const baseCreator = { id: 'creator', name: 'Original Creator' }
 
-const basePrn = () => ({
-  id: 'prn-1',
-  registrationId: 'reg-1',
-  accreditation: { id: 'acc-1' },
-  version: 1,
-  updatedAt: baseUpdatedAt,
-  updatedBy: baseCreator,
-  status: {
-    currentStatus: PRN_STATUS.DRAFT,
-    currentStatusAt: baseUpdatedAt,
-    history: [{ status: PRN_STATUS.DRAFT, at: baseUpdatedAt, by: baseCreator }]
-  }
-})
+/** @returns {PackagingRecyclingNote} */
+const basePrn = () =>
+  /** @type {PackagingRecyclingNote} */ (
+    /** @type {unknown} */ ({
+      id: 'prn-1',
+      registrationId: 'reg-1',
+      accreditation: { id: 'acc-1' },
+      version: 1,
+      updatedAt: baseUpdatedAt,
+      updatedBy: baseCreator,
+      status: {
+        currentStatus: PRN_STATUS.DRAFT,
+        currentStatusAt: baseUpdatedAt,
+        history: [
+          { status: PRN_STATUS.DRAFT, at: baseUpdatedAt, by: baseCreator }
+        ]
+      }
+    })
+  )
 
 const eventCreator = { id: 'user-1', name: 'Test User' }
 

--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest'
+
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { foldPrnFromTailEvents } from './fold-prn-from-tail-events.js'
+
+const basePrn = () => ({
+  id: 'prn-1',
+  registrationId: 'reg-1',
+  accreditation: { id: 'acc-1' },
+  status: {
+    currentStatus: PRN_STATUS.DRAFT,
+    currentStatusAt: new Date('2026-01-15T10:00:00.000Z')
+  }
+})
+
+const buildEvent = (kind, number, createdAt) => ({
+  id: `event-${number}`,
+  registrationId: 'reg-1',
+  accreditationId: 'acc-1',
+  organisationId: 'org-1',
+  number,
+  kind,
+  payload: { prnId: 'prn-1', amount: 50 },
+  openingBalance: { amount: 100, availableAmount: 100 },
+  closingBalance: { amount: 100, availableAmount: 50 },
+  createdAt: new Date(createdAt),
+  createdBy: { id: 'user-1', name: 'Test User' }
+})
+
+describe('foldPrnFromTailEvents', () => {
+  describe('with no tail events', () => {
+    it('returns the PRN unchanged', () => {
+      const prn = basePrn()
+
+      const result = foldPrnFromTailEvents(prn, [])
+
+      expect(result).toBe(prn)
+    })
+  })
+
+  describe('fold map', () => {
+    it('prn-created folds to awaiting_authorisation', () => {
+      const prn = basePrn()
+      const event = buildEvent(
+        STREAM_EVENT_KIND.PRN_CREATED,
+        1,
+        '2026-02-01T12:00:00.000Z'
+      )
+
+      const result = foldPrnFromTailEvents(prn, [event])
+
+      expect(result.status.currentStatus).toBe(
+        PRN_STATUS.AWAITING_AUTHORISATION
+      )
+      expect(result.status.currentStatusAt).toEqual(event.createdAt)
+      expect(result.lastAppliedEventNumber).toBe(1)
+    })
+
+    it('prn-issued folds to awaiting_acceptance', () => {
+      const prn = { ...basePrn(), lastAppliedEventNumber: 1 }
+      const event = buildEvent(
+        STREAM_EVENT_KIND.PRN_ISSUED,
+        2,
+        '2026-02-02T12:00:00.000Z'
+      )
+
+      const result = foldPrnFromTailEvents(prn, [event])
+
+      expect(result.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+      expect(result.status.currentStatusAt).toEqual(event.createdAt)
+      expect(result.lastAppliedEventNumber).toBe(2)
+    })
+
+    it('prn-creation-cancelled folds to deleted', () => {
+      const prn = basePrn()
+      const event = buildEvent(
+        STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
+        3,
+        '2026-02-03T12:00:00.000Z'
+      )
+
+      const result = foldPrnFromTailEvents(prn, [event])
+
+      expect(result.status.currentStatus).toBe(PRN_STATUS.DELETED)
+      expect(result.status.currentStatusAt).toEqual(event.createdAt)
+      expect(result.lastAppliedEventNumber).toBe(3)
+    })
+
+    it('prn-cancelled-after-issue folds to cancelled', () => {
+      const prn = basePrn()
+      const event = buildEvent(
+        STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+        4,
+        '2026-02-04T12:00:00.000Z'
+      )
+
+      const result = foldPrnFromTailEvents(prn, [event])
+
+      expect(result.status.currentStatus).toBe(PRN_STATUS.CANCELLED)
+      expect(result.status.currentStatusAt).toEqual(event.createdAt)
+      expect(result.lastAppliedEventNumber).toBe(4)
+    })
+
+    it('throws on an unmappable kind (e.g. summary-log-submitted)', () => {
+      const prn = basePrn()
+      const event = buildEvent(
+        STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        1,
+        '2026-02-01T12:00:00.000Z'
+      )
+
+      expect(() => foldPrnFromTailEvents(prn, [event])).toThrow(
+        /unmappable stream event kind/i
+      )
+    })
+  })
+
+  describe('with multiple tail events', () => {
+    it('folds from the latest (highest-numbered) event', () => {
+      const prn = basePrn()
+      const earlier = buildEvent(
+        STREAM_EVENT_KIND.PRN_CREATED,
+        1,
+        '2026-02-01T12:00:00.000Z'
+      )
+      const latest = buildEvent(
+        STREAM_EVENT_KIND.PRN_ISSUED,
+        2,
+        '2026-02-02T12:00:00.000Z'
+      )
+
+      const result = foldPrnFromTailEvents(prn, [earlier, latest])
+
+      expect(result.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+      expect(result.status.currentStatusAt).toEqual(latest.createdAt)
+      expect(result.lastAppliedEventNumber).toBe(2)
+    })
+  })
+
+  describe('preserves the rest of the PRN', () => {
+    it('does not mutate the input', () => {
+      const prn = basePrn()
+      const snapshot = structuredClone(prn)
+      const event = buildEvent(
+        STREAM_EVENT_KIND.PRN_ISSUED,
+        2,
+        '2026-02-02T12:00:00.000Z'
+      )
+
+      foldPrnFromTailEvents(prn, [event])
+
+      expect(prn).toEqual(snapshot)
+    })
+
+    it('keeps other top-level fields and nested status fields', () => {
+      const prn = {
+        ...basePrn(),
+        tonnage: 50,
+        prnNumber: 'ER1234567890A',
+        status: {
+          ...basePrn().status,
+          history: [{ status: PRN_STATUS.DRAFT, at: new Date(), by: {} }],
+          issued: { at: new Date('2026-01-16T14:30:00.000Z'), by: { id: 'u' } }
+        }
+      }
+      const event = buildEvent(
+        STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+        5,
+        '2026-02-05T12:00:00.000Z'
+      )
+
+      const result = foldPrnFromTailEvents(prn, [event])
+
+      expect(result.tonnage).toBe(50)
+      expect(result.prnNumber).toBe('ER1234567890A')
+      expect(result.status.history).toEqual(prn.status.history)
+      expect(result.status.issued).toEqual(prn.status.issued)
+      expect(result.status.currentStatus).toBe(PRN_STATUS.CANCELLED)
+    })
+  })
+})

--- a/src/packaging-recycling-notes/application/get-projected-prn.js
+++ b/src/packaging-recycling-notes/application/get-projected-prn.js
@@ -1,0 +1,41 @@
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { foldPrnFromTailEvents } from './fold-prn-from-tail-events.js'
+
+/**
+ * @typedef {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepository
+ * @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository
+ * @typedef {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} PackagingRecyclingNote
+ */
+
+/**
+ * Reads a PRN and brings it current by folding any stream tail events past its
+ * watermark, so callers receive the fully-formed PRN without touching the event
+ * stream themselves. A missing or soft-deleted document short-circuits with no
+ * stream query: a deleted PRN is terminal and has no further events to project.
+ *
+ * @param {Object} params
+ * @param {PackagingRecyclingNotesRepository} params.packagingRecyclingNotesRepository
+ * @param {WasteBalancesRepository} params.wasteBalancesRepository
+ * @param {string} params.prnId
+ * @returns {Promise<PackagingRecyclingNote | null>}
+ */
+export const getProjectedPrnById = async ({
+  packagingRecyclingNotesRepository,
+  wasteBalancesRepository,
+  prnId
+}) => {
+  const prn = await packagingRecyclingNotesRepository.findById(prnId)
+
+  if (!prn || prn.status.currentStatus === PRN_STATUS.DELETED) {
+    return prn
+  }
+
+  const tailEvents = await wasteBalancesRepository.getPrnCatchupEvents({
+    registrationId: prn.registrationId,
+    accreditationId: prn.accreditation.id,
+    prnId: prn.id,
+    afterEventNumber: prn.lastAppliedEventNumber ?? 0
+  })
+
+  return foldPrnFromTailEvents(prn, tailEvents)
+}

--- a/src/packaging-recycling-notes/application/get-projected-prn.test.js
+++ b/src/packaging-recycling-notes/application/get-projected-prn.test.js
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { getProjectedPrnById } from './get-projected-prn.js'
+
+/**
+ * @typedef {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} PackagingRecyclingNote
+ * @typedef {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepository
+ * @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository
+ */
+
+const baseUpdatedAt = new Date('2026-01-15T10:00:00.000Z')
+const baseCreator = { id: 'creator', name: 'Original Creator' }
+
+/**
+ * @param {Partial<PackagingRecyclingNote>} [overrides]
+ * @returns {PackagingRecyclingNote}
+ */
+const buildPrn = (overrides = {}) =>
+  /** @type {PackagingRecyclingNote} */ (
+    /** @type {unknown} */ ({
+      id: 'prn-1',
+      registrationId: 'reg-1',
+      accreditation: { id: 'acc-1' },
+      organisation: { id: 'org-1' },
+      version: 1,
+      updatedAt: baseUpdatedAt,
+      updatedBy: baseCreator,
+      status: {
+        currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+        currentStatusAt: baseUpdatedAt,
+        history: []
+      },
+      ...overrides
+    })
+  )
+
+const eventCreator = { id: 'user-1', name: 'Test User' }
+
+const buildEvent = (kind, number, createdAt) => ({
+  id: `event-${number}`,
+  registrationId: 'reg-1',
+  accreditationId: 'acc-1',
+  organisationId: 'org-1',
+  number,
+  kind,
+  payload: { prnId: 'prn-1', amount: 50 },
+  openingBalance: { amount: 100, availableAmount: 100 },
+  closingBalance: { amount: 100, availableAmount: 50 },
+  createdAt: new Date(createdAt),
+  createdBy: eventCreator
+})
+
+/**
+ * @param {{ findById: import('vitest').Mock }} repo
+ * @returns {PackagingRecyclingNotesRepository}
+ */
+const asPrnRepo = (repo) =>
+  /** @type {PackagingRecyclingNotesRepository} */ (
+    /** @type {unknown} */ (repo)
+  )
+
+/**
+ * @param {{ getPrnCatchupEvents: import('vitest').Mock }} repo
+ * @returns {WasteBalancesRepository}
+ */
+const asWasteRepo = (repo) =>
+  /** @type {WasteBalancesRepository} */ (/** @type {unknown} */ (repo))
+
+/**
+ * @param {{ prn?: PackagingRecyclingNote | null, tailEvents?: object[] }} setup
+ */
+const setupRepositories = ({ prn = null, tailEvents = [] }) => ({
+  prnRepository: { findById: vi.fn(async () => prn) },
+  wasteBalancesRepository: {
+    getPrnCatchupEvents: vi.fn(async () => tailEvents)
+  }
+})
+
+describe('getProjectedPrnById', () => {
+  it('folds tail events onto the PRN and returns the projected note', async () => {
+    const prn = buildPrn({ lastAppliedEventNumber: 1 })
+    const { prnRepository, wasteBalancesRepository } = setupRepositories({
+      prn,
+      tailEvents: [
+        buildEvent(STREAM_EVENT_KIND.PRN_ISSUED, 2, '2026-02-02T12:00:00.000Z')
+      ]
+    })
+
+    const result = await getProjectedPrnById({
+      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
+      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
+      prnId: 'prn-1'
+    })
+
+    expect(result?.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+  })
+
+  it('queries catch-up events using the PRN watermark', async () => {
+    const prn = buildPrn({ lastAppliedEventNumber: 3 })
+    const { prnRepository, wasteBalancesRepository } = setupRepositories({
+      prn
+    })
+
+    await getProjectedPrnById({
+      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
+      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
+      prnId: 'prn-1'
+    })
+
+    expect(wasteBalancesRepository.getPrnCatchupEvents).toHaveBeenCalledWith({
+      registrationId: 'reg-1',
+      accreditationId: 'acc-1',
+      prnId: 'prn-1',
+      afterEventNumber: 3
+    })
+  })
+
+  it('defaults afterEventNumber to 0 when the PRN has no watermark', async () => {
+    const prn = buildPrn()
+    const { prnRepository, wasteBalancesRepository } = setupRepositories({
+      prn
+    })
+
+    await getProjectedPrnById({
+      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
+      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
+      prnId: 'prn-1'
+    })
+
+    expect(wasteBalancesRepository.getPrnCatchupEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ afterEventNumber: 0 })
+    )
+  })
+
+  it('returns the PRN unchanged when no tail events exist', async () => {
+    const prn = buildPrn({ lastAppliedEventNumber: 2 })
+    const { prnRepository, wasteBalancesRepository } = setupRepositories({
+      prn,
+      tailEvents: []
+    })
+
+    const result = await getProjectedPrnById({
+      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
+      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
+      prnId: 'prn-1'
+    })
+
+    expect(result).toBe(prn)
+  })
+
+  it('returns null without querying the stream when the PRN does not exist', async () => {
+    const { prnRepository, wasteBalancesRepository } = setupRepositories({
+      prn: null
+    })
+
+    const result = await getProjectedPrnById({
+      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
+      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
+      prnId: 'prn-1'
+    })
+
+    expect(result).toBeNull()
+    expect(wasteBalancesRepository.getPrnCatchupEvents).not.toHaveBeenCalled()
+  })
+
+  it('returns a soft-deleted PRN as-is without querying the stream', async () => {
+    const deletedPrn = buildPrn({
+      status: {
+        currentStatus: PRN_STATUS.DELETED,
+        currentStatusAt: baseUpdatedAt,
+        history: []
+      }
+    })
+    const { prnRepository, wasteBalancesRepository } = setupRepositories({
+      prn: deletedPrn
+    })
+
+    const result = await getProjectedPrnById({
+      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
+      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
+      prnId: 'prn-1'
+    })
+
+    expect(result).toBe(deletedPrn)
+    expect(wasteBalancesRepository.getPrnCatchupEvents).not.toHaveBeenCalled()
+  })
+})

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -42,7 +42,10 @@ import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
  * @param {WasteBalancesRepository} wasteBalancesRepository
  * @param {Object} params
  */
-async function deductWasteBalanceIfNeeded(wasteBalancesRepository, params) {
+export async function deductWasteBalanceIfNeeded(
+  wasteBalancesRepository,
+  params
+) {
   const {
     accreditationId,
     registrationId,
@@ -80,7 +83,10 @@ async function deductWasteBalanceIfNeeded(wasteBalancesRepository, params) {
  * @param {WasteBalancesRepository} wasteBalancesRepository
  * @param {Object} params
  */
-async function deductTotalBalanceIfNeeded(wasteBalancesRepository, params) {
+export async function deductTotalBalanceIfNeeded(
+  wasteBalancesRepository,
+  params
+) {
   const {
     accreditationId,
     registrationId,
@@ -119,7 +125,10 @@ async function deductTotalBalanceIfNeeded(wasteBalancesRepository, params) {
  * @param {WasteBalancesRepository} wasteBalancesRepository
  * @param {Object} params
  */
-async function creditWasteBalanceIfNeeded(wasteBalancesRepository, params) {
+export async function creditWasteBalanceIfNeeded(
+  wasteBalancesRepository,
+  params
+) {
   const {
     accreditationId,
     registrationId,
@@ -154,7 +163,10 @@ async function creditWasteBalanceIfNeeded(wasteBalancesRepository, params) {
  * @param {WasteBalancesRepository} wasteBalancesRepository
  * @param {Object} params
  */
-async function creditFullBalanceIfNeeded(wasteBalancesRepository, params) {
+export async function creditFullBalanceIfNeeded(
+  wasteBalancesRepository,
+  params
+) {
   const {
     accreditationId,
     registrationId,
@@ -192,7 +204,7 @@ async function creditFullBalanceIfNeeded(wasteBalancesRepository, params) {
  * @param {string} fromStatus
  * @param {string} toStatus
  */
-function logWasteBalanceUpdate(
+export function logWasteBalanceUpdate(
   logger,
   operation,
   prnId,
@@ -229,6 +241,18 @@ export function balanceEventsFor(currentStatus, newStatus, params) {
     return [{ kind: STREAM_EVENT_KIND.PRN_ISSUED, params }]
   }
   if (
+    newStatus === PRN_STATUS.ACCEPTED &&
+    currentStatus === PRN_STATUS.AWAITING_ACCEPTANCE
+  ) {
+    return [{ kind: STREAM_EVENT_KIND.PRN_ACCEPTED, params }]
+  }
+  if (
+    newStatus === PRN_STATUS.AWAITING_CANCELLATION &&
+    currentStatus === PRN_STATUS.AWAITING_ACCEPTANCE
+  ) {
+    return [{ kind: STREAM_EVENT_KIND.PRN_REJECTED, params }]
+  }
+  if (
     (newStatus === PRN_STATUS.CANCELLED || newStatus === PRN_STATUS.DELETED) &&
     currentStatus === PRN_STATUS.AWAITING_AUTHORISATION
   ) {
@@ -244,9 +268,25 @@ export function balanceEventsFor(currentStatus, newStatus, params) {
 }
 
 /**
+ * Append a status-only stream event (PRN_ACCEPTED, PRN_REJECTED). No balance
+ * change; the ledger-only repository method appends to the stream and throws
+ * loudly if called on an embedded balance.
+ *
+ * @param {import('#waste-balances/repository/stream-schema.js').StreamEventKind} streamKind
+ */
+const appendStatusOnlyStreamEvent =
+  (streamKind) => async (wasteBalancesRepository, params) =>
+    wasteBalancesRepository.appendStreamEvent({
+      ...params,
+      streamKind
+    })
+
+/**
  * Per-kind dispatch: each kind pairs an effect handler with its log-operation
- * label. The handlers are the same primitives the embedded path has always
- * used; on the ledger path they append a stream event and return its number.
+ * label. Balance-affecting kinds mutate the balance (embedded) or append to
+ * the stream (ledger); status-only kinds (PRN_ACCEPTED, PRN_REJECTED) only
+ * append on the ledger — they should never be dispatched on the embedded path,
+ * and `appendStreamEvent` throws if they are.
  */
 const EFFECT_HANDLERS = Object.freeze({
   [STREAM_EVENT_KIND.PRN_CREATED]: {
@@ -256,6 +296,14 @@ const EFFECT_HANDLERS = Object.freeze({
   [STREAM_EVENT_KIND.PRN_ISSUED]: {
     apply: deductTotalBalanceIfNeeded,
     logOperation: 'deduct_total'
+  },
+  [STREAM_EVENT_KIND.PRN_ACCEPTED]: {
+    apply: appendStatusOnlyStreamEvent(STREAM_EVENT_KIND.PRN_ACCEPTED),
+    logOperation: 'append_accepted'
+  },
+  [STREAM_EVENT_KIND.PRN_REJECTED]: {
+    apply: appendStatusOnlyStreamEvent(STREAM_EVENT_KIND.PRN_REJECTED),
+    logOperation: 'append_rejected'
   },
   [STREAM_EVENT_KIND.PRN_CREATION_CANCELLED]: {
     apply: creditWasteBalanceIfNeeded,

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -223,6 +223,30 @@ export function logWasteBalanceUpdate(
 }
 
 /**
+ * Transition table keyed by `${currentStatus}|${newStatus}`. Each entry names
+ * the stream event kind the transition writes. Transitions without an entry
+ * have no balance effect.
+ *
+ * @type {Record<string, StreamEventKind>}
+ */
+const TRANSITION_TO_EVENT_KIND = Object.freeze({
+  [`${PRN_STATUS.DRAFT}|${PRN_STATUS.AWAITING_AUTHORISATION}`]:
+    STREAM_EVENT_KIND.PRN_CREATED,
+  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.AWAITING_ACCEPTANCE}`]:
+    STREAM_EVENT_KIND.PRN_ISSUED,
+  [`${PRN_STATUS.AWAITING_ACCEPTANCE}|${PRN_STATUS.ACCEPTED}`]:
+    STREAM_EVENT_KIND.PRN_ACCEPTED,
+  [`${PRN_STATUS.AWAITING_ACCEPTANCE}|${PRN_STATUS.AWAITING_CANCELLATION}`]:
+    STREAM_EVENT_KIND.PRN_REJECTED,
+  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.CANCELLED}`]:
+    STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
+  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.DELETED}`]:
+    STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
+  [`${PRN_STATUS.AWAITING_CANCELLATION}|${PRN_STATUS.CANCELLED}`]:
+    STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE
+})
+
+/**
  * Derives the balance events a status transition would write. An empty array
  * means the transition has no balance effect — callers use that to skip the
  * stream-write decision read entirely. The kinds align with `STREAM_EVENT_KIND`
@@ -234,37 +258,8 @@ export function logWasteBalanceUpdate(
  * @returns {BalanceEvent[]}
  */
 export function balanceEventsFor(currentStatus, newStatus, params) {
-  if (newStatus === PRN_STATUS.AWAITING_AUTHORISATION) {
-    return [{ kind: STREAM_EVENT_KIND.PRN_CREATED, params }]
-  }
-  if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
-    return [{ kind: STREAM_EVENT_KIND.PRN_ISSUED, params }]
-  }
-  if (
-    newStatus === PRN_STATUS.ACCEPTED &&
-    currentStatus === PRN_STATUS.AWAITING_ACCEPTANCE
-  ) {
-    return [{ kind: STREAM_EVENT_KIND.PRN_ACCEPTED, params }]
-  }
-  if (
-    newStatus === PRN_STATUS.AWAITING_CANCELLATION &&
-    currentStatus === PRN_STATUS.AWAITING_ACCEPTANCE
-  ) {
-    return [{ kind: STREAM_EVENT_KIND.PRN_REJECTED, params }]
-  }
-  if (
-    (newStatus === PRN_STATUS.CANCELLED || newStatus === PRN_STATUS.DELETED) &&
-    currentStatus === PRN_STATUS.AWAITING_AUTHORISATION
-  ) {
-    return [{ kind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED, params }]
-  }
-  if (
-    newStatus === PRN_STATUS.CANCELLED &&
-    currentStatus === PRN_STATUS.AWAITING_CANCELLATION
-  ) {
-    return [{ kind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE, params }]
-  }
-  return []
+  const kind = TRANSITION_TO_EVENT_KIND[`${currentStatus}|${newStatus}`]
+  return kind ? [{ kind, params }] : []
 }
 
 /**

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -268,28 +268,30 @@ const EFFECT_HANDLERS = Object.freeze({
 })
 
 /**
- * Applies the balance events for a status transition. Returns the last applied
- * event's number (the watermark) on the ledger path, or `null` on the embedded
- * path and when the events array is empty.
+ * Applies the balance events for a status transition. Returns the appended
+ * stream events on the ledger path. On the embedded path the array entries
+ * are `null` (no stream event was appended); the array still has one entry
+ * per input event so callers can map positionally.
  *
  * @param {WasteBalancesRepository} wasteBalancesRepository
  * @param {import('#common/hapi-types.js').TypedLogger} logger
  * @param {BalanceEvent[]} events
- * @returns {Promise<number|null>}
+ * @returns {Promise<Array<import('#waste-balances/repository/stream-port.js').StreamEvent|null>>}
  */
 export async function applyWasteBalanceEffects(
   wasteBalancesRepository,
   logger,
   events
 ) {
-  let lastAppliedEventNumber = null
+  const applied = []
   for (const event of events) {
     const handler = EFFECT_HANDLERS[event.kind]
     const { currentStatus, newStatus, ...balanceParams } = event.params
-    lastAppliedEventNumber = await handler.apply(
+    const streamEvent = await handler.apply(
       wasteBalancesRepository,
       balanceParams
     )
+    applied.push(streamEvent)
     logWasteBalanceUpdate(
       logger,
       handler.logOperation,
@@ -299,5 +301,5 @@ export async function applyWasteBalanceEffects(
       newStatus
     )
   }
-  return lastAppliedEventNumber
+  return applied
 }

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
@@ -140,6 +140,47 @@ describe('applyWasteBalanceEffects appended events return', () => {
     expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
   })
 
+  it('returns the appended event from the prn-accepted branch', async () => {
+    const { wasteBalancesRepository, streamRepository } =
+      await setupLedgerRepository()
+
+    const applied = await applyWasteBalanceEffects(
+      wasteBalancesRepository,
+      buildLogger(),
+      eventsForTransition(PRN_STATUS.AWAITING_ACCEPTANCE, PRN_STATUS.ACCEPTED)
+    )
+
+    const latest = await streamRepository.findLatestByPartition(
+      REGISTRATION_ID,
+      ACCREDITATION_ID
+    )
+    expect(applied[0]?.kind).toBe(STREAM_EVENT_KIND.PRN_ACCEPTED)
+    expect(applied[0]?.number).toBe(latest?.number)
+    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
+  })
+
+  it('returns the appended event from the prn-rejected branch', async () => {
+    const { wasteBalancesRepository, streamRepository } =
+      await setupLedgerRepository()
+
+    const applied = await applyWasteBalanceEffects(
+      wasteBalancesRepository,
+      buildLogger(),
+      eventsForTransition(
+        PRN_STATUS.AWAITING_ACCEPTANCE,
+        PRN_STATUS.AWAITING_CANCELLATION
+      )
+    )
+
+    const latest = await streamRepository.findLatestByPartition(
+      REGISTRATION_ID,
+      ACCREDITATION_ID
+    )
+    expect(applied[0]?.kind).toBe(STREAM_EVENT_KIND.PRN_REJECTED)
+    expect(applied[0]?.number).toBe(latest?.number)
+    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
+  })
+
   it('returns the appended event from the credit-full branch', async () => {
     const { wasteBalancesRepository, streamRepository } =
       await setupLedgerRepository()
@@ -220,24 +261,24 @@ describe('balanceEventsFor', () => {
     ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE, params }])
   })
 
-  it('emits no events when accepting an issued PRN', () => {
+  it('emits a prn-accepted event for accepting an issued PRN', () => {
     expect(
       balanceEventsFor(
         PRN_STATUS.AWAITING_ACCEPTANCE,
         PRN_STATUS.ACCEPTED,
         params
       )
-    ).toEqual([])
+    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_ACCEPTED, params }])
   })
 
-  it('emits no events when requesting cancellation of an issued PRN', () => {
+  it('emits a prn-rejected event for requesting cancellation of an issued PRN', () => {
     expect(
       balanceEventsFor(
         PRN_STATUS.AWAITING_ACCEPTANCE,
         PRN_STATUS.AWAITING_CANCELLATION,
         params
       )
-    ).toEqual([])
+    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_REJECTED, params }])
   })
 
   it('emits no events when discarding a draft PRN', () => {

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
@@ -81,12 +81,12 @@ const eventsForTransition = (currentStatus, newStatus) =>
     balanceParamsFor({ currentStatus, newStatus })
   )
 
-describe('applyWasteBalanceEffects watermark return', () => {
-  it('returns the appended event number from the deduct-available branch', async () => {
+describe('applyWasteBalanceEffects appended events return', () => {
+  it('returns the appended event from the deduct-available branch', async () => {
     const { wasteBalancesRepository, streamRepository } =
       await setupLedgerRepository()
 
-    const watermark = await applyWasteBalanceEffects(
+    const applied = await applyWasteBalanceEffects(
       wasteBalancesRepository,
       buildLogger(),
       eventsForTransition(PRN_STATUS.DRAFT, PRN_STATUS.AWAITING_AUTHORISATION)
@@ -96,15 +96,16 @@ describe('applyWasteBalanceEffects watermark return', () => {
       REGISTRATION_ID,
       ACCREDITATION_ID
     )
-    expect(watermark).toBe(latest?.number)
-    expect(watermark).toBe(APPENDED_EVENT_NUMBER)
+    expect(applied).toHaveLength(1)
+    expect(applied[0]?.number).toBe(latest?.number)
+    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
   })
 
-  it('returns the appended event number from the deduct-total branch', async () => {
+  it('returns the appended event from the deduct-total branch', async () => {
     const { wasteBalancesRepository, streamRepository } =
       await setupLedgerRepository()
 
-    const watermark = await applyWasteBalanceEffects(
+    const applied = await applyWasteBalanceEffects(
       wasteBalancesRepository,
       buildLogger(),
       eventsForTransition(
@@ -117,15 +118,15 @@ describe('applyWasteBalanceEffects watermark return', () => {
       REGISTRATION_ID,
       ACCREDITATION_ID
     )
-    expect(watermark).toBe(latest?.number)
-    expect(watermark).toBe(APPENDED_EVENT_NUMBER)
+    expect(applied[0]?.number).toBe(latest?.number)
+    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
   })
 
-  it('returns the appended event number from the credit-available branch', async () => {
+  it('returns the appended event from the credit-available branch', async () => {
     const { wasteBalancesRepository, streamRepository } =
       await setupLedgerRepository()
 
-    const watermark = await applyWasteBalanceEffects(
+    const applied = await applyWasteBalanceEffects(
       wasteBalancesRepository,
       buildLogger(),
       eventsForTransition(PRN_STATUS.AWAITING_AUTHORISATION, PRN_STATUS.DELETED)
@@ -135,15 +136,15 @@ describe('applyWasteBalanceEffects watermark return', () => {
       REGISTRATION_ID,
       ACCREDITATION_ID
     )
-    expect(watermark).toBe(latest?.number)
-    expect(watermark).toBe(APPENDED_EVENT_NUMBER)
+    expect(applied[0]?.number).toBe(latest?.number)
+    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
   })
 
-  it('returns the appended event number from the credit-full branch', async () => {
+  it('returns the appended event from the credit-full branch', async () => {
     const { wasteBalancesRepository, streamRepository } =
       await setupLedgerRepository()
 
-    const watermark = await applyWasteBalanceEffects(
+    const applied = await applyWasteBalanceEffects(
       wasteBalancesRepository,
       buildLogger(),
       eventsForTransition(
@@ -156,20 +157,20 @@ describe('applyWasteBalanceEffects watermark return', () => {
       REGISTRATION_ID,
       ACCREDITATION_ID
     )
-    expect(watermark).toBe(latest?.number)
-    expect(watermark).toBe(APPENDED_EVENT_NUMBER)
+    expect(applied[0]?.number).toBe(latest?.number)
+    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
   })
 
-  it('returns null when the events array is empty', async () => {
+  it('returns an empty array when the events array is empty', async () => {
     const { wasteBalancesRepository } = await setupLedgerRepository()
 
-    const watermark = await applyWasteBalanceEffects(
+    const applied = await applyWasteBalanceEffects(
       wasteBalancesRepository,
       buildLogger(),
       []
     )
 
-    expect(watermark).toBeNull()
+    expect(applied).toEqual([])
   })
 })
 

--- a/src/packaging-recycling-notes/application/update-status-embedded-write.js
+++ b/src/packaging-recycling-notes/application/update-status-embedded-write.js
@@ -1,0 +1,471 @@
+import Boom from '@hapi/boom'
+
+import {
+  creditFullBalanceIfNeeded,
+  creditWasteBalanceIfNeeded,
+  deductTotalBalanceIfNeeded,
+  deductWasteBalanceIfNeeded,
+  logWasteBalanceUpdate
+} from './update-status-balance-effects.js'
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/event.js'
+import {
+  PRN_STATUS,
+  assertAccreditationNotSuspended
+} from '#packaging-recycling-notes/domain/model.js'
+import { generatePrnNumber } from '#packaging-recycling-notes/domain/prn-number-generator.js'
+import { PrnNumberConflictError } from '#packaging-recycling-notes/repository/port.js'
+
+/**
+ * @typedef {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepository
+ * @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository
+ * @typedef {import('#packaging-recycling-notes/domain/model.js').PrnStatus} PrnStatus
+ */
+
+/** Suffixes A-Z for collision avoidance */
+export const COLLISION_SUFFIXES = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
+
+const STATUS_OPERATION_SLOT = Object.freeze({
+  [PRN_STATUS.AWAITING_AUTHORISATION]: 'created',
+  [PRN_STATUS.ACCEPTED]: 'accepted',
+  [PRN_STATUS.AWAITING_CANCELLATION]: 'rejected',
+  [PRN_STATUS.DELETED]: 'deleted',
+  [PRN_STATUS.CANCELLED]: 'cancelled'
+})
+
+/**
+ * Transition keys (currentStatus|newStatus) for the post-CAS path that needs a
+ * PRN rollback when the balance side-effect throws. Kept as a typed union so
+ * adding a new key without a matching entry in ROLLBACK_METHOD_BY_TRANSITION
+ * is a tsc error.
+ *
+ * @typedef {`${typeof PRN_STATUS.AWAITING_AUTHORISATION}|${typeof PRN_STATUS.AWAITING_ACCEPTANCE}`
+ *   | `${typeof PRN_STATUS.AWAITING_AUTHORISATION}|${typeof PRN_STATUS.DELETED}`
+ *   | `${typeof PRN_STATUS.AWAITING_CANCELLATION}|${typeof PRN_STATUS.CANCELLED}`} PostCasRollbackTransition
+ */
+
+/**
+ * @typedef {'rollbackIssuance' | 'rollbackPendingCancellation' | 'rollbackIssuedCancellation'} RollbackMethodName
+ */
+
+/**
+ * Maps a (currentStatus -> newStatus) transition to the rollback method on the
+ * PRN repository that reverses the forward write. Only post-CAS transitions
+ * with a follow-on balance side-effect appear here; creation is handled by
+ * crediting the balance back rather than rolling the PRN.
+ *
+ * tsc enforces:
+ *   - every key in PostCasRollbackTransition has an entry (exhaustiveness)
+ *   - no extra keys are present (no orphan rollback entries)
+ *   - every value is a valid RollbackMethodName
+ * Keys are literal strings so tsc can verify them — computed template-literal
+ * keys widen to string and lose the connection to the union. The keys are
+ * still tied to PRN_STATUS because PostCasRollbackTransition resolves via
+ * `typeof PRN_STATUS.*` — a value change in PRN_STATUS would tsc-error here.
+ */
+/** @type {Readonly<Record<PostCasRollbackTransition, RollbackMethodName>>} */
+const ROLLBACK_METHOD_BY_TRANSITION = {
+  'awaiting_authorisation|awaiting_acceptance': 'rollbackIssuance',
+  'awaiting_authorisation|deleted': 'rollbackPendingCancellation',
+  'awaiting_cancellation|cancelled': 'rollbackIssuedCancellation'
+}
+
+/**
+ * Embedded-path balance effects keyed by `${currentStatus}|${newStatus}`. The
+ * embedded path predates event sourcing — it doesn't emit stream events, it
+ * just mutates the balance document directly. Missing entry means the
+ * transition is lifecycle-only (no balance change) and just stamps the PRN.
+ */
+const EMBEDDED_BALANCE_EFFECTS = Object.freeze({
+  [`${PRN_STATUS.DRAFT}|${PRN_STATUS.AWAITING_AUTHORISATION}`]: {
+    apply: deductWasteBalanceIfNeeded,
+    log: 'deduct_available'
+  },
+  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.AWAITING_ACCEPTANCE}`]: {
+    apply: deductTotalBalanceIfNeeded,
+    log: 'deduct_total'
+  },
+  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.DELETED}`]: {
+    apply: creditWasteBalanceIfNeeded,
+    log: 'credit_available'
+  },
+  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.CANCELLED}`]: {
+    apply: creditWasteBalanceIfNeeded,
+    log: 'credit_available'
+  },
+  [`${PRN_STATUS.AWAITING_CANCELLATION}|${PRN_STATUS.CANCELLED}`]: {
+    apply: creditFullBalanceIfNeeded,
+    log: 'credit_full'
+  }
+})
+
+/**
+ * @typedef {Object} EmbeddedBalanceEffectParams
+ * @property {WasteBalancesRepository} wasteBalancesRepository
+ * @property {import('#common/hapi-types.js').TypedLogger} logger
+ * @property {PrnStatus} currentStatus
+ * @property {PrnStatus} newStatus
+ * @property {{accreditationId: string, registrationId: string, organisationId: string, prnId: string, tonnage: number, userId: string}} params
+ */
+
+/**
+ * Apply the embedded-path balance effect for a transition. No events are
+ * generated; the balance document is mutated directly.
+ *
+ * @param {EmbeddedBalanceEffectParams} args
+ */
+async function applyEmbeddedBalanceEffect({
+  wasteBalancesRepository,
+  logger,
+  currentStatus,
+  newStatus,
+  params
+}) {
+  const effect = EMBEDDED_BALANCE_EFFECTS[`${currentStatus}|${newStatus}`]
+  if (!effect) {
+    return
+  }
+  await effect.apply(wasteBalancesRepository, params)
+  logWasteBalanceUpdate(
+    logger,
+    effect.log,
+    params.prnId,
+    params.tonnage,
+    currentStatus,
+    newStatus
+  )
+}
+
+/**
+ * Issues a PRN with retry logic for PRN number collisions.
+ * Tries without suffix first, then A-Z on collision.
+ *
+ * @param {PackagingRecyclingNotesRepository} repository
+ * @param {Object} updateParams - Parameters for updateStatus
+ * @param {Object} prnParams - Parameters for PRN number generation
+ * @returns {Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote>}
+ */
+async function issuePrnWithRetry(repository, updateParams, prnParams) {
+  const suffixAttempts = [undefined, ...COLLISION_SUFFIXES]
+
+  for (const suffix of suffixAttempts) {
+    const prnNumber = generatePrnNumber({ ...prnParams, suffix })
+
+    try {
+      const result = await repository.updateStatus({
+        ...updateParams,
+        prnNumber
+      })
+      if (!result) {
+        throw new Error('Failed to update PRN status')
+      }
+      return result
+    } catch (error) {
+      if (error instanceof PrnNumberConflictError) {
+        continue
+      }
+      throw error
+    }
+  }
+
+  throw new Error('Unable to generate unique PRN number after all retries')
+}
+
+/**
+ * Performs the repository write for a status transition.
+ * Issuance (AWAITING_ACCEPTANCE) verifies the accreditation and
+ * generates a unique PRN number; all other transitions just stamp
+ * an operation slot and update.
+ *
+ * @param {Object} params
+ * @returns {Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote>}
+ */
+export async function applyStatusUpdate({
+  prnRepository,
+  organisationsRepository,
+  prn,
+  updateParams,
+  newStatus,
+  organisationId,
+  accreditationId,
+  user,
+  now,
+  accreditation: providedAccreditation
+}) {
+  if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
+    updateParams.operation = {
+      slot: 'issued',
+      at: now,
+      by: { id: user.id, name: user.name }
+    }
+
+    const accreditation =
+      providedAccreditation ??
+      (await organisationsRepository.findAccreditationById(
+        organisationId,
+        accreditationId
+      ))
+
+    assertAccreditationNotSuspended(accreditation)
+
+    return issuePrnWithRetry(prnRepository, updateParams, {
+      regulator: accreditation.submittedToRegulator,
+      isExport: prn.isExport,
+      accreditationYear: prn.accreditation.accreditationYear
+    })
+  }
+
+  const operationSlot = STATUS_OPERATION_SLOT[newStatus]
+  if (operationSlot) {
+    updateParams.operation = { slot: operationSlot, at: now, by: user }
+  }
+
+  const updatedPrn = await prnRepository.updateStatus(updateParams)
+  if (!updatedPrn) {
+    throw Boom.badImplementation('Failed to update PRN status')
+  }
+  return updatedPrn
+}
+
+/**
+ * CDP ingest drops fields outside its allowlist (see cdp-log-types.js),
+ * including bespoke top-level fields and any second error on the same entry.
+ * Both errors are therefore logged as paired entries that share the same
+ * event.reference (the prnId) and event.action so ops can correlate them,
+ * with each entry's `err` populated for indexing.
+ */
+function logCompensationFailure(
+  logger,
+  prnId,
+  fromStatus,
+  toStatus,
+  err,
+  kind
+) {
+  logger.error({
+    err,
+    message: `${kind} for PRN ${prnId} (${fromStatus} -> ${toStatus})`,
+    event: {
+      category: LOGGING_EVENT_CATEGORIES.DB,
+      action: LOGGING_EVENT_ACTIONS.COMPENSATION_FAILURE,
+      reference: prnId
+    }
+  })
+}
+
+/**
+ * Records that a forward failure was caught and cleanly reversed. The forward
+ * error is attached as `err` so it's indexed, and the event.reference is the
+ * prnId so ops can find every compensation event for a given PRN regardless
+ * of whether it ultimately succeeded or failed.
+ */
+function logCompensationSuccess(logger, prnId, fromStatus, toStatus, err) {
+  logger.warn({
+    err,
+    message: `Forward write failed; compensation succeeded for PRN ${prnId} (${fromStatus} -> ${toStatus})`,
+    event: {
+      category: LOGGING_EVENT_CATEGORIES.DB,
+      action: LOGGING_EVENT_ACTIONS.COMPENSATION_SUCCESS,
+      reference: prnId
+    }
+  })
+}
+
+/**
+ * Runs `compensator` to undo a forward write that has already committed.
+ * On success, logs a COMPENSATION_SUCCESS entry carrying the original forward
+ * error so ops can spot patterns of recovered failures. If the compensator
+ * itself throws, the failure is logged with full context (the original
+ * forward error and the compensation error) but not rethrown — the caller
+ * always sees the original forward error so the user-visible outcome stays
+ * coherent. The log entries are what ops use to find PRNs left in an
+ * inconsistent state for manual reconciliation.
+ *
+ * @param {() => Promise<unknown>} compensator
+ * @param {Object} context
+ * @param {Error} context.forwardError
+ * @param {import('#common/hapi-types.js').TypedLogger} context.logger
+ * @param {string} context.prnId
+ * @param {string} context.fromStatus
+ * @param {string} context.toStatus
+ */
+async function tryCompensate(compensator, context) {
+  try {
+    await compensator()
+    logCompensationSuccess(
+      context.logger,
+      context.prnId,
+      context.fromStatus,
+      context.toStatus,
+      context.forwardError
+    )
+  } catch (compensationError) {
+    logCompensationFailure(
+      context.logger,
+      context.prnId,
+      context.fromStatus,
+      context.toStatus,
+      context.forwardError,
+      'Forward write failed; compensation triggered'
+    )
+    logCompensationFailure(
+      context.logger,
+      context.prnId,
+      context.fromStatus,
+      context.toStatus,
+      compensationError,
+      'Compensation failed; manual reconciliation required'
+    )
+  }
+}
+
+/**
+ * Pre-flight balance debit, forward PRN write, and credit-back compensation
+ * if the forward write fails. Pre-flight debit already proved the balance
+ * exists, so the compensator calls the credit primitive directly rather than
+ * going through the wrapper that would re-fetch.
+ */
+export async function performCreation({
+  prnRepository,
+  organisationsRepository,
+  wasteBalancesRepository,
+  logger,
+  prn,
+  updateParams,
+  newStatus,
+  organisationId,
+  registrationId,
+  accreditationId,
+  user,
+  currentStatus,
+  now,
+  id
+}) {
+  await applyEmbeddedBalanceEffect({
+    wasteBalancesRepository,
+    logger,
+    currentStatus,
+    newStatus,
+    params: {
+      accreditationId,
+      registrationId,
+      organisationId,
+      prnId: id,
+      tonnage: prn.tonnage,
+      userId: user.id
+    }
+  })
+
+  try {
+    return await applyStatusUpdate({
+      prnRepository,
+      organisationsRepository,
+      prn,
+      updateParams,
+      newStatus,
+      organisationId,
+      accreditationId,
+      user,
+      now
+    })
+  } catch (forwardError) {
+    await tryCompensate(
+      () =>
+        wasteBalancesRepository.creditAvailableBalanceForPrnCancellation({
+          accreditationId,
+          registrationId,
+          organisationId,
+          prnId: id,
+          tonnage: prn.tonnage,
+          userId: user.id
+        }),
+      {
+        forwardError,
+        logger,
+        prnId: id,
+        fromStatus: currentStatus,
+        toStatus: newStatus
+      }
+    )
+    throw forwardError
+  }
+}
+
+/**
+ * Forward PRN write followed by post-CAS balance effects, rolling the PRN
+ * back via the transition-specific rollback method if the balance write
+ * fails. The per-PRN CAS gates the balance write so concurrent writers
+ * cannot double-debit or double-credit.
+ */
+export async function performTransition({
+  prnRepository,
+  organisationsRepository,
+  wasteBalancesRepository,
+  logger,
+  prn,
+  updateParams,
+  newStatus,
+  organisationId,
+  registrationId,
+  accreditationId,
+  user,
+  currentStatus,
+  now,
+  id
+}) {
+  const updatedPrn = await applyStatusUpdate({
+    prnRepository,
+    organisationsRepository,
+    prn,
+    updateParams,
+    newStatus,
+    organisationId,
+    accreditationId,
+    user,
+    now
+  })
+
+  try {
+    await applyEmbeddedBalanceEffect({
+      wasteBalancesRepository,
+      logger,
+      currentStatus,
+      newStatus,
+      params: {
+        accreditationId,
+        registrationId,
+        organisationId,
+        prnId: id,
+        tonnage: prn.tonnage,
+        userId: user.id
+      }
+    })
+  } catch (forwardError) {
+    const transitionKey = /** @type {PostCasRollbackTransition} */ (
+      `${currentStatus}|${newStatus}`
+    )
+    const rollbackMethod = ROLLBACK_METHOD_BY_TRANSITION[transitionKey]
+    await tryCompensate(
+      () =>
+        prnRepository[rollbackMethod]({
+          id,
+          expectedVersion: updatedPrn.version,
+          updatedBy: user,
+          updatedAt: now,
+          lastAppliedEventNumber: updatedPrn.lastAppliedEventNumber
+        }),
+      {
+        forwardError,
+        logger,
+        prnId: id,
+        fromStatus: currentStatus,
+        toStatus: newStatus
+      }
+    )
+    throw forwardError
+  }
+
+  return updatedPrn
+}

--- a/src/packaging-recycling-notes/application/update-status-stream.test.js
+++ b/src/packaging-recycling-notes/application/update-status-stream.test.js
@@ -7,6 +7,7 @@ import {
 } from '#packaging-recycling-notes/domain/model.js'
 import { REGULATOR } from '#domain/organisations/model.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
 
 vi.mock('./metrics.js', () => ({
   prnMetrics: {
@@ -22,6 +23,8 @@ const REG_ID = 'reg-789'
 const PRN_ID = '507f1f77bcf86cd799439011'
 const TONNAGE = 50
 const APPENDED_WATERMARK = 5
+const USER = { id: 'user-789', name: 'Test User' }
+const EVENT_AT = new Date('2026-02-01T12:00:00.000Z')
 
 const buildLogger = () => ({
   info: vi.fn(),
@@ -47,8 +50,25 @@ const buildPrn = (overrides = {}) => ({
   isExport: false,
   tonnage: TONNAGE,
   version: 3,
-  status: { currentStatus: PRN_STATUS.DRAFT },
+  status: {
+    currentStatus: PRN_STATUS.DRAFT,
+    history: []
+  },
   ...overrides
+})
+
+const buildStreamEvent = (kind, number = APPENDED_WATERMARK) => ({
+  id: `event-${number}`,
+  registrationId: REG_ID,
+  accreditationId: ACC_ID,
+  organisationId: ORG_ID,
+  number,
+  kind,
+  payload: { prnId: PRN_ID, amount: TONNAGE },
+  openingBalance: { amount: 1000, availableAmount: 1000 },
+  closingBalance: { amount: 1000, availableAmount: 950 },
+  createdAt: EVENT_AT,
+  createdBy: USER
 })
 
 const buildOrganisationsRepository = (accreditation = {}) => ({
@@ -65,7 +85,7 @@ const callUpdate = (overrides) =>
     organisationId: ORG_ID,
     registrationId: REG_ID,
     accreditationId: ACC_ID,
-    user: { id: 'user-789', name: 'Test User' },
+    user: USER,
     ...overrides
   })
 
@@ -74,36 +94,46 @@ afterEach(() => {
 })
 
 describe('updatePrnStatus on the ledger (event-first) path', () => {
-  it('stamps the appended watermark onto the PRN document when creating', async () => {
-    const updateStatus = vi.fn().mockResolvedValue(buildPrn())
-    const prnRepository = { findById: vi.fn(), updateStatus }
+  it('persists a projection carrying the appended watermark when creating', async () => {
+    const persistProjection = vi
+      .fn()
+      .mockImplementation(async ({ projection }) => projection)
+    const prnRepository = { findById: vi.fn(), persistProjection }
     const wasteBalancesRepository = {
       findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
       deductAvailableBalanceForPrnCreation: vi
         .fn()
-        .mockResolvedValue(APPENDED_WATERMARK)
+        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_CREATED))
     }
 
     await callUpdate({
       prnRepository,
       wasteBalancesRepository,
       organisationsRepository: buildOrganisationsRepository(),
-      providedPrn: buildPrn({ status: { currentStatus: PRN_STATUS.DRAFT } }),
+      providedPrn: buildPrn({
+        status: { currentStatus: PRN_STATUS.DRAFT, history: [] }
+      }),
       newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
       actor: PRN_ACTOR.REPROCESSOR_EXPORTER
     })
 
-    expect(updateStatus).toHaveBeenCalledWith(
-      expect.objectContaining({ lastAppliedEventNumber: APPENDED_WATERMARK })
+    expect(persistProjection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projection: expect.objectContaining({
+          lastAppliedEventNumber: APPENDED_WATERMARK
+        })
+      })
     )
   })
 
-  it('appends the balance event before writing the PRN document when issuing', async () => {
-    const updateStatus = vi.fn().mockResolvedValue(buildPrn())
-    const prnRepository = { findById: vi.fn(), updateStatus }
+  it('appends the balance event before persisting the projection when issuing', async () => {
+    const persistProjection = vi
+      .fn()
+      .mockImplementation(async ({ projection }) => projection)
+    const prnRepository = { findById: vi.fn(), persistProjection }
     const deductTotalBalanceForPrnIssue = vi
       .fn()
-      .mockResolvedValue(APPENDED_WATERMARK)
+      .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED))
     const wasteBalancesRepository = {
       findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
       deductTotalBalanceForPrnIssue
@@ -114,7 +144,10 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       wasteBalancesRepository,
       organisationsRepository: buildOrganisationsRepository(),
       providedPrn: buildPrn({
-        status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+        status: {
+          currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+          history: []
+        }
       }),
       newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
       actor: PRN_ACTOR.SIGNATORY
@@ -122,15 +155,19 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
 
     expect(
       deductTotalBalanceForPrnIssue.mock.invocationCallOrder[0]
-    ).toBeLessThan(updateStatus.mock.invocationCallOrder[0])
-    expect(updateStatus).toHaveBeenCalledWith(
-      expect.objectContaining({ lastAppliedEventNumber: APPENDED_WATERMARK })
+    ).toBeLessThan(persistProjection.mock.invocationCallOrder[0])
+    expect(persistProjection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projection: expect.objectContaining({
+          lastAppliedEventNumber: APPENDED_WATERMARK
+        })
+      })
     )
   })
 
   it('rejects issuance on a suspended accreditation before appending any event', async () => {
-    const updateStatus = vi.fn().mockResolvedValue(buildPrn())
-    const prnRepository = { findById: vi.fn(), updateStatus }
+    const persistProjection = vi.fn()
+    const prnRepository = { findById: vi.fn(), persistProjection }
     const deductTotalBalanceForPrnIssue = vi.fn()
     const wasteBalancesRepository = {
       findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
@@ -145,7 +182,10 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
           status: 'suspended'
         }),
         providedPrn: buildPrn({
-          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+          status: {
+            currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+            history: []
+          }
         }),
         newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
         actor: PRN_ACTOR.SIGNATORY
@@ -153,15 +193,19 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
     ).rejects.toThrow(SuspendedAccreditationError)
 
     expect(deductTotalBalanceForPrnIssue).not.toHaveBeenCalled()
-    expect(updateStatus).not.toHaveBeenCalled()
+    expect(persistProjection).not.toHaveBeenCalled()
   })
 
-  it('appends the credit event before writing the PRN document when cancelling an issued PRN', async () => {
-    const updateStatus = vi.fn().mockResolvedValue(buildPrn())
-    const prnRepository = { findById: vi.fn(), updateStatus }
+  it('appends the credit event before persisting the projection when cancelling an issued PRN', async () => {
+    const persistProjection = vi
+      .fn()
+      .mockImplementation(async ({ projection }) => projection)
+    const prnRepository = { findById: vi.fn(), persistProjection }
     const creditFullBalanceForIssuedPrnCancellation = vi
       .fn()
-      .mockResolvedValue(APPENDED_WATERMARK)
+      .mockResolvedValue(
+        buildStreamEvent(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE)
+      )
     const wasteBalancesRepository = {
       findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
       creditFullBalanceForIssuedPrnCancellation
@@ -172,7 +216,10 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       wasteBalancesRepository,
       organisationsRepository: buildOrganisationsRepository(),
       providedPrn: buildPrn({
-        status: { currentStatus: PRN_STATUS.AWAITING_CANCELLATION },
+        status: {
+          currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
+          history: []
+        },
         lastAppliedEventNumber: 2
       }),
       newStatus: PRN_STATUS.CANCELLED,
@@ -181,13 +228,17 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
 
     expect(
       creditFullBalanceForIssuedPrnCancellation.mock.invocationCallOrder[0]
-    ).toBeLessThan(updateStatus.mock.invocationCallOrder[0])
-    expect(updateStatus).toHaveBeenCalledWith(
-      expect.objectContaining({ lastAppliedEventNumber: APPENDED_WATERMARK })
+    ).toBeLessThan(persistProjection.mock.invocationCallOrder[0])
+    expect(persistProjection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projection: expect.objectContaining({
+          lastAppliedEventNumber: APPENDED_WATERMARK
+        })
+      })
     )
   })
 
-  it('carries the existing watermark forward on a lifecycle-only transition', async () => {
+  it('carries the existing watermark forward on a lifecycle-only transition (embedded path)', async () => {
     const updateStatus = vi.fn().mockResolvedValue(buildPrn())
     const prnRepository = { findById: vi.fn(), updateStatus }
 
@@ -196,7 +247,10 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       wasteBalancesRepository: {},
       organisationsRepository: buildOrganisationsRepository(),
       providedPrn: buildPrn({
-        status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE },
+        status: {
+          currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+          history: []
+        },
         lastAppliedEventNumber: 7
       }),
       newStatus: PRN_STATUS.ACCEPTED,
@@ -208,17 +262,17 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
     )
   })
 
-  it('does not credit the balance back when the PRN document write fails on creation', async () => {
-    const updateStatus = vi
+  it('does not credit the balance back when persistProjection fails on creation', async () => {
+    const persistProjection = vi
       .fn()
       .mockRejectedValue(new Error('doc write failed'))
-    const prnRepository = { findById: vi.fn(), updateStatus }
+    const prnRepository = { findById: vi.fn(), persistProjection }
     const creditAvailableBalanceForPrnCancellation = vi.fn()
     const wasteBalancesRepository = {
       findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
       deductAvailableBalanceForPrnCreation: vi
         .fn()
-        .mockResolvedValue(APPENDED_WATERMARK),
+        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_CREATED)),
       creditAvailableBalanceForPrnCancellation
     }
 
@@ -227,7 +281,9 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
         prnRepository,
         wasteBalancesRepository,
         organisationsRepository: buildOrganisationsRepository(),
-        providedPrn: buildPrn({ status: { currentStatus: PRN_STATUS.DRAFT } }),
+        providedPrn: buildPrn({
+          status: { currentStatus: PRN_STATUS.DRAFT, history: [] }
+        }),
         newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER
       })
@@ -236,17 +292,138 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
     expect(creditAvailableBalanceForPrnCancellation).not.toHaveBeenCalled()
   })
 
-  it('does not roll back the balance when the PRN document write fails on issuance', async () => {
-    const updateStatus = vi
+  it('retries issuance on a PrnNumberConflictError and persists on the second attempt', async () => {
+    const persistProjection = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        const { PrnNumberConflictError } =
+          await import('#packaging-recycling-notes/repository/port.js')
+        throw new PrnNumberConflictError('ER2600001')
+      })
+      .mockImplementation(async ({ projection }) => projection)
+    const prnRepository = { findById: vi.fn(), persistProjection }
+    const wasteBalancesRepository = {
+      findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
+      deductTotalBalanceForPrnIssue: vi
+        .fn()
+        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED))
+    }
+
+    await callUpdate({
+      prnRepository,
+      wasteBalancesRepository,
+      organisationsRepository: buildOrganisationsRepository(),
+      providedPrn: buildPrn({
+        status: {
+          currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+          history: []
+        }
+      }),
+      newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+      actor: PRN_ACTOR.SIGNATORY
+    })
+
+    expect(persistProjection).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws after exhausting every PRN number suffix retry on issuance', async () => {
+    const { PrnNumberConflictError } =
+      await import('#packaging-recycling-notes/repository/port.js')
+    const persistProjection = vi
+      .fn()
+      .mockRejectedValue(new PrnNumberConflictError('ER2600001'))
+    const prnRepository = { findById: vi.fn(), persistProjection }
+    const wasteBalancesRepository = {
+      findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
+      deductTotalBalanceForPrnIssue: vi
+        .fn()
+        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED))
+    }
+
+    await expect(
+      callUpdate({
+        prnRepository,
+        wasteBalancesRepository,
+        organisationsRepository: buildOrganisationsRepository(),
+        providedPrn: buildPrn({
+          status: {
+            currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+            history: []
+          }
+        }),
+        newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+        actor: PRN_ACTOR.SIGNATORY
+      })
+    ).rejects.toThrow(/Unable to generate unique PRN number/)
+  })
+
+  it('throws Boom.badImplementation when persistProjection returns null on issuance', async () => {
+    const persistProjection = vi.fn().mockResolvedValue(null)
+    const prnRepository = { findById: vi.fn(), persistProjection }
+    const wasteBalancesRepository = {
+      findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
+      deductTotalBalanceForPrnIssue: vi
+        .fn()
+        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED))
+    }
+
+    await expect(
+      callUpdate({
+        prnRepository,
+        wasteBalancesRepository,
+        organisationsRepository: buildOrganisationsRepository(),
+        providedPrn: buildPrn({
+          status: {
+            currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+            history: []
+          }
+        }),
+        newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+        actor: PRN_ACTOR.SIGNATORY
+      })
+    ).rejects.toThrow(/Failed to persist PRN projection/)
+  })
+
+  it('throws Boom.badImplementation when persistProjection returns null on a non-issuance ledger write', async () => {
+    const persistProjection = vi.fn().mockResolvedValue(null)
+    const prnRepository = { findById: vi.fn(), persistProjection }
+    const wasteBalancesRepository = {
+      findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
+      creditFullBalanceForIssuedPrnCancellation: vi
+        .fn()
+        .mockResolvedValue(
+          buildStreamEvent(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE)
+        )
+    }
+
+    await expect(
+      callUpdate({
+        prnRepository,
+        wasteBalancesRepository,
+        organisationsRepository: buildOrganisationsRepository(),
+        providedPrn: buildPrn({
+          status: {
+            currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
+            history: []
+          }
+        }),
+        newStatus: PRN_STATUS.CANCELLED,
+        actor: PRN_ACTOR.SIGNATORY
+      })
+    ).rejects.toThrow(/Failed to persist PRN projection/)
+  })
+
+  it('does not roll back the balance when persistProjection fails on issuance', async () => {
+    const persistProjection = vi
       .fn()
       .mockRejectedValue(new Error('doc write failed'))
-    const prnRepository = { findById: vi.fn(), updateStatus }
+    const prnRepository = { findById: vi.fn(), persistProjection }
     const creditFullBalanceForIssuedPrnCancellation = vi.fn()
     const wasteBalancesRepository = {
       findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
       deductTotalBalanceForPrnIssue: vi
         .fn()
-        .mockResolvedValue(APPENDED_WATERMARK),
+        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED)),
       creditFullBalanceForIssuedPrnCancellation
     }
 
@@ -256,7 +433,10 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
         wasteBalancesRepository,
         organisationsRepository: buildOrganisationsRepository(),
         providedPrn: buildPrn({
-          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+          status: {
+            currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+            history: []
+          }
         }),
         newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
         actor: PRN_ACTOR.SIGNATORY

--- a/src/packaging-recycling-notes/application/update-status-stream.test.js
+++ b/src/packaging-recycling-notes/application/update-status-stream.test.js
@@ -244,7 +244,9 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
 
     await callUpdate({
       prnRepository,
-      wasteBalancesRepository: {},
+      wasteBalancesRepository: {
+        findByAccreditationId: vi.fn().mockResolvedValue(null)
+      },
       organisationsRepository: buildOrganisationsRepository(),
       providedPrn: buildPrn({
         status: {

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -3,18 +3,15 @@ import Boom from '@hapi/boom'
 import { prnMetrics } from './metrics.js'
 import {
   applyWasteBalanceEffects,
-  balanceEventsFor,
-  creditFullBalanceIfNeeded,
-  creditWasteBalanceIfNeeded,
-  deductTotalBalanceIfNeeded,
-  deductWasteBalanceIfNeeded,
-  logWasteBalanceUpdate
+  balanceEventsFor
 } from './update-status-balance-effects.js'
-import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import {
-  LOGGING_EVENT_ACTIONS,
-  LOGGING_EVENT_CATEGORIES
-} from '#common/enums/event.js'
+  COLLISION_SUFFIXES,
+  applyStatusUpdate,
+  performCreation,
+  performTransition
+} from './update-status-embedded-write.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import {
   PRN_STATUS,
   validateTransition,
@@ -23,120 +20,6 @@ import {
 import { generatePrnNumber } from '#packaging-recycling-notes/domain/prn-number-generator.js'
 import { PrnNumberConflictError } from '#packaging-recycling-notes/repository/port.js'
 import { foldPrnFromTailEvents } from './fold-prn-from-tail-events.js'
-
-/** Suffixes A-Z for collision avoidance */
-const COLLISION_SUFFIXES = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
-
-const STATUS_OPERATION_SLOT = Object.freeze({
-  [PRN_STATUS.AWAITING_AUTHORISATION]: 'created',
-  [PRN_STATUS.ACCEPTED]: 'accepted',
-  [PRN_STATUS.AWAITING_CANCELLATION]: 'rejected',
-  [PRN_STATUS.DELETED]: 'deleted',
-  [PRN_STATUS.CANCELLED]: 'cancelled'
-})
-
-/**
- * Transition keys (currentStatus|newStatus) for the post-CAS path that needs a
- * PRN rollback when the balance side-effect throws. Kept as a typed union so
- * adding a new key without a matching entry in ROLLBACK_METHOD_BY_TRANSITION
- * is a tsc error.
- *
- * @typedef {`${typeof PRN_STATUS.AWAITING_AUTHORISATION}|${typeof PRN_STATUS.AWAITING_ACCEPTANCE}`
- *   | `${typeof PRN_STATUS.AWAITING_AUTHORISATION}|${typeof PRN_STATUS.DELETED}`
- *   | `${typeof PRN_STATUS.AWAITING_CANCELLATION}|${typeof PRN_STATUS.CANCELLED}`} PostCasRollbackTransition
- */
-
-/**
- * @typedef {'rollbackIssuance' | 'rollbackPendingCancellation' | 'rollbackIssuedCancellation'} RollbackMethodName
- */
-
-/**
- * Maps a (currentStatus -> newStatus) transition to the rollback method on the
- * PRN repository that reverses the forward write. Only post-CAS transitions
- * with a follow-on balance side-effect appear here; creation is handled by
- * crediting the balance back rather than rolling the PRN.
- *
- * tsc enforces:
- *   - every key in PostCasRollbackTransition has an entry (exhaustiveness)
- *   - no extra keys are present (no orphan rollback entries)
- *   - every value is a valid RollbackMethodName
- * Keys are literal strings so tsc can verify them — computed template-literal
- * keys widen to string and lose the connection to the union. The keys are
- * still tied to PRN_STATUS because PostCasRollbackTransition resolves via
- * `typeof PRN_STATUS.*` — a value change in PRN_STATUS would tsc-error here.
- */
-/** @type {Readonly<Record<PostCasRollbackTransition, RollbackMethodName>>} */
-const ROLLBACK_METHOD_BY_TRANSITION = {
-  'awaiting_authorisation|awaiting_acceptance': 'rollbackIssuance',
-  'awaiting_authorisation|deleted': 'rollbackPendingCancellation',
-  'awaiting_cancellation|cancelled': 'rollbackIssuedCancellation'
-}
-
-/**
- * Embedded-path balance effects keyed by `${currentStatus}|${newStatus}`. The
- * embedded path predates event sourcing — it doesn't emit stream events, it
- * just mutates the balance document directly. Missing entry means the
- * transition is lifecycle-only (no balance change) and just stamps the PRN.
- */
-const EMBEDDED_BALANCE_EFFECTS = Object.freeze({
-  [`${PRN_STATUS.DRAFT}|${PRN_STATUS.AWAITING_AUTHORISATION}`]: {
-    apply: deductWasteBalanceIfNeeded,
-    log: 'deduct_available'
-  },
-  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.AWAITING_ACCEPTANCE}`]: {
-    apply: deductTotalBalanceIfNeeded,
-    log: 'deduct_total'
-  },
-  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.DELETED}`]: {
-    apply: creditWasteBalanceIfNeeded,
-    log: 'credit_available'
-  },
-  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.CANCELLED}`]: {
-    apply: creditWasteBalanceIfNeeded,
-    log: 'credit_available'
-  },
-  [`${PRN_STATUS.AWAITING_CANCELLATION}|${PRN_STATUS.CANCELLED}`]: {
-    apply: creditFullBalanceIfNeeded,
-    log: 'credit_full'
-  }
-})
-
-/**
- * @typedef {Object} EmbeddedBalanceEffectParams
- * @property {WasteBalancesRepository} wasteBalancesRepository
- * @property {import('#common/hapi-types.js').TypedLogger} logger
- * @property {PrnStatus} currentStatus
- * @property {PrnStatus} newStatus
- * @property {{accreditationId: string, registrationId: string, organisationId: string, prnId: string, tonnage: number, userId: string}} params
- */
-
-/**
- * Apply the embedded-path balance effect for a transition. No events are
- * generated; the balance document is mutated directly.
- *
- * @param {EmbeddedBalanceEffectParams} args
- */
-async function applyEmbeddedBalanceEffect({
-  wasteBalancesRepository,
-  logger,
-  currentStatus,
-  newStatus,
-  params
-}) {
-  const effect = EMBEDDED_BALANCE_EFFECTS[`${currentStatus}|${newStatus}`]
-  if (!effect) {
-    return
-  }
-  await effect.apply(wasteBalancesRepository, params)
-  logWasteBalanceUpdate(
-    logger,
-    effect.log,
-    params.prnId,
-    params.tonnage,
-    currentStatus,
-    newStatus
-  )
-}
 
 /**
  * @typedef {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepository
@@ -167,338 +50,6 @@ async function applyEmbeddedBalanceEffect({
  * @property {Date} now
  * @property {string} id
  */
-
-/**
- * Issues a PRN with retry logic for PRN number collisions.
- * Tries without suffix first, then A-Z on collision.
- *
- * @param {PackagingRecyclingNotesRepository} repository
- * @param {Object} updateParams - Parameters for updateStatus
- * @param {Object} prnParams - Parameters for PRN number generation
- * @returns {Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote>}
- */
-async function issuePrnWithRetry(repository, updateParams, prnParams) {
-  const suffixAttempts = [undefined, ...COLLISION_SUFFIXES]
-
-  for (const suffix of suffixAttempts) {
-    const prnNumber = generatePrnNumber({ ...prnParams, suffix })
-
-    try {
-      const result = await repository.updateStatus({
-        ...updateParams,
-        prnNumber
-      })
-      if (!result) {
-        throw new Error('Failed to update PRN status')
-      }
-      return result
-    } catch (error) {
-      if (error instanceof PrnNumberConflictError) {
-        continue
-      }
-      throw error
-    }
-  }
-
-  throw new Error('Unable to generate unique PRN number after all retries')
-}
-
-/**
- * Performs the repository write for a status transition.
- * Issuance (AWAITING_ACCEPTANCE) verifies the accreditation and
- * generates a unique PRN number; all other transitions just stamp
- * an operation slot and update.
- *
- * @param {Object} params
- * @returns {Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote>}
- */
-async function applyStatusUpdate({
-  prnRepository,
-  organisationsRepository,
-  prn,
-  updateParams,
-  newStatus,
-  organisationId,
-  accreditationId,
-  user,
-  now,
-  accreditation: providedAccreditation
-}) {
-  if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
-    updateParams.operation = {
-      slot: 'issued',
-      at: now,
-      by: { id: user.id, name: user.name }
-    }
-
-    const accreditation =
-      providedAccreditation ??
-      (await organisationsRepository.findAccreditationById(
-        organisationId,
-        accreditationId
-      ))
-
-    assertAccreditationNotSuspended(accreditation)
-
-    return issuePrnWithRetry(prnRepository, updateParams, {
-      regulator: accreditation.submittedToRegulator,
-      isExport: prn.isExport,
-      accreditationYear: prn.accreditation.accreditationYear
-    })
-  }
-
-  const operationSlot = STATUS_OPERATION_SLOT[newStatus]
-  if (operationSlot) {
-    updateParams.operation = { slot: operationSlot, at: now, by: user }
-  }
-
-  const updatedPrn = await prnRepository.updateStatus(updateParams)
-  if (!updatedPrn) {
-    throw Boom.badImplementation('Failed to update PRN status')
-  }
-  return updatedPrn
-}
-
-/**
- * CDP ingest drops fields outside its allowlist (see cdp-log-types.js),
- * including bespoke top-level fields and any second error on the same entry.
- * Both errors are therefore logged as paired entries that share the same
- * event.reference (the prnId) and event.action so ops can correlate them,
- * with each entry's `err` populated for indexing.
- */
-function logCompensationFailure(
-  logger,
-  prnId,
-  fromStatus,
-  toStatus,
-  err,
-  kind
-) {
-  logger.error({
-    err,
-    message: `${kind} for PRN ${prnId} (${fromStatus} -> ${toStatus})`,
-    event: {
-      category: LOGGING_EVENT_CATEGORIES.DB,
-      action: LOGGING_EVENT_ACTIONS.COMPENSATION_FAILURE,
-      reference: prnId
-    }
-  })
-}
-
-/**
- * Records that a forward failure was caught and cleanly reversed. The forward
- * error is attached as `err` so it's indexed, and the event.reference is the
- * prnId so ops can find every compensation event for a given PRN regardless
- * of whether it ultimately succeeded or failed.
- */
-function logCompensationSuccess(logger, prnId, fromStatus, toStatus, err) {
-  logger.warn({
-    err,
-    message: `Forward write failed; compensation succeeded for PRN ${prnId} (${fromStatus} -> ${toStatus})`,
-    event: {
-      category: LOGGING_EVENT_CATEGORIES.DB,
-      action: LOGGING_EVENT_ACTIONS.COMPENSATION_SUCCESS,
-      reference: prnId
-    }
-  })
-}
-
-/**
- * Runs `compensator` to undo a forward write that has already committed.
- * On success, logs a COMPENSATION_SUCCESS entry carrying the original forward
- * error so ops can spot patterns of recovered failures. If the compensator
- * itself throws, the failure is logged with full context (the original
- * forward error and the compensation error) but not rethrown — the caller
- * always sees the original forward error so the user-visible outcome stays
- * coherent. The log entries are what ops use to find PRNs left in an
- * inconsistent state for manual reconciliation.
- *
- * @param {() => Promise<unknown>} compensator
- * @param {Object} context
- * @param {Error} context.forwardError
- * @param {import('#common/hapi-types.js').TypedLogger} context.logger
- * @param {string} context.prnId
- * @param {string} context.fromStatus
- * @param {string} context.toStatus
- */
-async function tryCompensate(compensator, context) {
-  try {
-    await compensator()
-    logCompensationSuccess(
-      context.logger,
-      context.prnId,
-      context.fromStatus,
-      context.toStatus,
-      context.forwardError
-    )
-  } catch (compensationError) {
-    logCompensationFailure(
-      context.logger,
-      context.prnId,
-      context.fromStatus,
-      context.toStatus,
-      context.forwardError,
-      'Forward write failed; compensation triggered'
-    )
-    logCompensationFailure(
-      context.logger,
-      context.prnId,
-      context.fromStatus,
-      context.toStatus,
-      compensationError,
-      'Compensation failed; manual reconciliation required'
-    )
-  }
-}
-
-/**
- * Pre-flight balance debit, forward PRN write, and credit-back compensation
- * if the forward write fails. Pre-flight debit already proved the balance
- * exists, so the compensator calls the credit primitive directly rather than
- * going through the wrapper that would re-fetch.
- */
-async function performCreation({
-  prnRepository,
-  organisationsRepository,
-  wasteBalancesRepository,
-  logger,
-  prn,
-  updateParams,
-  newStatus,
-  organisationId,
-  registrationId,
-  accreditationId,
-  user,
-  currentStatus,
-  now,
-  id
-}) {
-  await applyEmbeddedBalanceEffect({
-    wasteBalancesRepository,
-    logger,
-    currentStatus,
-    newStatus,
-    params: {
-      accreditationId,
-      registrationId,
-      organisationId,
-      prnId: id,
-      tonnage: prn.tonnage,
-      userId: user.id
-    }
-  })
-
-  try {
-    return await applyStatusUpdate({
-      prnRepository,
-      organisationsRepository,
-      prn,
-      updateParams,
-      newStatus,
-      organisationId,
-      accreditationId,
-      user,
-      now
-    })
-  } catch (forwardError) {
-    await tryCompensate(
-      () =>
-        wasteBalancesRepository.creditAvailableBalanceForPrnCancellation({
-          accreditationId,
-          registrationId,
-          organisationId,
-          prnId: id,
-          tonnage: prn.tonnage,
-          userId: user.id
-        }),
-      {
-        forwardError,
-        logger,
-        prnId: id,
-        fromStatus: currentStatus,
-        toStatus: newStatus
-      }
-    )
-    throw forwardError
-  }
-}
-
-/**
- * Forward PRN write followed by post-CAS balance effects, rolling the PRN
- * back via the transition-specific rollback method if the balance write
- * fails. The per-PRN CAS gates the balance write so concurrent writers
- * cannot double-debit or double-credit.
- */
-async function performTransition({
-  prnRepository,
-  organisationsRepository,
-  wasteBalancesRepository,
-  logger,
-  prn,
-  updateParams,
-  newStatus,
-  organisationId,
-  registrationId,
-  accreditationId,
-  user,
-  currentStatus,
-  now,
-  id
-}) {
-  const updatedPrn = await applyStatusUpdate({
-    prnRepository,
-    organisationsRepository,
-    prn,
-    updateParams,
-    newStatus,
-    organisationId,
-    accreditationId,
-    user,
-    now
-  })
-
-  try {
-    await applyEmbeddedBalanceEffect({
-      wasteBalancesRepository,
-      logger,
-      currentStatus,
-      newStatus,
-      params: {
-        accreditationId,
-        registrationId,
-        organisationId,
-        prnId: id,
-        tonnage: prn.tonnage,
-        userId: user.id
-      }
-    })
-  } catch (forwardError) {
-    const transitionKey = /** @type {PostCasRollbackTransition} */ (
-      `${currentStatus}|${newStatus}`
-    )
-    const rollbackMethod = ROLLBACK_METHOD_BY_TRANSITION[transitionKey]
-    await tryCompensate(
-      () =>
-        prnRepository[rollbackMethod]({
-          id,
-          expectedVersion: updatedPrn.version,
-          updatedBy: user,
-          updatedAt: now,
-          lastAppliedEventNumber: updatedPrn.lastAppliedEventNumber
-        }),
-      {
-        forwardError,
-        logger,
-        prnId: id,
-        fromStatus: currentStatus,
-        toStatus: newStatus
-      }
-    )
-    throw forwardError
-  }
-
-  return updatedPrn
-}
 
 /**
  * Persist a projected PRN, retrying issuance with new PRN number suffixes when
@@ -692,6 +243,18 @@ function selectEmbeddedWriteStrategy(newStatus) {
 }
 
 /**
+ * Picks the write path for a transition: the ledger (event-first) path when
+ * the accreditation has migrated, otherwise the embedded-write strategy.
+ *
+ * @param {PrnWriteContext} ctx
+ * @returns {Promise<PackagingRecyclingNote>}
+ */
+const dispatchStatusWrite = async (ctx) =>
+  (await isOnLedger(ctx.wasteBalancesRepository, ctx.accreditationId))
+    ? performLedgerWrite(ctx)
+    : selectEmbeddedWriteStrategy(ctx.newStatus)(ctx)
+
+/**
  * Updates PRN status with all business logic
  *
  * @param {Object} params
@@ -710,11 +273,6 @@ function selectEmbeddedWriteStrategy(newStatus) {
  * @param {Date} [params.updatedAt] - Optional timestamp override (defaults to now)
  * @returns {Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote>}
  */
-const dispatchStatusWrite = async (ctx) =>
-  (await isOnLedger(ctx.wasteBalancesRepository, ctx.accreditationId))
-    ? performLedgerWrite(ctx)
-    : selectEmbeddedWriteStrategy(ctx.newStatus)(ctx)
-
 export async function updatePrnStatus({
   prnRepository,
   wasteBalancesRepository,

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -17,6 +17,7 @@ import {
 } from '#packaging-recycling-notes/domain/model.js'
 import { generatePrnNumber } from '#packaging-recycling-notes/domain/prn-number-generator.js'
 import { PrnNumberConflictError } from '#packaging-recycling-notes/repository/port.js'
+import { foldPrnFromTailEvents } from './fold-prn-from-tail-events.js'
 
 /** Suffixes A-Z for collision avoidance */
 const COLLISION_SUFFIXES = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
@@ -405,12 +406,55 @@ async function performTransition({
 }
 
 /**
+ * Persist a projected PRN, retrying issuance with new PRN number suffixes when
+ * the existing one collides. The projection's `prnNumber` is the only field that
+ * changes between attempts.
+ *
+ * @param {Object} params
+ * @param {PackagingRecyclingNotesRepository} params.prnRepository
+ * @param {PackagingRecyclingNote} params.projection
+ * @param {number} params.expectedVersion
+ * @param {{ regulator: string, isExport: boolean, accreditationYear: number }} params.prnNumberParams
+ * @returns {Promise<PackagingRecyclingNote>}
+ */
+async function persistProjectionWithIssuanceRetry({
+  prnRepository,
+  projection,
+  expectedVersion,
+  prnNumberParams
+}) {
+  const suffixAttempts = [undefined, ...COLLISION_SUFFIXES]
+
+  for (const suffix of suffixAttempts) {
+    const prnNumber = generatePrnNumber({ ...prnNumberParams, suffix })
+
+    try {
+      const result = await prnRepository.persistProjection({
+        projection: { ...projection, prnNumber },
+        expectedVersion
+      })
+      if (!result) {
+        throw Boom.badImplementation('Failed to persist PRN projection')
+      }
+      return result
+    } catch (error) {
+      if (error instanceof PrnNumberConflictError) {
+        continue
+      }
+      throw error
+    }
+  }
+
+  throw new Error('Unable to generate unique PRN number after all retries')
+}
+
+/**
  * Event-first write for a migrated accreditation (canonicalSource 'ledger').
- * The balance-affecting event is appended before the PRN document is
- * projected, and the returned event number is stamped onto the document as its
- * watermark. There is no compensation: a partial failure (event appended, doc
- * not written) is recovered by the read-side catch-up, which folds events
- * after the watermark on the next read.
+ * The balance-affecting events are appended to the stream, then folded onto
+ * the in-memory PRN, then the resulting projection is persisted. There is no
+ * compensation: a partial failure (event appended, doc not persisted) is
+ * recovered by the read-side catch-up, which folds events after the watermark
+ * on the next read.
  */
 async function performStreamWrite({
   prnRepository,
@@ -418,20 +462,14 @@ async function performStreamWrite({
   wasteBalancesRepository,
   logger,
   prn,
-  updateParams,
   events,
   newStatus,
   organisationId,
-  accreditationId,
-  user,
-  now
+  accreditationId
 }) {
-  // The suspension check lives inside applyStatusUpdate, gating the document
-  // write. On the stream path the balance event is appended before that write,
-  // so the check is hoisted ahead of the append here to guarantee a suspended
-  // accreditation is never debited. The fetched accreditation is handed to
-  // applyStatusUpdate so the issuance write reuses it rather than reading it
-  // twice.
+  // The suspension check is hoisted ahead of the stream append so a suspended
+  // accreditation is never debited. The fetched accreditation is reused to
+  // stamp the PRN number on the issuance path.
   let accreditation
   if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
     accreditation = await organisationsRepository.findAccreditationById(
@@ -441,24 +479,39 @@ async function performStreamWrite({
     assertAccreditationNotSuspended(accreditation)
   }
 
-  updateParams.lastAppliedEventNumber = await applyWasteBalanceEffects(
+  const applied = await applyWasteBalanceEffects(
     wasteBalancesRepository,
     logger,
     events
   )
+  const streamEvents =
+    /** @type {import('#waste-balances/repository/stream-port.js').StreamEvent[]} */ (
+      applied.filter((e) => e !== null)
+    )
 
-  return applyStatusUpdate({
-    prnRepository,
-    organisationsRepository,
-    prn,
-    updateParams,
-    newStatus,
-    organisationId,
-    accreditationId,
-    user,
-    now,
-    accreditation
+  const projection = foldPrnFromTailEvents(prn, streamEvents)
+
+  if (newStatus === PRN_STATUS.AWAITING_ACCEPTANCE) {
+    return persistProjectionWithIssuanceRetry({
+      prnRepository,
+      projection,
+      expectedVersion: prn.version,
+      prnNumberParams: {
+        regulator: accreditation.submittedToRegulator,
+        isExport: prn.isExport,
+        accreditationYear: prn.accreditation.accreditationYear
+      }
+    })
+  }
+
+  const persisted = await prnRepository.persistProjection({
+    projection,
+    expectedVersion: prn.version
   })
+  if (!persisted) {
+    throw Boom.badImplementation('Failed to persist PRN projection')
+  }
+  return persisted
 }
 
 /**

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -124,7 +124,9 @@ async function applyEmbeddedBalanceEffect({
   params
 }) {
   const effect = EMBEDDED_BALANCE_EFFECTS[`${currentStatus}|${newStatus}`]
-  if (!effect) return
+  if (!effect) {
+    return
+  }
   await effect.apply(wasteBalancesRepository, params)
   logWasteBalanceUpdate(
     logger,
@@ -708,6 +710,11 @@ function selectEmbeddedWriteStrategy(newStatus) {
  * @param {Date} [params.updatedAt] - Optional timestamp override (defaults to now)
  * @returns {Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote>}
  */
+const dispatchStatusWrite = async (ctx) =>
+  (await isOnLedger(ctx.wasteBalancesRepository, ctx.accreditationId))
+    ? performLedgerWrite(ctx)
+    : selectEmbeddedWriteStrategy(ctx.newStatus)(ctx)
+
 export async function updatePrnStatus({
   prnRepository,
   wasteBalancesRepository,
@@ -746,68 +753,27 @@ export async function updatePrnStatus({
     lastAppliedEventNumber: prn.lastAppliedEventNumber
   }
 
-  // Pre-creation transition: the PRN never reached the stream, so the
-  // accreditation's marker is irrelevant. Doc-only update.
-  if (
-    currentStatus === PRN_STATUS.DRAFT &&
-    newStatus === PRN_STATUS.DISCARDED
-  ) {
-    const updatedPrn = await applyStatusUpdate({
-      prnRepository,
-      organisationsRepository,
-      prn,
-      updateParams,
-      newStatus,
-      organisationId,
-      accreditationId,
-      user,
-      now
-    })
-
-    await prnMetrics.recordStatusTransition({
-      fromStatus: currentStatus,
-      toStatus: newStatus,
-      material: prn.accreditation.material,
-      isExport: prn.isExport
-    })
-
-    return updatedPrn
+  const ctx = {
+    prnRepository,
+    organisationsRepository,
+    wasteBalancesRepository,
+    logger,
+    prn,
+    updateParams,
+    newStatus,
+    organisationId,
+    registrationId,
+    accreditationId,
+    user,
+    currentStatus,
+    now,
+    id
   }
 
-  const updatedPrn = (await isOnLedger(
-    wasteBalancesRepository,
-    accreditationId
-  ))
-    ? await performLedgerWrite({
-        prnRepository,
-        organisationsRepository,
-        wasteBalancesRepository,
-        logger,
-        prn,
-        newStatus,
-        organisationId,
-        registrationId,
-        accreditationId,
-        user,
-        currentStatus,
-        id
-      })
-    : await selectEmbeddedWriteStrategy(newStatus)({
-        prnRepository,
-        organisationsRepository,
-        wasteBalancesRepository,
-        logger,
-        prn,
-        updateParams,
-        newStatus,
-        organisationId,
-        registrationId,
-        accreditationId,
-        user,
-        currentStatus,
-        now,
-        id
-      })
+  const updatedPrn =
+    currentStatus === PRN_STATUS.DRAFT && newStatus === PRN_STATUS.DISCARDED
+      ? await applyStatusUpdate(ctx)
+      : await dispatchStatusWrite(ctx)
 
   await prnMetrics.recordStatusTransition({
     fromStatus: currentStatus,

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -3,7 +3,12 @@ import Boom from '@hapi/boom'
 import { prnMetrics } from './metrics.js'
 import {
   applyWasteBalanceEffects,
-  balanceEventsFor
+  balanceEventsFor,
+  creditFullBalanceIfNeeded,
+  creditWasteBalanceIfNeeded,
+  deductTotalBalanceIfNeeded,
+  deductWasteBalanceIfNeeded,
+  logWasteBalanceUpdate
 } from './update-status-balance-effects.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import {
@@ -68,6 +73,70 @@ const ROLLBACK_METHOD_BY_TRANSITION = {
 }
 
 /**
+ * Embedded-path balance effects keyed by `${currentStatus}|${newStatus}`. The
+ * embedded path predates event sourcing — it doesn't emit stream events, it
+ * just mutates the balance document directly. Missing entry means the
+ * transition is lifecycle-only (no balance change) and just stamps the PRN.
+ */
+const EMBEDDED_BALANCE_EFFECTS = Object.freeze({
+  [`${PRN_STATUS.DRAFT}|${PRN_STATUS.AWAITING_AUTHORISATION}`]: {
+    apply: deductWasteBalanceIfNeeded,
+    log: 'deduct_available'
+  },
+  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.AWAITING_ACCEPTANCE}`]: {
+    apply: deductTotalBalanceIfNeeded,
+    log: 'deduct_total'
+  },
+  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.DELETED}`]: {
+    apply: creditWasteBalanceIfNeeded,
+    log: 'credit_available'
+  },
+  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.CANCELLED}`]: {
+    apply: creditWasteBalanceIfNeeded,
+    log: 'credit_available'
+  },
+  [`${PRN_STATUS.AWAITING_CANCELLATION}|${PRN_STATUS.CANCELLED}`]: {
+    apply: creditFullBalanceIfNeeded,
+    log: 'credit_full'
+  }
+})
+
+/**
+ * @typedef {Object} EmbeddedBalanceEffectParams
+ * @property {WasteBalancesRepository} wasteBalancesRepository
+ * @property {import('#common/hapi-types.js').TypedLogger} logger
+ * @property {PrnStatus} currentStatus
+ * @property {PrnStatus} newStatus
+ * @property {{accreditationId: string, registrationId: string, organisationId: string, prnId: string, tonnage: number, userId: string}} params
+ */
+
+/**
+ * Apply the embedded-path balance effect for a transition. No events are
+ * generated; the balance document is mutated directly.
+ *
+ * @param {EmbeddedBalanceEffectParams} args
+ */
+async function applyEmbeddedBalanceEffect({
+  wasteBalancesRepository,
+  logger,
+  currentStatus,
+  newStatus,
+  params
+}) {
+  const effect = EMBEDDED_BALANCE_EFFECTS[`${currentStatus}|${newStatus}`]
+  if (!effect) return
+  await effect.apply(wasteBalancesRepository, params)
+  logWasteBalanceUpdate(
+    logger,
+    effect.log,
+    params.prnId,
+    params.tonnage,
+    currentStatus,
+    newStatus
+  )
+}
+
+/**
  * @typedef {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepository
  * @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository
  * @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository
@@ -76,9 +145,9 @@ const ROLLBACK_METHOD_BY_TRANSITION = {
  */
 
 /**
- * The shared context every write strategy receives. The three strategies
- * (create, transition, stream) consume overlapping subsets of it, so the
- * dispatcher hands all of it to whichever one it selects.
+ * The shared context handed to each top-level write strategy (ledger or
+ * embedded). Inner helpers (performStreamWrite, applyStatusUpdate,
+ * applyEmbeddedBalanceEffect) consume different subsets.
  *
  * @typedef {Object} PrnWriteContext
  * @property {PackagingRecyclingNotesRepository} prnRepository
@@ -87,7 +156,6 @@ const ROLLBACK_METHOD_BY_TRANSITION = {
  * @property {import('#common/hapi-types.js').TypedLogger} logger
  * @property {PackagingRecyclingNote} prn
  * @property {import('#packaging-recycling-notes/repository/port.js').UpdateStatusParams} updateParams
- * @property {import('./update-status-balance-effects.js').BalanceEvent[]} events
  * @property {PrnStatus} newStatus
  * @property {string} organisationId
  * @property {string} registrationId
@@ -294,7 +362,6 @@ async function performCreation({
   logger,
   prn,
   updateParams,
-  events,
   newStatus,
   organisationId,
   registrationId,
@@ -304,7 +371,20 @@ async function performCreation({
   now,
   id
 }) {
-  await applyWasteBalanceEffects(wasteBalancesRepository, logger, events)
+  await applyEmbeddedBalanceEffect({
+    wasteBalancesRepository,
+    logger,
+    currentStatus,
+    newStatus,
+    params: {
+      accreditationId,
+      registrationId,
+      organisationId,
+      prnId: id,
+      tonnage: prn.tonnage,
+      userId: user.id
+    }
+  })
 
   try {
     return await applyStatusUpdate({
@@ -354,9 +434,9 @@ async function performTransition({
   logger,
   prn,
   updateParams,
-  events,
   newStatus,
   organisationId,
+  registrationId,
   accreditationId,
   user,
   currentStatus,
@@ -376,7 +456,20 @@ async function performTransition({
   })
 
   try {
-    await applyWasteBalanceEffects(wasteBalancesRepository, logger, events)
+    await applyEmbeddedBalanceEffect({
+      wasteBalancesRepository,
+      logger,
+      currentStatus,
+      newStatus,
+      params: {
+        accreditationId,
+        registrationId,
+        organisationId,
+        prnId: id,
+        tonnage: prn.tonnage,
+        userId: user.id
+      }
+    })
   } catch (forwardError) {
     const transitionKey = /** @type {PostCasRollbackTransition} */ (
       `${currentStatus}|${newStatus}`
@@ -515,6 +608,59 @@ async function performStreamWrite({
 }
 
 /**
+ * Ledger-path write. Computes the stream events the transition emits and hands
+ * them to the event-first write. On the ledger path every status transition
+ * MUST produce at least one event — the fold is the projection of those events
+ * onto the PRN doc, so no events means no projection, which would mean an
+ * unrecoverable doc/stream divergence. Pre-creation transitions
+ * (DRAFT→DISCARDED) are filtered out before this branch is reached.
+ */
+async function performLedgerWrite({
+  prnRepository,
+  organisationsRepository,
+  wasteBalancesRepository,
+  logger,
+  prn,
+  newStatus,
+  organisationId,
+  registrationId,
+  accreditationId,
+  user,
+  currentStatus,
+  id
+}) {
+  const events = balanceEventsFor(currentStatus, newStatus, {
+    currentStatus,
+    newStatus,
+    accreditationId,
+    registrationId,
+    organisationId,
+    prnId: id,
+    tonnage: prn.tonnage,
+    userId: user.id
+  })
+
+  /* c8 ignore next 5 - defensive: the only legal transition with no balance events (DRAFT→DISCARDED) is handled before this branch */
+  if (events.length === 0) {
+    throw Boom.badImplementation(
+      `No stream events for transition ${currentStatus} -> ${newStatus} on ledger accreditation ${accreditationId}`
+    )
+  }
+
+  return performStreamWrite({
+    prnRepository,
+    organisationsRepository,
+    wasteBalancesRepository,
+    logger,
+    prn,
+    events,
+    newStatus,
+    organisationId,
+    accreditationId
+  })
+}
+
+/**
  * Whether the accreditation's balance has migrated to the event-sourced stream
  * (canonicalSource 'ledger'). Read up front so the write ordering is chosen
  * before any side effect runs.
@@ -530,18 +676,14 @@ async function isOnLedger(wasteBalancesRepository, accreditationId) {
 }
 
 /**
- * Selects the write strategy. A migrated accreditation uses the event-first
- * stream write; everything else keeps the embedded create/transition paths
- * with their compensation, byte-for-byte as before.
+ * Selects the embedded-path write strategy. Creation is its own strategy
+ * because the balance debit happens before the PRN write; everything else
+ * writes the PRN first and applies the balance effect after.
  *
- * @param {boolean} useStreamWrite
  * @param {PrnStatus} newStatus
  * @returns {(context: PrnWriteContext) => Promise<PackagingRecyclingNote>}
  */
-function selectWriteStrategy(useStreamWrite, newStatus) {
-  if (useStreamWrite) {
-    return performStreamWrite
-  }
+function selectEmbeddedWriteStrategy(newStatus) {
   return newStatus === PRN_STATUS.AWAITING_AUTHORISATION
     ? performCreation
     : performTransition
@@ -594,17 +736,6 @@ export async function updatePrnStatus({
   const currentStatus = prn.status.currentStatus
   validateTransition(currentStatus, newStatus, actor)
 
-  const events = balanceEventsFor(currentStatus, newStatus, {
-    currentStatus,
-    newStatus,
-    accreditationId,
-    registrationId,
-    organisationId,
-    prnId: id,
-    tonnage: prn.tonnage,
-    userId: user.id
-  })
-
   const now = updatedAt ?? new Date()
   const updateParams = {
     id,
@@ -615,29 +746,68 @@ export async function updatePrnStatus({
     lastAppliedEventNumber: prn.lastAppliedEventNumber
   }
 
-  const useStreamWrite =
-    events.length > 0 &&
-    (await isOnLedger(wasteBalancesRepository, accreditationId))
+  // Pre-creation transition: the PRN never reached the stream, so the
+  // accreditation's marker is irrelevant. Doc-only update.
+  if (
+    currentStatus === PRN_STATUS.DRAFT &&
+    newStatus === PRN_STATUS.DISCARDED
+  ) {
+    const updatedPrn = await applyStatusUpdate({
+      prnRepository,
+      organisationsRepository,
+      prn,
+      updateParams,
+      newStatus,
+      organisationId,
+      accreditationId,
+      user,
+      now
+    })
 
-  const perform = selectWriteStrategy(useStreamWrite, newStatus)
+    await prnMetrics.recordStatusTransition({
+      fromStatus: currentStatus,
+      toStatus: newStatus,
+      material: prn.accreditation.material,
+      isExport: prn.isExport
+    })
 
-  const updatedPrn = await perform({
-    prnRepository,
-    organisationsRepository,
+    return updatedPrn
+  }
+
+  const updatedPrn = (await isOnLedger(
     wasteBalancesRepository,
-    logger,
-    prn,
-    updateParams,
-    events,
-    newStatus,
-    organisationId,
-    registrationId,
-    accreditationId,
-    user,
-    currentStatus,
-    now,
-    id
-  })
+    accreditationId
+  ))
+    ? await performLedgerWrite({
+        prnRepository,
+        organisationsRepository,
+        wasteBalancesRepository,
+        logger,
+        prn,
+        newStatus,
+        organisationId,
+        registrationId,
+        accreditationId,
+        user,
+        currentStatus,
+        id
+      })
+    : await selectEmbeddedWriteStrategy(newStatus)({
+        prnRepository,
+        organisationsRepository,
+        wasteBalancesRepository,
+        logger,
+        prn,
+        updateParams,
+        newStatus,
+        organisationId,
+        registrationId,
+        accreditationId,
+        user,
+        currentStatus,
+        now,
+        id
+      })
 
   await prnMetrics.recordStatusTransition({
     fromStatus: currentStatus,

--- a/src/packaging-recycling-notes/repository/contract/persistProjection.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/persistProjection.contract.js
@@ -1,0 +1,241 @@
+import { describe, beforeEach, expect } from 'vitest'
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { PrnNumberConflictError } from '#packaging-recycling-notes/repository/port.js'
+import { buildDraftPrn } from './test-data.js'
+
+/** @typedef {import('../port.js').PackagingRecyclingNotesRepository} PrnRepository */
+
+const ISSUE_USER = { id: 'user-issuer', name: 'Issuer User' }
+const RAISER_USER = { id: 'user-raiser', name: 'Raiser User' }
+
+const buildProjection = (existing, overrides = {}) => ({
+  ...existing,
+  version: existing.version + 1,
+  ...overrides
+})
+
+export const testPersistProjectionBehaviour = (it) => {
+  describe('persistProjection', () => {
+    /** @type {PrnRepository} */
+    let repository
+
+    beforeEach(
+      async (
+        /** @type {{ prnRepository: PrnRepository }} */ { prnRepository }
+      ) => {
+        repository = prnRepository
+      }
+    )
+
+    describe('basic behaviour', () => {
+      it('persists the projection in full', async () => {
+        const created = await repository.create(buildDraftPrn())
+        const at = new Date()
+        const projection = buildProjection(created, {
+          updatedAt: at,
+          updatedBy: RAISER_USER,
+          lastAppliedEventNumber: 1,
+          status: {
+            currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+            currentStatusAt: at,
+            created: { at, by: RAISER_USER },
+            history: [
+              ...created.status.history,
+              {
+                status: PRN_STATUS.AWAITING_AUTHORISATION,
+                at,
+                by: RAISER_USER
+              }
+            ]
+          }
+        })
+
+        const persisted = await repository.persistProjection({
+          projection,
+          expectedVersion: created.version
+        })
+
+        expect(persisted.id).toBe(created.id)
+        expect(persisted.version).toBe(created.version + 1)
+        expect(persisted.status.currentStatus).toBe(
+          PRN_STATUS.AWAITING_AUTHORISATION
+        )
+        expect(persisted.status.currentStatusAt).toEqual(at)
+        expect(persisted.status.created).toEqual({ at, by: RAISER_USER })
+        expect(persisted.status.history).toHaveLength(2)
+        expect(persisted.status.history[1]).toEqual({
+          status: PRN_STATUS.AWAITING_AUTHORISATION,
+          at,
+          by: RAISER_USER
+        })
+        expect(persisted.updatedAt).toEqual(at)
+        expect(persisted.updatedBy).toEqual(RAISER_USER)
+        expect(persisted.lastAppliedEventNumber).toBe(1)
+      })
+
+      it('returns the persisted PRN with id and without _id leakage', async () => {
+        const created = await repository.create(buildDraftPrn())
+        const projection = buildProjection(created, {
+          updatedAt: new Date(),
+          updatedBy: RAISER_USER
+        })
+
+        const persisted = await repository.persistProjection({
+          projection,
+          expectedVersion: created.version
+        })
+
+        expect(persisted.id).toBe(created.id)
+        expect(persisted._id).toBeUndefined()
+      })
+
+      it('returns null when no PRN exists with the given id', async () => {
+        const stub = buildDraftPrn()
+        const projection = {
+          ...stub,
+          id: '000000000000000000000000',
+          version: 2
+        }
+
+        const result = await repository.persistProjection({
+          projection,
+          expectedVersion: 1
+        })
+
+        expect(result).toBeNull()
+      })
+    })
+
+    describe('optimistic concurrency', () => {
+      it('throws Boom.conflict when expectedVersion does not match the persisted doc', async () => {
+        const created = await repository.create(buildDraftPrn())
+        const projection = buildProjection(created)
+
+        await expect(
+          repository.persistProjection({
+            projection,
+            expectedVersion: created.version + 99
+          })
+        ).rejects.toThrow(/version/i)
+      })
+
+      it('rejects a second persistProjection at a stale version', async () => {
+        const created = await repository.create(buildDraftPrn())
+        const firstProjection = buildProjection(created)
+
+        await repository.persistProjection({
+          projection: firstProjection,
+          expectedVersion: created.version
+        })
+
+        await expect(
+          repository.persistProjection({
+            projection: buildProjection(created),
+            expectedVersion: created.version
+          })
+        ).rejects.toThrow(/version/i)
+      })
+    })
+
+    describe('watermark monotonicity', () => {
+      it('rejects a projection whose lastAppliedEventNumber regresses', async () => {
+        const created = await repository.create(buildDraftPrn())
+        const firstProjection = buildProjection(created, {
+          lastAppliedEventNumber: 5
+        })
+        await repository.persistProjection({
+          projection: firstProjection,
+          expectedVersion: created.version
+        })
+
+        const regression = buildProjection(firstProjection, {
+          version: firstProjection.version + 1,
+          lastAppliedEventNumber: 4
+        })
+
+        await expect(
+          repository.persistProjection({
+            projection: regression,
+            expectedVersion: firstProjection.version
+          })
+        ).rejects.toThrow()
+      })
+    })
+
+    describe('prnNumber uniqueness', () => {
+      it('throws PrnNumberConflictError on a duplicate prnNumber', async () => {
+        const prnNumber = `ER26${Date.now().toString().slice(-5)}Z`
+        const firstCreated = await repository.create(buildDraftPrn())
+        await repository.persistProjection({
+          projection: buildProjection(firstCreated, { prnNumber }),
+          expectedVersion: firstCreated.version
+        })
+
+        const secondCreated = await repository.create(buildDraftPrn())
+
+        await expect(
+          repository.persistProjection({
+            projection: buildProjection(secondCreated, { prnNumber }),
+            expectedVersion: secondCreated.version
+          })
+        ).rejects.toThrow(PrnNumberConflictError)
+      })
+
+      it('persists the projected prnNumber when supplied', async () => {
+        const prnNumber = `ER26${Date.now().toString().slice(-5)}A`
+        const created = await repository.create(buildDraftPrn())
+
+        const persisted = await repository.persistProjection({
+          projection: buildProjection(created, { prnNumber }),
+          expectedVersion: created.version
+        })
+
+        expect(persisted.prnNumber).toBe(prnNumber)
+        const refetched = await repository.findById(created.id)
+        expect(refetched.prnNumber).toBe(prnNumber)
+      })
+    })
+
+    describe('issued slot is recorded as a business operation', () => {
+      it('records the issued slot from the projection', async () => {
+        const created = await repository.create(buildDraftPrn())
+        const at = new Date()
+        const projection = buildProjection(created, {
+          updatedAt: at,
+          updatedBy: ISSUE_USER,
+          lastAppliedEventNumber: 2,
+          prnNumber: `ER26${Date.now().toString().slice(-5)}B`,
+          status: {
+            currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+            currentStatusAt: at,
+            created: { at: created.updatedAt, by: RAISER_USER },
+            issued: { at, by: ISSUE_USER },
+            history: [
+              ...created.status.history,
+              {
+                status: PRN_STATUS.AWAITING_AUTHORISATION,
+                at: created.updatedAt,
+                by: RAISER_USER
+              },
+              {
+                status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                at,
+                by: ISSUE_USER
+              }
+            ]
+          }
+        })
+
+        const persisted = await repository.persistProjection({
+          projection,
+          expectedVersion: created.version
+        })
+
+        expect(persisted.status.issued).toEqual({ at, by: ISSUE_USER })
+        expect(persisted.status.currentStatus).toBe(
+          PRN_STATUS.AWAITING_ACCEPTANCE
+        )
+      })
+    })
+  })
+}

--- a/src/packaging-recycling-notes/repository/inmemory.plugin.js
+++ b/src/packaging-recycling-notes/repository/inmemory.plugin.js
@@ -16,7 +16,7 @@ import {
 /** @import { TypedLogger } from '#common/hapi-types.js' */
 /** @import { Organisation } from '#domain/organisations/model.js' */
 /** @import { PackagingRecyclingNote } from '../domain/model.js' */
-/** @import { FindByStatusParams, PaginatedResult, RollbackParams, UpdateStatusParams } from './port.js' */
+/** @import { FindByStatusParams, PaginatedResult, PersistProjectionParams, RollbackParams, UpdateStatusParams } from './port.js' */
 
 /** @typedef {Map<string, PackagingRecyclingNote>} Storage */
 
@@ -255,6 +255,58 @@ const performUpdateStatus =
 /**
  * @param {Storage} storage
  * @param {TypedLogger} logger
+ * @returns {(params: PersistProjectionParams) => Promise<PackagingRecyclingNote | null>}
+ */
+const performPersistProjection =
+  (storage, logger) =>
+  async ({ projection, expectedVersion }) => {
+    const id = projection.id
+    const existing = storage.get(id)
+    if (!existing) {
+      return null
+    }
+
+    if (existing.version !== expectedVersion) {
+      const conflictError = buildVersionConflictError(
+        id,
+        expectedVersion,
+        existing.version
+      )
+      logger.error({
+        err: conflictError,
+        message: `Version conflict detected for PRN ${id}`,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.DB,
+          action: LOGGING_EVENT_ACTIONS.VERSION_CONFLICT_DETECTED,
+          reference: id
+        }
+      })
+      throw Boom.conflict(conflictError.message)
+    }
+
+    enforceMonotonicWatermark(
+      id,
+      existing.lastAppliedEventNumber,
+      projection.lastAppliedEventNumber,
+      logger
+    )
+
+    if (projection.prnNumber) {
+      for (const other of storage.values()) {
+        if (other.id !== id && other.prnNumber === projection.prnNumber) {
+          throw new PrnNumberConflictError(projection.prnNumber)
+        }
+      }
+    }
+
+    const persisted = { ...projection, id }
+    storage.set(id, structuredClone(persisted))
+    return structuredClone(persisted)
+  }
+
+/**
+ * @param {Storage} storage
+ * @param {TypedLogger} logger
  * @param {{ revertedStatus: import('#packaging-recycling-notes/domain/model.js').PrnStatus, slotsToUnset: Array<'issued' | 'cancelled' | 'deleted'>, unsetPrnNumber?: boolean }} options
  * @returns {(params: RollbackParams) => Promise<PackagingRecyclingNote | null>}
  */
@@ -354,6 +406,7 @@ export function createInMemoryPackagingRecyclingNotesRepository(
     findByPrnNumber: performFindByPrnNumber(storage),
     findByStatus: performFindByStatus(storage, excludeOrganisationIds),
     updateStatus: performUpdateStatus(storage, logger),
+    persistProjection: performPersistProjection(storage, logger),
     rollbackIssuance: performRollback(storage, logger, {
       revertedStatus: PRN_STATUS.AWAITING_AUTHORISATION,
       slotsToUnset: ['issued'],

--- a/src/packaging-recycling-notes/repository/mongodb.js
+++ b/src/packaging-recycling-notes/repository/mongodb.js
@@ -13,7 +13,7 @@ import { throwWatermarkRegression } from './watermark-guard.js'
 /** @import { Collection, Db, Document, Filter, WithId } from 'mongodb' */
 /** @import { Organisation } from '#domain/organisations/model.js' */
 /** @import { PackagingRecyclingNote } from '#packaging-recycling-notes/domain/model.js' */
-/** @import { FindByStatusParams, PackagingRecyclingNotesRepositoryFactory, PaginatedResult, RollbackParams, UpdateStatusParams } from './port.js' */
+/** @import { FindByStatusParams, PackagingRecyclingNotesRepositoryFactory, PaginatedResult, PersistProjectionParams, RollbackParams, UpdateStatusParams } from './port.js' */
 /** @import { TypedLogger } from '#common/hapi-types.js' */
 
 const COLLECTION_NAME = 'packaging-recycling-notes'
@@ -414,6 +414,57 @@ const performUpdateStatus = async (
 /**
  * @param {Db} db
  * @param {TypedLogger} logger
+ * @param {PersistProjectionParams} params
+ * @returns {Promise<PackagingRecyclingNote | null>}
+ */
+const performPersistProjection = async (
+  db,
+  logger,
+  { projection, expectedVersion }
+) => {
+  const objectId = ObjectId.createFromHexString(projection.id)
+  const { id: _id, ...replacement } = projection
+
+  try {
+    const result = await db.collection(COLLECTION_NAME).findOneAndReplace(
+      {
+        _id: objectId,
+        $expr: {
+          $and: [
+            { $eq: [{ $ifNull: ['$version', 1] }, expectedVersion] },
+            watermarkNotRegressing(projection.lastAppliedEventNumber)
+          ]
+        }
+      },
+      replacement,
+      { returnDocument: 'after' }
+    )
+
+    if (!result) {
+      return resolveMissedUpdate(
+        db,
+        projection.id,
+        expectedVersion,
+        projection.lastAppliedEventNumber,
+        logger
+      )
+    }
+
+    return validatePrnRead({ ...result, id: result._id.toHexString() })
+  } catch (error) {
+    if (
+      error.code === MONGODB_DUPLICATE_KEY_ERROR_CODE &&
+      error.keyPattern?.prnNumber
+    ) {
+      throw new PrnNumberConflictError(projection.prnNumber)
+    }
+    throw error
+  }
+}
+
+/**
+ * @param {Db} db
+ * @param {TypedLogger} logger
  * @param {RollbackParams} params
  * @param {{ revertedStatus: import('#packaging-recycling-notes/domain/model.js').PrnStatus, slotsToUnset: Array<'issued' | 'cancelled' | 'deleted'>, unsetPrnNumber?: boolean }} options
  * @returns {Promise<PackagingRecyclingNote | null>}
@@ -501,6 +552,7 @@ export const createPackagingRecyclingNotesRepository = async (
     findByPrnNumber: (prnNumber) => performFindByPrnNumber(db, prnNumber),
     findByStatus: performFindByStatus(db, excludeOrganisationIds),
     updateStatus: (params) => performUpdateStatus(db, logger, params),
+    persistProjection: (params) => performPersistProjection(db, logger, params),
     rollbackIssuance: (params) =>
       performRollback(db, logger, params, {
         revertedStatus: PRN_STATUS.AWAITING_AUTHORISATION,

--- a/src/packaging-recycling-notes/repository/mongodb.test.js
+++ b/src/packaging-recycling-notes/repository/mongodb.test.js
@@ -7,29 +7,45 @@ import { createPackagingRecyclingNotesRepository } from './mongodb.js'
 import { testPackagingRecyclingNotesRepositoryContract } from './port.contract.js'
 import { PrnNumberConflictError } from './port.js'
 
+/**
+ * @typedef {import('mongodb').Db} Db
+ * @typedef {import('#common/helpers/logging/logger.js').TypedLogger} TypedLogger
+ * @typedef {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} PackagingRecyclingNote
+ * @typedef {import('./port.js').PackagingRecyclingNotesRepository} PrnRepository
+ */
+
 const DATABASE_NAME = 'epr-backend'
 
+/** Asserts a structural test stub satisfies the Mongo Db surface the code under test exercises. */
+const asDb = (/** @type {unknown} */ stub) => /** @type {Db} */ (stub)
+
+/** A complete TypedLogger stub for tests that only execute paths preceding any log call. */
+const stubLogger = () =>
+  /** @type {TypedLogger} */ ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn()
+  })
+
 const it = mongoIt.extend({
-  mongoClient: async ({ db }, use) => {
+  mongoClient: async (/** @type {*} */ { db }, use) => {
     const client = await MongoClient.connect(db)
     await use(client)
     await client.close()
   },
 
-  prnRepositoryFactory: async ({ mongoClient }, use) => {
+  prnRepositoryFactory: async (/** @type {*} */ { mongoClient }, use) => {
     const database = mongoClient.db(DATABASE_NAME)
     const factory = await createPackagingRecyclingNotesRepository(database, [])
     await use(factory)
   },
 
-  prnRepository: async ({ prnRepositoryFactory }, use) => {
-    const mockLogger = {
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn()
-    }
-    const repository = prnRepositoryFactory(mockLogger)
+  prnRepository: async (/** @type {*} */ { prnRepositoryFactory }, use) => {
+    const repository = prnRepositoryFactory(stubLogger())
     await use(repository)
   }
 })
@@ -42,8 +58,9 @@ describe('MongoDB packaging recycling notes repository', () => {
   describe('MongoDB-specific error handling', () => {
     it('re-throws non-duplicate key errors from MongoDB', async () => {
       const hexId = '123456789012345678901234'
-      const otherError = new Error('Connection timeout')
-      otherError.code = 'ETIMEOUT'
+      const otherError = Object.assign(new Error('Connection timeout'), {
+        code: 'ETIMEOUT'
+      })
 
       const mockDb = {
         collection: function () {
@@ -61,8 +78,11 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      const factory = await createPackagingRecyclingNotesRepository(mockDb, [])
-      const repository = factory()
+      const factory = await createPackagingRecyclingNotesRepository(
+        asDb(mockDb),
+        []
+      )
+      const repository = factory(stubLogger())
 
       await expect(
         repository.updateStatus({
@@ -78,8 +98,9 @@ describe('MongoDB packaging recycling notes repository', () => {
 
     it('re-throws non-duplicate key errors from persistProjection', async () => {
       const hexId = '123456789012345678901234'
-      const otherError = new Error('Connection timeout')
-      otherError.code = 'ETIMEOUT'
+      const otherError = Object.assign(new Error('Connection timeout'), {
+        code: 'ETIMEOUT'
+      })
 
       const mockDb = {
         collection: function () {
@@ -97,22 +118,27 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      const factory = await createPackagingRecyclingNotesRepository(mockDb, [])
-      const repository = factory()
+      const factory = await createPackagingRecyclingNotesRepository(
+        asDb(mockDb),
+        []
+      )
+      const repository = factory(stubLogger())
 
       await expect(
         repository.persistProjection({
-          projection: {
-            id: hexId,
-            version: 2,
-            updatedAt: new Date(),
-            updatedBy: { id: 'user-123', name: 'Test User' },
-            status: {
-              currentStatus: 'awaiting_acceptance',
-              currentStatusAt: new Date(),
-              history: []
-            }
-          },
+          projection: /** @type {PackagingRecyclingNote} */ (
+            /** @type {unknown} */ ({
+              id: hexId,
+              version: 2,
+              updatedAt: new Date(),
+              updatedBy: { id: 'user-123', name: 'Test User' },
+              status: {
+                currentStatus: 'awaiting_acceptance',
+                currentStatusAt: new Date(),
+                history: []
+              }
+            })
+          ),
           expectedVersion: 1
         })
       ).rejects.toThrow('Connection timeout')
@@ -121,9 +147,10 @@ describe('MongoDB packaging recycling notes repository', () => {
     it('throws PrnNumberConflictError on duplicate key error for prnNumber', async () => {
       const hexId = '123456789012345678901234'
       const prnNumber = 'ER2612345'
-      const duplicateKeyError = new Error('duplicate key error')
-      duplicateKeyError.code = 11000
-      duplicateKeyError.keyPattern = { prnNumber: 1 }
+      const duplicateKeyError = Object.assign(
+        new Error('duplicate key error'),
+        { code: 11000, keyPattern: { prnNumber: 1 } }
+      )
 
       const mockDb = {
         collection: function () {
@@ -141,8 +168,11 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      const factory = await createPackagingRecyclingNotesRepository(mockDb, [])
-      const repository = factory()
+      const factory = await createPackagingRecyclingNotesRepository(
+        asDb(mockDb),
+        []
+      )
+      const repository = factory(stubLogger())
 
       await expect(
         repository.updateStatus({
@@ -178,7 +208,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      await createPackagingRecyclingNotesRepository(mockDb, [])
+      await createPackagingRecyclingNotesRepository(asDb(mockDb), [])
 
       const orgStatusIndex = createdIndexes.find(
         (idx) => idx.options.name === 'organisationId_status'
@@ -219,7 +249,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      await createPackagingRecyclingNotesRepository(mockDb, [])
+      await createPackagingRecyclingNotesRepository(asDb(mockDb), [])
 
       expect(droppedIndexes).toContain('organisationId_status')
 
@@ -258,14 +288,15 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      await createPackagingRecyclingNotesRepository(mockDb, [])
+      await createPackagingRecyclingNotesRepository(asDb(mockDb), [])
 
       expect(droppedIndex).toBeNull()
     })
 
     it('handles NamespaceNotFound error when collection is new', async () => {
-      const nsError = new Error('ns not found')
-      nsError.codeName = 'NamespaceNotFound'
+      const nsError = Object.assign(new Error('ns not found'), {
+        codeName: 'NamespaceNotFound'
+      })
 
       let indexesCalls = 0
       const createdIndexes = []
@@ -293,7 +324,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      await createPackagingRecyclingNotesRepository(mockDb, [])
+      await createPackagingRecyclingNotesRepository(asDb(mockDb), [])
 
       const orgStatusIndex = createdIndexes.find(
         (idx) => idx.options.name === 'organisationId_status'
@@ -302,8 +333,9 @@ describe('MongoDB packaging recycling notes repository', () => {
     })
 
     it('re-throws non-NamespaceNotFound errors', async () => {
-      const connectionError = new Error('Connection refused')
-      connectionError.codeName = 'NetworkError'
+      const connectionError = Object.assign(new Error('Connection refused'), {
+        codeName: 'NetworkError'
+      })
 
       let indexesCalls = 0
 
@@ -329,15 +361,16 @@ describe('MongoDB packaging recycling notes repository', () => {
       }
 
       await expect(
-        createPackagingRecyclingNotesRepository(mockDb, [])
+        createPackagingRecyclingNotesRepository(asDb(mockDb), [])
       ).rejects.toThrow('Connection refused')
     })
   })
 
   describe('ensurePrnNumberIndex error handling', () => {
     it('re-throws non-NamespaceNotFound errors from prnNumber indexes()', async () => {
-      const connectionError = new Error('Connection lost')
-      connectionError.codeName = 'NetworkError'
+      const connectionError = Object.assign(new Error('Connection lost'), {
+        codeName: 'NetworkError'
+      })
 
       let indexesCalls = 0
 
@@ -364,7 +397,7 @@ describe('MongoDB packaging recycling notes repository', () => {
       }
 
       await expect(
-        createPackagingRecyclingNotesRepository(mockDb, [])
+        createPackagingRecyclingNotesRepository(asDb(mockDb), [])
       ).rejects.toThrow('Connection lost')
     })
   })
@@ -390,7 +423,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      await createPackagingRecyclingNotesRepository(mockDb, [])
+      await createPackagingRecyclingNotesRepository(asDb(mockDb), [])
 
       const statusDateIndex = createdIndexes.find(
         (idx) => idx.options.name === 'status_currentStatusAt'
@@ -404,8 +437,9 @@ describe('MongoDB packaging recycling notes repository', () => {
     })
 
     it('handles NamespaceNotFound error when collection does not exist', async () => {
-      const nsError = new Error('ns not found')
-      nsError.codeName = 'NamespaceNotFound'
+      const nsError = Object.assign(new Error('ns not found'), {
+        codeName: 'NamespaceNotFound'
+      })
 
       let createIndexCalls = 0
 
@@ -430,13 +464,17 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      const factory = await createPackagingRecyclingNotesRepository(mockDb, [])
+      const factory = await createPackagingRecyclingNotesRepository(
+        asDb(mockDb),
+        []
+      )
       expect(factory).toBeTypeOf('function')
     })
 
     it('re-throws non-NamespaceNotFound errors from createIndex', async () => {
-      const connectionError = new Error('Connection lost')
-      connectionError.codeName = 'NetworkError'
+      const connectionError = Object.assign(new Error('Connection lost'), {
+        codeName: 'NetworkError'
+      })
 
       let createIndexCalls = 0
 
@@ -462,7 +500,7 @@ describe('MongoDB packaging recycling notes repository', () => {
       }
 
       await expect(
-        createPackagingRecyclingNotesRepository(mockDb, [])
+        createPackagingRecyclingNotesRepository(asDb(mockDb), [])
       ).rejects.toThrow('Connection lost')
     })
   })
@@ -488,7 +526,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      await createPackagingRecyclingNotesRepository(mockDb, [])
+      await createPackagingRecyclingNotesRepository(asDb(mockDb), [])
 
       const prnNumberIndex = createdIndexes.find(
         (idx) => idx.options.name === 'prnNumber'
@@ -524,7 +562,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      await createPackagingRecyclingNotesRepository(mockDb, [])
+      await createPackagingRecyclingNotesRepository(asDb(mockDb), [])
 
       expect(droppedIndex).toBe('prnNumber')
 
@@ -563,16 +601,16 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      await createPackagingRecyclingNotesRepository(mockDb, [])
+      await createPackagingRecyclingNotesRepository(asDb(mockDb), [])
 
       expect(droppedIndex).toBeNull()
     })
 
     it('handles ns does not exist error when collection is new', async () => {
-      const nsDoesNotExistError = new Error(
-        'ns does not exist: epr-backend.packaging-recycling-notes'
+      const nsDoesNotExistError = Object.assign(
+        new Error('ns does not exist: epr-backend.packaging-recycling-notes'),
+        { codeName: 'NamespaceNotFound' }
       )
-      nsDoesNotExistError.codeName = 'NamespaceNotFound'
 
       const createdIndexes = []
 
@@ -595,7 +633,7 @@ describe('MongoDB packaging recycling notes repository', () => {
         }
       }
 
-      await createPackagingRecyclingNotesRepository(mockDb, [])
+      await createPackagingRecyclingNotesRepository(asDb(mockDb), [])
 
       const prnNumberIndex = createdIndexes.find(
         (idx) => idx.options.name === 'prnNumber'
@@ -606,8 +644,9 @@ describe('MongoDB packaging recycling notes repository', () => {
     })
 
     it('re-throws non-NamespaceNotFound errors from indexes()', async () => {
-      const connectionError = new Error('Connection refused')
-      connectionError.codeName = 'NetworkError'
+      const connectionError = Object.assign(new Error('Connection refused'), {
+        codeName: 'NetworkError'
+      })
 
       const mockDb = {
         collection: function () {
@@ -627,7 +666,7 @@ describe('MongoDB packaging recycling notes repository', () => {
       }
 
       await expect(
-        createPackagingRecyclingNotesRepository(mockDb, [])
+        createPackagingRecyclingNotesRepository(asDb(mockDb), [])
       ).rejects.toThrow('Connection refused')
     })
   })
@@ -644,20 +683,25 @@ describe('MongoDB packaging recycling notes repository', () => {
     }
 
     it('reads back as version 1', async ({ mongoClient, prnRepository }) => {
-      const id = await seedVersionlessPrn(mongoClient)
+      const client = /** @type {MongoClient} */ (mongoClient)
+      const repo = /** @type {PrnRepository} */ (prnRepository)
 
-      const found = await prnRepository.findById(id)
+      const id = await seedVersionlessPrn(client)
+      const found = await repo.findById(id)
 
-      expect(found.version).toBe(1)
+      expect(found?.version).toBe(1)
     })
 
     it('accepts a CAS update with version 1 and bumps to version 2', async ({
       mongoClient,
       prnRepository
     }) => {
-      const id = await seedVersionlessPrn(mongoClient)
+      const client = /** @type {MongoClient} */ (mongoClient)
+      const repo = /** @type {PrnRepository} */ (prnRepository)
 
-      const updated = await prnRepository.updateStatus({
+      const id = await seedVersionlessPrn(client)
+
+      const updated = await repo.updateStatus({
         id,
         version: 1,
         status: PRN_STATUS.AWAITING_ACCEPTANCE,
@@ -666,22 +710,24 @@ describe('MongoDB packaging recycling notes repository', () => {
         prnNumber: `TT2699999`
       })
 
-      expect(updated.version).toBe(2)
-      expect(updated.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+      expect(updated?.version).toBe(2)
+      expect(updated?.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
 
-      const reread = await prnRepository.findById(id)
-      expect(reread.version).toBe(2)
+      const reread = await repo.findById(id)
+      expect(reread?.version).toBe(2)
     })
 
     it('reports actual version as 1 when conflict is detected', async ({
       mongoClient,
       prnRepository
     }) => {
-      const id = await seedVersionlessPrn(mongoClient)
+      const client = /** @type {MongoClient} */ (mongoClient)
+      const repo = /** @type {PrnRepository} */ (prnRepository)
+      const id = await seedVersionlessPrn(client)
 
       const staleVersion = 5
       await expect(
-        prnRepository.updateStatus({
+        repo.updateStatus({
           id,
           version: staleVersion,
           status: PRN_STATUS.AWAITING_ACCEPTANCE,

--- a/src/packaging-recycling-notes/repository/mongodb.test.js
+++ b/src/packaging-recycling-notes/repository/mongodb.test.js
@@ -76,6 +76,48 @@ describe('MongoDB packaging recycling notes repository', () => {
       ).rejects.toThrow('Connection timeout')
     })
 
+    it('re-throws non-duplicate key errors from persistProjection', async () => {
+      const hexId = '123456789012345678901234'
+      const otherError = new Error('Connection timeout')
+      otherError.code = 'ETIMEOUT'
+
+      const mockDb = {
+        collection: function () {
+          return this
+        },
+        indexes: async () => [],
+        createIndex: async () => {},
+        findOne: async () => null,
+        insertOne: async () => ({ insertedId: { toHexString: () => hexId } }),
+        find: function () {
+          return { toArray: async () => [] }
+        },
+        findOneAndReplace: async () => {
+          throw otherError
+        }
+      }
+
+      const factory = await createPackagingRecyclingNotesRepository(mockDb, [])
+      const repository = factory()
+
+      await expect(
+        repository.persistProjection({
+          projection: {
+            id: hexId,
+            version: 2,
+            updatedAt: new Date(),
+            updatedBy: { id: 'user-123', name: 'Test User' },
+            status: {
+              currentStatus: 'awaiting_acceptance',
+              currentStatusAt: new Date(),
+              history: []
+            }
+          },
+          expectedVersion: 1
+        })
+      ).rejects.toThrow('Connection timeout')
+    })
+
     it('throws PrnNumberConflictError on duplicate key error for prnNumber', async () => {
       const hexId = '123456789012345678901234'
       const prnNumber = 'ER2612345'

--- a/src/packaging-recycling-notes/repository/port.contract.js
+++ b/src/packaging-recycling-notes/repository/port.contract.js
@@ -3,6 +3,7 @@ import { testDataIsolation } from './contract/data-isolation.contract.js'
 import { testFindBehaviour } from './contract/find.contract.js'
 import { testFindByStatusBehaviour } from './contract/find-by-status.contract.js'
 import { testOptimisticConcurrency } from './contract/optimistic-concurrency.contract.js'
+import { testPersistProjectionBehaviour } from './contract/persistProjection.contract.js'
 import { testRollbackBehaviour } from './contract/rollback.contract.js'
 import { testUpdateStatusBehaviour } from './contract/update-status.contract.js'
 import { testPrnNumberUniqueness } from './contract/prn-number-uniqueness.contract.js'
@@ -16,6 +17,7 @@ export const testPackagingRecyclingNotesRepositoryContract = (
     testFindBehaviour(repositoryFactory)
     testFindByStatusBehaviour(repositoryFactory)
     testOptimisticConcurrency(repositoryFactory)
+    testPersistProjectionBehaviour(repositoryFactory)
     testRollbackBehaviour(repositoryFactory)
     testUpdateStatusBehaviour(repositoryFactory)
     testPrnNumberUniqueness(repositoryFactory)

--- a/src/packaging-recycling-notes/repository/port.js
+++ b/src/packaging-recycling-notes/repository/port.js
@@ -52,6 +52,17 @@ export class PrnNumberConflictError extends Error {
  */
 
 /**
+ * Save a fully projected PRN document with optimistic concurrency. The
+ * projection is constructed at the application layer (typically by folding
+ * stream events onto the prior PRN); the repository performs no projection
+ * logic itself.
+ *
+ * @typedef {Object} PersistProjectionParams
+ * @property {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} projection - Fully projected PRN document to persist.
+ * @property {number} expectedVersion - The version of the PRN before this projection step; the CAS gate.
+ */
+
+/**
  * @typedef {Object} PackagingRecyclingNotesRepository
  * @property {(id: string) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote | null>} findById
  * @property {(prnNumber: string) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote | null>} findByPrnNumber
@@ -59,6 +70,7 @@ export class PrnNumberConflictError extends Error {
  * @property {(accreditationId: string) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote[]>} findByAccreditation
  * @property {(params: FindByStatusParams) => Promise<PaginatedResult>} findByStatus
  * @property {(params: UpdateStatusParams) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote | null>} updateStatus
+ * @property {(params: PersistProjectionParams) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote | null>} persistProjection
  * @property {(params: RollbackParams) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote | null>} rollbackIssuance
  * @property {(params: RollbackParams) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote | null>} rollbackPendingCancellation
  * @property {(params: RollbackParams) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote | null>} rollbackIssuedCancellation

--- a/src/packaging-recycling-notes/routes/get-by-id.js
+++ b/src/packaging-recycling-notes/routes/get-by-id.js
@@ -74,8 +74,7 @@ export const packagingRecyclingNoteById = {
       ])
 
       if (
-        !prn ||
-        prn.organisation.id !== organisationId ||
+        prn?.organisation.id !== organisationId ||
         prn.accreditation.id !== accreditationId ||
         prn.status.currentStatus === PRN_STATUS.DELETED
       ) {

--- a/src/packaging-recycling-notes/routes/get-by-id.js
+++ b/src/packaging-recycling-notes/routes/get-by-id.js
@@ -77,8 +77,12 @@ export const packagingRecyclingNoteById = {
         )
       ])
 
+      if (!prn) {
+        throw Boom.notFound('PRN not found')
+      }
+
       if (
-        prn?.organisation.id !== organisationId ||
+        prn.organisation.id !== organisationId ||
         prn.accreditation.id !== accreditationId ||
         prn.status.currentStatus === PRN_STATUS.DELETED
       ) {

--- a/src/packaging-recycling-notes/routes/get-by-id.js
+++ b/src/packaging-recycling-notes/routes/get-by-id.js
@@ -76,7 +76,8 @@ export const packagingRecyclingNoteById = {
       if (
         !prn ||
         prn.organisation.id !== organisationId ||
-        prn.accreditation.id !== accreditationId
+        prn.accreditation.id !== accreditationId ||
+        prn.status.currentStatus === PRN_STATUS.DELETED
       ) {
         throw Boom.notFound('PRN not found')
       }

--- a/src/packaging-recycling-notes/routes/get-by-id.js
+++ b/src/packaging-recycling-notes/routes/get-by-id.js
@@ -9,7 +9,7 @@ import { ROLES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { getProcessCode } from '#packaging-recycling-notes/domain/get-process-code.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
-import { foldPrnFromTailEvents } from '#packaging-recycling-notes/application/fold-prn-from-tail-events.js'
+import { getProjectedPrnById } from '#packaging-recycling-notes/application/get-projected-prn.js'
 
 /** @typedef {import('#packaging-recycling-notes/domain/model.js').GetPrnResponse} GetPrnResponse */
 /** @typedef {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepository */
@@ -66,7 +66,11 @@ export const packagingRecyclingNoteById = {
 
     try {
       const [prn, accreditation] = await Promise.all([
-        packagingRecyclingNotesRepository.findById(prnId),
+        getProjectedPrnById({
+          packagingRecyclingNotesRepository,
+          wasteBalancesRepository,
+          prnId
+        }),
         organisationsRepository.findAccreditationById(
           organisationId,
           accreditationId
@@ -81,18 +85,6 @@ export const packagingRecyclingNoteById = {
         throw Boom.notFound('PRN not found')
       }
 
-      const tailEvents = await wasteBalancesRepository.getPrnCatchupEvents({
-        registrationId: prn.registrationId,
-        accreditationId: prn.accreditation.id,
-        prnId: prn.id,
-        afterEventNumber: prn.lastAppliedEventNumber ?? 0
-      })
-      const foldedPrn = foldPrnFromTailEvents(prn, tailEvents)
-
-      if (foldedPrn.status.currentStatus === PRN_STATUS.DELETED) {
-        throw Boom.notFound('PRN not found')
-      }
-
       logger.info({
         message: `PRN retrieved: id=${prnId}`,
         event: {
@@ -102,9 +94,7 @@ export const packagingRecyclingNoteById = {
         }
       })
 
-      return h
-        .response(buildResponse(foldedPrn, accreditation))
-        .code(StatusCodes.OK)
+      return h.response(buildResponse(prn, accreditation)).code(StatusCodes.OK)
     } catch (error) {
       if (error.isBoom) {
         throw error

--- a/src/packaging-recycling-notes/routes/get-by-id.js
+++ b/src/packaging-recycling-notes/routes/get-by-id.js
@@ -9,10 +9,12 @@ import { ROLES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { getProcessCode } from '#packaging-recycling-notes/domain/get-process-code.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { foldPrnFromTailEvents } from '#packaging-recycling-notes/application/fold-prn-from-tail-events.js'
 
 /** @typedef {import('#packaging-recycling-notes/domain/model.js').GetPrnResponse} GetPrnResponse */
 /** @typedef {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepository */
 /** @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository */
+/** @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository */
 
 export const packagingRecyclingNoteByIdPath =
   '/v1/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/packaging-recycling-notes/{prnId}'
@@ -49,13 +51,14 @@ export const packagingRecyclingNoteById = {
     tags: ['api']
   },
   /**
-   * @param {import('#common/hapi-types.js').HapiRequest & {packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository, organisationsRepository: OrganisationsRepository}} request
+   * @param {import('#common/hapi-types.js').HapiRequest & {packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository, organisationsRepository: OrganisationsRepository, wasteBalancesRepository: WasteBalancesRepository}} request
    * @param {object} h - Hapi response toolkit
    */
   handler: async (request, h) => {
     const {
       packagingRecyclingNotesRepository,
       organisationsRepository,
+      wasteBalancesRepository,
       params,
       logger
     } = request
@@ -70,13 +73,23 @@ export const packagingRecyclingNoteById = {
         )
       ])
 
-      // Verify the PRN exists, belongs to the requested organisation/accreditation,
-      // and treat deleted PRNs as not found (soft delete)
       if (
-        prn?.organisation.id !== organisationId ||
-        prn?.accreditation.id !== accreditationId ||
-        prn?.status.currentStatus === PRN_STATUS.DELETED
+        !prn ||
+        prn.organisation.id !== organisationId ||
+        prn.accreditation.id !== accreditationId
       ) {
+        throw Boom.notFound('PRN not found')
+      }
+
+      const tailEvents = await wasteBalancesRepository.getPrnCatchupEvents({
+        registrationId: prn.registrationId,
+        accreditationId: prn.accreditation.id,
+        prnId: prn.id,
+        afterEventNumber: prn.lastAppliedEventNumber ?? 0
+      })
+      const foldedPrn = foldPrnFromTailEvents(prn, tailEvents)
+
+      if (foldedPrn.status.currentStatus === PRN_STATUS.DELETED) {
         throw Boom.notFound('PRN not found')
       }
 
@@ -89,7 +102,9 @@ export const packagingRecyclingNoteById = {
         }
       })
 
-      return h.response(buildResponse(prn, accreditation)).code(StatusCodes.OK)
+      return h
+        .response(buildResponse(foldedPrn, accreditation))
+        .code(StatusCodes.OK)
     } catch (error) {
       if (error.isBoom) {
         throw error

--- a/src/packaging-recycling-notes/routes/get-by-id.test.js
+++ b/src/packaging-recycling-notes/routes/get-by-id.test.js
@@ -400,67 +400,7 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
         createdBy: { id: 'user-1', name: 'Test User' }
       })
 
-      it('queries catch-up events using the PRN watermark', async () => {
-        const issuedPrn = {
-          ...mockPrn,
-          lastAppliedEventNumber: 3,
-          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
-        }
-        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
-          issuedPrn
-        )
-
-        await server.inject({
-          method: 'GET',
-          url,
-          ...asStandardUser({ linkedOrgId: organisationId })
-        })
-
-        expect(
-          wasteBalancesRepository.getPrnCatchupEvents
-        ).toHaveBeenCalledWith({
-          registrationId,
-          accreditationId,
-          prnId,
-          afterEventNumber: 3
-        })
-      })
-
-      it('defaults afterEventNumber to 0 when the PRN has no watermark', async () => {
-        const draftPrn = {
-          ...mockPrn,
-          status: { currentStatus: PRN_STATUS.DRAFT }
-        }
-        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
-          draftPrn
-        )
-
-        await server.inject({
-          method: 'GET',
-          url,
-          ...asStandardUser({ linkedOrgId: organisationId })
-        })
-
-        expect(
-          wasteBalancesRepository.getPrnCatchupEvents
-        ).toHaveBeenCalledWith(expect.objectContaining({ afterEventNumber: 0 }))
-      })
-
-      it('returns the PRN unchanged when no tail events exist', async () => {
-        wasteBalancesRepository.getPrnCatchupEvents.mockResolvedValueOnce([])
-
-        const response = await server.inject({
-          method: 'GET',
-          url,
-          ...asStandardUser({ linkedOrgId: organisationId })
-        })
-
-        expect(response.statusCode).toBe(StatusCodes.OK)
-        const payload = JSON.parse(response.payload)
-        expect(payload.status).toBe(PRN_STATUS.AWAITING_AUTHORISATION)
-      })
-
-      it('recovers a partial failure: stale doc, fresh tail event projects to awaiting_acceptance', async () => {
+      it('surfaces the status projected from catch-up events', async () => {
         const stalePrn = {
           ...mockPrn,
           lastAppliedEventNumber: 1,
@@ -485,67 +425,6 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
         expect(response.statusCode).toBe(StatusCodes.OK)
         const payload = JSON.parse(response.payload)
         expect(payload.status).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
-      })
-
-      it('recovers a first-event failure: draft doc + null watermark + prn-created at 1', async () => {
-        const draftPrn = {
-          ...mockPrn,
-          status: { currentStatus: PRN_STATUS.DRAFT, history: [] }
-        }
-        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
-          draftPrn
-        )
-        wasteBalancesRepository.getPrnCatchupEvents.mockResolvedValueOnce([
-          tailEvent(
-            STREAM_EVENT_KIND.PRN_CREATED,
-            1,
-            '2026-02-01T12:00:00.000Z'
-          )
-        ])
-
-        const response = await server.inject({
-          method: 'GET',
-          url,
-          ...asStandardUser({ linkedOrgId: organisationId })
-        })
-
-        expect(response.statusCode).toBe(StatusCodes.OK)
-        expect(
-          wasteBalancesRepository.getPrnCatchupEvents
-        ).toHaveBeenCalledWith(expect.objectContaining({ afterEventNumber: 0 }))
-        const payload = JSON.parse(response.payload)
-        expect(payload.status).toBe(PRN_STATUS.AWAITING_AUTHORISATION)
-      })
-
-      it('folds prn-cancelled-after-issue to cancelled', async () => {
-        const issuedPrn = {
-          ...mockPrn,
-          lastAppliedEventNumber: 2,
-          status: {
-            currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
-            history: []
-          }
-        }
-        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
-          issuedPrn
-        )
-        wasteBalancesRepository.getPrnCatchupEvents.mockResolvedValueOnce([
-          tailEvent(
-            STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
-            3,
-            '2026-02-03T12:00:00.000Z'
-          )
-        ])
-
-        const response = await server.inject({
-          method: 'GET',
-          url,
-          ...asStandardUser({ linkedOrgId: organisationId })
-        })
-
-        expect(response.statusCode).toBe(StatusCodes.OK)
-        const payload = JSON.parse(response.payload)
-        expect(payload.status).toBe(PRN_STATUS.CANCELLED)
       })
 
       it('returns 404 when a prn-creation-cancelled event folds the PRN to deleted', async () => {
@@ -575,41 +454,6 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
         })
 
         expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
-      })
-
-      it('does not query catch-up events when the PRN does not exist (404 short-circuits the fold)', async () => {
-        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(null)
-
-        await server.inject({
-          method: 'GET',
-          url,
-          ...asStandardUser({ linkedOrgId: organisationId })
-        })
-
-        expect(
-          wasteBalancesRepository.getPrnCatchupEvents
-        ).not.toHaveBeenCalled()
-      })
-
-      it('does not query catch-up events when the PRN is already doc-soft-deleted', async () => {
-        const deletedPrn = {
-          ...mockPrn,
-          status: { currentStatus: PRN_STATUS.DELETED }
-        }
-        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
-          deletedPrn
-        )
-
-        const response = await server.inject({
-          method: 'GET',
-          url,
-          ...asStandardUser({ linkedOrgId: organisationId })
-        })
-
-        expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
-        expect(
-          wasteBalancesRepository.getPrnCatchupEvents
-        ).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/packaging-recycling-notes/routes/get-by-id.test.js
+++ b/src/packaging-recycling-notes/routes/get-by-id.test.js
@@ -451,7 +451,10 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
         const stalePrn = {
           ...mockPrn,
           lastAppliedEventNumber: 1,
-          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+          status: {
+            currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+            history: []
+          }
         }
         packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
           stalePrn
@@ -474,7 +477,7 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
       it('recovers a first-event failure: draft doc + null watermark + prn-created at 1', async () => {
         const draftPrn = {
           ...mockPrn,
-          status: { currentStatus: PRN_STATUS.DRAFT }
+          status: { currentStatus: PRN_STATUS.DRAFT, history: [] }
         }
         packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
           draftPrn
@@ -505,7 +508,10 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
         const issuedPrn = {
           ...mockPrn,
           lastAppliedEventNumber: 2,
-          status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
+          status: {
+            currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+            history: []
+          }
         }
         packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
           issuedPrn
@@ -533,7 +539,10 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
         const awaitingAuthPrn = {
           ...mockPrn,
           lastAppliedEventNumber: 1,
-          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+          status: {
+            currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+            history: []
+          }
         }
         packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
           awaitingAuthPrn

--- a/src/packaging-recycling-notes/routes/get-by-id.test.js
+++ b/src/packaging-recycling-notes/routes/get-by-id.test.js
@@ -568,6 +568,27 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
           wasteBalancesRepository.getPrnCatchupEvents
         ).not.toHaveBeenCalled()
       })
+
+      it('does not query catch-up events when the PRN is already doc-soft-deleted', async () => {
+        const deletedPrn = {
+          ...mockPrn,
+          status: { currentStatus: PRN_STATUS.DELETED }
+        }
+        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
+          deletedPrn
+        )
+
+        const response = await server.inject({
+          method: 'GET',
+          url,
+          ...asStandardUser({ linkedOrgId: organisationId })
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        expect(
+          wasteBalancesRepository.getPrnCatchupEvents
+        ).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/src/packaging-recycling-notes/routes/get-by-id.test.js
+++ b/src/packaging-recycling-notes/routes/get-by-id.test.js
@@ -23,6 +23,15 @@ const registrationId = 'reg-001'
 const accreditationId = 'acc-789'
 const prnId = 'prn-001'
 
+/**
+ * @typedef {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} PackagingRecyclingNote
+ */
+
+/**
+ * Intentionally lacks `version` so the fold's `prn.version ?? 0` defensive
+ * branch (legacy-doc compatibility) is exercised when this fixture flows
+ * through `foldPrnFromTailEvents`. Cast at the consumer boundary.
+ */
 const mockPrn = {
   id: prnId,
   schemaVersion: 2,
@@ -58,6 +67,10 @@ const mockPrn = {
   notes: 'Test notes'
 }
 
+const asPrn = (/** @type {unknown} */ p) =>
+  /** @type {PackagingRecyclingNote} */ (p)
+
+/** @param {PackagingRecyclingNote | null} prn */
 const createInMemoryPackagingRecyclingNotesRepository = (prn = null) => {
   return () => ({
     create: vi.fn(),
@@ -77,7 +90,7 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
 
     beforeAll(async () => {
       packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository(mockPrn)()
+        createInMemoryPackagingRecyclingNotesRepository(asPrn(mockPrn))()
 
       organisationsRepository = {
         findAccreditationById: vi.fn(async () => ({

--- a/src/packaging-recycling-notes/routes/get-by-id.test.js
+++ b/src/packaging-recycling-notes/routes/get-by-id.test.js
@@ -15,6 +15,7 @@ import { asStandardUser } from '#test/inject-auth.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { WASTE_PROCESSING_TYPE } from '#domain/organisations/model.js'
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
 import { packagingRecyclingNoteByIdPath } from './get-by-id.js'
 
 const organisationId = 'org-123'
@@ -72,6 +73,7 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
     let server
     let packagingRecyclingNotesRepository
     let organisationsRepository
+    let wasteBalancesRepository
 
     beforeAll(async () => {
       packagingRecyclingNotesRepository =
@@ -84,11 +86,16 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
         }))
       }
 
+      wasteBalancesRepository = {
+        getPrnCatchupEvents: vi.fn(async () => [])
+      }
+
       server = await createTestServer({
         repositories: {
           packagingRecyclingNotesRepository: () =>
             packagingRecyclingNotesRepository,
-          organisationsRepository: () => organisationsRepository
+          organisationsRepository: () => organisationsRepository,
+          wasteBalancesRepository: () => wasteBalancesRepository
         },
         featureFlags: createInMemoryFeatureFlags()
       })
@@ -98,6 +105,7 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
 
     afterEach(() => {
       vi.clearAllMocks()
+      wasteBalancesRepository.getPrnCatchupEvents.mockResolvedValue([])
     })
 
     afterAll(async () => {
@@ -359,6 +367,206 @@ describe(`${packagingRecyclingNoteByIdPath} route`, () => {
         })
 
         expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+      })
+    })
+
+    describe('read-side catch-up from event stream', () => {
+      const url = `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${prnId}`
+
+      const tailEvent = (kind, number, createdAt) => ({
+        id: `event-${number}`,
+        registrationId,
+        accreditationId,
+        organisationId,
+        number,
+        kind,
+        payload: { prnId, amount: 50 },
+        openingBalance: { amount: 100, availableAmount: 100 },
+        closingBalance: { amount: 100, availableAmount: 50 },
+        createdAt: new Date(createdAt),
+        createdBy: { id: 'user-1', name: 'Test User' }
+      })
+
+      it('queries catch-up events using the PRN watermark', async () => {
+        const issuedPrn = {
+          ...mockPrn,
+          lastAppliedEventNumber: 3,
+          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+        }
+        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
+          issuedPrn
+        )
+
+        await server.inject({
+          method: 'GET',
+          url,
+          ...asStandardUser({ linkedOrgId: organisationId })
+        })
+
+        expect(
+          wasteBalancesRepository.getPrnCatchupEvents
+        ).toHaveBeenCalledWith({
+          registrationId,
+          accreditationId,
+          prnId,
+          afterEventNumber: 3
+        })
+      })
+
+      it('defaults afterEventNumber to 0 when the PRN has no watermark', async () => {
+        const draftPrn = {
+          ...mockPrn,
+          status: { currentStatus: PRN_STATUS.DRAFT }
+        }
+        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
+          draftPrn
+        )
+
+        await server.inject({
+          method: 'GET',
+          url,
+          ...asStandardUser({ linkedOrgId: organisationId })
+        })
+
+        expect(
+          wasteBalancesRepository.getPrnCatchupEvents
+        ).toHaveBeenCalledWith(expect.objectContaining({ afterEventNumber: 0 }))
+      })
+
+      it('returns the PRN unchanged when no tail events exist', async () => {
+        wasteBalancesRepository.getPrnCatchupEvents.mockResolvedValueOnce([])
+
+        const response = await server.inject({
+          method: 'GET',
+          url,
+          ...asStandardUser({ linkedOrgId: organisationId })
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const payload = JSON.parse(response.payload)
+        expect(payload.status).toBe(PRN_STATUS.AWAITING_AUTHORISATION)
+      })
+
+      it('recovers a partial failure: stale doc, fresh tail event projects to awaiting_acceptance', async () => {
+        const stalePrn = {
+          ...mockPrn,
+          lastAppliedEventNumber: 1,
+          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+        }
+        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
+          stalePrn
+        )
+        wasteBalancesRepository.getPrnCatchupEvents.mockResolvedValueOnce([
+          tailEvent(STREAM_EVENT_KIND.PRN_ISSUED, 2, '2026-02-02T12:00:00.000Z')
+        ])
+
+        const response = await server.inject({
+          method: 'GET',
+          url,
+          ...asStandardUser({ linkedOrgId: organisationId })
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const payload = JSON.parse(response.payload)
+        expect(payload.status).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+      })
+
+      it('recovers a first-event failure: draft doc + null watermark + prn-created at 1', async () => {
+        const draftPrn = {
+          ...mockPrn,
+          status: { currentStatus: PRN_STATUS.DRAFT }
+        }
+        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
+          draftPrn
+        )
+        wasteBalancesRepository.getPrnCatchupEvents.mockResolvedValueOnce([
+          tailEvent(
+            STREAM_EVENT_KIND.PRN_CREATED,
+            1,
+            '2026-02-01T12:00:00.000Z'
+          )
+        ])
+
+        const response = await server.inject({
+          method: 'GET',
+          url,
+          ...asStandardUser({ linkedOrgId: organisationId })
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(
+          wasteBalancesRepository.getPrnCatchupEvents
+        ).toHaveBeenCalledWith(expect.objectContaining({ afterEventNumber: 0 }))
+        const payload = JSON.parse(response.payload)
+        expect(payload.status).toBe(PRN_STATUS.AWAITING_AUTHORISATION)
+      })
+
+      it('folds prn-cancelled-after-issue to cancelled', async () => {
+        const issuedPrn = {
+          ...mockPrn,
+          lastAppliedEventNumber: 2,
+          status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
+        }
+        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
+          issuedPrn
+        )
+        wasteBalancesRepository.getPrnCatchupEvents.mockResolvedValueOnce([
+          tailEvent(
+            STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+            3,
+            '2026-02-03T12:00:00.000Z'
+          )
+        ])
+
+        const response = await server.inject({
+          method: 'GET',
+          url,
+          ...asStandardUser({ linkedOrgId: organisationId })
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const payload = JSON.parse(response.payload)
+        expect(payload.status).toBe(PRN_STATUS.CANCELLED)
+      })
+
+      it('returns 404 when a prn-creation-cancelled event folds the PRN to deleted', async () => {
+        const awaitingAuthPrn = {
+          ...mockPrn,
+          lastAppliedEventNumber: 1,
+          status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
+        }
+        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
+          awaitingAuthPrn
+        )
+        wasteBalancesRepository.getPrnCatchupEvents.mockResolvedValueOnce([
+          tailEvent(
+            STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
+            2,
+            '2026-02-02T12:00:00.000Z'
+          )
+        ])
+
+        const response = await server.inject({
+          method: 'GET',
+          url,
+          ...asStandardUser({ linkedOrgId: organisationId })
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+      })
+
+      it('does not query catch-up events when the PRN does not exist (404 short-circuits the fold)', async () => {
+        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(null)
+
+        await server.inject({
+          method: 'GET',
+          url,
+          ...asStandardUser({ linkedOrgId: organisationId })
+        })
+
+        expect(
+          wasteBalancesRepository.getPrnCatchupEvents
+        ).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/packaging-recycling-notes/routes/reject.test.js
+++ b/src/packaging-recycling-notes/routes/reject.test.js
@@ -63,7 +63,9 @@ describe(`POST /v1/packaging-recycling-notes/{prnNumber}/reject`, () => {
         repositories: {
           packagingRecyclingNotesRepository: () =>
             packagingRecyclingNotesRepository,
-          wasteBalancesRepository: () => ({}),
+          wasteBalancesRepository: () => ({
+            findByAccreditationId: vi.fn().mockResolvedValue(null)
+          }),
           organisationsRepository: () => ({})
         },
         featureFlags: createInMemoryFeatureFlags()

--- a/src/waste-balances/repository/contract/appendStreamEvent.contract.js
+++ b/src/waste-balances/repository/contract/appendStreamEvent.contract.js
@@ -1,0 +1,81 @@
+import { describe, beforeEach, expect } from 'vitest'
+import { buildWasteBalance } from './test-data.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
+import { STREAM_EVENT_KIND } from '../stream-schema.js'
+
+export const testAppendStreamEventBehaviour = (it) => {
+  describe('appendStreamEvent', () => {
+    let repository
+
+    beforeEach(async ({ wasteBalancesRepository }) => {
+      repository = await wasteBalancesRepository()
+    })
+
+    it('appends a status-only stream event on the ledger path', async ({
+      insertWasteBalance,
+      streamRepository
+    }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-append-1',
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      const appended = await repository.appendStreamEvent({
+        accreditationId: 'acc-append-1',
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        prnId: 'prn-1',
+        tonnage: 10,
+        userId: 'user-abc',
+        streamKind: STREAM_EVENT_KIND.PRN_ACCEPTED
+      })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        'acc-append-1'
+      )
+      expect(appended.number).toBe(latest.number)
+      expect(appended.kind).toBe(STREAM_EVENT_KIND.PRN_ACCEPTED)
+      expect(appended.payload).toEqual({ prnId: 'prn-1', amount: 10 })
+    })
+
+    it('throws on the embedded path', async ({ insertWasteBalance }) => {
+      const wasteBalance = buildWasteBalance({
+        accreditationId: 'acc-append-embedded',
+        organisationId: 'org-1'
+      })
+
+      await insertWasteBalance(wasteBalance)
+
+      await expect(
+        repository.appendStreamEvent({
+          accreditationId: 'acc-append-embedded',
+          registrationId: 'reg-1',
+          organisationId: 'org-1',
+          prnId: 'prn-2',
+          tonnage: 10,
+          userId: 'user-abc',
+          streamKind: STREAM_EVENT_KIND.PRN_REJECTED
+        })
+      ).rejects.toThrow(/ledger-only/)
+    })
+
+    it('throws when no balance exists', async () => {
+      await expect(
+        repository.appendStreamEvent({
+          accreditationId: 'acc-append-missing',
+          registrationId: 'reg-1',
+          organisationId: 'org-1',
+          prnId: 'prn-3',
+          tonnage: 10,
+          userId: 'user-abc',
+          streamKind: STREAM_EVENT_KIND.PRN_ACCEPTED
+        })
+      ).rejects.toThrow(/ledger-only/)
+    })
+  })
+}

--- a/src/waste-balances/repository/contract/creditAvailableBalanceForPrnCancellation.contract.js
+++ b/src/waste-balances/repository/contract/creditAvailableBalanceForPrnCancellation.contract.js
@@ -83,7 +83,7 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
       ).rejects.toThrow(Boom.Boom)
     })
 
-    it('returns the appended stream event number on the ledger path', async ({
+    it('returns the appended stream event on the ledger path', async ({
       insertWasteBalance,
       streamRepository
     }) => {
@@ -96,7 +96,7 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
 
       await insertWasteBalance(wasteBalance)
 
-      const watermark =
+      const appended =
         await repository.creditAvailableBalanceForPrnCancellation({
           accreditationId: 'acc-cancel-ledger',
           registrationId: 'reg-1',
@@ -110,8 +110,8 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
         'reg-1',
         'acc-cancel-ledger'
       )
-      expect(watermark).toBe(latest.number)
-      expect(watermark).toBe(1)
+      expect(appended.number).toBe(latest.number)
+      expect(appended.number).toBe(1)
     })
 
     it('returns null on the embedded path', async ({ insertWasteBalance }) => {

--- a/src/waste-balances/repository/contract/creditFullBalanceForIssuedPrnCancellation.contract.js
+++ b/src/waste-balances/repository/contract/creditFullBalanceForIssuedPrnCancellation.contract.js
@@ -83,7 +83,7 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
       ).rejects.toThrow(Boom.Boom)
     })
 
-    it('returns the appended stream event number on the ledger path', async ({
+    it('returns the appended stream event on the ledger path', async ({
       insertWasteBalance,
       streamRepository
     }) => {
@@ -96,7 +96,7 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
 
       await insertWasteBalance(wasteBalance)
 
-      const watermark =
+      const appended =
         await repository.creditFullBalanceForIssuedPrnCancellation({
           accreditationId: 'acc-full-cancel-ledger',
           registrationId: 'reg-1',
@@ -110,8 +110,8 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
         'reg-1',
         'acc-full-cancel-ledger'
       )
-      expect(watermark).toBe(latest.number)
-      expect(watermark).toBe(1)
+      expect(appended.number).toBe(latest.number)
+      expect(appended.number).toBe(1)
     })
 
     it('returns null on the embedded path', async ({ insertWasteBalance }) => {

--- a/src/waste-balances/repository/contract/deductAvailableBalanceForPrnCreation.contract.js
+++ b/src/waste-balances/repository/contract/deductAvailableBalanceForPrnCreation.contract.js
@@ -84,7 +84,7 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
       expect(watermark).toBeNull()
     })
 
-    it('returns the appended stream event number on the ledger path', async ({
+    it('returns the appended stream event on the ledger path', async ({
       insertWasteBalance,
       streamRepository
     }) => {
@@ -97,7 +97,7 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
 
       await insertWasteBalance(wasteBalance)
 
-      const watermark = await repository.deductAvailableBalanceForPrnCreation({
+      const appended = await repository.deductAvailableBalanceForPrnCreation({
         accreditationId: 'acc-prn-ledger',
         registrationId: 'reg-1',
         organisationId: 'org-1',
@@ -110,8 +110,8 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
         'reg-1',
         'acc-prn-ledger'
       )
-      expect(watermark).toBe(latest.number)
-      expect(watermark).toBe(1)
+      expect(appended.number).toBe(latest.number)
+      expect(appended.number).toBe(1)
     })
 
     it('returns null on the embedded path', async ({ insertWasteBalance }) => {

--- a/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
+++ b/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
@@ -117,7 +117,7 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
       expect(watermark).toBeNull()
     })
 
-    it('returns the appended stream event number on the ledger path', async ({
+    it('returns the appended stream event on the ledger path', async ({
       insertWasteBalance,
       streamRepository
     }) => {
@@ -130,7 +130,7 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
 
       await insertWasteBalance(wasteBalance)
 
-      const watermark = await repository.deductTotalBalanceForPrnIssue({
+      const appended = await repository.deductTotalBalanceForPrnIssue({
         accreditationId: 'acc-issue-ledger',
         registrationId: 'reg-1',
         organisationId: 'org-1',
@@ -143,8 +143,8 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         'reg-1',
         'acc-issue-ledger'
       )
-      expect(watermark).toBe(latest.number)
-      expect(watermark).toBe(1)
+      expect(appended.number).toBe(latest.number)
+      expect(appended.number).toBe(1)
     })
 
     it('returns null on the embedded path', async ({ insertWasteBalance }) => {

--- a/src/waste-balances/repository/contract/getPrnCatchupEvents.contract.js
+++ b/src/waste-balances/repository/contract/getPrnCatchupEvents.contract.js
@@ -1,0 +1,183 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
+import { STREAM_EVENT_KIND } from '../stream-schema.js'
+import { buildWasteBalance } from './test-data.js'
+import {
+  buildPrnCreatedEvent,
+  buildPrnIssuedEvent
+} from '../stream-test-data.js'
+
+const PRN_ID = 'prn-catchup'
+
+const partition = (suffix) => ({
+  registrationId: `reg-catchup-${suffix}`,
+  accreditationId: `acc-catchup-${suffix}`
+})
+
+const ledgerBalance = (suffix) =>
+  buildWasteBalance({
+    ...partition(suffix),
+    canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+  })
+
+const params = ({ suffix, afterEventNumber = 0 }) => ({
+  ...partition(suffix),
+  prnId: PRN_ID,
+  afterEventNumber
+})
+
+export const testGetPrnCatchupEventsBehaviour = (it) => {
+  describe('getPrnCatchupEvents', () => {
+    let repository
+
+    beforeEach(async ({ wasteBalancesRepository }) => {
+      repository = await wasteBalancesRepository()
+    })
+
+    it('returns an empty array when no balance document exists', async () => {
+      const result = await repository.getPrnCatchupEvents(
+        params({ suffix: 'missing' })
+      )
+
+      expect(result).toEqual([])
+    })
+
+    it('returns an empty array when the marker is embedded', async ({
+      insertWasteBalance,
+      streamRepository
+    }) => {
+      const suffix = 'embedded'
+      await insertWasteBalance(
+        buildWasteBalance({
+          ...partition(suffix),
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+        })
+      )
+      await streamRepository.appendEvent(
+        buildPrnCreatedEvent({
+          ...partition(suffix),
+          number: 1,
+          payload: { prnId: PRN_ID, amount: 10 }
+        })
+      )
+
+      const result = await repository.getPrnCatchupEvents(params({ suffix }))
+
+      expect(result).toEqual([])
+    })
+
+    it('returns an empty array when the marker is migrating', async ({
+      insertWasteBalance,
+      streamRepository
+    }) => {
+      const suffix = 'migrating'
+      await insertWasteBalance(
+        buildWasteBalance({
+          ...partition(suffix),
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+        })
+      )
+      await streamRepository.appendEvent(
+        buildPrnCreatedEvent({
+          ...partition(suffix),
+          number: 1,
+          payload: { prnId: PRN_ID, amount: 10 }
+        })
+      )
+
+      const result = await repository.getPrnCatchupEvents(params({ suffix }))
+
+      expect(result).toEqual([])
+    })
+
+    it('returns an empty array when the marker is ledger but there are no matching tail events', async ({
+      insertWasteBalance,
+      streamRepository
+    }) => {
+      const suffix = 'ledger-no-tail'
+      await insertWasteBalance(ledgerBalance(suffix))
+      await streamRepository.appendEvent(
+        buildPrnCreatedEvent({
+          ...partition(suffix),
+          number: 1,
+          payload: { prnId: 'other-prn', amount: 10 }
+        })
+      )
+
+      const result = await repository.getPrnCatchupEvents(params({ suffix }))
+
+      expect(result).toEqual([])
+    })
+
+    it('returns tail events when the marker is ledger and events exist for the PRN', async ({
+      insertWasteBalance,
+      streamRepository
+    }) => {
+      const suffix = 'ledger-tail'
+      await insertWasteBalance(ledgerBalance(suffix))
+      await streamRepository.appendEvent(
+        buildPrnCreatedEvent({
+          ...partition(suffix),
+          number: 1,
+          payload: { prnId: PRN_ID, amount: 10 }
+        })
+      )
+      await streamRepository.appendEvent(
+        buildPrnIssuedEvent({
+          ...partition(suffix),
+          number: 2,
+          payload: { prnId: PRN_ID, amount: 10 }
+        })
+      )
+
+      const result = await repository.getPrnCatchupEvents(params({ suffix }))
+
+      expect(result).toHaveLength(2)
+      expect(result[0].number).toBe(1)
+      expect(result[0].kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+      expect(result[1].number).toBe(2)
+      expect(result[1].kind).toBe(STREAM_EVENT_KIND.PRN_ISSUED)
+    })
+
+    it('filters out events at or below afterEventNumber', async ({
+      insertWasteBalance,
+      streamRepository
+    }) => {
+      const suffix = 'ledger-filter'
+      await insertWasteBalance(ledgerBalance(suffix))
+      await streamRepository.appendEvent(
+        buildPrnCreatedEvent({
+          ...partition(suffix),
+          number: 1,
+          payload: { prnId: PRN_ID, amount: 10 }
+        })
+      )
+      await streamRepository.appendEvent(
+        buildPrnIssuedEvent({
+          ...partition(suffix),
+          number: 2,
+          payload: { prnId: PRN_ID, amount: 10 }
+        })
+      )
+
+      const result = await repository.getPrnCatchupEvents(
+        params({ suffix, afterEventNumber: 1 })
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].number).toBe(2)
+    })
+
+    it('throws when accreditationId is missing', async () => {
+      await expect(
+        repository.getPrnCatchupEvents({
+          registrationId: 'reg-missing-acc',
+          accreditationId: undefined,
+          prnId: PRN_ID,
+          afterEventNumber: 0
+        })
+      ).rejects.toThrow()
+    })
+  })
+}

--- a/src/waste-balances/repository/contract/getPrnCatchupEvents.contract.js
+++ b/src/waste-balances/repository/contract/getPrnCatchupEvents.contract.js
@@ -169,7 +169,7 @@ export const testGetPrnCatchupEventsBehaviour = (it) => {
       expect(result[0].number).toBe(2)
     })
 
-    it('throws when accreditationId is missing', async () => {
+    it('throws Boom badData when accreditationId is missing', async () => {
       await expect(
         repository.getPrnCatchupEvents({
           registrationId: 'reg-missing-acc',
@@ -177,7 +177,10 @@ export const testGetPrnCatchupEventsBehaviour = (it) => {
           prnId: PRN_ID,
           afterEventNumber: 0
         })
-      ).rejects.toThrow()
+      ).rejects.toMatchObject({
+        isBoom: true,
+        output: { statusCode: 422 }
+      })
     })
   })
 }

--- a/src/waste-balances/repository/helpers-prn.js
+++ b/src/waste-balances/repository/helpers-prn.js
@@ -61,7 +61,7 @@ export const buildPrnCreationTransaction = ({
  * @param {number} params.tonnage
  * @param {string} params.userId
  * @param {import('./stream-schema.js').StreamEventKind} params.streamKind
- * @returns {Promise<number>} The event number of the appended event (the watermark).
+ * @returns {Promise<import('./stream-port.js').StreamEvent>} The appended event.
  */
 const appendPrnStreamEvent = async ({
   streamRepository,
@@ -72,8 +72,8 @@ const appendPrnStreamEvent = async ({
   tonnage,
   userId,
   streamKind
-}) => {
-  const event = await appendToStream(
+}) =>
+  appendToStream(
     {
       repository: streamRepository,
       registrationId,
@@ -86,8 +86,6 @@ const appendPrnStreamEvent = async ({
       createdBy: { id: userId, name: userId }
     }
   )
-  return event.number
-}
 
 /**
  * Deduct available balance for PRN creation (ringfencing tonnage).
@@ -98,8 +96,9 @@ const appendPrnStreamEvent = async ({
  * @param {(balance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>} params.saveBalance
  * @param {Object} [params.dependencies]
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} [params.dependencies.streamRepository]
- * @returns {Promise<number|null>} The appended event number on the ledger path,
- *   or `null` on the embedded path and when no balance exists.
+ * @returns {Promise<import('./stream-port.js').StreamEvent|null>} The appended
+ *   stream event on the ledger path, or `null` on the embedded path and when
+ *   no balance exists.
  */
 export const performDeductAvailableBalanceForPrnCreation = async ({
   deductParams,
@@ -203,8 +202,9 @@ export const buildPrnIssuedTransaction = ({
  * @param {(balance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>} params.saveBalance
  * @param {Object} [params.dependencies]
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} [params.dependencies.streamRepository]
- * @returns {Promise<number|null>} The appended event number on the ledger path,
- *   or `null` on the embedded path and when no balance exists.
+ * @returns {Promise<import('./stream-port.js').StreamEvent|null>} The appended
+ *   stream event on the ledger path, or `null` on the embedded path and when
+ *   no balance exists.
  */
 export const performDeductTotalBalanceForPrnIssue = async ({
   deductParams,
@@ -350,8 +350,9 @@ export const buildIssuedPrnCancellationTransaction = ({
  * @param {(balance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>} params.saveBalance
  * @param {Object} [params.dependencies]
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} [params.dependencies.streamRepository]
- * @returns {Promise<number|null>} The appended event number on the ledger path,
- *   or `null` on the embedded path. Throws when no balance exists.
+ * @returns {Promise<import('./stream-port.js').StreamEvent|null>} The appended
+ *   stream event on the ledger path, or `null` on the embedded path. Throws
+ *   when no balance exists.
  */
 export const performCreditFullBalanceForIssuedPrnCancellation = async ({
   creditParams,
@@ -422,8 +423,9 @@ export const performCreditFullBalanceForIssuedPrnCancellation = async ({
  * @param {(balance: import('../domain/model.js').WasteBalance, newTransactions: any[]) => Promise<void>} params.saveBalance
  * @param {Object} [params.dependencies]
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} [params.dependencies.streamRepository]
- * @returns {Promise<number|null>} The appended event number on the ledger path,
- *   or `null` on the embedded path. Throws when no balance exists.
+ * @returns {Promise<import('./stream-port.js').StreamEvent|null>} The appended
+ *   stream event on the ledger path, or `null` on the embedded path. Throws
+ *   when no balance exists.
  */
 export const performCreditAvailableBalanceForPrnCancellation = async ({
   creditParams,

--- a/src/waste-balances/repository/helpers-prn.js
+++ b/src/waste-balances/repository/helpers-prn.js
@@ -88,6 +88,67 @@ const appendPrnStreamEvent = async ({
   )
 
 /**
+ * Append a PRN stream event with no balance side-effect (PRN_ACCEPTED,
+ * PRN_REJECTED). Ledger-only — throws on embedded balances and when no balance
+ * exists. The dispatcher in update-status routes status-only kinds here on the
+ * ledger path; if the marker is anything else, that's a contract violation we
+ * surface rather than silently no-op.
+ *
+ * @param {Object} params
+ * @param {Object} params.appendParams
+ * @param {string} params.appendParams.accreditationId
+ * @param {string} params.appendParams.registrationId
+ * @param {string} params.appendParams.organisationId
+ * @param {string} params.appendParams.prnId
+ * @param {number} params.appendParams.tonnage
+ * @param {string} params.appendParams.userId
+ * @param {import('./stream-schema.js').StreamEventKind} params.appendParams.streamKind
+ * @param {(accreditationId: string) => Promise<import('../domain/model.js').WasteBalance | null>} params.findBalance
+ * @param {Object} [params.dependencies]
+ * @param {import('./stream-port.js').WasteBalanceStreamRepository} [params.dependencies.streamRepository]
+ * @returns {Promise<import('./stream-port.js').StreamEvent>}
+ */
+export const performAppendPrnStreamEvent = async ({
+  appendParams,
+  findBalance,
+  dependencies
+}) => {
+  const {
+    accreditationId,
+    registrationId,
+    organisationId,
+    prnId,
+    tonnage,
+    userId,
+    streamKind
+  } = appendParams
+  const validatedAccreditationId = validateAccreditationId(accreditationId)
+
+  const wasteBalance = await findBalance(validatedAccreditationId)
+
+  if (
+    !wasteBalance ||
+    wasteBalance.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER ||
+    !dependencies?.streamRepository
+  ) {
+    throw Boom.badImplementation(
+      `appendStreamEvent is ledger-only and requires a stream-backed balance (accreditation ${validatedAccreditationId})`
+    )
+  }
+
+  return appendPrnStreamEvent({
+    streamRepository: dependencies.streamRepository,
+    registrationId,
+    accreditationId: validatedAccreditationId,
+    organisationId,
+    prnId,
+    tonnage,
+    userId,
+    streamKind
+  })
+}
+
+/**
  * Deduct available balance for PRN creation (ringfencing tonnage).
  *
  * @param {Object} params

--- a/src/waste-balances/repository/helpers-prn.js
+++ b/src/waste-balances/repository/helpers-prn.js
@@ -127,8 +127,7 @@ export const performAppendPrnStreamEvent = async ({
   const wasteBalance = await findBalance(validatedAccreditationId)
 
   if (
-    !wasteBalance ||
-    wasteBalance.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER ||
+    wasteBalance?.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER ||
     !dependencies?.streamRepository
   ) {
     throw Boom.badImplementation(

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -141,10 +141,7 @@ const performGetPrnCatchupEvents =
     const current = wasteBalanceStorage.find(
       (b) => b.accreditationId === validatedAccreditationId
     )
-    if (
-      !current ||
-      current.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
-    ) {
+    if (current?.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER) {
       return []
     }
     return streamRepository.findEventsByPrnIdAfter(
@@ -183,12 +180,66 @@ const performResetCanonicalSourceToEmbedded =
  * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [dependencies.featureFlags]
  * @returns {import('./port.js').WasteBalancesRepositoryFactory}
  */
+const balanceMutators = (wasteBalanceStorage, dependencies) => {
+  const find = findBalance(wasteBalanceStorage)
+  const save = saveBalance(wasteBalanceStorage)
+  return {
+    updateWasteBalanceTransactions: async (
+      wasteRecords,
+      { user, accreditation, overseasSites, summaryLogId }
+    ) =>
+      performUpdateWasteBalanceTransactions({
+        wasteRecords,
+        accreditation,
+        dependencies,
+        findBalance: find,
+        saveBalance: save,
+        user,
+        overseasSites,
+        summaryLogId
+      }),
+    deductAvailableBalanceForPrnCreation: async (deductParams) =>
+      performDeductAvailableBalanceForPrnCreation({
+        deductParams,
+        findBalance: find,
+        saveBalance: save,
+        dependencies
+      }),
+    deductTotalBalanceForPrnIssue: async (deductParams) =>
+      performDeductTotalBalanceForPrnIssue({
+        deductParams,
+        findBalance: find,
+        saveBalance: save,
+        dependencies
+      }),
+    creditAvailableBalanceForPrnCancellation: async (creditParams) =>
+      performCreditAvailableBalanceForPrnCancellation({
+        creditParams,
+        findBalance: find,
+        saveBalance: save,
+        dependencies
+      }),
+    creditFullBalanceForIssuedPrnCancellation: async (creditParams) =>
+      performCreditFullBalanceForIssuedPrnCancellation({
+        creditParams,
+        findBalance: find,
+        saveBalance: save,
+        dependencies
+      }),
+    appendStreamEvent: async (appendParams) =>
+      performAppendPrnStreamEvent({
+        appendParams,
+        findBalance: find,
+        dependencies
+      })
+  }
+}
+
 export const createInMemoryWasteBalancesRepository = (
   initialWasteBalances,
   dependencies
 ) => {
   const wasteBalanceStorage = initialWasteBalances
-
   const { streamRepository } = dependencies
 
   return () => ({
@@ -200,60 +251,7 @@ export const createInMemoryWasteBalancesRepository = (
       wasteBalanceStorage,
       streamRepository
     ),
-    updateWasteBalanceTransactions: async (
-      wasteRecords,
-      { user, accreditation, overseasSites, summaryLogId }
-    ) => {
-      return performUpdateWasteBalanceTransactions({
-        wasteRecords,
-        accreditation,
-        dependencies,
-        findBalance: findBalance(wasteBalanceStorage),
-        saveBalance: saveBalance(wasteBalanceStorage),
-        user,
-        overseasSites,
-        summaryLogId
-      })
-    },
-    deductAvailableBalanceForPrnCreation: async (deductParams) => {
-      return performDeductAvailableBalanceForPrnCreation({
-        deductParams,
-        findBalance: findBalance(wasteBalanceStorage),
-        saveBalance: saveBalance(wasteBalanceStorage),
-        dependencies
-      })
-    },
-    deductTotalBalanceForPrnIssue: async (deductParams) => {
-      return performDeductTotalBalanceForPrnIssue({
-        deductParams,
-        findBalance: findBalance(wasteBalanceStorage),
-        saveBalance: saveBalance(wasteBalanceStorage),
-        dependencies
-      })
-    },
-    creditAvailableBalanceForPrnCancellation: async (creditParams) => {
-      return performCreditAvailableBalanceForPrnCancellation({
-        creditParams,
-        findBalance: findBalance(wasteBalanceStorage),
-        saveBalance: saveBalance(wasteBalanceStorage),
-        dependencies
-      })
-    },
-    creditFullBalanceForIssuedPrnCancellation: async (creditParams) => {
-      return performCreditFullBalanceForIssuedPrnCancellation({
-        creditParams,
-        findBalance: findBalance(wasteBalanceStorage),
-        saveBalance: saveBalance(wasteBalanceStorage),
-        dependencies
-      })
-    },
-    appendStreamEvent: async (appendParams) => {
-      return performAppendPrnStreamEvent({
-        appendParams,
-        findBalance: findBalance(wasteBalanceStorage),
-        dependencies
-      })
-    },
+    ...balanceMutators(wasteBalanceStorage, dependencies),
     flipCanonicalSourceToMigrating:
       performFlipCanonicalSourceToMigrating(wasteBalanceStorage),
     flipCanonicalSourceToLedger:
@@ -264,7 +262,6 @@ export const createInMemoryWasteBalancesRepository = (
       wasteBalanceStorage,
       streamRepository
     ),
-    // Test-only method to access internal storage
     _getStorageForTesting: () => wasteBalanceStorage
   })
 }

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -133,6 +133,27 @@ const performFlipCanonicalSourceToLedger =
     return { canonicalSource: current.canonicalSource }
   }
 
+const performGetPrnCatchupEvents =
+  (wasteBalanceStorage, streamRepository) =>
+  async ({ registrationId, accreditationId, prnId, afterEventNumber }) => {
+    const validatedAccreditationId = validateAccreditationId(accreditationId)
+    const current = wasteBalanceStorage.find(
+      (b) => b.accreditationId === validatedAccreditationId
+    )
+    if (
+      !current ||
+      current.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+    ) {
+      return []
+    }
+    return streamRepository.findEventsByPrnIdAfter(
+      registrationId,
+      validatedAccreditationId,
+      prnId,
+      afterEventNumber
+    )
+  }
+
 const performResetCanonicalSourceToEmbedded =
   (wasteBalanceStorage) =>
   async ({ accreditationId }) => {
@@ -231,6 +252,10 @@ export const createInMemoryWasteBalancesRepository = (
       performFlipCanonicalSourceToLedger(wasteBalanceStorage),
     resetCanonicalSourceToEmbedded:
       performResetCanonicalSourceToEmbedded(wasteBalanceStorage),
+    getPrnCatchupEvents: performGetPrnCatchupEvents(
+      wasteBalanceStorage,
+      streamRepository
+    ),
     // Test-only method to access internal storage
     _getStorageForTesting: () => wasteBalanceStorage
   })

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -2,6 +2,7 @@ import { validateAccreditationId } from './validation.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
 import { performUpdateWasteBalanceTransactions } from './helpers.js'
 import {
+  performAppendPrnStreamEvent,
   performDeductAvailableBalanceForPrnCreation,
   performDeductTotalBalanceForPrnIssue,
   performCreditAvailableBalanceForPrnCancellation,
@@ -243,6 +244,13 @@ export const createInMemoryWasteBalancesRepository = (
         creditParams,
         findBalance: findBalance(wasteBalanceStorage),
         saveBalance: saveBalance(wasteBalanceStorage),
+        dependencies
+      })
+    },
+    appendStreamEvent: async (appendParams) => {
+      return performAppendPrnStreamEvent({
+        appendParams,
+        findBalance: findBalance(wasteBalanceStorage),
         dependencies
       })
     },

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -170,15 +170,14 @@ const performResetCanonicalSourceToEmbedded =
   }
 
 /**
- * Create an in-memory waste balances repository.
- * Ensures data isolation by deep-cloning on read.
+ * The balance-mutating repository methods, sharing one find/save pair over the
+ * in-memory storage. Spread into the repository factory's result.
  *
- * @param {Array} initialWasteBalances
+ * @param {import('../domain/model.js').WasteBalance[]} wasteBalanceStorage
  * @param {Object} dependencies
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} dependencies.streamRepository
  * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [dependencies.systemLogsRepository]
  * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [dependencies.featureFlags]
- * @returns {import('./port.js').WasteBalancesRepositoryFactory}
  */
 const balanceMutators = (wasteBalanceStorage, dependencies) => {
   const find = findBalance(wasteBalanceStorage)
@@ -235,6 +234,17 @@ const balanceMutators = (wasteBalanceStorage, dependencies) => {
   }
 }
 
+/**
+ * Create an in-memory waste balances repository.
+ * Ensures data isolation by deep-cloning on read.
+ *
+ * @param {Array} initialWasteBalances
+ * @param {Object} dependencies
+ * @param {import('./stream-port.js').WasteBalanceStreamRepository} dependencies.streamRepository
+ * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [dependencies.systemLogsRepository]
+ * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [dependencies.featureFlags]
+ * @returns {import('./port.js').WasteBalancesRepositoryFactory}
+ */
 export const createInMemoryWasteBalancesRepository = (
   initialWasteBalances,
   dependencies

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -2,6 +2,7 @@ import { validateAccreditationId } from './validation.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
 import { performUpdateWasteBalanceTransactions } from './helpers.js'
 import {
+  performAppendPrnStreamEvent,
   performDeductAvailableBalanceForPrnCreation,
   performDeductTotalBalanceForPrnIssue,
   performCreditAvailableBalanceForPrnCancellation,
@@ -298,6 +299,13 @@ export const createWasteBalancesRepository = async (db, dependencies) => {
         creditParams,
         findBalance: findBalance(db),
         saveBalance: saveBalance(db),
+        dependencies
+      })
+    },
+    appendStreamEvent: async (appendParams) => {
+      return performAppendPrnStreamEvent({
+        appendParams,
+        findBalance: findBalance(db),
         dependencies
       })
     },

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -128,6 +128,27 @@ const performFlipCanonicalSourceToLedger =
     return { canonicalSource: current.canonicalSource }
   }
 
+const performGetPrnCatchupEvents =
+  (db, streamRepository) =>
+  async ({ registrationId, accreditationId, prnId, afterEventNumber }) => {
+    const validatedAccreditationId = validateAccreditationId(accreditationId)
+    const doc = await db
+      .collection(WASTE_BALANCE_COLLECTION_NAME)
+      .findOne(
+        { accreditationId: validatedAccreditationId },
+        { projection: { canonicalSource: 1 } }
+      )
+    if (!doc || doc.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER) {
+      return []
+    }
+    return streamRepository.findEventsByPrnIdAfter(
+      registrationId,
+      validatedAccreditationId,
+      prnId,
+      afterEventNumber
+    )
+  }
+
 const performResetCanonicalSourceToEmbedded =
   (db) =>
   async ({ accreditationId }) => {
@@ -282,6 +303,7 @@ export const createWasteBalancesRepository = async (db, dependencies) => {
     },
     flipCanonicalSourceToMigrating: performFlipCanonicalSourceToMigrating(db),
     flipCanonicalSourceToLedger: performFlipCanonicalSourceToLedger(db),
-    resetCanonicalSourceToEmbedded: performResetCanonicalSourceToEmbedded(db)
+    resetCanonicalSourceToEmbedded: performResetCanonicalSourceToEmbedded(db),
+    getPrnCatchupEvents: performGetPrnCatchupEvents(db, streamRepository)
   })
 }

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -139,7 +139,7 @@ const performGetPrnCatchupEvents =
         { accreditationId: validatedAccreditationId },
         { projection: { canonicalSource: 1 } }
       )
-    if (!doc || doc.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER) {
+    if (doc?.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER) {
       return []
     }
     return streamRepository.findEventsByPrnIdAfter(

--- a/src/waste-balances/repository/port.contract.js
+++ b/src/waste-balances/repository/port.contract.js
@@ -8,6 +8,7 @@ import { testCreditFullBalanceForIssuedPrnCancellationBehaviour } from './contra
 import { testFlipCanonicalSourceToMigratingBehaviour } from './contract/flipCanonicalSourceToMigrating.contract.js'
 import { testFlipCanonicalSourceToLedgerBehaviour } from './contract/flipCanonicalSourceToLedger.contract.js'
 import { testResetCanonicalSourceToEmbeddedBehaviour } from './contract/resetCanonicalSourceToEmbedded.contract.js'
+import { testGetPrnCatchupEventsBehaviour } from './contract/getPrnCatchupEvents.contract.js'
 
 export const testWasteBalancesRepositoryContract = (repositoryFactory) => {
   testFindByAccreditationIdBehaviour(repositoryFactory)
@@ -20,4 +21,5 @@ export const testWasteBalancesRepositoryContract = (repositoryFactory) => {
   testFlipCanonicalSourceToMigratingBehaviour(repositoryFactory)
   testFlipCanonicalSourceToLedgerBehaviour(repositoryFactory)
   testResetCanonicalSourceToEmbeddedBehaviour(repositoryFactory)
+  testGetPrnCatchupEventsBehaviour(repositoryFactory)
 }

--- a/src/waste-balances/repository/port.contract.js
+++ b/src/waste-balances/repository/port.contract.js
@@ -5,6 +5,7 @@ import { testDeductAvailableBalanceForPrnCreationBehaviour } from './contract/de
 import { testDeductTotalBalanceForPrnIssueBehaviour } from './contract/deductTotalBalanceForPrnIssue.contract.js'
 import { testCreditAvailableBalanceForPrnCancellationBehaviour } from './contract/creditAvailableBalanceForPrnCancellation.contract.js'
 import { testCreditFullBalanceForIssuedPrnCancellationBehaviour } from './contract/creditFullBalanceForIssuedPrnCancellation.contract.js'
+import { testAppendStreamEventBehaviour } from './contract/appendStreamEvent.contract.js'
 import { testFlipCanonicalSourceToMigratingBehaviour } from './contract/flipCanonicalSourceToMigrating.contract.js'
 import { testFlipCanonicalSourceToLedgerBehaviour } from './contract/flipCanonicalSourceToLedger.contract.js'
 import { testResetCanonicalSourceToEmbeddedBehaviour } from './contract/resetCanonicalSourceToEmbedded.contract.js'
@@ -18,6 +19,7 @@ export const testWasteBalancesRepositoryContract = (repositoryFactory) => {
   testDeductTotalBalanceForPrnIssueBehaviour(repositoryFactory)
   testCreditAvailableBalanceForPrnCancellationBehaviour(repositoryFactory)
   testCreditFullBalanceForIssuedPrnCancellationBehaviour(repositoryFactory)
+  testAppendStreamEventBehaviour(repositoryFactory)
   testFlipCanonicalSourceToMigratingBehaviour(repositoryFactory)
   testFlipCanonicalSourceToLedgerBehaviour(repositoryFactory)
   testResetCanonicalSourceToEmbeddedBehaviour(repositoryFactory)

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -120,18 +120,18 @@
  * @property {(accreditationId: string) => Promise<import('../domain/model.js').WasteBalance | null>} findByAccreditationId
  * @property {(accreditationIds: string[]) => Promise<import('../domain/model.js').WasteBalance[]>} findByAccreditationIds
  * @property {(wasteRecords: import('#domain/waste-records/model.js').WasteRecord[], options: { user: import('#domain/summary-logs/worker/port.js').SubmitUser, accreditation: import('#domain/organisations/accreditation.js').Accreditation, overseasSites: import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext, summaryLogId: string }) => Promise<void>} updateWasteBalanceTransactions
- * @property {(params: DeductAvailableBalanceParams) => Promise<number|null>} deductAvailableBalanceForPrnCreation
- *   Resolves to the appended stream event number on the ledger path, or `null`
- *   on the embedded path (and when no balance exists).
- * @property {(params: DeductTotalBalanceParams) => Promise<number|null>} deductTotalBalanceForPrnIssue
- *   Resolves to the appended stream event number on the ledger path, or `null`
- *   on the embedded path (and when no balance exists).
- * @property {(params: CreditAvailableBalanceParams) => Promise<number|null>} creditAvailableBalanceForPrnCancellation
- *   Resolves to the appended stream event number on the ledger path, or `null`
- *   on the embedded path.
- * @property {(params: CreditFullBalanceParams) => Promise<number|null>} creditFullBalanceForIssuedPrnCancellation
- *   Resolves to the appended stream event number on the ledger path, or `null`
- *   on the embedded path.
+ * @property {(params: DeductAvailableBalanceParams) => Promise<import('./stream-port.js').StreamEvent|null>} deductAvailableBalanceForPrnCreation
+ *   Resolves to the appended stream event on the ledger path, or `null` on the
+ *   embedded path (and when no balance exists).
+ * @property {(params: DeductTotalBalanceParams) => Promise<import('./stream-port.js').StreamEvent|null>} deductTotalBalanceForPrnIssue
+ *   Resolves to the appended stream event on the ledger path, or `null` on the
+ *   embedded path (and when no balance exists).
+ * @property {(params: CreditAvailableBalanceParams) => Promise<import('./stream-port.js').StreamEvent|null>} creditAvailableBalanceForPrnCancellation
+ *   Resolves to the appended stream event on the ledger path, or `null` on the
+ *   embedded path.
+ * @property {(params: CreditFullBalanceParams) => Promise<import('./stream-port.js').StreamEvent|null>} creditFullBalanceForIssuedPrnCancellation
+ *   Resolves to the appended stream event on the ledger path, or `null` on the
+ *   embedded path.
  * @property {(params: FlipCanonicalSourceToMigratingParams) => Promise<FlipCanonicalSourceToMigratingResult>} flipCanonicalSourceToMigrating
  *   Promote an `'embedded'` accreditation to `'migrating'` and stamp
  *   `migratingSince`, gated on `version` matching the captured value. The

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -39,6 +39,17 @@
  */
 
 /**
+ * @typedef {Object} AppendStreamEventParams
+ * @property {string} accreditationId
+ * @property {string} registrationId
+ * @property {string} organisationId
+ * @property {string} prnId
+ * @property {number} tonnage
+ * @property {string} userId
+ * @property {import('./stream-schema.js').StreamEventKind} streamKind
+ */
+
+/**
  * @typedef {Object} FlipCanonicalSourceToMigratingParams
  * @property {string} accreditationId
  * @property {number} capturedVersion - The `version` observed on the embedded
@@ -132,6 +143,9 @@
  * @property {(params: CreditFullBalanceParams) => Promise<import('./stream-port.js').StreamEvent|null>} creditFullBalanceForIssuedPrnCancellation
  *   Resolves to the appended stream event on the ledger path, or `null` on the
  *   embedded path.
+ * @property {(params: AppendStreamEventParams) => Promise<import('./stream-port.js').StreamEvent>} appendStreamEvent
+ *   Append a status-only PRN event (PRN_ACCEPTED, PRN_REJECTED) to the stream.
+ *   Ledger-only: throws on embedded balances and when no balance exists.
  * @property {(params: FlipCanonicalSourceToMigratingParams) => Promise<FlipCanonicalSourceToMigratingResult>} flipCanonicalSourceToMigrating
  *   Promote an `'embedded'` accreditation to `'migrating'` and stamp
  *   `migratingSince`, gated on `version` matching the captured value. The

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -93,6 +93,17 @@
  */
 
 /**
+ * @typedef {Object} GetPrnCatchupEventsParams
+ * @property {string} registrationId
+ * @property {string} accreditationId
+ * @property {string} prnId
+ * @property {number} afterEventNumber - The watermark to fold past. Pass
+ *   `lastAppliedEventNumber ?? 0` so the first event of a first-event-failure
+ *   case (where no watermark was ever stamped onto the PRN doc) is still
+ *   returned.
+ */
+
+/**
  * @typedef {{ canonicalSource: import('../domain/model.js').WasteBalanceCanonicalSource } | null} ResetCanonicalSourceToEmbeddedResult
  *   Post-state of the accreditation's balance document.
  *
@@ -146,6 +157,11 @@
  *   the rebuild process died between the two flips and submissions for the
  *   registration are blocked until the marker is reset. Strictly demotes:
  *   `'embedded'` is left as-is and `'ledger'` is never demoted.
+ * @property {(params: GetPrnCatchupEventsParams) => Promise<import('./stream-schema.js').StreamEvent[]>} getPrnCatchupEvents
+ *   Return the stream tail events to project onto a PRN read. Empty array
+ *   when the accreditation's marker is not `'ledger'` (no stream query is
+ *   issued), when no balance document exists, or when the ledger-canonical
+ *   accreditation has no tail events for this PRN past the watermark.
  */
 
 /**


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)

## Summary

Makes a single pure fold the canonical projection of PRN status for accreditations whose waste balance has migrated to the event stream (`canonicalSource: 'ledger'`). The same `foldPrnFromTailEvents` drives both the write and read paths, so the two can no longer encode the event-kind→status mapping differently and silently diverge.

**Write path** — A ledger-marker status transition is written event-first: compute the balance-affecting stream events, fold them onto the PRN, then persist the resulting projection through a new `prnRepository.persistProjection` (optimistic concurrency on version). There is no compensation — a partial failure (events appended, doc not persisted) self-heals on the next read. Embedded-marker accreditations keep their existing field-level write path until they migrate.

**Read path** — `GET .../packaging-recycling-notes/{prnId}` returns the PRN folded forward over any stream events past its `lastAppliedEventNumber`, so a partial write failure surfaces as the correct current state. This sits behind a single `getProjectedPrnById` application function: routes ask for the fully-formed PRN and never touch the event stream themselves. A missing or soft-deleted document short-circuits with no stream query.

**Repository** — `persistProjection` on the PRN repository, and `getPrnCatchupEvents` / `appendStreamEvent` on the waste-balances repository, each across the MongoDB and in-memory adapters and covered by shared contract tests.

The gate is the marker, not the feature flag — once an accreditation is on the ledger, its truth lives in the events and both reads and writes go through the fold.

## Rollout

Dormant in production: `FEATURE_FLAG_WASTE_BALANCE_LEDGER` defaults false and every existing waste-balance doc has `canonicalSource: 'embedded'`, so the new code paths run for nobody until the cutover.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
