### PR TITLE
PAE-1382: Lift ZERO_BALANCE to a single shared constant

### DIFF
--- a/src/waste-balances/application/append-to-stream.js
+++ b/src/waste-balances/application/append-to-stream.js
@@ -1,10 +1,8 @@
-import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import { STREAM_EVENT_KIND, ZERO_BALANCE } from '../repository/stream-schema.js'
 import {
   closingForSummaryLogSubmitted,
   closingForPrn
 } from './stream-closing-balance.js'
-
-const ZERO_BALANCE = Object.freeze({ amount: 0, availableAmount: 0 })
 
 /**
  * @param {import('../repository/stream-port.js').StreamEvent | null} latest

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -2,7 +2,7 @@ import { add, toNumber } from '#common/helpers/decimal-utils.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 
-import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import { STREAM_EVENT_KIND, ZERO_BALANCE } from '../repository/stream-schema.js'
 import {
   closingForSummaryLogSubmitted,
   closingForPrn
@@ -171,7 +171,7 @@ const buildChronologicalEvents = ({
  */
 const replayStream = (events) => {
   const result = []
-  let previousBalance = { amount: 0, availableAmount: 0 }
+  let previousBalance = { ...ZERO_BALANCE }
   let previousCreditTotal = 0
 
   for (let i = 0; i < events.length; i++) {
@@ -242,7 +242,7 @@ export const computeRebuiltStream = ({
   const events = replayStream(unsorted)
 
   if (events.length === 0) {
-    return { events, amount: 0, availableAmount: 0 }
+    return { events, ...ZERO_BALANCE }
   }
 
   const finalBalance =

--- a/src/waste-balances/repository/stream-schema.js
+++ b/src/waste-balances/repository/stream-schema.js
@@ -31,6 +31,9 @@ const PRN_KINDS = new Set([
  * @property {number} availableAmount
  */
 
+/** @type {Readonly<StreamBalanceSnapshot>} */
+export const ZERO_BALANCE = Object.freeze({ amount: 0, availableAmount: 0 })
+
 /**
  * @typedef {Object} StreamUserSummary
  * @property {string} id


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

The "empty stream implies a balance of 0" rule was codified three times in `src/waste-balances/application/`, only one of which was named. Exports `ZERO_BALANCE` from `src/waste-balances/repository/stream-schema.js` (alongside the `StreamBalanceSnapshot` typedef it instantiates) and imports it at all three sites.

## Changes

- `stream-schema.js` — export `ZERO_BALANCE = Object.freeze({ amount: 0, availableAmount: 0 })`, typed as `Readonly<StreamBalanceSnapshot>`.
- `append-to-stream.js` — drop the module-private `ZERO_BALANCE` constant; import from the schema module instead. `openingBalanceFrom(latest)` still spreads to return a fresh mutable copy.
- `compute-rebuilt-stream.js` — replace inline `{ amount: 0, availableAmount: 0 }` at the `replayStream` accumulator seed and the empty-events early return in `computeRebuiltStream` with spreads of the shared constant.

Behaviour unchanged: every callsite spreads `ZERO_BALANCE` into a fresh object, so the `Object.freeze` never leaks into a context that later mutates. +7 / -6 across three files.

## Why now

The fold-from-events function on the read path (tracked separately) needs the same constant. Lifting it first means the new code is a straight import rather than a fourth inline duplicate.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ