### PR TITLE
PAE-1382: Fold PRN on read in the external accept/reject path

### DIFF
--- a/src/packaging-recycling-notes/application/get-projected-prn.js
+++ b/src/packaging-recycling-notes/application/get-projected-prn.js
@@ -8,10 +8,32 @@ import { foldPrnFromTailEvents } from './fold-prn-from-tail-events.js'
  */
 
 /**
- * Reads a PRN and brings it current by folding any stream tail events past its
+ * Brings a fetched PRN current by folding any stream tail events past its
  * watermark, so callers receive the fully-formed PRN without touching the event
  * stream themselves. A missing or soft-deleted document short-circuits with no
  * stream query: a deleted PRN is terminal and has no further events to project.
+ *
+ * @param {PackagingRecyclingNote | null} prn
+ * @param {WasteBalancesRepository} wasteBalancesRepository
+ * @returns {Promise<PackagingRecyclingNote | null>}
+ */
+const projectFromStreamTail = async (prn, wasteBalancesRepository) => {
+  if (!prn || prn.status.currentStatus === PRN_STATUS.DELETED) {
+    return prn
+  }
+
+  const tailEvents = await wasteBalancesRepository.getPrnCatchupEvents({
+    registrationId: prn.registrationId,
+    accreditationId: prn.accreditation.id,
+    prnId: prn.id,
+    afterEventNumber: prn.lastAppliedEventNumber ?? 0
+  })
+
+  return foldPrnFromTailEvents(prn, tailEvents)
+}
+
+/**
+ * Reads a PRN by id and projects it from its stream tail.
  *
  * @param {Object} params
  * @param {PackagingRecyclingNotesRepository} params.packagingRecyclingNotesRepository
@@ -25,17 +47,25 @@ export const getProjectedPrnById = async ({
   prnId
 }) => {
   const prn = await packagingRecyclingNotesRepository.findById(prnId)
+  return projectFromStreamTail(prn, wasteBalancesRepository)
+}
 
-  if (!prn || prn.status.currentStatus === PRN_STATUS.DELETED) {
-    return prn
-  }
-
-  const tailEvents = await wasteBalancesRepository.getPrnCatchupEvents({
-    registrationId: prn.registrationId,
-    accreditationId: prn.accreditation.id,
-    prnId: prn.id,
-    afterEventNumber: prn.lastAppliedEventNumber ?? 0
-  })
-
-  return foldPrnFromTailEvents(prn, tailEvents)
+/**
+ * Reads a PRN by its public number and projects it from its stream tail. The
+ * external accept/reject path decides the next transition from the returned
+ * status, so folding here keeps that decision off a stale document.
+ *
+ * @param {Object} params
+ * @param {PackagingRecyclingNotesRepository} params.packagingRecyclingNotesRepository
+ * @param {WasteBalancesRepository} params.wasteBalancesRepository
+ * @param {string} params.prnNumber
+ * @returns {Promise<PackagingRecyclingNote | null>}
+ */
+export const getProjectedPrnByNumber = async ({
+  packagingRecyclingNotesRepository,
+  wasteBalancesRepository,
+  prnNumber
+}) => {
+  const prn = await packagingRecyclingNotesRepository.findByPrnNumber(prnNumber)
+  return projectFromStreamTail(prn, wasteBalancesRepository)
 }

--- a/src/packaging-recycling-notes/application/get-projected-prn.test.js
+++ b/src/packaging-recycling-notes/application/get-projected-prn.test.js
@@ -11,6 +11,11 @@ import {
   getProjectedPrnByNumber
 } from './get-projected-prn.js'
 
+/**
+ * @import { PackagingRecyclingNote } from '#packaging-recycling-notes/domain/model.js'
+ * @import { StreamEvent, StreamEventKind } from '#waste-balances/repository/stream-schema.js'
+ */
+
 const REG_ID = 'reg-789'
 const ACC_ID = 'acc-456'
 const ORG_ID = 'org-123'
@@ -31,7 +36,10 @@ const noopLogger = () =>
     child: () => {}
   })
 
-/** @param {object} [overrides] */
+/**
+ * @param {Partial<PackagingRecyclingNote>} [overrides]
+ * @returns {PackagingRecyclingNote}
+ */
 const buildPrn = (overrides = {}) => ({
   id: PRN_ID,
   schemaVersion: 2,
@@ -62,7 +70,12 @@ const buildPrn = (overrides = {}) => ({
   ...overrides
 })
 
-/** @param {string} kind @param {number} number @param {string} createdAt */
+/**
+ * @param {StreamEventKind} kind
+ * @param {number} number
+ * @param {string} createdAt
+ * @returns {StreamEvent}
+ */
 const buildEvent = (kind, number, createdAt) => ({
   id: `event-${number}`,
   registrationId: REG_ID,
@@ -95,8 +108,8 @@ const buildBalance = (canonicalSource) => ({
  * balance is what gates whether catch-up events are returned.
  *
  * @param {object} params
- * @param {object | null} [params.prn]
- * @param {object[]} [params.events]
+ * @param {PackagingRecyclingNote | null} [params.prn]
+ * @param {StreamEvent[]} [params.events]
  * @param {string} [params.canonicalSource]
  */
 const buildRepositories = ({
@@ -108,9 +121,7 @@ const buildRepositories = ({
     createInMemoryPackagingRecyclingNotesRepository(prn ? [prn] : [])(
       noopLogger()
     )
-  const streamRepository = createInMemoryStreamRepository(
-    /** @type {*} */ (events)
-  )()
+  const streamRepository = createInMemoryStreamRepository(events)()
   const wasteBalancesRepository = createInMemoryWasteBalancesRepository(
     [buildBalance(canonicalSource)],
     { streamRepository }

--- a/src/packaging-recycling-notes/application/get-projected-prn.test.js
+++ b/src/packaging-recycling-notes/application/get-projected-prn.test.js
@@ -1,189 +1,298 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 
 import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
-import { getProjectedPrnById } from './get-projected-prn.js'
+import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
+import { createInMemoryWasteBalancesRepository } from '#waste-balances/repository/inmemory.js'
+import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
+import {
+  getProjectedPrnById,
+  getProjectedPrnByNumber
+} from './get-projected-prn.js'
 
-/**
- * @typedef {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} PackagingRecyclingNote
- * @typedef {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepository
- * @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository
- */
+const REG_ID = 'reg-789'
+const ACC_ID = 'acc-456'
+const ORG_ID = 'org-123'
+const PRN_ID = '507f1f77bcf86cd799439011'
+const PRN_NUMBER = 'ER2600001'
+const baseAt = new Date('2026-01-15T10:00:00.000Z')
+const creator = { id: 'creator', name: 'Original Creator' }
+const eventActor = { id: 'user-1', name: 'Test User' }
 
-const baseUpdatedAt = new Date('2026-01-15T10:00:00.000Z')
-const baseCreator = { id: 'creator', name: 'Original Creator' }
+const noopLogger = () =>
+  /** @type {*} */ ({
+    info: () => {},
+    error: () => {},
+    warn: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => {}
+  })
 
-/**
- * @param {Partial<PackagingRecyclingNote>} [overrides]
- * @returns {PackagingRecyclingNote}
- */
-const buildPrn = (overrides = {}) =>
-  /** @type {PackagingRecyclingNote} */ (
-    /** @type {unknown} */ ({
-      id: 'prn-1',
-      registrationId: 'reg-1',
-      accreditation: { id: 'acc-1' },
-      organisation: { id: 'org-1' },
-      version: 1,
-      updatedAt: baseUpdatedAt,
-      updatedBy: baseCreator,
-      status: {
-        currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
-        currentStatusAt: baseUpdatedAt,
-        history: []
-      },
-      ...overrides
-    })
-  )
+/** @param {object} [overrides] */
+const buildPrn = (overrides = {}) => ({
+  id: PRN_ID,
+  schemaVersion: 2,
+  prnNumber: PRN_NUMBER,
+  registrationId: REG_ID,
+  organisation: { id: ORG_ID, name: 'Test Reprocessor' },
+  accreditation: {
+    id: ACC_ID,
+    accreditationNumber: 'ACC-1',
+    accreditationYear: 2026,
+    material: 'plastic',
+    submittedToRegulator: 'ea'
+  },
+  issuedToOrganisation: { id: 'producer-1', name: 'Producer Org' },
+  tonnage: 50,
+  isExport: false,
+  isDecemberWaste: false,
+  version: 1,
+  createdAt: baseAt,
+  createdBy: creator,
+  updatedAt: baseAt,
+  updatedBy: creator,
+  status: {
+    currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+    currentStatusAt: baseAt,
+    history: []
+  },
+  ...overrides
+})
 
-const eventCreator = { id: 'user-1', name: 'Test User' }
-
+/** @param {string} kind @param {number} number @param {string} createdAt */
 const buildEvent = (kind, number, createdAt) => ({
   id: `event-${number}`,
-  registrationId: 'reg-1',
-  accreditationId: 'acc-1',
-  organisationId: 'org-1',
+  registrationId: REG_ID,
+  accreditationId: ACC_ID,
+  organisationId: ORG_ID,
   number,
   kind,
-  payload: { prnId: 'prn-1', amount: 50 },
+  payload: { prnId: PRN_ID, amount: 50 },
   openingBalance: { amount: 100, availableAmount: 100 },
   closingBalance: { amount: 100, availableAmount: 50 },
   createdAt: new Date(createdAt),
-  createdBy: eventCreator
+  createdBy: eventActor
+})
+
+const buildBalance = (canonicalSource) => ({
+  id: 'wb-1',
+  accreditationId: ACC_ID,
+  organisationId: ORG_ID,
+  amount: 100,
+  availableAmount: 100,
+  transactions: [],
+  version: 0,
+  schemaVersion: 1,
+  canonicalSource
 })
 
 /**
- * @param {{ findById: import('vitest').Mock }} repo
- * @returns {PackagingRecyclingNotesRepository}
+ * Assembles the real in-memory adapters: the PRN store, the event stream, and
+ * the waste-balance store that shares that stream. The marker on the seeded
+ * balance is what gates whether catch-up events are returned.
+ *
+ * @param {object} params
+ * @param {object | null} [params.prn]
+ * @param {object[]} [params.events]
+ * @param {string} [params.canonicalSource]
  */
-const asPrnRepo = (repo) =>
-  /** @type {PackagingRecyclingNotesRepository} */ (
-    /** @type {unknown} */ (repo)
-  )
-
-/**
- * @param {{ getPrnCatchupEvents: import('vitest').Mock }} repo
- * @returns {WasteBalancesRepository}
- */
-const asWasteRepo = (repo) =>
-  /** @type {WasteBalancesRepository} */ (/** @type {unknown} */ (repo))
-
-/**
- * @param {{ prn?: PackagingRecyclingNote | null, tailEvents?: object[] }} setup
- */
-const setupRepositories = ({ prn = null, tailEvents = [] }) => ({
-  prnRepository: { findById: vi.fn(async () => prn) },
-  wasteBalancesRepository: {
-    getPrnCatchupEvents: vi.fn(async () => tailEvents)
-  }
-})
+const buildRepositories = ({
+  prn = null,
+  events = [],
+  canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+}) => {
+  const packagingRecyclingNotesRepository =
+    createInMemoryPackagingRecyclingNotesRepository(prn ? [prn] : [])(
+      noopLogger()
+    )
+  const streamRepository = createInMemoryStreamRepository(
+    /** @type {*} */ (events)
+  )()
+  const wasteBalancesRepository = createInMemoryWasteBalancesRepository(
+    [buildBalance(canonicalSource)],
+    { streamRepository }
+  )()
+  return { packagingRecyclingNotesRepository, wasteBalancesRepository }
+}
 
 describe('getProjectedPrnById', () => {
-  it('folds tail events onto the PRN and returns the projected note', async () => {
-    const prn = buildPrn({ lastAppliedEventNumber: 1 })
-    const { prnRepository, wasteBalancesRepository } = setupRepositories({
-      prn,
-      tailEvents: [
-        buildEvent(STREAM_EVENT_KIND.PRN_ISSUED, 2, '2026-02-02T12:00:00.000Z')
-      ]
-    })
+  it('folds tail events past the watermark onto the PRN', async () => {
+    const { packagingRecyclingNotesRepository, wasteBalancesRepository } =
+      buildRepositories({
+        prn: buildPrn({
+          status: {
+            currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+            currentStatusAt: baseAt,
+            history: []
+          }
+        }),
+        events: [
+          buildEvent(
+            STREAM_EVENT_KIND.PRN_ISSUED,
+            1,
+            '2026-02-02T12:00:00.000Z'
+          )
+        ]
+      })
 
     const result = await getProjectedPrnById({
-      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
-      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
-      prnId: 'prn-1'
+      packagingRecyclingNotesRepository,
+      wasteBalancesRepository,
+      prnId: PRN_ID
     })
 
     expect(result?.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+    expect(result?.lastAppliedEventNumber).toBe(1)
   })
 
-  it('queries catch-up events using the PRN watermark', async () => {
+  it('ignores events at or before the watermark', async () => {
+    const { packagingRecyclingNotesRepository, wasteBalancesRepository } =
+      buildRepositories({
+        prn: buildPrn({ version: 1, lastAppliedEventNumber: 1 }),
+        events: [
+          buildEvent(
+            STREAM_EVENT_KIND.PRN_ISSUED,
+            1,
+            '2026-02-01T12:00:00.000Z'
+          ),
+          buildEvent(
+            STREAM_EVENT_KIND.PRN_ACCEPTED,
+            2,
+            '2026-02-02T12:00:00.000Z'
+          )
+        ]
+      })
+
+    const result = await getProjectedPrnById({
+      packagingRecyclingNotesRepository,
+      wasteBalancesRepository,
+      prnId: PRN_ID
+    })
+
+    // Only event 2 is folded (event 1 is at the watermark): one version bump.
+    expect(result?.status.currentStatus).toBe(PRN_STATUS.ACCEPTED)
+    expect(result?.lastAppliedEventNumber).toBe(2)
+    expect(result?.version).toBe(2)
+  })
+
+  it('does not fold for an embedded-marker accreditation', async () => {
+    const { packagingRecyclingNotesRepository, wasteBalancesRepository } =
+      buildRepositories({
+        prn: buildPrn(),
+        events: [
+          buildEvent(
+            STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+            1,
+            '2026-02-02T12:00:00.000Z'
+          )
+        ],
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+
+    const result = await getProjectedPrnById({
+      packagingRecyclingNotesRepository,
+      wasteBalancesRepository,
+      prnId: PRN_ID
+    })
+
+    expect(result?.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+    expect(result?.version).toBe(1)
+  })
+
+  it('returns the PRN unchanged when the ledger stream has no later events', async () => {
     const prn = buildPrn({ lastAppliedEventNumber: 3 })
-    const { prnRepository, wasteBalancesRepository } = setupRepositories({
-      prn
-    })
-
-    await getProjectedPrnById({
-      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
-      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
-      prnId: 'prn-1'
-    })
-
-    expect(wasteBalancesRepository.getPrnCatchupEvents).toHaveBeenCalledWith({
-      registrationId: 'reg-1',
-      accreditationId: 'acc-1',
-      prnId: 'prn-1',
-      afterEventNumber: 3
-    })
-  })
-
-  it('defaults afterEventNumber to 0 when the PRN has no watermark', async () => {
-    const prn = buildPrn()
-    const { prnRepository, wasteBalancesRepository } = setupRepositories({
-      prn
-    })
-
-    await getProjectedPrnById({
-      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
-      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
-      prnId: 'prn-1'
-    })
-
-    expect(wasteBalancesRepository.getPrnCatchupEvents).toHaveBeenCalledWith(
-      expect.objectContaining({ afterEventNumber: 0 })
-    )
-  })
-
-  it('returns the PRN unchanged when no tail events exist', async () => {
-    const prn = buildPrn({ lastAppliedEventNumber: 2 })
-    const { prnRepository, wasteBalancesRepository } = setupRepositories({
-      prn,
-      tailEvents: []
-    })
+    const { packagingRecyclingNotesRepository, wasteBalancesRepository } =
+      buildRepositories({ prn })
 
     const result = await getProjectedPrnById({
-      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
-      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
-      prnId: 'prn-1'
+      packagingRecyclingNotesRepository,
+      wasteBalancesRepository,
+      prnId: PRN_ID
     })
 
-    expect(result).toBe(prn)
+    expect(result?.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+    expect(result?.version).toBe(1)
   })
 
-  it('returns null without querying the stream when the PRN does not exist', async () => {
-    const { prnRepository, wasteBalancesRepository } = setupRepositories({
-      prn: null
-    })
+  it('returns null when the PRN does not exist', async () => {
+    const { packagingRecyclingNotesRepository, wasteBalancesRepository } =
+      buildRepositories({ prn: null })
 
     const result = await getProjectedPrnById({
-      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
-      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
-      prnId: 'prn-1'
+      packagingRecyclingNotesRepository,
+      wasteBalancesRepository,
+      prnId: PRN_ID
     })
 
     expect(result).toBeNull()
-    expect(wasteBalancesRepository.getPrnCatchupEvents).not.toHaveBeenCalled()
   })
 
-  it('returns a soft-deleted PRN as-is without querying the stream', async () => {
-    const deletedPrn = buildPrn({
-      status: {
-        currentStatus: PRN_STATUS.DELETED,
-        currentStatusAt: baseUpdatedAt,
-        history: []
-      }
-    })
-    const { prnRepository, wasteBalancesRepository } = setupRepositories({
-      prn: deletedPrn
-    })
+  it('returns a soft-deleted PRN as-is without folding', async () => {
+    const { packagingRecyclingNotesRepository, wasteBalancesRepository } =
+      buildRepositories({
+        prn: buildPrn({
+          status: {
+            currentStatus: PRN_STATUS.DELETED,
+            currentStatusAt: baseAt,
+            history: []
+          }
+        }),
+        events: [
+          buildEvent(
+            STREAM_EVENT_KIND.PRN_ISSUED,
+            1,
+            '2026-02-02T12:00:00.000Z'
+          )
+        ]
+      })
 
     const result = await getProjectedPrnById({
-      packagingRecyclingNotesRepository: asPrnRepo(prnRepository),
-      wasteBalancesRepository: asWasteRepo(wasteBalancesRepository),
-      prnId: 'prn-1'
+      packagingRecyclingNotesRepository,
+      wasteBalancesRepository,
+      prnId: PRN_ID
     })
 
-    expect(result).toBe(deletedPrn)
-    expect(wasteBalancesRepository.getPrnCatchupEvents).not.toHaveBeenCalled()
+    expect(result?.status.currentStatus).toBe(PRN_STATUS.DELETED)
+    expect(result?.version).toBe(1)
+  })
+})
+
+describe('getProjectedPrnByNumber', () => {
+  it('folds the stream tail onto the PRN found by number', async () => {
+    const { packagingRecyclingNotesRepository, wasteBalancesRepository } =
+      buildRepositories({
+        prn: buildPrn(),
+        events: [
+          buildEvent(
+            STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+            1,
+            '2026-02-02T12:00:00.000Z'
+          )
+        ]
+      })
+
+    const result = await getProjectedPrnByNumber({
+      packagingRecyclingNotesRepository,
+      wasteBalancesRepository,
+      prnNumber: PRN_NUMBER
+    })
+
+    expect(result?.status.currentStatus).toBe(PRN_STATUS.CANCELLED)
+  })
+
+  it('returns null when no PRN matches the number', async () => {
+    const { packagingRecyclingNotesRepository, wasteBalancesRepository } =
+      buildRepositories({ prn: null })
+
+    const result = await getProjectedPrnByNumber({
+      packagingRecyclingNotesRepository,
+      wasteBalancesRepository,
+      prnNumber: 'NONEXISTENT'
+    })
+
+    expect(result).toBeNull()
   })
 })

--- a/src/packaging-recycling-notes/routes/accept.test.js
+++ b/src/packaging-recycling-notes/routes/accept.test.js
@@ -4,6 +4,7 @@ import {
   afterAll,
   afterEach,
   beforeAll,
+  beforeEach,
   describe,
   expect,
   it,
@@ -58,6 +59,7 @@ describe(`POST /v1/packaging-recycling-notes/{prnNumber}/accept`, () => {
       wasteBalancesRepository = {
         findByAccreditationId: vi.fn(),
         findByAccreditationIds: vi.fn(),
+        getPrnCatchupEvents: vi.fn().mockResolvedValue([]),
         deductAvailableBalanceForPrnCreation: vi.fn(),
         deductTotalBalanceForPrnIssue: vi.fn(),
         creditAvailableBalanceForPrnCancellation: vi.fn()
@@ -82,6 +84,12 @@ describe(`POST /v1/packaging-recycling-notes/{prnNumber}/accept`, () => {
 
     afterEach(() => {
       vi.resetAllMocks()
+    })
+
+    beforeEach(() => {
+      // resetAllMocks wipes implementations between tests; the read-side fold
+      // needs a stream-tail response on every transition.
+      wasteBalancesRepository.getPrnCatchupEvents.mockResolvedValue([])
     })
 
     afterAll(async () => {

--- a/src/packaging-recycling-notes/routes/external-transition-handler.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.js
@@ -121,7 +121,7 @@ export function createExternalTransitionHandler({
   }
 }
 
-function mapTransitionError(error, path, logger) {
+export function mapTransitionError(error, path, logger) {
   if (error instanceof StatusConflictError) {
     return Boom.conflict(error.message)
   }

--- a/src/packaging-recycling-notes/routes/external-transition-handler.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.js
@@ -12,6 +12,7 @@ import {
 } from '#packaging-recycling-notes/domain/model.js'
 import { updatePrnStatus } from '#packaging-recycling-notes/application/update-status.js'
 import { auditPrnStatusTransition } from '#packaging-recycling-notes/application/audit.js'
+import { getProjectedPrnByNumber } from '#packaging-recycling-notes/application/get-projected-prn.js'
 
 /**
  * @import { Request, Lifecycle } from '@hapi/hapi'
@@ -65,8 +66,11 @@ export function createExternalTransitionHandler({
       const { prnNumber } = params
 
       try {
-        const prn =
-          await packagingRecyclingNotesRepository.findByPrnNumber(prnNumber)
+        const prn = await getProjectedPrnByNumber({
+          packagingRecyclingNotesRepository,
+          wasteBalancesRepository,
+          prnNumber
+        })
 
         if (!prn) {
           throw Boom.notFound(

--- a/src/packaging-recycling-notes/routes/external-transition-handler.test.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.test.js
@@ -1,13 +1,125 @@
-import { vi, describe, it, expect } from 'vitest'
+import { describe, it, expect } from 'vitest'
 
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
-import { createMockIssuedPrn } from './test-helpers.js'
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
+import { createInMemoryWasteBalancesRepository } from '#waste-balances/repository/inmemory.js'
+import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
+import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createExternalTransitionHandler } from './external-transition-handler.js'
 
+const REG_ID = 'reg-789'
+const ACC_ID = 'acc-456'
+const ORG_ID = 'org-123'
+const PRN_ID = '507f1f77bcf86cd799439011'
+const PRN_NUMBER = 'ER2600001'
+const baseAt = new Date('2026-01-15T10:00:00.000Z')
+const actor = { id: 'rpd', name: 'RPD' }
+
+const noopLogger = () =>
+  /** @type {*} */ ({
+    info: () => {},
+    error: () => {},
+    warn: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => {}
+  })
+
+/** @param {string} currentStatus */
+const buildPrn = (currentStatus) => ({
+  id: PRN_ID,
+  schemaVersion: 2,
+  prnNumber: PRN_NUMBER,
+  registrationId: REG_ID,
+  organisation: { id: ORG_ID, name: 'Test Reprocessor' },
+  accreditation: {
+    id: ACC_ID,
+    accreditationNumber: 'ACC-1',
+    accreditationYear: 2026,
+    material: 'plastic',
+    submittedToRegulator: 'ea'
+  },
+  issuedToOrganisation: { id: 'producer-1', name: 'Producer Org' },
+  tonnage: 50,
+  isExport: false,
+  isDecemberWaste: false,
+  version: 1,
+  createdAt: baseAt,
+  createdBy: actor,
+  updatedAt: baseAt,
+  updatedBy: actor,
+  status: { currentStatus, currentStatusAt: baseAt, history: [] }
+})
+
+/** @param {string} kind @param {number} number */
+const buildEvent = (kind, number) => ({
+  id: `event-${number}`,
+  registrationId: REG_ID,
+  accreditationId: ACC_ID,
+  organisationId: ORG_ID,
+  number,
+  kind,
+  payload: { prnId: PRN_ID, amount: 50 },
+  openingBalance: { amount: 100, availableAmount: 100 },
+  closingBalance: { amount: 100, availableAmount: 50 },
+  createdAt: new Date('2026-02-01T10:00:00.000Z'),
+  createdBy: { id: 'signatory', name: 'Signatory' }
+})
+
+/**
+ * @param {object} params
+ * @param {string} params.currentStatus
+ * @param {object[]} [params.events]
+ * @param {string} [params.canonicalSource]
+ */
+const buildRequest = ({
+  currentStatus,
+  events = [],
+  canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+}) => {
+  const streamRepository = createInMemoryStreamRepository(
+    /** @type {*} */ (events)
+  )()
+  return {
+    packagingRecyclingNotesRepository:
+      createInMemoryPackagingRecyclingNotesRepository([
+        buildPrn(currentStatus)
+      ])(noopLogger()),
+    wasteBalancesRepository: createInMemoryWasteBalancesRepository(
+      [
+        {
+          id: 'wb-1',
+          accreditationId: ACC_ID,
+          organisationId: ORG_ID,
+          amount: 100,
+          availableAmount: 100,
+          transactions: [],
+          version: 0,
+          schemaVersion: 1,
+          canonicalSource
+        }
+      ],
+      { streamRepository }
+    )(),
+    organisationsRepository: createInMemoryOrganisationsRepository([])(),
+    params: { prnNumber: PRN_NUMBER },
+    payload: null,
+    logger: noopLogger(),
+    auth: { credentials: actor }
+  }
+}
+
+const h = {
+  response: () => ({ code: () => {} })
+}
+
 describe('createExternalTransitionHandler', () => {
-  it('returns 400 when actor is not permitted for the transition', async () => {
-    // AWAITING_CANCELLATION → CANCELLED exists but only for SIGNATORY actor.
-    // The factory always uses PRODUCER, so this triggers UnauthorisedTransitionError.
+  it('returns 400 when the actor is not permitted for the transition', () => {
+    // AWAITING_CANCELLATION → CANCELLED exists but only for the SIGNATORY
+    // actor; the factory always uses PRODUCER, so this is unauthorised.
     const { handler } = createExternalTransitionHandler({
       newStatus: PRN_STATUS.CANCELLED,
       timestampField: 'cancelledAt',
@@ -15,37 +127,36 @@ describe('createExternalTransitionHandler', () => {
       path: '/test'
     })
 
-    const awaitingCancellationPrn = createMockIssuedPrn({
-      status: {
-        currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
-        history: [
-          {
-            status: PRN_STATUS.AWAITING_CANCELLATION,
-            updatedAt: new Date()
-          }
-        ]
-      }
+    const request = buildRequest({
+      currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
     })
 
-    const request = {
-      packagingRecyclingNotesRepository: {
-        findByPrnNumber: vi.fn().mockResolvedValue(awaitingCancellationPrn)
-      },
-      wasteBalancesRepository: {},
-      organisationsRepository: {},
-      params: { prnNumber: 'ER2600001' },
-      payload: null,
-      logger: { info: vi.fn(), error: vi.fn() },
-      auth: { credentials: { id: 'rpd', name: 'RPD' } }
-    }
-
-    const h = {
-      response: vi.fn(() => ({ code: vi.fn() }))
-    }
-
-    await expect(handler(request, h)).rejects.toMatchObject({
+    return expect(handler(request, h)).rejects.toMatchObject({
       isBoom: true,
       output: { statusCode: 400 }
+    })
+  })
+
+  it('folds the stream tail before validating, rejecting an accept on a PRN the stream has already cancelled', () => {
+    // The persisted doc is stale at awaiting_acceptance, but a cancel event in
+    // the ledger stream means the PRN is really cancelled. Folding on read puts
+    // the transition decision on the true status instead of the stale doc.
+    const { handler } = createExternalTransitionHandler({
+      newStatus: PRN_STATUS.ACCEPTED,
+      timestampField: 'acceptedAt',
+      actionVerb: 'accepted',
+      path: '/test'
+    })
+
+    const request = buildRequest({
+      currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+      events: [buildEvent(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE, 1)]
+    })
+
+    return expect(handler(request, h)).rejects.toMatchObject({
+      isBoom: true,
+      output: { statusCode: 409 }
     })
   })
 })

--- a/src/packaging-recycling-notes/routes/external-transition-handler.test.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.test.js
@@ -1,13 +1,38 @@
-import { describe, it, expect } from 'vitest'
+import { StatusCodes } from 'http-status-codes'
+import { randomUUID } from 'node:crypto'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { MATERIAL, REGULATOR } from '#domain/organisations/model.js'
+import {
+  PRN_ACTOR,
+  PRN_STATUS,
+  UnauthorisedTransitionError
+} from '#packaging-recycling-notes/domain/model.js'
 import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { config } from '#root/config.js'
+import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
 import { createInMemoryWasteBalancesRepository } from '#waste-balances/repository/inmemory.js'
 import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
-import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
-import { createExternalTransitionHandler } from './external-transition-handler.js'
+import { createTestServer } from '#test/create-test-server.js'
+import {
+  setupAuthContext,
+  cognitoJwksUrl
+} from '#vite/helpers/setup-auth-mocking.js'
+import { generateExternalApiToken } from './test-helpers.js'
+import { mapTransitionError } from './external-transition-handler.js'
+
+/**
+ * @import { PackagingRecyclingNote, PrnStatus } from '#packaging-recycling-notes/domain/model.js'
+ * @import { StreamEvent, StreamEventKind } from '#waste-balances/repository/stream-schema.js'
+ */
+
+const mockCdpAuditing = vi.fn()
+
+vi.mock('@defra/cdp-auditing', () => ({
+  audit: (...args) => mockCdpAuditing(...args)
+}))
 
 const REG_ID = 'reg-789'
 const ACC_ID = 'acc-456'
@@ -15,20 +40,19 @@ const ORG_ID = 'org-123'
 const PRN_ID = '507f1f77bcf86cd799439011'
 const PRN_NUMBER = 'ER2600001'
 const baseAt = new Date('2026-01-15T10:00:00.000Z')
-const actor = { id: 'rpd', name: 'RPD' }
+const eventAt = new Date('2026-02-01T10:00:00.000Z')
+const actor = { id: 'creator', name: 'Creator' }
 
-const noopLogger = () =>
-  /** @type {*} */ ({
-    info: () => {},
-    error: () => {},
-    warn: () => {},
-    debug: () => {},
-    trace: () => {},
-    fatal: () => {},
-    child: () => {}
-  })
+const externalApiClientId = randomUUID()
+const acceptUrl = `/v1/packaging-recycling-notes/${PRN_NUMBER}/accept`
+const authHeaders = {
+  authorization: `Bearer ${generateExternalApiToken(externalApiClientId)}`
+}
 
-/** @param {string} currentStatus */
+/**
+ * @param {PrnStatus} currentStatus
+ * @returns {PackagingRecyclingNote}
+ */
 const buildPrn = (currentStatus) => ({
   id: PRN_ID,
   schemaVersion: 2,
@@ -39,8 +63,8 @@ const buildPrn = (currentStatus) => ({
     id: ACC_ID,
     accreditationNumber: 'ACC-1',
     accreditationYear: 2026,
-    material: 'plastic',
-    submittedToRegulator: 'ea'
+    material: MATERIAL.PLASTIC,
+    submittedToRegulator: REGULATOR.EA
   },
   issuedToOrganisation: { id: 'producer-1', name: 'Producer Org' },
   tonnage: 50,
@@ -54,7 +78,11 @@ const buildPrn = (currentStatus) => ({
   status: { currentStatus, currentStatusAt: baseAt, history: [] }
 })
 
-/** @param {string} kind @param {number} number */
+/**
+ * @param {StreamEventKind} kind
+ * @param {number} number
+ * @returns {StreamEvent}
+ */
 const buildEvent = (kind, number) => ({
   id: `event-${number}`,
   registrationId: REG_ID,
@@ -65,98 +93,119 @@ const buildEvent = (kind, number) => ({
   payload: { prnId: PRN_ID, amount: 50 },
   openingBalance: { amount: 100, availableAmount: 100 },
   closingBalance: { amount: 100, availableAmount: 50 },
-  createdAt: new Date('2026-02-01T10:00:00.000Z'),
+  createdAt: eventAt,
   createdBy: { id: 'signatory', name: 'Signatory' }
 })
 
+const buildBalance = (canonicalSource) => ({
+  id: 'wb-1',
+  accreditationId: ACC_ID,
+  organisationId: ORG_ID,
+  amount: 100,
+  availableAmount: 100,
+  transactions: [],
+  version: 0,
+  schemaVersion: 1,
+  canonicalSource
+})
+
+let server
+
 /**
+ * Starts a test server wired with real in-memory adapters: the PRN store, the
+ * event stream, and the waste-balance store sharing that stream. The marker on
+ * the seeded balance is what gates whether the read-side fold runs.
+ *
  * @param {object} params
- * @param {string} params.currentStatus
- * @param {object[]} [params.events]
- * @param {string} [params.canonicalSource]
+ * @param {PrnStatus} params.currentStatus
+ * @param {StreamEvent[]} params.events
+ * @param {string} params.canonicalSource
  */
-const buildRequest = ({
-  currentStatus,
-  events = [],
-  canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
-}) => {
-  const streamRepository = createInMemoryStreamRepository(
-    /** @type {*} */ (events)
-  )()
-  return {
-    packagingRecyclingNotesRepository:
-      createInMemoryPackagingRecyclingNotesRepository([
-        buildPrn(currentStatus)
-      ])(noopLogger()),
-    wasteBalancesRepository: createInMemoryWasteBalancesRepository(
-      [
-        {
-          id: 'wb-1',
-          accreditationId: ACC_ID,
-          organisationId: ORG_ID,
-          amount: 100,
-          availableAmount: 100,
-          transactions: [],
-          version: 0,
-          schemaVersion: 1,
-          canonicalSource
-        }
-      ],
-      { streamRepository }
-    )(),
-    organisationsRepository: createInMemoryOrganisationsRepository([])(),
-    params: { prnNumber: PRN_NUMBER },
-    payload: null,
-    logger: noopLogger(),
-    auth: { credentials: actor }
-  }
+const startServer = async ({ currentStatus, events, canonicalSource }) => {
+  const streamRepository = createInMemoryStreamRepository(events)()
+  server = await createTestServer({
+    config: {
+      packagingRecyclingNotesExternalApi: {
+        clientId: externalApiClientId,
+        jwksUrl: cognitoJwksUrl
+      }
+    },
+    repositories: {
+      packagingRecyclingNotesRepository:
+        createInMemoryPackagingRecyclingNotesRepository([
+          buildPrn(currentStatus)
+        ]),
+      wasteBalancesRepository: createInMemoryWasteBalancesRepository(
+        [buildBalance(canonicalSource)],
+        { streamRepository }
+      ),
+      organisationsRepository: () => ({})
+    },
+    featureFlags: createInMemoryFeatureFlags()
+  })
+  return server
 }
 
-const h = {
-  response: () => ({ code: () => {} })
-}
+describe('external PRN transition read-side fold', () => {
+  setupAuthContext()
 
-describe('createExternalTransitionHandler', () => {
-  it('returns 400 when the actor is not permitted for the transition', () => {
-    // AWAITING_CANCELLATION → CANCELLED exists but only for the SIGNATORY
-    // actor; the factory always uses PRODUCER, so this is unauthorised.
-    const { handler } = createExternalTransitionHandler({
-      newStatus: PRN_STATUS.CANCELLED,
-      timestampField: 'cancelledAt',
-      actionVerb: 'cancelled',
-      path: '/test'
+  afterEach(async () => {
+    await server.stop()
+    config.reset('packagingRecyclingNotesExternalApi.clientId')
+  })
+
+  it('rejects an accept on a ledger PRN the stream has already cancelled', async () => {
+    // The persisted doc is stale at awaiting_acceptance, but a cancel event in
+    // the ledger stream means the PRN is really cancelled. Folding on read puts
+    // the transition decision on the true status, so the accept conflicts.
+    await startServer({
+      currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+      events: [buildEvent(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE, 1)],
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
     })
 
-    const request = buildRequest({
-      currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
+    const response = await server.inject({
+      method: 'POST',
+      url: acceptUrl,
+      headers: authHeaders
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+  })
+
+  it('accepts an embedded PRN even when the stream shows it cancelled', async () => {
+    // For an embedded-marker accreditation the fold is a no-op, so the same
+    // stream cancel event is ignored and the accept proceeds off the doc.
+    await startServer({
+      currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+      events: [buildEvent(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE, 1)],
       canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
     })
 
-    return expect(handler(request, h)).rejects.toMatchObject({
-      isBoom: true,
-      output: { statusCode: 400 }
+    const response = await server.inject({
+      method: 'POST',
+      url: acceptUrl,
+      headers: authHeaders
     })
+
+    expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
   })
+})
 
-  it('folds the stream tail before validating, rejecting an accept on a PRN the stream has already cancelled', () => {
-    // The persisted doc is stale at awaiting_acceptance, but a cancel event in
-    // the ledger stream means the PRN is really cancelled. Folding on read puts
-    // the transition decision on the true status instead of the stale doc.
-    const { handler } = createExternalTransitionHandler({
-      newStatus: PRN_STATUS.ACCEPTED,
-      timestampField: 'acceptedAt',
-      actionVerb: 'accepted',
-      path: '/test'
-    })
+describe('mapTransitionError', () => {
+  // Both wired external routes (accept, reject) drive PRODUCER-only transitions,
+  // so a wrong-actor error never arises through them. The mapping is exercised
+  // here directly to keep the generic handler's 400 path verified.
+  it('maps an unauthorised transition to a 400', () => {
+    const error = new UnauthorisedTransitionError(
+      PRN_STATUS.AWAITING_CANCELLATION,
+      PRN_STATUS.CANCELLED,
+      PRN_ACTOR.PRODUCER
+    )
 
-    const request = buildRequest({
-      currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
-      events: [buildEvent(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE, 1)]
-    })
+    const result = mapTransitionError(error, '/test', { error: () => {} })
 
-    return expect(handler(request, h)).rejects.toMatchObject({
-      isBoom: true,
-      output: { statusCode: 409 }
-    })
+    expect(result.isBoom).toBe(true)
+    expect(result.output.statusCode).toBe(StatusCodes.BAD_REQUEST)
   })
 })

--- a/src/packaging-recycling-notes/routes/reject.test.js
+++ b/src/packaging-recycling-notes/routes/reject.test.js
@@ -64,7 +64,8 @@ describe(`POST /v1/packaging-recycling-notes/{prnNumber}/reject`, () => {
           packagingRecyclingNotesRepository: () =>
             packagingRecyclingNotesRepository,
           wasteBalancesRepository: () => ({
-            findByAccreditationId: vi.fn().mockResolvedValue(null)
+            findByAccreditationId: vi.fn().mockResolvedValue(null),
+            getPrnCatchupEvents: vi.fn().mockResolvedValue([])
           }),
           organisationsRepository: () => ({})
         },


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
The external PRN accept and reject endpoints (`POST /v1/packaging-recycling-notes/{prnNumber}/accept` and `/reject`) read the PRN with `findByPrnNumber` and fed the raw document straight into the transition logic, which decides the next status from `status.currentStatus`. For an accreditation whose balance has migrated to the event-sourced stream (`canonicalSource: 'ledger'`), the PRN document is a projection of that stream; if a status event is appended but the projection write does not land — an infra-level partial failure — the document is left stale. Deciding a transition from that stale status could append a contradictory event to the stream, an unrecoverable wrong write. The get-by-id read already guards against this by folding the stream tail; this path did not fold at all.

This change makes the accept/reject path fold the PRN's stream tail on read before the transition decision, using the same projection as the get-by-id route. `get-projected-prn.js` now exposes a shared projection core consumed by both `getProjectedPrnById` and a new `getProjectedPrnByNumber`, and the external transition handler reads through the latter. The fold is gated by the ledger marker, so for embedded accreditations — all of production while the feature flag is off — it is a no-op and behaviour is unchanged.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ