### PR TITLE
PAE-1542: Assert organisation audit logs via in-memory repository read-back

### DIFF
--- a/src/auditing/organisations.test.js
+++ b/src/auditing/organisations.test.js
@@ -1,9 +1,10 @@
 import { auditOrganisationUpdate } from './organisations.js'
-import { vi, describe, it, beforeEach, afterEach } from 'vitest'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { logger } from '#common/helpers/logging/logger.js'
+import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest'
 import { randomBytes } from 'crypto'
 
 const mockAudit = vi.fn()
-const mockInsert = vi.fn()
 
 vi.mock('@defra/cdp-auditing', () => ({
   audit: (...args) => mockAudit(...args)
@@ -11,10 +12,14 @@ vi.mock('@defra/cdp-auditing', () => ({
 
 describe('auditOrganisationUpdate', () => {
   const now = new Date('2026-01-06T15:47:00.000Z')
+  const organisationId = 'org-id-001'
+
+  let systemLogsRepository
 
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(now)
+    systemLogsRepository = createSystemLogsRepository()(logger)
   })
 
   afterEach(() => {
@@ -22,21 +27,32 @@ describe('auditOrganisationUpdate', () => {
     vi.clearAllMocks()
   })
 
-  const organisationId = 'org-id-001'
+  const createRequest = () =>
+    /** @type {import('#common/hapi-types.js').HapiRequest & {systemLogsRepository: import('#repositories/system-logs/port.js').SystemLogsRepository}} */ ({
+      systemLogsRepository
+    })
 
-  const createMockRequest = () => ({
-    systemLogsRepository: {
-      insert: mockInsert
-    }
-  })
+  const findStoredLogs = async () => {
+    const { systemLogs } = await systemLogsRepository.find({
+      organisationId,
+      limit: 10
+    })
+    return systemLogs
+  }
+
+  const expectedEvent = {
+    action: 'update',
+    category: 'entity',
+    subCategory: 'epr-organisations'
+  }
 
   describe('large payload handling', () => {
-    it('captures context.previous and context.next in both the audit and system log for small payloads', async () => {
+    it('records context.previous and context.next in both the audit and the stored system log for small payloads', async () => {
       const previous = { version: '1' }
       const next = { version: '2' }
 
       await auditOrganisationUpdate(
-        createMockRequest(),
+        createRequest(),
         organisationId,
         previous,
         next
@@ -44,34 +60,25 @@ describe('auditOrganisationUpdate', () => {
 
       expect(mockAudit).toHaveBeenCalledWith(
         expect.objectContaining({
-          event: {
-            action: 'update',
-            category: 'entity',
-            subCategory: 'epr-organisations'
-          },
+          event: expectedEvent,
           context: { organisationId, previous, next }
         })
       )
 
-      expect(mockInsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          event: {
-            action: 'update',
-            category: 'entity',
-            subCategory: 'epr-organisations'
-          },
-          context: { organisationId, previous, next }
-        })
-      )
+      const storedLogs = await findStoredLogs()
+      expect(storedLogs).toHaveLength(1)
+      expect(storedLogs[0].event).toEqual(expectedEvent)
+      expect(storedLogs[0].context).toEqual({ organisationId, previous, next })
+      expect(storedLogs[0].createdAt).toEqual(now)
     })
 
-    it('omits context.previous and context.next from the audit event for large payloads', async () => {
+    it('omits context.previous and context.next from the audit event but keeps them in the stored system log for large payloads', async () => {
       const veryLongString = randomBytes(1e6).toString('hex')
       const previous = { version: '1', veryLongString }
       const next = { version: '2', veryLongString }
 
       await auditOrganisationUpdate(
-        createMockRequest(),
+        createRequest(),
         organisationId,
         previous,
         next
@@ -79,25 +86,15 @@ describe('auditOrganisationUpdate', () => {
 
       expect(mockAudit).toHaveBeenCalledWith(
         expect.objectContaining({
-          event: {
-            action: 'update',
-            category: 'entity',
-            subCategory: 'epr-organisations'
-          },
+          event: expectedEvent,
           context: { organisationId }
         })
       )
 
-      expect(mockInsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          event: {
-            action: 'update',
-            category: 'entity',
-            subCategory: 'epr-organisations'
-          },
-          context: { organisationId, previous, next }
-        })
-      )
+      const storedLogs = await findStoredLogs()
+      expect(storedLogs).toHaveLength(1)
+      expect(storedLogs[0].event).toEqual(expectedEvent)
+      expect(storedLogs[0].context).toEqual({ organisationId, previous, next })
     })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1542](https://eaflood.atlassian.net/browse/PAE-1542)
The test for `auditOrganisationUpdate` stubbed the system-logs repository with a `vi.fn()` and asserted that `insert` was called with a particular payload. That verifies an interaction — how the code calls the repository — rather than the behaviour that matters: that the audit record is stored and is retrievable afterwards with the right information in the right place. A spy assertion still passes if a field is written under the wrong key or if a later read would not find the record.

This converts the test to use the real in-memory system-logs repository. It drives `auditOrganisationUpdate`, then reads the record back through the repository's `find` and asserts the stored `event`, `context`, and `createdAt`. The oversized-payload case still proves the divergence between the two sinks: the CDP audit event drops `previous`/`next`, while the stored system log retains the full context. The CDP auditing client has no in-memory equivalent, so it stays mocked.

This is the first conversion under PAE-1542; further test files that stub repositories with `vi.fn()` will be migrated to the existing in-memory adapters on this branch.


[PAE-1542]: https://eaflood.atlassian.net/browse/PAE-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ