### PR TITLE
PAE-1382: Make rebuilt waste-balance events seedable into the stream store

### DIFF
--- a/src/server/run-balance-divergence-diagnostic.integration.test.js
+++ b/src/server/run-balance-divergence-diagnostic.integration.test.js
@@ -156,6 +156,8 @@ describe('balance divergence diagnostic (integration)', () => {
 
     const result = computeRebuiltStream({
       accreditation: { id: 'acc-1' },
+      registrationId,
+      organisationId,
       wasteRecords,
       prns: [],
       overseasSites: {},

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -206,7 +206,8 @@ const buildComparison = (
     rebuilt.availableAmount,
     stream.availableAmount
   ),
-  streamEventCount: stream.events.length
+  streamEventCount: stream.events.length,
+  backfilledActorCount: stream.backfilledActorCount
 })
 
 const isDivergent = (comparison) =>
@@ -249,6 +250,16 @@ const formatErrorLine = (embedded, error) =>
     `error="${error.message}"`
   ].join(' ')
 
+const formatBackfillLine = (comparison) =>
+  [
+    'Waste-balance rebuild used backfill actor:',
+    `organisationId=${comparison.organisationId}`,
+    `registrationNumber=${comparison.registrationNumber}`,
+    `accreditationNumber=${comparison.accreditationNumber}`,
+    `backfilledActorCount=${comparison.backfilledActorCount}`,
+    `streamEventCount=${comparison.streamEventCount}`
+  ].join(' ')
+
 /**
  * @param {import('mongodb').Db} db
  * @param {DiagnosticDependencies} deps
@@ -268,6 +279,9 @@ const runDiagnostic = async (db, deps) => {
     scanned += 1
     try {
       const comparison = await compareForEmbedded(row, deps)
+      if (comparison.backfilledActorCount > 0) {
+        logger.warn({ message: formatBackfillLine(comparison) })
+      }
       if (isDivergent(comparison)) {
         changed += 1
         logger.info({ message: formatDivergenceLine(comparison) })

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -148,6 +148,8 @@ const compareForEmbedded = async (embedded, deps) => {
 
   const stream = computeRebuiltStream({
     accreditation,
+    registrationId: registration.id,
+    organisationId: embedded.organisationId,
     wasteRecords,
     prns,
     overseasSites,

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -7,6 +7,7 @@ import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-no
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
 import { computeRebuiltTotals } from '#waste-balances/application/compute-rebuilt-totals.js'
 import { computeRebuiltStream } from '#waste-balances/application/compute-rebuilt-stream.js'
+import { buildStreamEvent } from '#waste-balances/repository/stream-test-data.js'
 import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
 import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.js'
 
@@ -15,6 +16,7 @@ import { runBalanceDivergenceDiagnostic } from './run-balance-divergence-diagnos
 vi.mock('#common/helpers/logging/logger.js', () => ({
   logger: {
     info: vi.fn(),
+    warn: vi.fn(),
     error: vi.fn()
   }
 }))
@@ -133,7 +135,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 0,
-      availableAmount: 0
+      availableAmount: 0,
+      backfilledActorCount: 0
     })
     vi.mocked(resolveOverseasSites).mockResolvedValue({})
   })
@@ -213,7 +216,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 7,
-      availableAmount: 5
+      availableAmount: 5,
+      backfilledActorCount: 0
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -262,7 +266,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 95,
-      availableAmount: 80
+      availableAmount: 80,
+      backfilledActorCount: 0
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -386,7 +391,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 7,
-      availableAmount: 7
+      availableAmount: 7,
+      backfilledActorCount: 0
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -534,7 +540,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 5,
-      availableAmount: 5
+      availableAmount: 5,
+      backfilledActorCount: 0
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -720,7 +727,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 95,
-      availableAmount: 75
+      availableAmount: 75,
+      backfilledActorCount: 0
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -736,5 +744,72 @@ describe('runBalanceDivergenceDiagnostic', () => {
     expect(divergenceLines[0][0].message).toContain('streamAmount=95')
     expect(divergenceLines[0][0].message).toContain('streamAvailableAmount=75')
     expect(divergenceLines[0][0].message).toContain('streamEventCount=0')
+  })
+
+  it('warns with a tagged key=value line when the rebuild used the backfill actor', async () => {
+    setEmbeddedBalances([
+      {
+        accreditationId: 'acc-1',
+        organisationId: 'org-1',
+        amount: 0,
+        availableAmount: 0
+      }
+    ])
+    registrations['org-1'] = [
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: 'REG-1',
+        status: 'approved'
+      }
+    ]
+    accreditations['org-1'] = [
+      { id: 'acc-1', accreditationNumber: 'ACC-1', status: 'approved' }
+    ]
+    vi.mocked(computeRebuiltStream).mockReturnValue({
+      events: [buildStreamEvent(), buildStreamEvent(), buildStreamEvent()],
+      amount: 0,
+      availableAmount: 0,
+      backfilledActorCount: 2
+    })
+
+    await runBalanceDivergenceDiagnostic(mockServer)
+
+    expect(logger.warn).toHaveBeenCalledWith({
+      message:
+        'Waste-balance rebuild used backfill actor: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-1 backfilledActorCount=2 streamEventCount=3'
+    })
+  })
+
+  it('does not warn when every rebuilt event carried a real actor', async () => {
+    setEmbeddedBalances([
+      {
+        accreditationId: 'acc-1',
+        organisationId: 'org-1',
+        amount: 0,
+        availableAmount: 0
+      }
+    ])
+    registrations['org-1'] = [
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: 'REG-1',
+        status: 'approved'
+      }
+    ]
+    accreditations['org-1'] = [
+      { id: 'acc-1', accreditationNumber: 'ACC-1', status: 'approved' }
+    ]
+    vi.mocked(computeRebuiltStream).mockReturnValue({
+      events: [buildStreamEvent()],
+      amount: 0,
+      availableAmount: 0,
+      backfilledActorCount: 0
+    })
+
+    await runBalanceDivergenceDiagnostic(mockServer)
+
+    expect(logger.warn).not.toHaveBeenCalled()
   })
 })

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -622,6 +622,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
     )
     expect(computeRebuiltStream).toHaveBeenCalledWith({
       accreditation,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
       wasteRecords,
       prns,
       overseasSites: {},

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -1,5 +1,8 @@
 import { add, toNumber } from '#common/helpers/decimal-utils.js'
-import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import {
+  PRN_STATUS,
+  PRN_STATUS_TRANSITIONS
+} from '#packaging-recycling-notes/domain/model.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 
 import { STREAM_EVENT_KIND, ZERO_BALANCE } from '../repository/stream-schema.js'
@@ -8,6 +11,17 @@ import {
   closingForPrn
 } from './stream-closing-balance.js'
 import { getTargetAmount } from './target-amount.js'
+
+/**
+ * Attribution for backfilled events with no recoverable real actor. The
+ * submitting session for historical summary-log submissions is not persisted
+ * on the summary-log document or the waste-record version, so a backfill
+ * supplies it out of band where it can; absent that, events are attributed to
+ * the system.
+ *
+ * @type {Readonly<import('../repository/stream-schema.js').StreamUserSummary>}
+ */
+export const BACKFILL_ACTOR = Object.freeze({ id: 'system', name: 'backfill' })
 
 /**
  * Reconstruct a waste record's data as it existed at a given submission
@@ -81,18 +95,43 @@ export const prnTransitionToStreamKind = (prevStatus, newStatus) =>
   null
 
 /**
+ * Whether a status move exists in the PRN state machine, irrespective of
+ * which actor performed it. Used to detect corrupt source history rather
+ * than to authorise a live transition.
+ *
+ * @param {string} fromStatus
+ * @param {string} toStatus
+ * @returns {boolean}
+ */
+const isStructurallyValidPrnTransition = (fromStatus, toStatus) =>
+  (PRN_STATUS_TRANSITIONS[fromStatus] ?? []).some((t) => t.status === toStatus)
+
+/**
+ * Reduce a PRN status-history actor to the stream's user-summary shape.
+ *
+ * @param {{ id: string, name: string } | undefined} actor
+ * @returns {import('../repository/stream-schema.js').StreamUserSummary}
+ */
+const actorOf = (actor) =>
+  actor ? { id: actor.id, name: actor.name } : { ...BACKFILL_ACTOR }
+
+/**
  * Build an unsorted list of chronologically timestamped event tuples
  * from summary log submissions and PRN status transitions.
  *
  * @param {Object} params
  * @param {{ id: string }} params.accreditation
+ * @param {string} params.registrationId
+ * @param {string} params.organisationId
  * @param {Array} params.wasteRecords
  * @param {Array} params.prns
  * @param {Object} params.overseasSites
- * @param {Array<{ id: string, status: string, submittedAt?: string }>} params.summaryLogs
+ * @param {Array<{ id: string, status: string, submittedAt?: string, submittedBy?: import('../repository/stream-schema.js').StreamUserSummary }>} params.summaryLogs
  */
 const buildChronologicalEvents = ({
   accreditation,
+  registrationId,
+  organisationId,
   wasteRecords,
   prns,
   overseasSites,
@@ -102,7 +141,7 @@ const buildChronologicalEvents = ({
 
   const submitted = summaryLogs
     .filter(
-      /** @returns {sl is { id: string, status: string, submittedAt: string }} */
+      /** @returns {sl is { id: string, status: string, submittedAt: string, submittedBy?: import('../repository/stream-schema.js').StreamUserSummary }} */
       (sl) => sl.status === SUMMARY_LOG_STATUS.SUBMITTED
     )
     .sort(
@@ -136,9 +175,10 @@ const buildChronologicalEvents = ({
       timestamp: new Date(summaryLog.submittedAt),
       kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
       payload: { summaryLogId: summaryLog.id, creditTotal },
-      registrationId: wasteRecords[0]?.registrationId,
+      registrationId,
       accreditationId: accreditation.id,
-      organisationId: wasteRecords[0]?.organisationId
+      organisationId,
+      createdBy: summaryLog.submittedBy ?? { ...BACKFILL_ACTOR }
     })
   }
 
@@ -146,17 +186,28 @@ const buildChronologicalEvents = ({
     const history = prn.status.history
     for (let i = 0; i < history.length; i++) {
       const prevStatus = i === 0 ? null : history[i - 1].status
-      const kind = prnTransitionToStreamKind(prevStatus, history[i].status)
+      const newStatus = history[i].status
+      const kind = prnTransitionToStreamKind(prevStatus, newStatus)
+
       if (kind === null) {
+        if (
+          prevStatus !== null &&
+          !isStructurallyValidPrnTransition(prevStatus, newStatus)
+        ) {
+          throw new Error(
+            `Impossible PRN status transition in history for prnId=${prn.id}: ${prevStatus} -> ${newStatus}`
+          )
+        }
         continue
       }
       events.push({
         timestamp: history[i].at,
         kind,
         payload: { prnId: prn.id, amount: prn.tonnage },
-        registrationId: wasteRecords[0]?.registrationId,
+        registrationId,
         accreditationId: accreditation.id,
-        organisationId: wasteRecords[0]?.organisationId
+        organisationId,
+        createdBy: actorOf(history[i].by)
       })
     }
   }
@@ -174,7 +225,8 @@ const buildChronologicalEvents = ({
  *   payload: Object,
  *   registrationId: string,
  *   accreditationId: string | null,
- *   organisationId: string
+ *   organisationId: string,
+ *   createdBy: import('../repository/stream-schema.js').StreamUserSummary
  * }>} events
  * @returns {import('../repository/stream-schema.js').StreamEventInsert[]}
  */
@@ -184,7 +236,7 @@ const replayStream = (events) => {
   let previousCreditTotal = 0
 
   for (let i = 0; i < events.length; i++) {
-    const { timestamp, kind, payload, ...context } = events[i]
+    const { timestamp, kind, payload, createdBy, ...context } = events[i]
     const openingBalance = { ...previousBalance }
 
     let closingBalance
@@ -208,7 +260,7 @@ const replayStream = (events) => {
       openingBalance,
       closingBalance,
       createdAt: timestamp,
-      createdBy: { id: 'system', name: 'replay' }
+      createdBy
     })
 
     previousBalance = closingBalance
@@ -217,22 +269,53 @@ const replayStream = (events) => {
   return result
 }
 
+const SUMMARY_LOG_KIND_PRIORITY = 0
+const PRN_KIND_PRIORITY = 1
+
+const kindOrdering = (kind) =>
+  kind === STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED
+    ? SUMMARY_LOG_KIND_PRIORITY
+    : PRN_KIND_PRIORITY
+
+const naturalKey = (event) =>
+  event.kind === STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED
+    ? event.payload.summaryLogId
+    : event.payload.prnId
+
+/**
+ * Total order over events for deterministic seeding. Primary by timestamp;
+ * a summary-log submission precedes a PRN op sharing its instant so the PRN
+ * sees the post-submission balance; remaining ties break on natural key.
+ *
+ * @param {{ timestamp: Date, kind: string, payload: Object }} a
+ * @param {{ timestamp: Date, kind: string, payload: Object }} b
+ * @returns {number}
+ */
+const byStreamOrder = (a, b) =>
+  a.timestamp.getTime() - b.timestamp.getTime() ||
+  kindOrdering(a.kind) - kindOrdering(b.kind) ||
+  naturalKey(a).localeCompare(naturalKey(b))
+
 /**
  * Reconstruct the full historical event stream for an accreditation and
- * derive balance totals from it. The event list validates the stream
- * replay logic against authoritative sources; seeding these events into
- * a store requires further work (deterministic tiebreaks, partition
- * shape, createdBy attribution) tracked separately under PAE-1382.
+ * derive balance totals from it. Events are totally ordered, carry real
+ * registration / organisation context and actor attribution, and throw on
+ * source history that violates the PRN state machine — so the sequence is
+ * seedable into the stream store, not only a totals cross-check.
  *
  * @param {Object} params
  * @param {{ id: string }} params.accreditation
+ * @param {string} params.registrationId
+ * @param {string} params.organisationId
  * @param {Array} params.wasteRecords
  * @param {Array} params.prns
  * @param {Object} params.overseasSites
- * @param {Array<{ id: string, status: string, submittedAt?: string }>} params.summaryLogs
+ * @param {Array<{ id: string, status: string, submittedAt?: string, submittedBy?: import('../repository/stream-schema.js').StreamUserSummary }>} params.summaryLogs
  */
 export const computeRebuiltStream = ({
   accreditation,
+  registrationId,
+  organisationId,
   wasteRecords,
   prns,
   overseasSites,
@@ -240,13 +323,15 @@ export const computeRebuiltStream = ({
 }) => {
   const unsorted = buildChronologicalEvents({
     accreditation,
+    registrationId,
+    organisationId,
     wasteRecords,
     prns,
     overseasSites,
     summaryLogs
   })
 
-  unsorted.sort((a, b) => a.timestamp - b.timestamp)
+  unsorted.sort(byStreamOrder)
 
   const events = replayStream(unsorted)
 

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -178,7 +178,7 @@ const buildChronologicalEvents = ({
       registrationId,
       accreditationId: accreditation.id,
       organisationId,
-      createdBy: summaryLog.submittedBy ?? { ...BACKFILL_ACTOR }
+      createdBy: actorOf(summaryLog.submittedBy)
     })
   }
 

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -240,6 +240,46 @@ const prnTransitionEvent = ({
 }
 
 /**
+ * Build the events from a single PRN's status history, counting those that
+ * fall back to the system backfill actor because the history entry names none.
+ *
+ * @param {Object} params
+ * @param {Object} params.prn
+ * @param {{ id: string }} params.accreditation
+ * @param {string} params.registrationId
+ * @param {string} params.organisationId
+ */
+const buildPrnHistoryEvents = ({
+  prn,
+  accreditation,
+  registrationId,
+  organisationId
+}) => {
+  const history = prn.status.history
+  const events = []
+  let backfilledActorCount = 0
+
+  for (let i = 0; i < history.length; i++) {
+    const event = prnTransitionEvent({
+      prn,
+      index: i,
+      accreditation,
+      registrationId,
+      organisationId
+    })
+    if (event === null) {
+      continue
+    }
+    events.push(event)
+    if (!history[i].by) {
+      backfilledActorCount += 1
+    }
+  }
+
+  return { events, backfilledActorCount }
+}
+
+/**
  * Build PRN events from every status transition in each PRN's history.
  *
  * @param {Object} params
@@ -254,29 +294,22 @@ const buildPrnEvents = ({
   organisationId,
   prns
 }) => {
-  const events = []
-  let backfilledActorCount = 0
+  const perPrn = prns.map((prn) =>
+    buildPrnHistoryEvents({
+      prn,
+      accreditation,
+      registrationId,
+      organisationId
+    })
+  )
 
-  for (const prn of prns) {
-    const history = prn.status.history
-    for (let i = 0; i < history.length; i++) {
-      const event = prnTransitionEvent({
-        prn,
-        index: i,
-        accreditation,
-        registrationId,
-        organisationId
-      })
-      if (event !== null) {
-        events.push(event)
-        if (!history[i].by) {
-          backfilledActorCount += 1
-        }
-      }
-    }
+  return {
+    events: perPrn.flatMap(({ events }) => events),
+    backfilledActorCount: perPrn.reduce(
+      (sum, { backfilledActorCount }) => sum + backfilledActorCount,
+      0
+    )
   }
-
-  return { events, backfilledActorCount }
 }
 
 /**

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -170,6 +170,9 @@ const buildSummaryLogEvents = ({
       creditTotal = toNumber(add(creditTotal, amount))
     }
 
+    // One event is emitted per submitted log, so a missing submitter is
+    // exactly one backfilled event — no need to gate on emission as the PRN
+    // builder does.
     if (!summaryLog.submittedBy) {
       backfilledActorCount += 1
     }

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -148,6 +148,7 @@ const buildSummaryLogEvents = ({
 
   const seenSummaryLogIds = new Set()
   const events = []
+  let backfilledActorCount = 0
 
   for (const summaryLog of submitted) {
     seenSummaryLogIds.add(summaryLog.id)
@@ -169,6 +170,10 @@ const buildSummaryLogEvents = ({
       creditTotal = toNumber(add(creditTotal, amount))
     }
 
+    if (!summaryLog.submittedBy) {
+      backfilledActorCount += 1
+    }
+
     events.push({
       timestamp: new Date(summaryLog.submittedAt),
       kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
@@ -180,7 +185,7 @@ const buildSummaryLogEvents = ({
     })
   }
 
-  return events
+  return { events, backfilledActorCount }
 }
 
 /**
@@ -247,9 +252,11 @@ const buildPrnEvents = ({
   prns
 }) => {
   const events = []
+  let backfilledActorCount = 0
 
   for (const prn of prns) {
-    for (let i = 0; i < prn.status.history.length; i++) {
+    const history = prn.status.history
+    for (let i = 0; i < history.length; i++) {
       const event = prnTransitionEvent({
         prn,
         index: i,
@@ -259,11 +266,14 @@ const buildPrnEvents = ({
       })
       if (event !== null) {
         events.push(event)
+        if (!history[i].by) {
+          backfilledActorCount += 1
+        }
       }
     }
   }
 
-  return events
+  return { events, backfilledActorCount }
 }
 
 /**
@@ -279,10 +289,16 @@ const buildPrnEvents = ({
  * @param {Object} params.overseasSites
  * @param {Array<{ id: string, status: string, submittedAt?: string, submittedBy?: import('../repository/stream-schema.js').StreamUserSummary }>} params.summaryLogs
  */
-const buildChronologicalEvents = (params) => [
-  ...buildSummaryLogEvents(params),
-  ...buildPrnEvents(params)
-]
+const buildChronologicalEvents = (params) => {
+  const summaryLog = buildSummaryLogEvents(params)
+  const prn = buildPrnEvents(params)
+
+  return {
+    events: [...summaryLog.events, ...prn.events],
+    backfilledActorCount:
+      summaryLog.backfilledActorCount + prn.backfilledActorCount
+  }
+}
 
 /**
  * Replay a chronologically sorted list of events, threading opening and
@@ -370,7 +386,10 @@ const byStreamOrder = (a, b) =>
  * derive balance totals from it. Events are totally ordered, carry real
  * registration / organisation context and actor attribution, and throw on
  * source history that violates the PRN state machine — so the sequence is
- * seedable into the stream store, not only a totals cross-check.
+ * seedable into the stream store, not only a totals cross-check. Also reports
+ * `backfilledActorCount`: how many events fell back to the backfill actor
+ * because no real actor was recoverable, so callers can surface attribution
+ * gaps.
  *
  * @param {Object} params
  * @param {{ id: string }} params.accreditation
@@ -390,7 +409,7 @@ export const computeRebuiltStream = ({
   overseasSites,
   summaryLogs
 }) => {
-  const unsorted = buildChronologicalEvents({
+  const { events: unsorted, backfilledActorCount } = buildChronologicalEvents({
     accreditation,
     registrationId,
     organisationId,
@@ -405,7 +424,7 @@ export const computeRebuiltStream = ({
   const events = replayStream(unsorted)
 
   if (events.length === 0) {
-    return { events, ...ZERO_BALANCE }
+    return { events, ...ZERO_BALANCE, backfilledActorCount }
   }
 
   const finalBalance =
@@ -416,6 +435,7 @@ export const computeRebuiltStream = ({
   return {
     events,
     amount: finalBalance.amount,
-    availableAmount: finalBalance.availableAmount
+    availableAmount: finalBalance.availableAmount,
+    backfilledActorCount
   }
 }

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -116,29 +116,26 @@ const actorOf = (actor) =>
   actor ? { id: actor.id, name: actor.name } : { ...BACKFILL_ACTOR }
 
 /**
- * Build an unsorted list of chronologically timestamped event tuples
- * from summary log submissions and PRN status transitions.
+ * Build summary-log-submitted events, threading the running set of seen
+ * summary-log ids so each submission credits the waste-record data as it
+ * stood at that point.
  *
  * @param {Object} params
  * @param {{ id: string }} params.accreditation
  * @param {string} params.registrationId
  * @param {string} params.organisationId
  * @param {Array} params.wasteRecords
- * @param {Array} params.prns
  * @param {Object} params.overseasSites
  * @param {Array<{ id: string, status: string, submittedAt?: string, submittedBy?: import('../repository/stream-schema.js').StreamUserSummary }>} params.summaryLogs
  */
-const buildChronologicalEvents = ({
+const buildSummaryLogEvents = ({
   accreditation,
   registrationId,
   organisationId,
   wasteRecords,
-  prns,
   overseasSites,
   summaryLogs
 }) => {
-  const events = []
-
   const submitted = summaryLogs
     .filter(
       /** @returns {sl is { id: string, status: string, submittedAt: string, submittedBy?: import('../repository/stream-schema.js').StreamUserSummary }} */
@@ -150,6 +147,7 @@ const buildChronologicalEvents = ({
     )
 
   const seenSummaryLogIds = new Set()
+  const events = []
 
   for (const summaryLog of submitted) {
     seenSummaryLogIds.add(summaryLog.id)
@@ -182,38 +180,109 @@ const buildChronologicalEvents = ({
     })
   }
 
-  for (const prn of prns) {
-    const history = prn.status.history
-    for (let i = 0; i < history.length; i++) {
-      const prevStatus = i === 0 ? null : history[i - 1].status
-      const newStatus = history[i].status
-      const kind = prnTransitionToStreamKind(prevStatus, newStatus)
+  return events
+}
 
-      if (kind === null) {
-        if (
-          prevStatus !== null &&
-          !isStructurallyValidPrnTransition(prevStatus, newStatus)
-        ) {
-          throw new Error(
-            `Impossible PRN status transition in history for prnId=${prn.id}: ${prevStatus} -> ${newStatus}`
-          )
-        }
-        continue
-      }
-      events.push({
-        timestamp: history[i].at,
-        kind,
-        payload: { prnId: prn.id, amount: prn.tonnage },
+/**
+ * Build the stream event for a single PRN status-history entry, or null when
+ * the transition is a valid state-machine move that produces no balance event.
+ * Throws when the transition cannot occur in the PRN state machine at all,
+ * surfacing corrupt source history.
+ *
+ * @param {Object} params
+ * @param {{ id: string, tonnage: number, status: { history: Array<{ status: string, at: Date, by?: { id: string, name: string } }> } }} params.prn
+ * @param {number} params.index
+ * @param {{ id: string }} params.accreditation
+ * @param {string} params.registrationId
+ * @param {string} params.organisationId
+ */
+const prnTransitionEvent = ({
+  prn,
+  index,
+  accreditation,
+  registrationId,
+  organisationId
+}) => {
+  const history = prn.status.history
+  const prevStatus = index === 0 ? null : history[index - 1].status
+  const newStatus = history[index].status
+  const kind = prnTransitionToStreamKind(prevStatus, newStatus)
+
+  if (kind === null) {
+    if (
+      prevStatus !== null &&
+      !isStructurallyValidPrnTransition(prevStatus, newStatus)
+    ) {
+      throw new Error(
+        `Impossible PRN status transition in history for prnId=${prn.id}: ${prevStatus} -> ${newStatus}`
+      )
+    }
+    return null
+  }
+
+  return {
+    timestamp: history[index].at,
+    kind,
+    payload: { prnId: prn.id, amount: prn.tonnage },
+    registrationId,
+    accreditationId: accreditation.id,
+    organisationId,
+    createdBy: actorOf(history[index].by)
+  }
+}
+
+/**
+ * Build PRN events from every status transition in each PRN's history.
+ *
+ * @param {Object} params
+ * @param {{ id: string }} params.accreditation
+ * @param {string} params.registrationId
+ * @param {string} params.organisationId
+ * @param {Array} params.prns
+ */
+const buildPrnEvents = ({
+  accreditation,
+  registrationId,
+  organisationId,
+  prns
+}) => {
+  const events = []
+
+  for (const prn of prns) {
+    for (let i = 0; i < prn.status.history.length; i++) {
+      const event = prnTransitionEvent({
+        prn,
+        index: i,
+        accreditation,
         registrationId,
-        accreditationId: accreditation.id,
-        organisationId,
-        createdBy: actorOf(history[i].by)
+        organisationId
       })
+      if (event !== null) {
+        events.push(event)
+      }
     }
   }
 
   return events
 }
+
+/**
+ * Build an unsorted list of chronologically timestamped event tuples
+ * from summary log submissions and PRN status transitions.
+ *
+ * @param {Object} params
+ * @param {{ id: string }} params.accreditation
+ * @param {string} params.registrationId
+ * @param {string} params.organisationId
+ * @param {Array} params.wasteRecords
+ * @param {Array} params.prns
+ * @param {Object} params.overseasSites
+ * @param {Array<{ id: string, status: string, submittedAt?: string, submittedBy?: import('../repository/stream-schema.js').StreamUserSummary }>} params.summaryLogs
+ */
+const buildChronologicalEvents = (params) => [
+  ...buildSummaryLogEvents(params),
+  ...buildPrnEvents(params)
+]
 
 /**
  * Replay a chronologically sorted list of events, threading opening and

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -4,7 +4,10 @@ import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 
-import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import {
+  STREAM_EVENT_KIND,
+  streamEventInsertSchema
+} from '../repository/stream-schema.js'
 import {
   BACKFILL_ACTOR,
   computeRebuiltStream
@@ -565,8 +568,12 @@ describe('computeRebuiltStream', () => {
       ...(submittedBy ? { submittedBy } : {})
     })
 
-    it('attributes PRN events to the actor on the status history entry', () => {
-      const signatory = { id: 'sig-7', name: 'Sam Signatory' }
+    it('attributes PRN events to the actor on the status history entry, reduced to id and name', () => {
+      const signatory = {
+        id: 'sig-7',
+        name: 'Sam Signatory',
+        position: 'Signatory'
+      }
       const result = computeRebuiltStream({
         accreditation,
         registrationId,
@@ -604,7 +611,7 @@ describe('computeRebuiltStream', () => {
       const issued = result.events.find(
         (e) => e.kind === STREAM_EVENT_KIND.PRN_ISSUED
       )
-      expect(issued.createdBy).toEqual(signatory)
+      expect(issued.createdBy).toEqual({ id: 'sig-7', name: 'Sam Signatory' })
     })
 
     it('attributes summary-log events to the supplied submitter', () => {
@@ -870,6 +877,37 @@ describe('computeRebuiltStream', () => {
         'sl-alpha',
         'sl-zulu'
       ])
+    })
+
+    it('emits events that satisfy the stream insert schema', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 30,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date('2025-01-21T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: [submittedLog()]
+      })
+
+      expect(result.events).toHaveLength(2)
+      for (const event of result.events) {
+        expect(streamEventInsertSchema.validate(event).error).toBeUndefined()
+      }
     })
   })
 })

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -55,7 +55,8 @@ describe('computeRebuiltStream', () => {
     expect(result).toEqual({
       events: [],
       amount: 0,
-      availableAmount: 0
+      availableAmount: 0,
+      backfilledActorCount: 0
     })
   })
 
@@ -611,7 +612,7 @@ describe('computeRebuiltStream', () => {
       const issued = result.events.find(
         (e) => e.kind === STREAM_EVENT_KIND.PRN_ISSUED
       )
-      expect(issued.createdBy).toEqual({ id: 'sig-7', name: 'Sam Signatory' })
+      expect(issued?.createdBy).toEqual({ id: 'sig-7', name: 'Sam Signatory' })
     })
 
     it('attributes summary-log events to the supplied submitter', () => {
@@ -740,10 +741,11 @@ describe('computeRebuiltStream', () => {
         summaryLogs: []
       })
 
-      expect(result.events.map((e) => e.payload.prnId)).toEqual([
-        'prn-alpha',
-        'prn-zulu'
-      ])
+      expect(
+        result.events.map((e) =>
+          'prnId' in e.payload ? e.payload.prnId : undefined
+        )
+      ).toEqual(['prn-alpha', 'prn-zulu'])
     })
 
     it('throws on an impossible PRN status transition in history', () => {
@@ -873,10 +875,11 @@ describe('computeRebuiltStream', () => {
         ]
       })
 
-      expect(result.events.map((e) => e.payload.summaryLogId)).toEqual([
-        'sl-alpha',
-        'sl-zulu'
-      ])
+      expect(
+        result.events.map((e) =>
+          'summaryLogId' in e.payload ? e.payload.summaryLogId : undefined
+        )
+      ).toEqual(['sl-alpha', 'sl-zulu'])
     })
 
     it('emits events that satisfy the stream insert schema', () => {
@@ -908,6 +911,104 @@ describe('computeRebuiltStream', () => {
       for (const event of result.events) {
         expect(streamEventInsertSchema.validate(event).error).toBeUndefined()
       }
+    })
+  })
+
+  describe('backfilled actor count', () => {
+    const registrationId = 'reg-1'
+    const organisationId = 'org-1'
+
+    const submittedLog = (id, submittedBy) => ({
+      id,
+      status: SUMMARY_LOG_STATUS.SUBMITTED,
+      submittedAt: '2025-01-15T10:00:00.000Z',
+      ...(submittedBy ? { submittedBy } : {})
+    })
+
+    const createdPrn = (id, by) => ({
+      id,
+      tonnage: 10,
+      status: {
+        history: [
+          {
+            status: PRN_STATUS.AWAITING_AUTHORISATION,
+            at: new Date('2025-01-21T00:00:00.000Z'),
+            ...(by ? { by } : {})
+          }
+        ]
+      }
+    })
+
+    it('reports zero when every event carries a real actor', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [],
+        prns: [createdPrn('prn-1', { id: 'rep-1', name: 'Rita Reprocessor' })],
+        overseasSites,
+        summaryLogs: [
+          submittedLog('sl-1', { id: 'usr-9', name: 'submitter@example.com' })
+        ]
+      })
+
+      expect(result.backfilledActorCount).toBe(0)
+    })
+
+    it('counts a summary-log event with no submitter', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [],
+        prns: [],
+        overseasSites,
+        summaryLogs: [submittedLog('sl-1')]
+      })
+
+      expect(result.backfilledActorCount).toBe(1)
+    })
+
+    it('counts a PRN event whose history entry has no actor', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [],
+        prns: [createdPrn('prn-1')],
+        overseasSites,
+        summaryLogs: []
+      })
+
+      expect(result.backfilledActorCount).toBe(1)
+    })
+
+    it('sums backfilled summary-log and PRN events', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [],
+        prns: [createdPrn('prn-1')],
+        overseasSites,
+        summaryLogs: [submittedLog('sl-1')]
+      })
+
+      expect(result.backfilledActorCount).toBe(2)
+    })
+
+    it('reports zero for an empty stream', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [],
+        prns: [],
+        overseasSites,
+        summaryLogs: []
+      })
+
+      expect(result.backfilledActorCount).toBe(0)
     })
   })
 })

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -5,7 +5,10 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 
 import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
-import { computeRebuiltStream } from './compute-rebuilt-stream.js'
+import {
+  BACKFILL_ACTOR,
+  computeRebuiltStream
+} from './compute-rebuilt-stream.js'
 
 vi.mock('#domain/summary-logs/table-schemas/index.js', () => ({
   findSchemaForProcessingType: vi.fn()
@@ -38,6 +41,8 @@ describe('computeRebuiltStream', () => {
   it('returns zero totals and empty events when given no inputs', () => {
     const result = computeRebuiltStream({
       accreditation,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
       wasteRecords: [],
       prns: [],
       overseasSites,
@@ -99,6 +104,8 @@ describe('computeRebuiltStream', () => {
 
     const result = computeRebuiltStream({
       accreditation,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
       wasteRecords,
       prns,
       overseasSites,
@@ -164,6 +171,8 @@ describe('computeRebuiltStream', () => {
 
     const result = computeRebuiltStream({
       accreditation,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
       wasteRecords,
       prns,
       overseasSites,
@@ -194,6 +203,8 @@ describe('computeRebuiltStream', () => {
   it('ignores non-submitted summary logs', () => {
     const result = computeRebuiltStream({
       accreditation,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
       wasteRecords: [
         {
           organisationId: 'org-1',
@@ -228,6 +239,8 @@ describe('computeRebuiltStream', () => {
   it('excludes waste records not yet created at a submission point', () => {
     const result = computeRebuiltStream({
       accreditation,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
       wasteRecords: [
         {
           organisationId: 'org-1',
@@ -272,6 +285,8 @@ describe('computeRebuiltStream', () => {
   it('reverses availableAmount for a pre-issue PRN cancellation', () => {
     const result = computeRebuiltStream({
       accreditation,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
       wasteRecords: [
         {
           organisationId: 'org-1',
@@ -327,6 +342,8 @@ describe('computeRebuiltStream', () => {
   it('records a zero-delta PRN_ACCEPTED event when a producer accepts', () => {
     const result = computeRebuiltStream({
       accreditation,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
       wasteRecords: [
         {
           organisationId: 'org-1',
@@ -393,6 +410,8 @@ describe('computeRebuiltStream', () => {
   it('records a zero-delta PRN_REJECTED event when a producer rejects', () => {
     const result = computeRebuiltStream({
       accreditation,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
       wasteRecords: [
         {
           organisationId: 'org-1',
@@ -459,6 +478,8 @@ describe('computeRebuiltStream', () => {
   it('reverses both amount and availableAmount for a post-issue cancellation', () => {
     const result = computeRebuiltStream({
       accreditation,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
       wasteRecords: [
         {
           organisationId: 'org-1',
@@ -517,5 +538,338 @@ describe('computeRebuiltStream', () => {
     // PRN created, issued, then cancelled: net zero effect
     expect(result.amount).toBe(100)
     expect(result.availableAmount).toBe(100)
+  })
+
+  describe('event linkage for stream seeding', () => {
+    const registrationId = 'reg-1'
+    const organisationId = 'org-1'
+
+    const submittedRecord = (tonnage) => ({
+      organisationId,
+      registrationId,
+      type: 'received',
+      data: { processingType: 'INPUT', tonnage },
+      versions: [
+        {
+          summaryLog: { id: 'sl-1' },
+          data: { processingType: 'INPUT', tonnage }
+        }
+      ],
+      excludedFromWasteBalance: false
+    })
+
+    const submittedLog = (submittedBy) => ({
+      id: 'sl-1',
+      status: SUMMARY_LOG_STATUS.SUBMITTED,
+      submittedAt: '2025-01-15T10:00:00.000Z',
+      ...(submittedBy ? { submittedBy } : {})
+    })
+
+    it('attributes PRN events to the actor on the status history entry', () => {
+      const signatory = { id: 'sig-7', name: 'Sam Signatory' }
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 30,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.DRAFT,
+                  at: new Date('2025-01-20T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                },
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date('2025-01-21T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                },
+                {
+                  status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                  at: new Date('2025-01-22T00:00:00.000Z'),
+                  by: signatory
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: [submittedLog()]
+      })
+
+      const issued = result.events.find(
+        (e) => e.kind === STREAM_EVENT_KIND.PRN_ISSUED
+      )
+      expect(issued.createdBy).toEqual(signatory)
+    })
+
+    it('attributes summary-log events to the supplied submitter', () => {
+      const submitter = { id: 'usr-9', name: 'submitter@example.com' }
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [],
+        overseasSites,
+        summaryLogs: [submittedLog(submitter)]
+      })
+
+      expect(result.events[0].kind).toBe(
+        STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED
+      )
+      expect(result.events[0].createdBy).toEqual(submitter)
+    })
+
+    it('falls back to a system backfill actor when no submitter is supplied', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [],
+        overseasSites,
+        summaryLogs: [submittedLog()]
+      })
+
+      expect(result.events[0].createdBy).toEqual(BACKFILL_ACTOR)
+    })
+
+    it('sources registrationId and organisationId from parameters for a PRN-only accreditation', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId: 'reg-prn-only',
+        organisationId: 'org-prn-only',
+        wasteRecords: [],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 30,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date('2025-01-21T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: []
+      })
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].registrationId).toBe('reg-prn-only')
+      expect(result.events[0].organisationId).toBe('org-prn-only')
+      expect(result.events[0].accreditationId).toBe(accreditation.id)
+    })
+
+    it('orders a summary-log submission before a PRN event sharing its timestamp', () => {
+      const sharedInstant = '2025-01-15T10:00:00.000Z'
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 30,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.DRAFT,
+                  at: new Date('2025-01-10T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                },
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date(sharedInstant),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: [submittedLog()]
+      })
+
+      expect(result.events[0].kind).toBe(
+        STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED
+      )
+      expect(result.events[1].kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+    })
+
+    it('breaks PRN-vs-PRN timestamp ties by natural key', () => {
+      const sharedInstant = new Date('2025-01-21T00:00:00.000Z')
+      const createdAt = (id) => ({
+        id,
+        tonnage: 10,
+        status: {
+          history: [
+            {
+              status: PRN_STATUS.AWAITING_AUTHORISATION,
+              at: sharedInstant,
+              by: { id: 'rep-1', name: 'Rita Reprocessor' }
+            }
+          ]
+        }
+      })
+
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [],
+        prns: [createdAt('prn-zulu'), createdAt('prn-alpha')],
+        overseasSites,
+        summaryLogs: []
+      })
+
+      expect(result.events.map((e) => e.payload.prnId)).toEqual([
+        'prn-alpha',
+        'prn-zulu'
+      ])
+    })
+
+    it('throws on an impossible PRN status transition in history', () => {
+      expect(() =>
+        computeRebuiltStream({
+          accreditation,
+          registrationId,
+          organisationId,
+          wasteRecords: [],
+          prns: [
+            {
+              id: 'prn-1',
+              tonnage: 10,
+              status: {
+                history: [
+                  {
+                    status: PRN_STATUS.DRAFT,
+                    at: new Date('2025-01-20T00:00:00.000Z'),
+                    by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                  },
+                  {
+                    status: PRN_STATUS.AWAITING_AUTHORISATION,
+                    at: new Date('2025-01-21T00:00:00.000Z'),
+                    by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                  },
+                  {
+                    status: PRN_STATUS.AWAITING_CANCELLATION,
+                    at: new Date('2025-01-22T00:00:00.000Z'),
+                    by: { id: 'sig-1', name: 'Sam Signatory' }
+                  }
+                ]
+              }
+            }
+          ],
+          overseasSites,
+          summaryLogs: []
+        })
+      ).toThrow(/prn-1/)
+    })
+
+    it('skips a valid transition that maps to no balance event without throwing', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 10,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.DRAFT,
+                  at: new Date('2025-01-20T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                },
+                {
+                  status: PRN_STATUS.DISCARDED,
+                  at: new Date('2025-01-21T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: []
+      })
+
+      expect(result.events).toHaveLength(0)
+    })
+
+    it('throws when a history entry transitions from an unrecognised status', () => {
+      expect(() =>
+        computeRebuiltStream({
+          accreditation,
+          registrationId,
+          organisationId,
+          wasteRecords: [],
+          prns: [
+            {
+              id: 'prn-1',
+              tonnage: 10,
+              status: {
+                history: [
+                  {
+                    status: 'not-a-real-status',
+                    at: new Date('2025-01-20T00:00:00.000Z'),
+                    by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                  },
+                  {
+                    status: PRN_STATUS.DRAFT,
+                    at: new Date('2025-01-21T00:00:00.000Z'),
+                    by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                  }
+                ]
+              }
+            }
+          ],
+          overseasSites,
+          summaryLogs: []
+        })
+      ).toThrow(/prn-1/)
+    })
+
+    it('breaks summary-log timestamp ties by natural key', () => {
+      const sharedInstant = '2025-01-15T10:00:00.000Z'
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [],
+        prns: [],
+        overseasSites,
+        summaryLogs: [
+          {
+            id: 'sl-zulu',
+            status: SUMMARY_LOG_STATUS.SUBMITTED,
+            submittedAt: sharedInstant
+          },
+          {
+            id: 'sl-alpha',
+            status: SUMMARY_LOG_STATUS.SUBMITTED,
+            submittedAt: sharedInstant
+          }
+        ]
+      })
+
+      expect(result.events.map((e) => e.payload.summaryLogId)).toEqual([
+        'sl-alpha',
+        'sl-zulu'
+      ])
+    })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
The waste-balance event stream for an accreditation is rebuilt from authoritative sources (waste records, PRN status history, and submitted summary logs) by `computeRebuiltStream`. Until now that function produced an event list good enough to cross-check balance totals in the divergence diagnostic, but the events themselves were not safe to seed into the stream store: ordering relied on insertion order, every event was attributed to a placeholder `system`/`replay` actor, registration and organisation context were read from the first waste record (absent for a PRN-only accreditation), and source history that violated the PRN state machine was silently skipped.

This change makes the emitted events seedable:

- Events are placed in a total order — by timestamp, then a summary-log submission ahead of a PRN operation sharing the same instant (so the PRN op sees the post-submission balance), then by natural key — so a rebuild is reproducible rather than dependent on insertion order.
- Each event carries real linkage: PRN events take the actor from their status-history entry (reduced to id and name), summary-log events take an optional submitting actor supplied by the caller, and both fall back to an explicit system backfill actor when no real actor is available. Registration and organisation ids are sourced from explicit parameters rather than the first waste record, so a PRN-only accreditation produces valid events.
- A PRN history transition that maps to no balance event and is not a valid state-machine move now throws, naming the offending PRN, so corrupt source data surfaces during a rebuild instead of producing a silently wrong stream.
- The rebuild reports how many events fell back to the system backfill actor because no real actor was recoverable, and the divergence diagnostic logs a per-accreditation warning whenever that count is non-zero, so attribution gaps are visible before any stream is seeded.

The divergence diagnostic, the only current caller, is updated to pass the registration and organisation ids it already holds and to surface the backfill-actor warning.

Sourcing the real historical submitter for summary-log events, the registered-only stream partition, and using point-in-time exclusion state in per-event snapshots are tracked separately.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ