### PR TITLE
PAE-1536: downgrade validation issue logs from warn to info

### DIFF
--- a/src/application/summary-logs/validate-issue-logging.js
+++ b/src/application/summary-logs/validate-issue-logging.js
@@ -93,7 +93,7 @@ const buildSummaryLogPayload = ({
 })
 
 /**
- * Emits a warn-level log per validation issue plus a single summary log so
+ * Emits an info-level log per validation issue plus a single summary log so
  * support can investigate failures via OpenSearch DQL. No-op when there are
  * no issues. PII (issue.context.actual) and org/reg are never included in
  * per-issue logs; org/reg appear only in the run-level summary log.
@@ -116,9 +116,9 @@ export const logValidationIssues = ({
   }
   const issuesToLog = issues.getAllIssues().slice(0, MAX_VALIDATION_ISSUES)
   issuesToLog.forEach((issue) => {
-    logger.warn(buildIssueLogPayload(issue, summaryLogId))
+    logger.info(buildIssueLogPayload(issue, summaryLogId))
   })
-  logger.warn(
+  logger.info(
     buildSummaryLogPayload({
       counts: issues.getCounts(),
       logged: issuesToLog.length,

--- a/src/application/summary-logs/validate-issue-logging.test.js
+++ b/src/application/summary-logs/validate-issue-logging.test.js
@@ -52,14 +52,14 @@ describe('logValidationIssues', () => {
         logger
       })
 
-      const warnCalls = /** @type {{ mock: { calls: any[][] } }} */ (
-        /** @type {unknown} */ (logger.warn)
+      const infoCalls = /** @type {{ mock: { calls: any[][] } }} */ (
+        /** @type {unknown} */ (logger.info)
       ).mock.calls
 
-      const issueLogs = warnCalls.filter(
+      const issueLogs = infoCalls.filter(
         ([payload]) => payload?.event?.action === 'summary_log_validation_issue'
       )
-      const [summaryPayload] = warnCalls
+      const [summaryPayload] = infoCalls
         .filter(
           ([payload]) =>
             payload?.event?.action === 'summary_log_validation_completed'
@@ -86,10 +86,10 @@ describe('logValidationIssues', () => {
         logger
       })
 
-      const warnCalls = /** @type {{ mock: { calls: any[][] } }} */ (
-        /** @type {unknown} */ (logger.warn)
+      const infoCalls = /** @type {{ mock: { calls: any[][] } }} */ (
+        /** @type {unknown} */ (logger.info)
       ).mock.calls
-      const [summaryPayload] = warnCalls
+      const [summaryPayload] = infoCalls
         .filter(
           ([payload]) =>
             payload?.event?.action === 'summary_log_validation_completed'

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -691,22 +691,22 @@ describe('SummaryLogsValidator integration', () => {
   })
 
   describe('validation issue logging', () => {
-    let warnSpy
+    let infoSpy
 
     beforeEach(() => {
-      warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {})
     })
 
     afterEach(() => {
-      warnSpy.mockRestore()
+      infoSpy.mockRestore()
     })
 
     const filterByAction = (action) =>
-      warnSpy.mock.calls
+      infoSpy.mock.calls
         .map(([payload]) => payload)
         .filter((payload) => payload?.event?.action === action)
 
-    it('should emit a warn log per issue plus a summary log when validation produces issues', async () => {
+    it('should emit an info log per issue plus a summary log when validation produces issues', async () => {
       const metadata = {
         REGISTRATION_NUMBER: {
           value: 'REG-123',
@@ -735,7 +735,7 @@ describe('SummaryLogsValidator integration', () => {
       expect(summaryLogs).toHaveLength(1)
     })
 
-    it('should not emit validation-issue warn logs when validation passes cleanly', async () => {
+    it('should not emit validation-issue info logs when validation passes cleanly', async () => {
       const accreditationNumber = 'ACC-001'
       const metadata = {
         REGISTRATION_NUMBER: {


### PR DESCRIPTION
Ticket: [PAE-1536](https://eaflood.atlassian.net/browse/PAE-1536)
## Summary

- Downgrade the per-issue (`Summary log validation issue`) and summary (`Summary log validation completed`) log messages in `logValidationIssues` from `warn` to `info` level
- These messages represent expected validation outcomes, not application warnings, and were triggering production alerts unnecessarily

[PAE-1536]: https://eaflood.atlassian.net/browse/PAE-1536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ