### PR TITLE
PAE-1382: Wire PRN_ACCEPTED and PRN_REJECTED into stream replay

### DIFF
--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -68,6 +68,18 @@ export const prnTransitionToStreamKind = (prevStatus, newStatus) => {
   ) {
     return STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE
   }
+  if (
+    newStatus === PRN_STATUS.ACCEPTED &&
+    prevStatus === PRN_STATUS.AWAITING_ACCEPTANCE
+  ) {
+    return STREAM_EVENT_KIND.PRN_ACCEPTED
+  }
+  if (
+    newStatus === PRN_STATUS.AWAITING_CANCELLATION &&
+    prevStatus === PRN_STATUS.AWAITING_ACCEPTANCE
+  ) {
+    return STREAM_EVENT_KIND.PRN_REJECTED
+  }
   return null
 }
 

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -39,6 +39,35 @@ const reconstructDataAtSubmission = (versions, seenSummaryLogIds) => {
   return data
 }
 
+/** @type {Map<string, import('../repository/stream-schema.js').StreamEventKind>} */
+const PRN_TRANSITION_MAP = new Map([
+  [`*→${PRN_STATUS.AWAITING_AUTHORISATION}`, STREAM_EVENT_KIND.PRN_CREATED],
+  [
+    `${PRN_STATUS.AWAITING_AUTHORISATION}→${PRN_STATUS.AWAITING_ACCEPTANCE}`,
+    STREAM_EVENT_KIND.PRN_ISSUED
+  ],
+  [
+    `${PRN_STATUS.AWAITING_AUTHORISATION}→${PRN_STATUS.CANCELLED}`,
+    STREAM_EVENT_KIND.PRN_CREATION_CANCELLED
+  ],
+  [
+    `${PRN_STATUS.AWAITING_AUTHORISATION}→${PRN_STATUS.DELETED}`,
+    STREAM_EVENT_KIND.PRN_CREATION_CANCELLED
+  ],
+  [
+    `${PRN_STATUS.AWAITING_CANCELLATION}→${PRN_STATUS.CANCELLED}`,
+    STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE
+  ],
+  [
+    `${PRN_STATUS.AWAITING_ACCEPTANCE}→${PRN_STATUS.ACCEPTED}`,
+    STREAM_EVENT_KIND.PRN_ACCEPTED
+  ],
+  [
+    `${PRN_STATUS.AWAITING_ACCEPTANCE}→${PRN_STATUS.AWAITING_CANCELLATION}`,
+    STREAM_EVENT_KIND.PRN_REJECTED
+  ]
+])
+
 /**
  * Map a PRN status transition to a stream event kind.
  *
@@ -46,42 +75,10 @@ const reconstructDataAtSubmission = (versions, seenSummaryLogIds) => {
  * @param {string} newStatus
  * @returns {import('../repository/stream-schema.js').StreamEventKind | null}
  */
-export const prnTransitionToStreamKind = (prevStatus, newStatus) => {
-  if (newStatus === PRN_STATUS.AWAITING_AUTHORISATION) {
-    return STREAM_EVENT_KIND.PRN_CREATED
-  }
-  if (
-    newStatus === PRN_STATUS.AWAITING_ACCEPTANCE &&
-    prevStatus === PRN_STATUS.AWAITING_AUTHORISATION
-  ) {
-    return STREAM_EVENT_KIND.PRN_ISSUED
-  }
-  if (
-    (newStatus === PRN_STATUS.CANCELLED || newStatus === PRN_STATUS.DELETED) &&
-    prevStatus === PRN_STATUS.AWAITING_AUTHORISATION
-  ) {
-    return STREAM_EVENT_KIND.PRN_CREATION_CANCELLED
-  }
-  if (
-    newStatus === PRN_STATUS.CANCELLED &&
-    prevStatus === PRN_STATUS.AWAITING_CANCELLATION
-  ) {
-    return STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE
-  }
-  if (
-    newStatus === PRN_STATUS.ACCEPTED &&
-    prevStatus === PRN_STATUS.AWAITING_ACCEPTANCE
-  ) {
-    return STREAM_EVENT_KIND.PRN_ACCEPTED
-  }
-  if (
-    newStatus === PRN_STATUS.AWAITING_CANCELLATION &&
-    prevStatus === PRN_STATUS.AWAITING_ACCEPTANCE
-  ) {
-    return STREAM_EVENT_KIND.PRN_REJECTED
-  }
-  return null
-}
+export const prnTransitionToStreamKind = (prevStatus, newStatus) =>
+  PRN_TRANSITION_MAP.get(`${prevStatus}→${newStatus}`) ??
+  PRN_TRANSITION_MAP.get(`*→${newStatus}`) ??
+  null
 
 /**
  * Build an unsorted list of chronologically timestamped event tuples

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -378,9 +378,10 @@ describe('computeRebuiltStream', () => {
       ]
     })
 
-    const accepted = result.events.find(
-      (e) => e.kind === STREAM_EVENT_KIND.PRN_ACCEPTED
-    )
+    const accepted =
+      /** @type {import('../repository/stream-schema.js').StreamEventInsert} */ (
+        result.events.find((e) => e.kind === STREAM_EVENT_KIND.PRN_ACCEPTED)
+      )
     expect(accepted).toBeDefined()
     expect(accepted.openingBalance).toEqual(accepted.closingBalance)
 
@@ -443,9 +444,10 @@ describe('computeRebuiltStream', () => {
       ]
     })
 
-    const rejected = result.events.find(
-      (e) => e.kind === STREAM_EVENT_KIND.PRN_REJECTED
-    )
+    const rejected =
+      /** @type {import('../repository/stream-schema.js').StreamEventInsert} */ (
+        result.events.find((e) => e.kind === STREAM_EVENT_KIND.PRN_REJECTED)
+      )
     expect(rejected).toBeDefined()
     expect(rejected.openingBalance).toEqual(rejected.closingBalance)
 

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -324,6 +324,136 @@ describe('computeRebuiltStream', () => {
     expect(result.availableAmount).toBe(100)
   })
 
+  it('records a zero-delta PRN_ACCEPTED event when a producer accepts', () => {
+    const result = computeRebuiltStream({
+      accreditation,
+      wasteRecords: [
+        {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          type: 'received',
+          data: { processingType: 'INPUT', tonnage: 100 },
+          versions: [
+            {
+              summaryLog: { id: 'sl-1' },
+              data: { processingType: 'INPUT', tonnage: 100 }
+            }
+          ],
+          excludedFromWasteBalance: false
+        }
+      ],
+      prns: [
+        {
+          id: 'prn-1',
+          tonnage: 30,
+          status: {
+            history: [
+              {
+                status: PRN_STATUS.DRAFT,
+                at: new Date('2025-01-20T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.AWAITING_AUTHORISATION,
+                at: new Date('2025-01-21T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                at: new Date('2025-01-22T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.ACCEPTED,
+                at: new Date('2025-01-23T00:00:00.000Z')
+              }
+            ]
+          }
+        }
+      ],
+      overseasSites,
+      summaryLogs: [
+        {
+          id: 'sl-1',
+          status: SUMMARY_LOG_STATUS.SUBMITTED,
+          submittedAt: '2025-01-15T10:00:00.000Z'
+        }
+      ]
+    })
+
+    const accepted = result.events.find(
+      (e) => e.kind === STREAM_EVENT_KIND.PRN_ACCEPTED
+    )
+    expect(accepted).toBeDefined()
+    expect(accepted.openingBalance).toEqual(accepted.closingBalance)
+
+    // Final balance unchanged by acceptance: created (-30 avail), issued (-30 amount)
+    expect(result.amount).toBe(70)
+    expect(result.availableAmount).toBe(70)
+  })
+
+  it('records a zero-delta PRN_REJECTED event when a producer rejects', () => {
+    const result = computeRebuiltStream({
+      accreditation,
+      wasteRecords: [
+        {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          type: 'received',
+          data: { processingType: 'INPUT', tonnage: 100 },
+          versions: [
+            {
+              summaryLog: { id: 'sl-1' },
+              data: { processingType: 'INPUT', tonnage: 100 }
+            }
+          ],
+          excludedFromWasteBalance: false
+        }
+      ],
+      prns: [
+        {
+          id: 'prn-1',
+          tonnage: 30,
+          status: {
+            history: [
+              {
+                status: PRN_STATUS.DRAFT,
+                at: new Date('2025-01-20T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.AWAITING_AUTHORISATION,
+                at: new Date('2025-01-21T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                at: new Date('2025-01-22T00:00:00.000Z')
+              },
+              {
+                status: PRN_STATUS.AWAITING_CANCELLATION,
+                at: new Date('2025-01-23T00:00:00.000Z')
+              }
+            ]
+          }
+        }
+      ],
+      overseasSites,
+      summaryLogs: [
+        {
+          id: 'sl-1',
+          status: SUMMARY_LOG_STATUS.SUBMITTED,
+          submittedAt: '2025-01-15T10:00:00.000Z'
+        }
+      ]
+    })
+
+    const rejected = result.events.find(
+      (e) => e.kind === STREAM_EVENT_KIND.PRN_REJECTED
+    )
+    expect(rejected).toBeDefined()
+    expect(rejected.openingBalance).toEqual(rejected.closingBalance)
+
+    // Balance after created (-30 avail) + issued (-30 amount) + rejected (no-op)
+    expect(result.amount).toBe(70)
+    expect(result.availableAmount).toBe(70)
+  })
+
   it('reverses both amount and availableAmount for a post-issue cancellation', () => {
     const result = computeRebuiltStream({
       accreditation,

--- a/src/waste-balances/application/compute-rebuilt-totals.js
+++ b/src/waste-balances/application/compute-rebuilt-totals.js
@@ -27,7 +27,9 @@ const PRN_DELTAS = Object.freeze({
   [STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE]: (tonnage) => ({
     amount: tonnage,
     availableAmount: tonnage
-  })
+  }),
+  [STREAM_EVENT_KIND.PRN_ACCEPTED]: () => ({ amount: 0, availableAmount: 0 }),
+  [STREAM_EVENT_KIND.PRN_REJECTED]: () => ({ amount: 0, availableAmount: 0 })
 })
 
 /**

--- a/src/waste-balances/application/stream-closing-balance.js
+++ b/src/waste-balances/application/stream-closing-balance.js
@@ -56,6 +56,9 @@ export const closingForPrn = (opening, kind, prnAmount) => {
         amount: toNumber(add(opening.amount, prnAmount)),
         availableAmount: toNumber(add(opening.availableAmount, prnAmount))
       }
+    case STREAM_EVENT_KIND.PRN_ACCEPTED:
+    case STREAM_EVENT_KIND.PRN_REJECTED:
+      return { ...opening }
     default:
       throw new Error(`Unknown PRN event kind: ${kind}`)
   }


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

- Map two new PRN status transitions (`ACCEPTED`, `AWAITING_CANCELLATION` from producer) to `PRN_ACCEPTED` and `PRN_REJECTED` stream event kinds in `prnTransitionToStreamKind`
- Add zero-balance-delta handling in `closingForPrn` and `PRN_DELTAS` so the replay and totals paths don't throw on these kinds
- Add integration tests for both accepted and rejected PRN lifecycles

## Test plan

- [x] New tests verify `PRN_ACCEPTED` and `PRN_REJECTED` events appear with `openingBalance === closingBalance`
- [x] Existing post-issue cancellation test still passes (its history now includes a `PRN_REJECTED` event but final balances are unchanged)
- [x] All 411 waste-balances tests green
- [x] Type checker clean

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ