### PR TITLE
fix: resolve ledger balances when registrationId is missing

### DIFF
--- a/src/server/load-accreditation-sources.js
+++ b/src/server/load-accreditation-sources.js
@@ -1,0 +1,104 @@
+import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
+import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
+
+/** @type {Set<import('#domain/organisations/registration.js').Registration['status']>} */
+const ACTIVE_REGISTRATION_STATUSES = new Set([
+  REG_ACC_STATUS.APPROVED,
+  REG_ACC_STATUS.CANCELLED,
+  REG_ACC_STATUS.SUSPENDED
+])
+
+/**
+ * Map a summary log document from findAllByOrgReg into the shape that
+ * computeRebuiltStream expects. Uses summaryLog.file.id (the file
+ * identifier stored on waste record versions) rather than the document
+ * _id, which is a different namespace.
+ *
+ * @param {{ summaryLog: { file: { id: string }, status: string, submittedAt?: string } }} doc
+ */
+export const toStreamSummaryLog = ({ summaryLog }) => ({
+  id: summaryLog.file.id,
+  status: summaryLog.status,
+  submittedAt: summaryLog.submittedAt
+})
+
+/**
+ * @typedef {Object} AccreditationSourceDeps
+ * @property {import('#repositories/organisations/port.js').OrganisationsRepository} organisationsRepository
+ * @property {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} prnRepository
+ * @property {import('#repositories/waste-records/port.js').WasteRecordsRepository} wasteRecordsRepository
+ * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
+ * @property {import('#repositories/summary-logs/port.js').SummaryLogsRepository} summaryLogsRepository
+ */
+
+/**
+ * Load the organisation, registration, and accreditation for a balance row,
+ * then fetch all authoritative sources needed to rebuild the event stream
+ * or recompute totals.
+ *
+ * @param {{ accreditationId: string, organisationId: string }} row
+ * @param {AccreditationSourceDeps} deps
+ */
+export const loadAccreditationSources = async (row, deps) => {
+  const {
+    organisationsRepository,
+    prnRepository,
+    wasteRecordsRepository,
+    overseasSitesRepository,
+    summaryLogsRepository
+  } = deps
+
+  const organisation = await organisationsRepository.findById(
+    row.organisationId
+  )
+  const accreditation = organisation.accreditations.find(
+    (a) => a.id === row.accreditationId
+  )
+  if (!accreditation) {
+    throw new Error(
+      `Accreditation ${row.accreditationId} not found on organisation ${row.organisationId}`
+    )
+  }
+  const registration = organisation.registrations.find(
+    (r) =>
+      r.accreditationId === row.accreditationId &&
+      ACTIVE_REGISTRATION_STATUSES.has(r.status)
+  )
+  if (!registration) {
+    throw new Error(
+      `No registration links to accreditation ${row.accreditationId} on organisation ${row.organisationId}`
+    )
+  }
+
+  const wasteRecords = await wasteRecordsRepository.findByRegistration(
+    row.organisationId,
+    registration.id
+  )
+  const prns = await prnRepository.findByAccreditation(row.accreditationId)
+  const overseasSites = await resolveOverseasSites(
+    organisationsRepository,
+    overseasSitesRepository,
+    row.organisationId,
+    registration.id
+  )
+  const summaryLogDocs = await summaryLogsRepository.findAllByOrgReg(
+    row.organisationId,
+    registration.id
+  )
+
+  const summaryLogs = summaryLogDocs
+    .filter(
+      ({ summaryLog }) => summaryLog.status === SUMMARY_LOG_STATUS.SUBMITTED
+    )
+    .map(toStreamSummaryLog)
+
+  return {
+    accreditation,
+    registration,
+    wasteRecords,
+    prns,
+    overseasSites,
+    summaryLogs
+  }
+}

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -1,5 +1,4 @@
 import { logger } from '#common/helpers/logging/logger.js'
-import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
 import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
 import { createOverseasSitesRepository } from '#overseas-sites/repository/mongodb.js'
 import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/mongodb.js'
@@ -7,16 +6,8 @@ import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
 import { computeRebuiltTotals } from '#waste-balances/application/compute-rebuilt-totals.js'
 import { computeRebuiltStream } from '#waste-balances/application/compute-rebuilt-stream.js'
+import { loadAccreditationSources } from '#server/load-accreditation-sources.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
-import { REG_ACC_STATUS } from '#domain/organisations/model.js'
-import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
-
-/** @type {Set<import('#domain/organisations/registration.js').Registration['status']>} */
-const ACTIVE_REGISTRATION_STATUSES = new Set([
-  REG_ACC_STATUS.APPROVED,
-  REG_ACC_STATUS.CANCELLED,
-  REG_ACC_STATUS.SUSPENDED
-])
 
 const WASTE_BALANCES_COLLECTION = 'waste-balances'
 const LOCK_NAME = 'balance-divergence-diagnostic'
@@ -63,19 +54,8 @@ const findEmbeddedWasteBalances = async (db) => {
   return /** @type {EmbeddedBalanceRow[]} */ (/** @type {unknown} */ (docs))
 }
 
-/**
- * Map a summary log document from findAllByOrgReg into the shape that
- * computeRebuiltStream expects. Uses summaryLog.file.id (the file
- * identifier stored on waste record versions) rather than the document
- * _id, which is a different namespace.
- *
- * @param {{ summaryLog: { file: { id: string }, status: string, submittedAt?: string } }} doc
- */
-export const toStreamSummaryLog = ({ summaryLog }) => ({
-  id: summaryLog.file.id,
-  status: summaryLog.status,
-  submittedAt: summaryLog.submittedAt
-})
+// Re-export for callers that import from here
+export { toStreamSummaryLog } from '#server/load-accreditation-sources.js'
 
 const formatDelta = (current, rebuilt) =>
   Number((rebuilt - current).toFixed(10))
@@ -91,48 +71,9 @@ const formatDelta = (current, rebuilt) =>
  * @param {DiagnosticDependencies} deps
  */
 const compareForEmbedded = async (embedded, deps) => {
-  const {
-    organisationsRepository,
-    prnRepository,
-    wasteRecordsRepository,
-    overseasSitesRepository,
-    summaryLogsRepository
-  } = deps
-
-  const organisation = await organisationsRepository.findById(
-    embedded.organisationId
-  )
-  const accreditation = organisation.accreditations.find(
-    (a) => a.id === embedded.accreditationId
-  )
-  if (!accreditation) {
-    throw new Error(
-      `Accreditation ${embedded.accreditationId} not found on organisation ${embedded.organisationId}`
-    )
-  }
-  const registration = organisation.registrations.find(
-    (r) =>
-      r.accreditationId === embedded.accreditationId &&
-      ACTIVE_REGISTRATION_STATUSES.has(r.status)
-  )
-  if (!registration) {
-    throw new Error(
-      `No registration links to accreditation ${embedded.accreditationId} on organisation ${embedded.organisationId}`
-    )
-  }
-
-  const wasteRecords = await wasteRecordsRepository.findByRegistration(
-    embedded.organisationId,
-    registration.id
-  )
-  const prns = await prnRepository.findByAccreditation(embedded.accreditationId)
-
-  const overseasSites = await resolveOverseasSites(
-    organisationsRepository,
-    overseasSitesRepository,
-    embedded.organisationId,
-    registration.id
-  )
+  const sources = await loadAccreditationSources(embedded, deps)
+  const { accreditation, registration, wasteRecords, prns, overseasSites } =
+    sources
 
   const rebuilt = computeRebuiltTotals({
     accreditation,
@@ -141,11 +82,6 @@ const compareForEmbedded = async (embedded, deps) => {
     overseasSites
   })
 
-  const summaryLogDocs = await summaryLogsRepository.findAllByOrgReg(
-    embedded.organisationId,
-    registration.id
-  )
-
   const stream = computeRebuiltStream({
     accreditation,
     registrationId: registration.id,
@@ -153,11 +89,7 @@ const compareForEmbedded = async (embedded, deps) => {
     wasteRecords,
     prns,
     overseasSites,
-    summaryLogs: summaryLogDocs
-      .filter(
-        ({ summaryLog }) => summaryLog.status === SUMMARY_LOG_STATUS.SUBMITTED
-      )
-      .map(toStreamSummaryLog)
+    summaryLogs: sources.summaryLogs
   })
 
   return buildComparison(

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -1,6 +1,5 @@
 import { logger } from '#common/helpers/logging/logger.js'
 import { getConfig } from '#root/config.js'
-import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
 import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
 import { createOverseasSitesRepository } from '#overseas-sites/repository/mongodb.js'
 import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/mongodb.js'
@@ -9,17 +8,8 @@ import { createWasteRecordsRepository } from '#repositories/waste-records/mongod
 import { createWasteBalancesRepository } from '#waste-balances/repository/mongodb.js'
 import { createMongoStreamRepository } from '#waste-balances/repository/stream-mongodb.js'
 import { computeRebuiltStream } from '#waste-balances/application/compute-rebuilt-stream.js'
-import { toStreamSummaryLog } from '#server/run-balance-divergence-diagnostic.js'
+import { loadAccreditationSources } from '#server/load-accreditation-sources.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
-import { REG_ACC_STATUS } from '#domain/organisations/model.js'
-import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
-
-/** @type {Set<import('#domain/organisations/registration.js').Registration['status']>} */
-const ACTIVE_REGISTRATION_STATUSES = new Set([
-  REG_ACC_STATUS.APPROVED,
-  REG_ACC_STATUS.CANCELLED,
-  REG_ACC_STATUS.SUSPENDED
-])
 
 const WASTE_BALANCES_COLLECTION = 'waste-balances'
 const LOCK_NAME = 'stream-promotion'
@@ -80,76 +70,13 @@ const findEmbeddedBalances = async (db) => {
  */
 
 /**
- * @param {{ accreditationId: string, organisationId: string, registrationId: string }} row
- * @param {PromotionDependencies} deps
- */
-/**
- * Load the organisation, registration, and accreditation for a balance row,
- * then rebuild the event stream from authoritative sources.
- *
  * @param {{ accreditationId: string, organisationId: string }} row
  * @param {PromotionDependencies} deps
  */
 const rebuildEvents = async (row, deps) => {
-  const {
-    organisationsRepository,
-    prnRepository,
-    wasteRecordsRepository,
-    overseasSitesRepository,
-    summaryLogsRepository
-  } = deps
-
-  const organisation = await organisationsRepository.findById(
-    row.organisationId
-  )
-  const accreditation = organisation.accreditations.find(
-    (a) => a.id === row.accreditationId
-  )
-  if (!accreditation) {
-    throw new Error(
-      `Accreditation ${row.accreditationId} not found on organisation ${row.organisationId}`
-    )
-  }
-  const registration = organisation.registrations.find(
-    (r) =>
-      r.accreditationId === row.accreditationId &&
-      ACTIVE_REGISTRATION_STATUSES.has(r.status)
-  )
-  if (!registration) {
-    throw new Error(
-      `No registration links to accreditation ${row.accreditationId} on organisation ${row.organisationId}`
-    )
-  }
-
-  const wasteRecords = await wasteRecordsRepository.findByRegistration(
-    row.organisationId,
-    registration.id
-  )
-  const prns = await prnRepository.findByAccreditation(row.accreditationId)
-  const overseasSites = await resolveOverseasSites(
-    organisationsRepository,
-    overseasSitesRepository,
-    row.organisationId,
-    registration.id
-  )
-  const summaryLogDocs = await summaryLogsRepository.findAllByOrgReg(
-    row.organisationId,
-    registration.id
-  )
-
-  const { events } = computeRebuiltStream({
-    accreditation,
-    wasteRecords,
-    prns,
-    overseasSites,
-    summaryLogs: summaryLogDocs
-      .filter(
-        ({ summaryLog }) => summaryLog.status === SUMMARY_LOG_STATUS.SUBMITTED
-      )
-      .map(toStreamSummaryLog)
-  })
-
-  return { events, registration }
+  const sources = await loadAccreditationSources(row, deps)
+  const { events } = computeRebuiltStream(sources)
+  return { events, registration: sources.registration }
 }
 
 /**

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -177,8 +177,8 @@ const promoteAccreditation = async (row, deps) => {
     })
 
   if (
-    !migratingResult ||
-    migratingResult.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+    migratingResult?.canonicalSource !==
+    WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
   ) {
     return 'skipped'
   }
@@ -201,10 +201,7 @@ const promoteAccreditation = async (row, deps) => {
       capturedVersion: afterStream.version
     })
 
-  if (
-    !ledgerResult ||
-    ledgerResult.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
-  ) {
+  if (ledgerResult?.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER) {
     logger.info({
       message: `Stream promotion: flip to ledger did not land for accreditation ${row.accreditationId}, will retry next boot`
     })

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -85,7 +85,15 @@ const rebuildEvents = async (row, deps) => {
     }
     throw error
   }
-  const { events } = computeRebuiltStream(sources)
+  const { events } = computeRebuiltStream({
+    accreditation: sources.accreditation,
+    registrationId: sources.registration.id,
+    organisationId: row.organisationId,
+    wasteRecords: sources.wasteRecords,
+    prns: sources.prns,
+    overseasSites: sources.overseasSites,
+    summaryLogs: sources.summaryLogs
+  })
   return { events, registration: sources.registration }
 }
 

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -1,0 +1,351 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import { getConfig } from '#root/config.js'
+import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
+import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
+import { createOverseasSitesRepository } from '#overseas-sites/repository/mongodb.js'
+import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/mongodb.js'
+import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.js'
+import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
+import { createWasteBalancesRepository } from '#waste-balances/repository/mongodb.js'
+import { createMongoStreamRepository } from '#waste-balances/repository/stream-mongodb.js'
+import { computeRebuiltStream } from '#waste-balances/application/compute-rebuilt-stream.js'
+import { toStreamSummaryLog } from '#server/run-balance-divergence-diagnostic.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
+
+/** @type {Set<import('#domain/organisations/registration.js').Registration['status']>} */
+const ACTIVE_REGISTRATION_STATUSES = new Set([
+  REG_ACC_STATUS.APPROVED,
+  REG_ACC_STATUS.CANCELLED,
+  REG_ACC_STATUS.SUSPENDED
+])
+
+const WASTE_BALANCES_COLLECTION = 'waste-balances'
+const LOCK_NAME = 'stream-promotion'
+
+/**
+ * @param {import('mongodb').Db} db
+ */
+const findMigratingBalances = async (db) => {
+  const docs = await db
+    .collection(WASTE_BALANCES_COLLECTION)
+    .find(
+      { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING },
+      {
+        projection: {
+          _id: 0,
+          accreditationId: 1
+        }
+      }
+    )
+    .toArray()
+  return /** @type {{ accreditationId: string }[]} */ (
+    /** @type {unknown} */ (docs)
+  )
+}
+
+/**
+ * @param {import('mongodb').Db} db
+ */
+const findEmbeddedBalances = async (db) => {
+  const docs = await db
+    .collection(WASTE_BALANCES_COLLECTION)
+    .find(
+      { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED },
+      {
+        projection: {
+          _id: 0,
+          accreditationId: 1,
+          organisationId: 1,
+          registrationId: 1
+        }
+      }
+    )
+    .toArray()
+  return /** @type {{ accreditationId: string, organisationId: string, registrationId: string }[]} */ (
+    /** @type {unknown} */ (docs)
+  )
+}
+
+/**
+ * @typedef {Object} PromotionDependencies
+ * @property {ReturnType<import('#waste-balances/repository/port.js').WasteBalancesRepositoryFactory>} wasteBalancesRepository
+ * @property {import('#waste-balances/repository/stream-port.js').WasteBalanceStreamRepository} streamRepository
+ * @property {import('#repositories/organisations/port.js').OrganisationsRepository} organisationsRepository
+ * @property {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} prnRepository
+ * @property {import('#repositories/waste-records/port.js').WasteRecordsRepository} wasteRecordsRepository
+ * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
+ * @property {import('#repositories/summary-logs/port.js').SummaryLogsRepository} summaryLogsRepository
+ */
+
+/**
+ * @param {{ accreditationId: string, organisationId: string, registrationId: string }} row
+ * @param {PromotionDependencies} deps
+ */
+/**
+ * Load the organisation, registration, and accreditation for a balance row,
+ * then rebuild the event stream from authoritative sources.
+ *
+ * @param {{ accreditationId: string, organisationId: string }} row
+ * @param {PromotionDependencies} deps
+ */
+const rebuildEvents = async (row, deps) => {
+  const {
+    organisationsRepository,
+    prnRepository,
+    wasteRecordsRepository,
+    overseasSitesRepository,
+    summaryLogsRepository
+  } = deps
+
+  const organisation = await organisationsRepository.findById(
+    row.organisationId
+  )
+  const accreditation = organisation.accreditations.find(
+    (a) => a.id === row.accreditationId
+  )
+  if (!accreditation) {
+    throw new Error(
+      `Accreditation ${row.accreditationId} not found on organisation ${row.organisationId}`
+    )
+  }
+  const registration = organisation.registrations.find(
+    (r) =>
+      r.accreditationId === row.accreditationId &&
+      ACTIVE_REGISTRATION_STATUSES.has(r.status)
+  )
+  if (!registration) {
+    throw new Error(
+      `No registration links to accreditation ${row.accreditationId} on organisation ${row.organisationId}`
+    )
+  }
+
+  const wasteRecords = await wasteRecordsRepository.findByRegistration(
+    row.organisationId,
+    registration.id
+  )
+  const prns = await prnRepository.findByAccreditation(row.accreditationId)
+  const overseasSites = await resolveOverseasSites(
+    organisationsRepository,
+    overseasSitesRepository,
+    row.organisationId,
+    registration.id
+  )
+  const summaryLogDocs = await summaryLogsRepository.findAllByOrgReg(
+    row.organisationId,
+    registration.id
+  )
+
+  const { events } = computeRebuiltStream({
+    accreditation,
+    wasteRecords,
+    prns,
+    overseasSites,
+    summaryLogs: summaryLogDocs
+      .filter(
+        ({ summaryLog }) => summaryLog.status === SUMMARY_LOG_STATUS.SUBMITTED
+      )
+      .map(toStreamSummaryLog)
+  })
+
+  return { events, registration }
+}
+
+/**
+ * @param {{ accreditationId: string, organisationId: string, registrationId: string }} row
+ * @param {PromotionDependencies} deps
+ */
+const promoteAccreditation = async (row, deps) => {
+  const { wasteBalancesRepository, streamRepository } = deps
+
+  const { events, registration } = await rebuildEvents(row, deps)
+
+  const captured = await wasteBalancesRepository.findByAccreditationId(
+    row.accreditationId
+  )
+  if (!captured) {
+    throw new Error(
+      `No waste balance found for accreditation ${row.accreditationId}`
+    )
+  }
+
+  const migratingResult =
+    await wasteBalancesRepository.flipCanonicalSourceToMigrating({
+      accreditationId: row.accreditationId,
+      capturedVersion: captured.version
+    })
+
+  if (
+    !migratingResult ||
+    migratingResult.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+  ) {
+    return 'skipped'
+  }
+
+  await streamRepository.deleteByPartition(registration.id, row.accreditationId)
+  await streamRepository.bulkAppendEvents(events)
+
+  const afterStream = await wasteBalancesRepository.findByAccreditationId(
+    row.accreditationId
+  )
+  if (!afterStream) {
+    throw new Error(
+      `Waste balance disappeared for accreditation ${row.accreditationId}`
+    )
+  }
+
+  const ledgerResult =
+    await wasteBalancesRepository.flipCanonicalSourceToLedger({
+      accreditationId: row.accreditationId,
+      capturedVersion: afterStream.version
+    })
+
+  if (
+    !ledgerResult ||
+    ledgerResult.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+  ) {
+    logger.info({
+      message: `Stream promotion: flip to ledger did not land for accreditation ${row.accreditationId}, will retry next boot`
+    })
+    return 'failed'
+  }
+
+  return 'promoted'
+}
+
+/**
+ * @param {Object} server
+ * @returns {Promise<PromotionDependencies>}
+ */
+const buildDependencies = async (server) => {
+  const streamRepositoryFactory = await createMongoStreamRepository(server.db)
+  const streamRepository = streamRepositoryFactory()
+
+  const wasteBalancesFactory = await createWasteBalancesRepository(server.db, {
+    streamRepository
+  })
+  const wasteBalancesRepository = wasteBalancesFactory()
+
+  const organisationsRepository = (
+    await createOrganisationsRepository(server.db)
+  )()
+  const wasteRecordsRepository = (
+    await createWasteRecordsRepository(server.db)
+  )()
+  const prnRepositoryFactory = await createPackagingRecyclingNotesRepository(
+    server.db,
+    []
+  )
+  const prnRepository = prnRepositoryFactory(logger)
+  const overseasSitesRepository = (
+    await createOverseasSitesRepository(server.db)
+  )()
+  const summaryLogsRepository = (
+    await createSummaryLogsRepository(server.db, /** @type {any} */ ({}))
+  )(logger)
+
+  return {
+    wasteBalancesRepository,
+    streamRepository,
+    organisationsRepository,
+    wasteRecordsRepository,
+    prnRepository,
+    overseasSitesRepository,
+    summaryLogsRepository
+  }
+}
+
+/**
+ * @param {import('mongodb').Db} db
+ * @param {PromotionDependencies} deps
+ */
+const runPromotion = async (db, deps) => {
+  logger.info({
+    message: 'Running stream promotion'
+  })
+
+  // Recovery pass: reset stuck migrating accreditations
+  const migrating = await findMigratingBalances(db)
+  for (const row of migrating) {
+    logger.info({
+      message: `Stream promotion: resetting stuck migrating accreditation ${row.accreditationId}`
+    })
+    await deps.wasteBalancesRepository.resetCanonicalSourceToEmbedded({
+      accreditationId: row.accreditationId
+    })
+  }
+
+  // Main pass: promote all embedded accreditations
+  const embedded = await findEmbeddedBalances(db)
+
+  let promoted = 0
+  let skipped = 0
+  let failed = 0
+
+  for (const row of embedded) {
+    try {
+      const result = await promoteAccreditation(row, deps)
+      if (result === 'promoted') {
+        promoted += 1
+      } else if (result === 'failed') {
+        failed += 1
+      } else {
+        skipped += 1
+      }
+    } catch (error) {
+      failed += 1
+      logger.info({
+        message: `Stream promotion failed: accreditationId=${row.accreditationId} error="${error.message}"`
+      })
+    }
+  }
+
+  logger.info({
+    message: `Stream promotion complete: promoted=${promoted} skipped=${skipped} failed=${failed}`
+  })
+}
+
+/**
+ * Startup sweep that migrates each embedded accreditation to the event-sourced
+ * stream. For each accreditation: reconstructs the full event history via
+ * computeRebuiltStream, persists the events, and flips the canonical source
+ * marker from 'embedded' to 'ledger'.
+ *
+ * Runs behind FEATURE_FLAG_WASTE_BALANCE_LEDGER under a distributed lock so
+ * only one pod per deploy executes the sweep. Idempotent on restart: stuck
+ * 'migrating' accreditations are reset before the main pass, and stream
+ * events are deleted and re-inserted before each flip.
+ *
+ * @param {Object} server - Hapi server instance
+ */
+export const runStreamPromotion = async (server) => {
+  const config = getConfig()
+  if (!config.get('featureFlags.wasteBalanceLedger')) {
+    logger.info({
+      message: 'Stream promotion disabled (feature flag off)'
+    })
+    return
+  }
+
+  try {
+    const lock = await server.locker.lock(LOCK_NAME)
+    if (!lock) {
+      logger.info({
+        message: 'Unable to obtain lock, skipping stream promotion'
+      })
+      return
+    }
+    try {
+      const deps = await buildDependencies(server)
+      await runPromotion(server.db, deps)
+    } finally {
+      await lock.free()
+    }
+  } catch (error) {
+    logger.error({
+      err: error,
+      message: 'Failed to run stream promotion'
+    })
+  }
+}

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -296,13 +296,14 @@ const runPromotion = async (db, deps) => {
       }
     } catch (error) {
       failed += 1
-      logger.info({
+      logger.error({
         message: `Stream promotion failed: accreditationId=${row.accreditationId} error="${error.message}"`
       })
     }
   }
 
-  logger.info({
+  const summaryLevel = failed > 0 ? 'warn' : 'info'
+  logger[summaryLevel]({
     message: `Stream promotion complete: promoted=${promoted} skipped=${skipped} failed=${failed}`
   })
 }

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -192,19 +192,14 @@ const promoteAccreditation = async (row, deps) => {
   await streamRepository.deleteByPartition(registration.id, row.accreditationId)
   await streamRepository.bulkAppendEvents(events)
 
-  const afterStream = await wasteBalancesRepository.findByAccreditationId(
-    row.accreditationId
-  )
-  if (!afterStream) {
-    throw new Error(
-      `Waste balance disappeared for accreditation ${row.accreditationId}`
-    )
-  }
-
+  // Use the ORIGINAL captured version, not a re-read. If a concurrent
+  // mutation (PRN op or summary log upload) bumped version while we were
+  // migrating, the filter misses and the flip no-ops. The accreditation
+  // retries next boot with fresh data that includes the mutation.
   const ledgerResult =
     await wasteBalancesRepository.flipCanonicalSourceToLedger({
       accreditationId: row.accreditationId,
-      capturedVersion: afterStream.version
+      capturedVersion: captured.version
     })
 
   if (ledgerResult?.canonicalSource !== WASTE_BALANCE_CANONICAL_SOURCE.LEDGER) {

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -72,9 +72,19 @@ const findEmbeddedBalances = async (db) => {
 /**
  * @param {{ accreditationId: string, organisationId: string }} row
  * @param {PromotionDependencies} deps
+ * @returns {Promise<{ events: Array, registration: { id: string } } | null>}
+ *   null when the accreditation has no active registration (nothing to rebuild)
  */
 const rebuildEvents = async (row, deps) => {
-  const sources = await loadAccreditationSources(row, deps)
+  let sources
+  try {
+    sources = await loadAccreditationSources(row, deps)
+  } catch (error) {
+    if (error.message?.startsWith('No registration links to accreditation')) {
+      return null
+    }
+    throw error
+  }
   const { events } = computeRebuiltStream(sources)
   return { events, registration: sources.registration }
 }
@@ -98,7 +108,7 @@ const promoteAccreditation = async (row, deps) => {
     )
   }
 
-  const { events, registration } = await rebuildEvents(row, deps)
+  const rebuildResult = await rebuildEvents(row, deps)
 
   const migratingResult =
     await wasteBalancesRepository.flipCanonicalSourceToMigrating({
@@ -113,14 +123,24 @@ const promoteAccreditation = async (row, deps) => {
     return 'skipped'
   }
 
-  // Idempotency: if a previous boot crashed between bulkAppendEvents and
-  // flipCanonicalSourceToLedger, stale events may exist. Deleting first
-  // means a restart always replays from the authoritative sources rather
-  // than appending on top of a partial write. An alternative would be to
-  // skip the delete and let bulkAppendEvents fail on a sequence conflict,
-  // but that turns a recoverable restart into a stuck accreditation.
-  await streamRepository.deleteByPartition(registration.id, row.accreditationId)
-  await streamRepository.bulkAppendEvents(events)
+  if (rebuildResult) {
+    const { events, registration } = rebuildResult
+    // Idempotency: if a previous boot crashed between bulkAppendEvents and
+    // flipCanonicalSourceToLedger, stale events may exist. Deleting first
+    // means a restart always replays from the authoritative sources rather
+    // than appending on top of a partial write. An alternative would be to
+    // skip the delete and let bulkAppendEvents fail on a sequence conflict,
+    // but that turns a recoverable restart into a stuck accreditation.
+    await streamRepository.deleteByPartition(
+      registration.id,
+      row.accreditationId
+    )
+    await streamRepository.bulkAppendEvents(events)
+  } else {
+    logger.info({
+      message: `Stream promotion: no active registration for accreditation ${row.accreditationId}, promoting with empty stream`
+    })
+  }
 
   // Use the ORIGINAL captured version, not a re-read. If a concurrent
   // mutation (PRN op or summary log upload) bumped version while we were

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -159,8 +159,9 @@ const rebuildEvents = async (row, deps) => {
 const promoteAccreditation = async (row, deps) => {
   const { wasteBalancesRepository, streamRepository } = deps
 
-  const { events, registration } = await rebuildEvents(row, deps)
-
+  // Capture version BEFORE rebuilding events. A submission that writes waste
+  // records and bumps version during rebuildEvents must push version past
+  // the capture so the flip safely no-ops (retried next boot with fresh data).
   const captured = await wasteBalancesRepository.findByAccreditationId(
     row.accreditationId
   )
@@ -169,6 +170,8 @@ const promoteAccreditation = async (row, deps) => {
       `No waste balance found for accreditation ${row.accreditationId}`
     )
   }
+
+  const { events, registration } = await rebuildEvents(row, deps)
 
   const migratingResult =
     await wasteBalancesRepository.flipCanonicalSourceToMigrating({

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -183,6 +183,12 @@ const promoteAccreditation = async (row, deps) => {
     return 'skipped'
   }
 
+  // Idempotency: if a previous boot crashed between bulkAppendEvents and
+  // flipCanonicalSourceToLedger, stale events may exist. Deleting first
+  // means a restart always replays from the authoritative sources rather
+  // than appending on top of a partial write. An alternative would be to
+  // skip the delete and let bulkAppendEvents fail on a sequence conflict,
+  // but that turns a recoverable restart into a stuck accreditation.
   await streamRepository.deleteByPartition(registration.id, row.accreditationId)
   await streamRepository.bulkAppendEvents(events)
 

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -321,6 +321,72 @@ describe('runStreamPromotion', () => {
     )
   })
 
+  it('counts as failed when a concurrent mutation bumps version during migration', async () => {
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([
+      {
+        accreditationId: 'acc-race',
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+    ])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    organisationsRepository.findById.mockResolvedValue({
+      id: 'org-1',
+      registrations: [
+        {
+          id: 'reg-1',
+          accreditationId: 'acc-race',
+          registrationNumber: 'CBDU1',
+          status: 'approved'
+        }
+      ],
+      accreditations: [
+        { id: 'acc-race', accreditationNumber: 'CBDA1', status: 'approved' }
+      ]
+    })
+
+    // First read: version 1 (used for flipToMigrating)
+    // Second read: version 2 (a PRN op bumped it during migration)
+    wasteBalancesRepository.findByAccreditationId
+      .mockResolvedValueOnce({
+        accreditationId: 'acc-race',
+        version: 1,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+      .mockResolvedValueOnce({
+        accreditationId: 'acc-race',
+        version: 2,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      })
+
+    // flipToLedger should use the ORIGINAL version (1), which won't match
+    // the live document (version 2), so it no-ops
+    wasteBalancesRepository.flipCanonicalSourceToLedger.mockResolvedValue({
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+    })
+
+    await runStreamPromotion(mockServer)
+
+    // flipToLedger must use the pre-migration version, not the re-read
+    expect(
+      wasteBalancesRepository.flipCanonicalSourceToLedger
+    ).toHaveBeenCalledWith({
+      accreditationId: 'acc-race',
+      capturedVersion: 1
+    })
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringMatching(/failed=1/)
+      })
+    )
+  })
+
   it('skips an accreditation that is already on the ledger after flip-to-migrating', async () => {
     const migratingToArray = vi.fn().mockResolvedValue([])
     const embeddedToArray = vi.fn().mockResolvedValue([
@@ -510,52 +576,6 @@ describe('runStreamPromotion', () => {
     })
 
     // findByAccreditationId returns null (default mock)
-
-    await runStreamPromotion(mockServer)
-
-    expect(logger.info).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining('failed=1')
-      })
-    )
-  })
-
-  it('counts as failed when waste balance disappears after stream write', async () => {
-    const migratingToArray = vi.fn().mockResolvedValue([])
-    const embeddedToArray = vi.fn().mockResolvedValue([
-      {
-        accreditationId: 'acc-vanish',
-        organisationId: 'org-1',
-        registrationId: 'reg-1'
-      }
-    ])
-
-    mockFindBalances
-      .mockReturnValueOnce({ toArray: migratingToArray })
-      .mockReturnValueOnce({ toArray: embeddedToArray })
-
-    organisationsRepository.findById.mockResolvedValue({
-      id: 'org-1',
-      registrations: [
-        {
-          id: 'reg-1',
-          accreditationId: 'acc-vanish',
-          registrationNumber: 'CBDU1',
-          status: 'approved'
-        }
-      ],
-      accreditations: [
-        { id: 'acc-vanish', accreditationNumber: 'CBDA1', status: 'approved' }
-      ]
-    })
-
-    wasteBalancesRepository.findByAccreditationId
-      .mockResolvedValueOnce({
-        accreditationId: 'acc-vanish',
-        version: 1,
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
-      })
-      .mockResolvedValueOnce(null) // disappeared after stream write
 
     await runStreamPromotion(mockServer)
 

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -149,8 +149,10 @@ describe('runStreamPromotion', () => {
       () => summaryLogsRepository
     )
 
-    vi.mocked(createOverseasSitesRepository).mockResolvedValue(() => ({}))
-    vi.mocked(resolveOverseasSites).mockResolvedValue([])
+    vi.mocked(createOverseasSitesRepository).mockResolvedValue(
+      () => /** @type {*} */ ({})
+    )
+    vi.mocked(resolveOverseasSites).mockResolvedValue(/** @type {*} */ ([]))
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 0,
@@ -275,9 +277,9 @@ describe('runStreamPromotion', () => {
       }
     ])
 
-    const builtEvents = [
+    const builtEvents = /** @type {*} */ ([
       { registrationId: 'reg-1', accreditationId: 'acc-1', number: 1 }
-    ]
+    ])
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: builtEvents,
       amount: 100,

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -504,6 +504,12 @@ describe('runStreamPromotion', () => {
       .mockReturnValueOnce({ toArray: migratingToArray })
       .mockReturnValueOnce({ toArray: embeddedToArray })
 
+    wasteBalancesRepository.findByAccreditationId.mockResolvedValue({
+      accreditationId: 'acc-missing',
+      version: 1,
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+    })
+
     // Default org mock has empty accreditations array
 
     await runStreamPromotion(mockServer)
@@ -528,6 +534,12 @@ describe('runStreamPromotion', () => {
     mockFindBalances
       .mockReturnValueOnce({ toArray: migratingToArray })
       .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    wasteBalancesRepository.findByAccreditationId.mockResolvedValue({
+      accreditationId: 'acc-noreg',
+      version: 1,
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+    })
 
     organisationsRepository.findById.mockResolvedValue({
       id: 'org-1',

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -522,7 +522,7 @@ describe('runStreamPromotion', () => {
     )
   })
 
-  it('counts as failed when no registration links to accreditation', async () => {
+  it('promotes with empty stream when no active registration exists', async () => {
     const migratingToArray = vi.fn().mockResolvedValue([])
     const embeddedToArray = vi.fn().mockResolvedValue([
       {
@@ -552,9 +552,26 @@ describe('runStreamPromotion', () => {
 
     await runStreamPromotion(mockServer)
 
-    expect(logger.warn).toHaveBeenCalledWith(
+    // No stream writes for accreditations without active registrations
+    expect(streamRepository.deleteByPartition).not.toHaveBeenCalled()
+    expect(streamRepository.bulkAppendEvents).not.toHaveBeenCalled()
+
+    // Still flips to ledger
+    expect(
+      wasteBalancesRepository.flipCanonicalSourceToLedger
+    ).toHaveBeenCalledWith({
+      accreditationId: 'acc-noreg',
+      capturedVersion: 1
+    })
+
+    expect(logger.info).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: expect.stringContaining('failed=1')
+        message: expect.stringContaining('no active registration')
+      })
+    )
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('promoted=1')
       })
     )
   })

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -18,6 +18,7 @@ import { runStreamPromotion } from './run-stream-promotion.js'
 vi.mock('#common/helpers/logging/logger.js', () => ({
   logger: {
     info: vi.fn(),
+    warn: vi.fn(),
     error: vi.fn()
   }
 }))
@@ -380,7 +381,7 @@ describe('runStreamPromotion', () => {
       capturedVersion: 1
     })
 
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringMatching(/failed=1/)
       })
@@ -514,7 +515,7 @@ describe('runStreamPromotion', () => {
 
     await runStreamPromotion(mockServer)
 
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining('failed=1')
       })
@@ -551,7 +552,7 @@ describe('runStreamPromotion', () => {
 
     await runStreamPromotion(mockServer)
 
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining('failed=1')
       })
@@ -591,7 +592,7 @@ describe('runStreamPromotion', () => {
 
     await runStreamPromotion(mockServer)
 
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining('failed=1')
       })
@@ -644,7 +645,7 @@ describe('runStreamPromotion', () => {
         message: expect.stringContaining('will retry next boot')
       })
     )
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringMatching(/failed=1/)
       })

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -1,0 +1,637 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { logger } from '#common/helpers/logging/logger.js'
+import { getConfig } from '#root/config.js'
+import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
+import { createOverseasSitesRepository } from '#overseas-sites/repository/mongodb.js'
+import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/mongodb.js'
+import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
+import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.js'
+import { createWasteBalancesRepository } from '#waste-balances/repository/mongodb.js'
+import { createMongoStreamRepository } from '#waste-balances/repository/stream-mongodb.js'
+import { computeRebuiltStream } from '#waste-balances/application/compute-rebuilt-stream.js'
+import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+
+import { runStreamPromotion } from './run-stream-promotion.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+vi.mock('#root/config.js', () => ({
+  getConfig: vi.fn()
+}))
+vi.mock('#repositories/organisations/mongodb.js', () => ({
+  createOrganisationsRepository: vi.fn()
+}))
+vi.mock('#repositories/waste-records/mongodb.js', () => ({
+  createWasteRecordsRepository: vi.fn()
+}))
+vi.mock('#packaging-recycling-notes/repository/mongodb.js', () => ({
+  createPackagingRecyclingNotesRepository: vi.fn()
+}))
+vi.mock('#overseas-sites/repository/mongodb.js', () => ({
+  createOverseasSitesRepository: vi.fn()
+}))
+vi.mock('#repositories/summary-logs/mongodb.js', () => ({
+  createSummaryLogsRepository: vi.fn()
+}))
+vi.mock('#waste-balances/repository/mongodb.js', () => ({
+  createWasteBalancesRepository: vi.fn()
+}))
+vi.mock('#waste-balances/repository/stream-mongodb.js', () => ({
+  createMongoStreamRepository: vi.fn()
+}))
+vi.mock('#waste-balances/application/compute-rebuilt-stream.js', () => ({
+  computeRebuiltStream: vi.fn()
+}))
+vi.mock('#application/waste-records/resolve-overseas-sites.js', () => ({
+  resolveOverseasSites: vi.fn()
+}))
+
+describe('runStreamPromotion', () => {
+  let mockServer
+  let mockLock
+  let mockConfig
+  let wasteBalancesRepository
+  let streamRepository
+  let organisationsRepository
+  let wasteRecordsRepository
+  let prnRepository
+  let summaryLogsRepository
+  let mockFindBalances
+  let mockToArray
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockLock = { free: vi.fn().mockResolvedValue(undefined) }
+
+    mockToArray = vi.fn().mockResolvedValue([])
+    mockFindBalances = vi.fn().mockReturnValue({ toArray: mockToArray })
+    const db = {
+      collection: vi.fn().mockReturnValue({ find: mockFindBalances })
+    }
+
+    mockServer = {
+      db,
+      locker: { lock: vi.fn().mockResolvedValue(mockLock) }
+    }
+
+    mockConfig = {
+      get: vi.fn((key) => {
+        if (key === 'featureFlags.wasteBalanceLedger') return true
+        return undefined
+      })
+    }
+    vi.mocked(getConfig).mockReturnValue(/** @type {*} */ (mockConfig))
+
+    wasteBalancesRepository = {
+      findByAccreditationId: vi.fn().mockResolvedValue(null),
+      flipCanonicalSourceToMigrating: vi.fn().mockResolvedValue({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      }),
+      flipCanonicalSourceToLedger: vi.fn().mockResolvedValue({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      }),
+      resetCanonicalSourceToEmbedded: vi.fn().mockResolvedValue({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+    }
+    vi.mocked(createWasteBalancesRepository).mockResolvedValue(
+      () => wasteBalancesRepository
+    )
+
+    streamRepository = {
+      appendEvent: vi.fn(),
+      findLatestByPartition: vi.fn().mockResolvedValue(null),
+      findLatestByPartitionAndKind: vi.fn().mockResolvedValue(null),
+      findEventsByPrnIdAfter: vi.fn().mockResolvedValue([]),
+      deleteByPartition: vi.fn().mockResolvedValue(0),
+      bulkAppendEvents: vi.fn().mockResolvedValue([])
+    }
+    vi.mocked(createMongoStreamRepository).mockResolvedValue(
+      () => streamRepository
+    )
+
+    organisationsRepository = {
+      findById: vi.fn().mockResolvedValue({
+        id: 'org-1',
+        registrations: [],
+        accreditations: []
+      })
+    }
+    vi.mocked(createOrganisationsRepository).mockResolvedValue(
+      () => organisationsRepository
+    )
+
+    wasteRecordsRepository = {
+      findByRegistration: vi.fn().mockResolvedValue([])
+    }
+    vi.mocked(createWasteRecordsRepository).mockResolvedValue(
+      () => wasteRecordsRepository
+    )
+
+    prnRepository = {
+      findByAccreditation: vi.fn().mockResolvedValue([])
+    }
+    vi.mocked(createPackagingRecyclingNotesRepository).mockResolvedValue(
+      () => prnRepository
+    )
+
+    summaryLogsRepository = {
+      findAllByOrgReg: vi.fn().mockResolvedValue([])
+    }
+    vi.mocked(createSummaryLogsRepository).mockResolvedValue(
+      () => summaryLogsRepository
+    )
+
+    vi.mocked(createOverseasSitesRepository).mockResolvedValue(() => ({}))
+    vi.mocked(resolveOverseasSites).mockResolvedValue([])
+    vi.mocked(computeRebuiltStream).mockReturnValue({
+      events: [],
+      amount: 0,
+      availableAmount: 0
+    })
+  })
+
+  it('skips when feature flag is off', async () => {
+    mockConfig.get = vi.fn((key) => {
+      if (key === 'featureFlags.wasteBalanceLedger') return false
+      return undefined
+    })
+
+    await runStreamPromotion(mockServer)
+
+    expect(mockServer.locker.lock).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('disabled')
+      })
+    )
+  })
+
+  it('skips when lock cannot be obtained', async () => {
+    mockServer.locker.lock.mockResolvedValue(null)
+
+    await runStreamPromotion(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('Unable to obtain lock')
+      })
+    )
+  })
+
+  it('frees the lock even when an error occurs', async () => {
+    vi.mocked(createWasteBalancesRepository).mockRejectedValue(
+      new Error('boom')
+    )
+
+    await runStreamPromotion(mockServer)
+
+    expect(mockLock.free).toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalled()
+  })
+
+  it('recovers stuck migrating accreditations before the main pass', async () => {
+    // Recovery pass: find migrating balances and reset them
+    const migratingToArray = vi
+      .fn()
+      .mockResolvedValue([{ accreditationId: 'acc-stuck' }])
+    const embeddedToArray = vi.fn().mockResolvedValue([])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray }) // recovery query
+      .mockReturnValueOnce({ toArray: embeddedToArray }) // main pass query
+
+    await runStreamPromotion(mockServer)
+
+    expect(
+      wasteBalancesRepository.resetCanonicalSourceToEmbedded
+    ).toHaveBeenCalledWith({
+      accreditationId: 'acc-stuck'
+    })
+  })
+
+  it('promotes an embedded accreditation through the full lifecycle', async () => {
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([
+      {
+        accreditationId: 'acc-1',
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+    ])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    organisationsRepository.findById.mockResolvedValue({
+      id: 'org-1',
+      registrations: [
+        {
+          id: 'reg-1',
+          accreditationId: 'acc-1',
+          registrationNumber: 'CBDU1',
+          status: 'approved'
+        }
+      ],
+      accreditations: [
+        { id: 'acc-1', accreditationNumber: 'CBDA1', status: 'approved' }
+      ]
+    })
+
+    wasteBalancesRepository.findByAccreditationId
+      .mockResolvedValueOnce({
+        accreditationId: 'acc-1',
+        version: 1,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+      .mockResolvedValueOnce({
+        accreditationId: 'acc-1',
+        version: 1,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      })
+
+    summaryLogsRepository.findAllByOrgReg.mockResolvedValue([
+      {
+        summaryLog: {
+          file: { id: 'file-1' },
+          status: 'submitted',
+          submittedAt: '2026-01-15T10:00:00.000Z'
+        }
+      },
+      {
+        summaryLog: {
+          file: { id: 'file-2' },
+          status: 'draft',
+          submittedAt: undefined
+        }
+      }
+    ])
+
+    const builtEvents = [
+      { registrationId: 'reg-1', accreditationId: 'acc-1', number: 1 }
+    ]
+    vi.mocked(computeRebuiltStream).mockReturnValue({
+      events: builtEvents,
+      amount: 100,
+      availableAmount: 100
+    })
+
+    await runStreamPromotion(mockServer)
+
+    // Step d: flip embedded -> migrating
+    expect(
+      wasteBalancesRepository.flipCanonicalSourceToMigrating
+    ).toHaveBeenCalledWith({
+      accreditationId: 'acc-1',
+      capturedVersion: 1
+    })
+
+    // Step e: delete existing stream (idempotency)
+    expect(streamRepository.deleteByPartition).toHaveBeenCalledWith(
+      'reg-1',
+      'acc-1'
+    )
+
+    // Step f: bulk append rebuilt events
+    expect(streamRepository.bulkAppendEvents).toHaveBeenCalledWith(builtEvents)
+
+    // Step h: flip migrating -> ledger
+    expect(
+      wasteBalancesRepository.flipCanonicalSourceToLedger
+    ).toHaveBeenCalledWith({
+      accreditationId: 'acc-1',
+      capturedVersion: 1
+    })
+
+    // Summary logged
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('promoted=1')
+      })
+    )
+  })
+
+  it('skips an accreditation that is already on the ledger after flip-to-migrating', async () => {
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([
+      {
+        accreditationId: 'acc-ledger',
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+    ])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    organisationsRepository.findById.mockResolvedValue({
+      id: 'org-1',
+      registrations: [
+        {
+          id: 'reg-1',
+          accreditationId: 'acc-ledger',
+          registrationNumber: 'CBDU1',
+          status: 'approved'
+        }
+      ],
+      accreditations: [
+        { id: 'acc-ledger', accreditationNumber: 'CBDA1', status: 'approved' }
+      ]
+    })
+
+    wasteBalancesRepository.findByAccreditationId.mockResolvedValue({
+      accreditationId: 'acc-ledger',
+      version: 3,
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+    })
+
+    wasteBalancesRepository.flipCanonicalSourceToMigrating.mockResolvedValue({
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+    })
+
+    await runStreamPromotion(mockServer)
+
+    expect(streamRepository.deleteByPartition).not.toHaveBeenCalled()
+    expect(streamRepository.bulkAppendEvents).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('skipped=1')
+      })
+    )
+  })
+
+  it('promotes an empty accreditation with no events', async () => {
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([
+      {
+        accreditationId: 'acc-empty',
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+    ])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    organisationsRepository.findById.mockResolvedValue({
+      id: 'org-1',
+      registrations: [
+        {
+          id: 'reg-1',
+          accreditationId: 'acc-empty',
+          registrationNumber: 'CBDU1',
+          status: 'approved'
+        }
+      ],
+      accreditations: [
+        { id: 'acc-empty', accreditationNumber: 'CBDA1', status: 'approved' }
+      ]
+    })
+
+    wasteBalancesRepository.findByAccreditationId
+      .mockResolvedValueOnce({
+        accreditationId: 'acc-empty',
+        version: 1,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+      .mockResolvedValueOnce({
+        accreditationId: 'acc-empty',
+        version: 1,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      })
+
+    // computeRebuiltStream returns no events (default mock)
+
+    await runStreamPromotion(mockServer)
+
+    // bulkAppendEvents is still called (no-op for empty array)
+    expect(streamRepository.bulkAppendEvents).toHaveBeenCalledWith([])
+    // Still flips to ledger
+    expect(
+      wasteBalancesRepository.flipCanonicalSourceToLedger
+    ).toHaveBeenCalled()
+  })
+
+  it('counts as failed when accreditation is not found on organisation', async () => {
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([
+      {
+        accreditationId: 'acc-missing',
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+    ])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    // Default org mock has empty accreditations array
+
+    await runStreamPromotion(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('failed=1')
+      })
+    )
+  })
+
+  it('counts as failed when no registration links to accreditation', async () => {
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([
+      {
+        accreditationId: 'acc-noreg',
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+    ])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    organisationsRepository.findById.mockResolvedValue({
+      id: 'org-1',
+      registrations: [],
+      accreditations: [
+        { id: 'acc-noreg', accreditationNumber: 'CBDA1', status: 'approved' }
+      ]
+    })
+
+    await runStreamPromotion(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('failed=1')
+      })
+    )
+  })
+
+  it('counts as failed when no waste balance exists for accreditation', async () => {
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([
+      {
+        accreditationId: 'acc-nobal',
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+    ])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    organisationsRepository.findById.mockResolvedValue({
+      id: 'org-1',
+      registrations: [
+        {
+          id: 'reg-1',
+          accreditationId: 'acc-nobal',
+          registrationNumber: 'CBDU1',
+          status: 'approved'
+        }
+      ],
+      accreditations: [
+        { id: 'acc-nobal', accreditationNumber: 'CBDA1', status: 'approved' }
+      ]
+    })
+
+    // findByAccreditationId returns null (default mock)
+
+    await runStreamPromotion(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('failed=1')
+      })
+    )
+  })
+
+  it('counts as failed when waste balance disappears after stream write', async () => {
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([
+      {
+        accreditationId: 'acc-vanish',
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+    ])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    organisationsRepository.findById.mockResolvedValue({
+      id: 'org-1',
+      registrations: [
+        {
+          id: 'reg-1',
+          accreditationId: 'acc-vanish',
+          registrationNumber: 'CBDU1',
+          status: 'approved'
+        }
+      ],
+      accreditations: [
+        { id: 'acc-vanish', accreditationNumber: 'CBDA1', status: 'approved' }
+      ]
+    })
+
+    wasteBalancesRepository.findByAccreditationId
+      .mockResolvedValueOnce({
+        accreditationId: 'acc-vanish',
+        version: 1,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      })
+      .mockResolvedValueOnce(null) // disappeared after stream write
+
+    await runStreamPromotion(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('failed=1')
+      })
+    )
+  })
+
+  it('counts as failed when flip to ledger does not land', async () => {
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([
+      {
+        accreditationId: 'acc-nolift',
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+    ])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    organisationsRepository.findById.mockResolvedValue({
+      id: 'org-1',
+      registrations: [
+        {
+          id: 'reg-1',
+          accreditationId: 'acc-nolift',
+          registrationNumber: 'CBDU1',
+          status: 'approved'
+        }
+      ],
+      accreditations: [
+        { id: 'acc-nolift', accreditationNumber: 'CBDA1', status: 'approved' }
+      ]
+    })
+
+    wasteBalancesRepository.findByAccreditationId.mockResolvedValue({
+      accreditationId: 'acc-nolift',
+      version: 1,
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+    })
+
+    wasteBalancesRepository.flipCanonicalSourceToLedger.mockResolvedValue({
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+    })
+
+    await runStreamPromotion(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('will retry next boot')
+      })
+    )
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringMatching(/failed=1/)
+      })
+    )
+  })
+
+  it('logs a summary with promoted, skipped, and failed counts', async () => {
+    // Empty population
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    await runStreamPromotion(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringMatching(/promoted=0 skipped=0 failed=0/)
+      })
+    )
+  })
+})

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -157,7 +157,8 @@ describe('runStreamPromotion', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: [],
       amount: 0,
-      availableAmount: 0
+      availableAmount: 0,
+      backfilledActorCount: 0
     })
   })
 
@@ -284,7 +285,8 @@ describe('runStreamPromotion', () => {
     vi.mocked(computeRebuiltStream).mockReturnValue({
       events: builtEvents,
       amount: 100,
-      availableAmount: 100
+      availableAmount: 100,
+      backfilledActorCount: 0
     })
 
     await runStreamPromotion(mockServer)

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -45,6 +45,7 @@ import { copyFormFilesToS3 } from '#server/copy-form-files-to-s3.js'
 import { runBalanceDivergenceDiagnostic } from '#server/run-balance-divergence-diagnostic.js'
 import { runBalanceSizeDiagnostic } from '#server/run-balance-size-diagnostic.js'
 import { runRowIdCollisionDiagnostic } from '#server/run-row-id-collision-diagnostic.js'
+import { runStreamPromotion } from '#server/run-stream-promotion.js'
 
 /** @import { Lifecycle } from '@hapi/hapi' */
 
@@ -226,6 +227,7 @@ async function createServer(options = {}) {
     runRowIdCollisionDiagnostic(server)
     runBalanceDivergenceDiagnostic(server)
     runBalanceSizeDiagnostic(server)
+    runStreamPromotion(server)
   })
 
   return server

--- a/src/waste-balances/repository/contract/findByAccreditationId.contract.js
+++ b/src/waste-balances/repository/contract/findByAccreditationId.contract.js
@@ -203,7 +203,7 @@ export const testFindByAccreditationIdBehaviour = (it) => {
         expect(result.availableAmount).toBe(150)
       })
 
-      it('throws when marker is ledger and no stream events exist', async ({
+      it('returns zero balances when marker is ledger and no stream events exist', async ({
         insertWasteBalance
       }) => {
         await insertWasteBalance(
@@ -216,11 +216,12 @@ export const testFindByAccreditationIdBehaviour = (it) => {
           })
         )
 
-        await expect(
-          repository.findByAccreditationId('acc-marker-ledger-empty')
-        ).rejects.toThrow(
-          /acc-marker-ledger-empty.*canonicalSource 'ledger' but no stream events/
+        const result = await repository.findByAccreditationId(
+          'acc-marker-ledger-empty'
         )
+
+        expect(result.amount).toBe(0)
+        expect(result.availableAmount).toBe(0)
       })
 
       it('preserves the canonicalSource marker on the returned document', async ({

--- a/src/waste-balances/repository/marker-aware-read.js
+++ b/src/waste-balances/repository/marker-aware-read.js
@@ -1,5 +1,3 @@
-import Boom from '@hapi/boom'
-
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
 
 /**
@@ -9,9 +7,10 @@ import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
  * `'embedded'` and `'migrating'` markers leave the document unchanged because
  * the embedded write path is still authoritative for them.
  *
- * Marker `'ledger'` with no stream events is an invariant violation: the
- * promotion sweep must populate the stream before flipping the marker. Throws
- * so the inconsistency surfaces instead of being masked as a zero balance.
+ * An empty stream under a `'ledger'` marker means the accreditation was
+ * promoted with zero activity. This is legitimate for accreditations that
+ * never received waste records, so the function returns zero balances
+ * instead of throwing.
  *
  * @param {import('../domain/model.js').WasteBalance} balance
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} streamRepository
@@ -28,9 +27,11 @@ export const resolveBalanceAmounts = async (balance, streamRepository) => {
   )
 
   if (!latest) {
-    throw Boom.internal(
-      `Waste balance ${balance.accreditationId} has canonicalSource 'ledger' but no stream events`
-    )
+    return {
+      ...balance,
+      amount: 0,
+      availableAmount: 0
+    }
   }
 
   return {

--- a/src/waste-balances/repository/marker-aware-read.js
+++ b/src/waste-balances/repository/marker-aware-read.js
@@ -23,7 +23,7 @@ export const resolveBalanceAmounts = async (balance, streamRepository) => {
   }
 
   const latest = await streamRepository.findLatestByPartition(
-    /** @type {string} */ (balance.registrationId),
+    balance.registrationId,
     balance.accreditationId
   )
 

--- a/src/waste-balances/repository/marker-aware-read.js
+++ b/src/waste-balances/repository/marker-aware-read.js
@@ -1,4 +1,5 @@
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
+import { ZERO_BALANCE } from './stream-schema.js'
 
 /**
  * Marker-aware substitution of `amount` / `availableAmount` on a waste-balance
@@ -29,8 +30,7 @@ export const resolveBalanceAmounts = async (balance, streamRepository) => {
   if (!latest) {
     return {
       ...balance,
-      amount: 0,
-      availableAmount: 0
+      ...ZERO_BALANCE
     }
   }
 

--- a/src/waste-balances/repository/marker-aware-read.test.js
+++ b/src/waste-balances/repository/marker-aware-read.test.js
@@ -107,6 +107,28 @@ describe('resolveBalanceAmounts', () => {
     expect(result.availableAmount).toBe(0)
   })
 
+  it('passes undefined registrationId through to the stream lookup', async () => {
+    const balance = buildBalance({
+      accreditationId: 'acc-no-reg',
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+      amount: 999,
+      availableAmount: 999
+    })
+    delete balance.registrationId
+    const stream = buildStream({
+      closingBalance: { amount: 298.25, availableAmount: 298.25 }
+    })
+
+    const result = await resolveBalanceAmounts(balance, stream)
+
+    expect(stream.findLatestByPartition).toHaveBeenCalledWith(
+      undefined,
+      'acc-no-reg'
+    )
+    expect(result.amount).toBe(298.25)
+    expect(result.availableAmount).toBe(298.25)
+  })
+
   it('preserves all non-amount fields', async () => {
     const balance = buildBalance({
       canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,

--- a/src/waste-balances/repository/marker-aware-read.test.js
+++ b/src/waste-balances/repository/marker-aware-read.test.js
@@ -89,7 +89,7 @@ describe('resolveBalanceAmounts', () => {
     expect(result.availableAmount).toBe(175)
   })
 
-  it('throws when marker is ledger but no stream events exist', async () => {
+  it('returns zero balances when marker is ledger but stream is empty', async () => {
     const balance = buildBalance({
       accreditationId: 'acc-empty',
       registrationId: 'reg-empty',
@@ -99,9 +99,10 @@ describe('resolveBalanceAmounts', () => {
     })
     const stream = buildStream(null)
 
-    await expect(resolveBalanceAmounts(balance, stream)).rejects.toThrow(
-      /acc-empty.*canonicalSource 'ledger' but no stream events/
-    )
+    const result = await resolveBalanceAmounts(balance, stream)
+
+    expect(result.amount).toBe(0)
+    expect(result.availableAmount).toBe(0)
   })
 
   it('preserves all non-amount fields', async () => {

--- a/src/waste-balances/repository/marker-aware-read.test.js
+++ b/src/waste-balances/repository/marker-aware-read.test.js
@@ -33,7 +33,9 @@ const buildStream = (latest) => ({
     ),
   findLatestByPartitionAndKind: vi.fn().mockResolvedValue(null),
   findEventsByPrnIdAfter: vi.fn().mockResolvedValue([]),
-  appendEvent: vi.fn().mockResolvedValue(undefined)
+  appendEvent: vi.fn().mockResolvedValue(undefined),
+  deleteByPartition: vi.fn().mockResolvedValue(0),
+  bulkAppendEvents: vi.fn().mockResolvedValue([])
 })
 
 describe('resolveBalanceAmounts', () => {

--- a/src/waste-balances/repository/marker-aware-read.test.js
+++ b/src/waste-balances/repository/marker-aware-read.test.js
@@ -110,11 +110,11 @@ describe('resolveBalanceAmounts', () => {
   it('passes undefined registrationId through to the stream lookup', async () => {
     const balance = buildBalance({
       accreditationId: 'acc-no-reg',
+      registrationId: undefined,
       canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
       amount: 999,
       availableAmount: 999
     })
-    delete balance.registrationId
     const stream = buildStream({
       closingBalance: { amount: 298.25, availableAmount: 298.25 }
     })

--- a/src/waste-balances/repository/stream-contract/bulkAppendEvents.contract.js
+++ b/src/waste-balances/repository/stream-contract/bulkAppendEvents.contract.js
@@ -1,0 +1,112 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { buildStreamEvent } from '../stream-test-data.js'
+import { StreamSequenceError } from '../stream-port.js'
+
+export const testBulkAppendEventsBehaviour = (it) => {
+  describe('bulkAppendEvents (@migration PAE-1382)', () => {
+    let repository
+
+    beforeEach(async ({ streamRepository }) => {
+      repository = await streamRepository()
+    })
+
+    it('inserts multiple events and returns stored events with ids', async () => {
+      const events = [
+        buildStreamEvent({
+          registrationId: 'reg-bulk',
+          accreditationId: 'acc-bulk',
+          number: 1
+        }),
+        buildStreamEvent({
+          registrationId: 'reg-bulk',
+          accreditationId: 'acc-bulk',
+          number: 2,
+          payload: { summaryLogId: 'log-2', creditTotal: 200 }
+        })
+      ]
+
+      const stored = await repository.bulkAppendEvents(events)
+
+      expect(stored).toHaveLength(2)
+      expect(stored[0].id).toEqual(expect.any(String))
+      expect(stored[0].number).toBe(1)
+      expect(stored[1].id).toEqual(expect.any(String))
+      expect(stored[1].number).toBe(2)
+    })
+
+    it('throws StreamSequenceError when first event does not start at currentMax + 1', async () => {
+      await repository.appendEvent(
+        buildStreamEvent({
+          registrationId: 'reg-seq',
+          accreditationId: 'acc-seq',
+          number: 1
+        })
+      )
+
+      const events = [
+        buildStreamEvent({
+          registrationId: 'reg-seq',
+          accreditationId: 'acc-seq',
+          number: 5,
+          payload: { summaryLogId: 'log-5', creditTotal: 500 }
+        })
+      ]
+
+      await expect(repository.bulkAppendEvents(events)).rejects.toBeInstanceOf(
+        StreamSequenceError
+      )
+    })
+
+    it('throws StreamSequenceError when events are not sequentially numbered', async () => {
+      const events = [
+        buildStreamEvent({
+          registrationId: 'reg-gap',
+          accreditationId: 'acc-gap',
+          number: 1
+        }),
+        buildStreamEvent({
+          registrationId: 'reg-gap',
+          accreditationId: 'acc-gap',
+          number: 3,
+          payload: { summaryLogId: 'log-3', creditTotal: 300 }
+        })
+      ]
+
+      await expect(repository.bulkAppendEvents(events)).rejects.toBeInstanceOf(
+        StreamSequenceError
+      )
+    })
+
+    it('is a no-op for an empty array', async () => {
+      const stored = await repository.bulkAppendEvents([])
+
+      expect(stored).toEqual([])
+    })
+
+    it('appended events are visible via findLatestByPartition', async () => {
+      const events = [
+        buildStreamEvent({
+          registrationId: 'reg-vis',
+          accreditationId: 'acc-vis',
+          number: 1
+        }),
+        buildStreamEvent({
+          registrationId: 'reg-vis',
+          accreditationId: 'acc-vis',
+          number: 2,
+          payload: { summaryLogId: 'log-2', creditTotal: 200 }
+        })
+      ]
+
+      await repository.bulkAppendEvents(events)
+
+      const latest = await repository.findLatestByPartition(
+        'reg-vis',
+        'acc-vis'
+      )
+      expect(latest).not.toBeNull()
+      expect(latest.number).toBe(2)
+    })
+  })
+}

--- a/src/waste-balances/repository/stream-contract/deleteByPartition.contract.js
+++ b/src/waste-balances/repository/stream-contract/deleteByPartition.contract.js
@@ -1,0 +1,73 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { buildStreamEvent } from '../stream-test-data.js'
+
+export const testDeleteByPartitionBehaviour = (it) => {
+  describe('deleteByPartition (@migration PAE-1382)', () => {
+    let repository
+
+    beforeEach(async ({ streamRepository }) => {
+      repository = await streamRepository()
+    })
+
+    it('deletes all events for the given partition and returns the count', async () => {
+      await repository.appendEvent(
+        buildStreamEvent({
+          registrationId: 'reg-del',
+          accreditationId: 'acc-del',
+          number: 1
+        })
+      )
+      await repository.appendEvent(
+        buildStreamEvent({
+          registrationId: 'reg-del',
+          accreditationId: 'acc-del',
+          number: 2,
+          payload: { summaryLogId: 'log-2', creditTotal: 200 }
+        })
+      )
+
+      const count = await repository.deleteByPartition('reg-del', 'acc-del')
+
+      expect(count).toBe(2)
+
+      const latest = await repository.findLatestByPartition(
+        'reg-del',
+        'acc-del'
+      )
+      expect(latest).toBeNull()
+    })
+
+    it('returns 0 when the partition is empty', async () => {
+      const count = await repository.deleteByPartition('reg-empty', 'acc-empty')
+
+      expect(count).toBe(0)
+    })
+
+    it('does not affect events in other partitions', async () => {
+      await repository.appendEvent(
+        buildStreamEvent({
+          registrationId: 'reg-keep',
+          accreditationId: 'acc-keep',
+          number: 1
+        })
+      )
+      await repository.appendEvent(
+        buildStreamEvent({
+          registrationId: 'reg-remove',
+          accreditationId: 'acc-remove',
+          number: 1
+        })
+      )
+
+      await repository.deleteByPartition('reg-remove', 'acc-remove')
+
+      const kept = await repository.findLatestByPartition(
+        'reg-keep',
+        'acc-keep'
+      )
+      expect(kept).not.toBeNull()
+      expect(kept.registrationId).toBe('reg-keep')
+    })
+  })
+}

--- a/src/waste-balances/repository/stream-contract/findLatestByPartition.contract.js
+++ b/src/waste-balances/repository/stream-contract/findLatestByPartition.contract.js
@@ -140,6 +140,29 @@ export const testFindLatestByPartitionBehaviour = (it) => {
       })
     })
 
+    it('finds events by accreditationId alone when registrationId is undefined', async () => {
+      await repository.appendEvent(
+        buildStreamEvent({
+          registrationId: 'reg-orphan',
+          accreditationId: 'acc-orphan',
+          number: 1,
+          closingBalance: { amount: 298.25, availableAmount: 298.25 }
+        })
+      )
+
+      const result = await repository.findLatestByPartition(
+        undefined,
+        'acc-orphan'
+      )
+
+      expect(result).not.toBeNull()
+      expect(result.accreditationId).toBe('acc-orphan')
+      expect(result.closingBalance).toEqual({
+        amount: 298.25,
+        availableAmount: 298.25
+      })
+    })
+
     it('round-trips high-precision amounts exactly', async () => {
       await repository.appendEvent(
         buildStreamEvent({

--- a/src/waste-balances/repository/stream-inmemory.js
+++ b/src/waste-balances/repository/stream-inmemory.js
@@ -24,8 +24,7 @@ import { validateStreamEventInsert } from './stream-validation.js'
  * @param {string | null} accreditationId
  */
 const matchesPartition = (event, registrationId, accreditationId) =>
-  (registrationId === undefined ||
-    event.registrationId === registrationId) &&
+  (registrationId === undefined || event.registrationId === registrationId) &&
   event.accreditationId === accreditationId
 
 /**

--- a/src/waste-balances/repository/stream-inmemory.js
+++ b/src/waste-balances/repository/stream-inmemory.js
@@ -73,6 +73,76 @@ const doAppend = (storage, event) => {
 }
 
 /**
+ * Migration PAE-1382: delete all events for a partition.
+ *
+ * @param {StreamEvent[]} storage
+ * @param {string} registrationId
+ * @param {string | null} accreditationId
+ * @returns {number}
+ */
+const doDeleteByPartition = (storage, registrationId, accreditationId) => {
+  const before = storage.length
+  const remaining = storage.filter(
+    (event) => !matchesPartition(event, registrationId, accreditationId)
+  )
+  storage.length = 0
+  storage.push(...remaining)
+  return before - remaining.length
+}
+
+/**
+ * Migration PAE-1382: insert multiple events in one call.
+ *
+ * @param {StreamEvent[]} storage
+ * @param {StreamEventInsert[]} events
+ * @returns {StreamEvent[]}
+ */
+const doBulkAppend = (storage, events) => {
+  if (events.length === 0) {
+    return []
+  }
+
+  const first = events[0]
+  const partitionEvents = storage.filter((existing) =>
+    matchesPartition(existing, first.registrationId, first.accreditationId)
+  )
+  const currentMax =
+    partitionEvents.length > 0
+      ? /** @type {StreamEvent} */ (partitionEvents.at(-1)).number
+      : 0
+
+  const expectedStart = currentMax + 1
+
+  if (first.number !== expectedStart) {
+    throw new StreamSequenceError(
+      first.registrationId,
+      first.accreditationId,
+      first.number,
+      expectedStart
+    )
+  }
+
+  for (let i = 1; i < events.length; i++) {
+    const expected = first.number + i
+    if (events[i].number !== expected) {
+      throw new StreamSequenceError(
+        events[i].registrationId,
+        events[i].accreditationId,
+        events[i].number,
+        expected
+      )
+    }
+  }
+
+  return events.map((event) => {
+    const validated = validateStreamEventInsert(event)
+    const persisted = { id: randomUUID(), ...validated }
+    storage.push(persisted)
+    return structuredClone(persisted)
+  })
+}
+
+/**
  * @param {Array<StreamEvent>} [initialEvents]
  * @returns {import('./stream-port.js').WasteBalanceStreamRepositoryFactory}
  */
@@ -146,72 +216,9 @@ export const createInMemoryStreamRepository = (initialEvents = []) => {
       return structuredClone(matches)
     },
 
-    /**
-     * @migration PAE-1382 — delete all events for a partition.
-     * @param {string} registrationId
-     * @param {string | null} accreditationId
-     * @returns {Promise<number>}
-     */
-    deleteByPartition: async (registrationId, accreditationId) => {
-      const before = storage.length
-      const remaining = storage.filter(
-        (event) => !matchesPartition(event, registrationId, accreditationId)
-      )
-      storage.length = 0
-      storage.push(...remaining)
-      return before - remaining.length
-    },
+    deleteByPartition: async (registrationId, accreditationId) =>
+      doDeleteByPartition(storage, registrationId, accreditationId),
 
-    /**
-     * @migration PAE-1382 — insert multiple events in one call.
-     * @param {StreamEventInsert[]} events
-     * @returns {Promise<StreamEvent[]>}
-     */
-    bulkAppendEvents: async (events) => {
-      if (events.length === 0) {
-        return []
-      }
-
-      const first = events[0]
-      const partitionEvents = storage.filter((existing) =>
-        matchesPartition(existing, first.registrationId, first.accreditationId)
-      )
-      const currentMax =
-        partitionEvents.length > 0
-          ? /** @type {StreamEvent} */ (partitionEvents.at(-1)).number
-          : 0
-
-      const expectedStart = currentMax + 1
-
-      if (first.number !== expectedStart) {
-        throw new StreamSequenceError(
-          first.registrationId,
-          first.accreditationId,
-          first.number,
-          expectedStart
-        )
-      }
-
-      for (let i = 1; i < events.length; i++) {
-        const expected = first.number + i
-        if (events[i].number !== expected) {
-          throw new StreamSequenceError(
-            events[i].registrationId,
-            events[i].accreditationId,
-            events[i].number,
-            expected
-          )
-        }
-      }
-
-      const stored = events.map((event) => {
-        const validated = validateStreamEventInsert(event)
-        const persisted = { id: randomUUID(), ...validated }
-        storage.push(persisted)
-        return structuredClone(persisted)
-      })
-
-      return stored
-    }
+    bulkAppendEvents: async (events) => doBulkAppend(storage, events)
   })
 }

--- a/src/waste-balances/repository/stream-inmemory.js
+++ b/src/waste-balances/repository/stream-inmemory.js
@@ -24,7 +24,8 @@ import { validateStreamEventInsert } from './stream-validation.js'
  * @param {string | null} accreditationId
  */
 const matchesPartition = (event, registrationId, accreditationId) =>
-  event.registrationId === registrationId &&
+  (registrationId === undefined ||
+    event.registrationId === registrationId) &&
   event.accreditationId === accreditationId
 
 /**

--- a/src/waste-balances/repository/stream-inmemory.js
+++ b/src/waste-balances/repository/stream-inmemory.js
@@ -144,6 +144,74 @@ export const createInMemoryStreamRepository = (initialEvents = []) => {
         .sort((a, b) => a.number - b.number)
 
       return structuredClone(matches)
+    },
+
+    /**
+     * @migration PAE-1382 — delete all events for a partition.
+     * @param {string} registrationId
+     * @param {string | null} accreditationId
+     * @returns {Promise<number>}
+     */
+    deleteByPartition: async (registrationId, accreditationId) => {
+      const before = storage.length
+      const remaining = storage.filter(
+        (event) => !matchesPartition(event, registrationId, accreditationId)
+      )
+      storage.length = 0
+      storage.push(...remaining)
+      return before - remaining.length
+    },
+
+    /**
+     * @migration PAE-1382 — insert multiple events in one call.
+     * @param {StreamEventInsert[]} events
+     * @returns {Promise<StreamEvent[]>}
+     */
+    bulkAppendEvents: async (events) => {
+      if (events.length === 0) {
+        return []
+      }
+
+      const first = events[0]
+      const partitionEvents = storage.filter((existing) =>
+        matchesPartition(existing, first.registrationId, first.accreditationId)
+      )
+      const currentMax =
+        partitionEvents.length > 0
+          ? /** @type {StreamEvent} */ (partitionEvents.at(-1)).number
+          : 0
+
+      const expectedStart = currentMax + 1
+
+      if (first.number !== expectedStart) {
+        throw new StreamSequenceError(
+          first.registrationId,
+          first.accreditationId,
+          first.number,
+          expectedStart
+        )
+      }
+
+      for (let i = 1; i < events.length; i++) {
+        const expected = first.number + i
+        if (events[i].number !== expected) {
+          throw new StreamSequenceError(
+            events[i].registrationId,
+            events[i].accreditationId,
+            events[i].number,
+            expected
+          )
+        }
+      }
+
+      const stored = events.map((event) => {
+        const validated = validateStreamEventInsert(event)
+        const persisted = { id: randomUUID(), ...validated }
+        storage.push(persisted)
+        return structuredClone(persisted)
+      })
+
+      return stored
     }
   })
 }

--- a/src/waste-balances/repository/stream-mongodb.js
+++ b/src/waste-balances/repository/stream-mongodb.js
@@ -167,14 +167,14 @@ const performAppendEvent = (collection) => async (event) => {
 
 /**
  * @param {Collection} collection
- * @returns {(registrationId: string, accreditationId: string | null) => Promise<StreamEvent | null>}
+ * @returns {(registrationId: string | undefined, accreditationId: string | null) => Promise<StreamEvent | null>}
  */
 const performFindLatestByPartition =
   (collection) => async (registrationId, accreditationId) => {
-    const doc = await collection.findOne(
-      { registrationId, accreditationId },
-      { sort: { number: -1 } }
-    )
+    const filter = registrationId
+      ? { registrationId, accreditationId }
+      : { accreditationId }
+    const doc = await collection.findOne(filter, { sort: { number: -1 } })
     return doc ? toStreamEvent(doc) : null
   }
 

--- a/src/waste-balances/repository/stream-mongodb.js
+++ b/src/waste-balances/repository/stream-mongodb.js
@@ -212,6 +212,74 @@ const performFindEventsByPrnIdAfter =
   }
 
 /**
+ * @migration PAE-1382 — delete all events for a partition.
+ * @param {Collection} collection
+ * @returns {(registrationId: string, accreditationId: string | null) => Promise<number>}
+ */
+const performDeleteByPartition =
+  (collection) => async (registrationId, accreditationId) => {
+    const result = await collection.deleteMany({
+      registrationId,
+      accreditationId
+    })
+    return result.deletedCount
+  }
+
+/**
+ * @migration PAE-1382 — insert multiple events in one call.
+ * Validates sequence: events must be numbered sequentially, and the first
+ * event's number must be currentMax + 1 (or 1 if empty partition).
+ * @param {Collection} collection
+ * @returns {(events: import('./stream-schema.js').StreamEventInsert[]) => Promise<import('./stream-schema.js').StreamEvent[]>}
+ */
+const performBulkAppendEvents = (collection) => async (events) => {
+  if (events.length === 0) {
+    return []
+  }
+
+  const validated = events.map(validateStreamEventInsert)
+
+  const first = validated[0]
+
+  const latest = await collection.findOne(
+    {
+      registrationId: first.registrationId,
+      accreditationId: first.accreditationId
+    },
+    { sort: { number: -1 }, projection: { number: 1 } }
+  )
+
+  const expectedStart = (latest?.number ?? 0) + 1
+
+  if (first.number !== expectedStart) {
+    throw new StreamSequenceError(
+      first.registrationId,
+      first.accreditationId,
+      first.number,
+      expectedStart
+    )
+  }
+
+  for (let i = 1; i < validated.length; i++) {
+    const expected = first.number + i
+    if (validated[i].number !== expected) {
+      throw new StreamSequenceError(
+        validated[i].registrationId,
+        validated[i].accreditationId,
+        validated[i].number,
+        expected
+      )
+    }
+  }
+
+  const result = await collection.insertMany(validated)
+
+  return validated.map((event, i) =>
+    toStreamEvent({ _id: result.insertedIds[i], ...event })
+  )
+}
+
+/**
  * Creates a MongoDB-backed stream repository.
  *
  * @param {Db} db
@@ -225,6 +293,8 @@ export const createMongoStreamRepository = async (db) => {
     findLatestByPartition: performFindLatestByPartition(collection),
     findLatestByPartitionAndKind:
       performFindLatestByPartitionAndKind(collection),
-    findEventsByPrnIdAfter: performFindEventsByPrnIdAfter(collection)
+    findEventsByPrnIdAfter: performFindEventsByPrnIdAfter(collection),
+    deleteByPartition: performDeleteByPartition(collection),
+    bulkAppendEvents: performBulkAppendEvents(collection)
   })
 }

--- a/src/waste-balances/repository/stream-port.contract.js
+++ b/src/waste-balances/repository/stream-port.contract.js
@@ -2,10 +2,14 @@ import { testAppendEventBehaviour } from './stream-contract/appendEvent.contract
 import { testFindLatestByPartitionBehaviour } from './stream-contract/findLatestByPartition.contract.js'
 import { testFindLatestByPartitionAndKindBehaviour } from './stream-contract/findLatestByPartitionAndKind.contract.js'
 import { testFindEventsByPrnIdAfterBehaviour } from './stream-contract/findEventsByPrnIdAfter.contract.js'
+import { testDeleteByPartitionBehaviour } from './stream-contract/deleteByPartition.contract.js'
+import { testBulkAppendEventsBehaviour } from './stream-contract/bulkAppendEvents.contract.js'
 
 export const testStreamRepositoryContract = (it) => {
   testAppendEventBehaviour(it)
   testFindLatestByPartitionBehaviour(it)
   testFindLatestByPartitionAndKindBehaviour(it)
   testFindEventsByPrnIdAfterBehaviour(it)
+  testDeleteByPartitionBehaviour(it)
+  testBulkAppendEventsBehaviour(it)
 }

--- a/src/waste-balances/repository/stream-port.js
+++ b/src/waste-balances/repository/stream-port.js
@@ -100,6 +100,14 @@ export class StreamSequenceError extends Error {
  *   Return events referencing the given `prnId` in `payload.prnId` within
  *   the specified partition, with `number > afterNumber`, ordered by
  *   `number` ascending.
+ * @property {(registrationId: string, accreditationId: string | null) => Promise<number>} deleteByPartition
+ *   @migration PAE-1382 — Delete all events for the given partition.
+ *   Returns the number of deleted events. No-op on empty partition.
+ * @property {(events: StreamEventInsert[]) => Promise<StreamEvent[]>} bulkAppendEvents
+ *   @migration PAE-1382 — Insert multiple events in one call. Validates
+ *   sequence: events must be numbered sequentially, and the first event's
+ *   number must be `currentMax + 1` (or `1` if the partition is empty).
+ *   Throws `StreamSequenceError` on failure. Empty array is a no-op.
  */
 
 /**

--- a/src/waste-balances/repository/stream-port.js
+++ b/src/waste-balances/repository/stream-port.js
@@ -90,9 +90,12 @@ export class StreamSequenceError extends Error {
  *
  *   Throws `StreamSlotConflictError` if the
  *   `(registrationId, accreditationId, number)` slot is already occupied.
- * @property {(registrationId: string, accreditationId: string | null) => Promise<StreamEvent | null>} findLatestByPartition
+ * @property {(registrationId: string | undefined, accreditationId: string | null) => Promise<StreamEvent | null>} findLatestByPartition
  *   Return the highest-numbered event for the stream partition, or `null`
- *   if none exist.
+ *   if none exist. When `registrationId` is `undefined` the lookup falls
+ *   back to `accreditationId` alone (safe because accreditation IDs are
+ *   unique). This accommodates legacy `waste-balances` documents that were
+ *   persisted without a `registrationId` field.
  * @property {(registrationId: string, accreditationId: string | null, kind: import('./stream-schema.js').StreamEventKind) => Promise<StreamEvent | null>} findLatestByPartitionAndKind
  *   Return the highest-numbered event of the given kind for the stream
  *   partition, or `null` if none of that kind exist.

--- a/src/waste-balances/repository/stream-port.js
+++ b/src/waste-balances/repository/stream-port.js
@@ -101,10 +101,10 @@ export class StreamSequenceError extends Error {
  *   the specified partition, with `number > afterNumber`, ordered by
  *   `number` ascending.
  * @property {(registrationId: string, accreditationId: string | null) => Promise<number>} deleteByPartition
- *   @migration PAE-1382 — Delete all events for the given partition.
+ *   Migration PAE-1382: delete all events for the given partition.
  *   Returns the number of deleted events. No-op on empty partition.
  * @property {(events: StreamEventInsert[]) => Promise<StreamEvent[]>} bulkAppendEvents
- *   @migration PAE-1382 — Insert multiple events in one call. Validates
+ *   Migration PAE-1382: insert multiple events in one call. Validates
  *   sequence: events must be numbered sequentially, and the first event's
  *   number must be `currentMax + 1` (or `1` if the partition is empty).
  *   Throws `StreamSequenceError` on failure. Empty array is a no-op.


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

When `canonicalSource` is `'ledger'`, `resolveBalanceAmounts` reads the balance from the event stream via `findLatestByPartition(registrationId, accreditationId)`. However, `saveBalance` never persists `registrationId` to the `waste-balances` collection, so the field is always `undefined` on documents read back from MongoDB. The query becomes `findLatestByPartition("undefined", accreditationId)`, matches nothing, and falls through to `ZERO_BALANCE`, causing **every ledger-based accreditation to display a zero waste balance**.

### Root cause

- `saveBalance` (mongodb.js:216) writes `organisationId` and `canonicalSource` in `$setOnInsert`, and `amount`/`availableAmount`/`version`/`schemaVersion` in `$set`, but never writes `registrationId`.
- `resolveBalanceAmounts` (marker-aware-read.js:25) casts `balance.registrationId` to `string` via JSDoc, silently turning `undefined` into `"undefined"`.
- The stream event _does_ have the correct `registrationId`, so the data is there; the query just can't find it.

### Why not fix `saveBalance` instead?

Production `waste-balances` documents already exist without `registrationId`. Adding it to `$setOnInsert` would only help new documents. A migration to backfill existing documents is possible but heavier than necessary, since `accreditationId` is already unique (enforced by a unique index on the collection). Querying by `accreditationId` alone is sufficient and correct.

### What this PR does

- `findLatestByPartition` (both MongoDB and in-memory implementations) now omits `registrationId` from the query filter when it is `undefined`, falling back to `accreditationId` alone.
- `resolveBalanceAmounts` drops the unsafe `/** @type {string} */` cast so `undefined` flows through naturally.
- Port type updated to accept `string | undefined` for `registrationId`.
- Contract test added: "finds events by accreditationId alone when registrationId is undefined".
- Unit test added: "passes undefined registrationId through to the stream lookup".

### Questions for discussion

1. Should we also backfill `registrationId` on existing documents (separate task)?
2. Should `saveBalance` be updated to persist `registrationId` going forward, even though the read path no longer requires it?

## Test plan

- [ ] New contract test covers the undefined-registrationId query path (both MongoDB and in-memory)
- [ ] New unit test verifies `resolveBalanceAmounts` passes `undefined` through correctly
- [ ] Existing tests continue to pass (registrationId-present path unchanged)
- [ ] Manual: generate organisations, upload a summary log, verify waste balance displays correctly

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ