### PR TITLE
PAE-1538: report all failing cells on a rejected upload, not just the first table

### DIFF
--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -8,6 +8,7 @@ import {
   WASTE_PROCESSING_TYPE
 } from '#domain/organisations/model.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
+import { TABLE_SCHEMAS as EXPORTER_TABLE_SCHEMAS } from '#domain/summary-logs/table-schemas/exporter/index.js'
 import { buildOrganisation } from '#repositories/organisations/contract/test-data.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
@@ -964,6 +965,85 @@ describe('SummaryLogsValidator integration', () => {
       expect(serialised).not.toContain(piiValue)
       expect(serialised).not.toContain(testOrg.id)
       expect(serialised).not.toContain(testOrg.registrations[0].id)
+    })
+  })
+
+  describe('cross-sheet error capture', () => {
+    const accreditationNumber = 'ACC-002'
+
+    const exporterMetadata = {
+      REGISTRATION_NUMBER: {
+        value: 'REG-456',
+        location: { sheet: 'Cover', row: 1, column: 'B' }
+      },
+      PROCESSING_TYPE: {
+        value: 'EXPORTER',
+        location: { sheet: 'Cover', row: 2, column: 'B' }
+      },
+      MATERIAL: {
+        value: 'Paper_and_board',
+        location: { sheet: 'Cover', row: 3, column: 'B' }
+      },
+      TEMPLATE_VERSION: {
+        value: 5,
+        location: { sheet: 'Cover', row: 4, column: 'B' }
+      },
+      ACCREDITATION_NUMBER: {
+        value: accreditationNumber,
+        location: { sheet: 'Cover', row: 5, column: 'B' }
+      }
+    }
+
+    /**
+     * @param {{ requiredHeaders: string[] }} schema - Only requiredHeaders is used, to fix the column order
+     * @param {number} rowNumber
+     * @param {Record<string, unknown>} overrides - Cell values keyed by header; absent headers default to null
+     * @returns {{ rowNumber: number, values: unknown[] }}
+     */
+    const rowForTable = (schema, rowNumber, overrides) => ({
+      rowNumber,
+      values: schema.requiredHeaders.map((header) => overrides[header] ?? null)
+    })
+
+    it('should capture cell errors from every sheet, not just the first', async () => {
+      const { updated } = await runValidation({
+        registrationType: 'exporter',
+        registrationWRN: 'REG-456',
+        accreditationNumber,
+        metadata: exporterMetadata,
+        data: {
+          RECEIVED_LOADS_FOR_EXPORT: {
+            location: { sheet: 'Exported', row: 7, column: 'A' },
+            headers:
+              EXPORTER_TABLE_SCHEMAS.RECEIVED_LOADS_FOR_EXPORT.requiredHeaders,
+            rows: [
+              rowForTable(EXPORTER_TABLE_SCHEMAS.RECEIVED_LOADS_FOR_EXPORT, 8, {
+                ROW_ID: 1000,
+                DATE_RECEIVED_FOR_EXPORT: 'not-a-date'
+              })
+            ]
+          },
+          SENT_ON_LOADS: {
+            location: { sheet: 'Sent on', row: 7, column: 'A' },
+            headers: EXPORTER_TABLE_SCHEMAS.SENT_ON_LOADS.requiredHeaders,
+            rows: [
+              rowForTable(EXPORTER_TABLE_SCHEMAS.SENT_ON_LOADS, 8, {
+                ROW_ID: 5000,
+                DATE_LOAD_LEFT_SITE: 'not-a-date'
+              })
+            ]
+          }
+        }
+      })
+
+      const erroringSheets = updated.summaryLog.validation.issues.map(
+        (issue) => issue.context?.location?.sheet
+      )
+
+      expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.INVALID)
+      expect(erroringSheets).toEqual(
+        expect.arrayContaining(['Exported', 'Sent on'])
+      )
     })
   })
 })

--- a/src/application/summary-logs/validations/data-syntax.js
+++ b/src/application/summary-logs/validations/data-syntax.js
@@ -133,6 +133,13 @@ export const JOI_MESSAGE_TO_ERROR_CODE = Object.freeze({
 const mapMessageToErrorCode = (message) => JOI_MESSAGE_TO_ERROR_CODE[message]
 
 /**
+ * @param {ValidationIssue[]} issues
+ * @returns {boolean} True if any issue is fatal
+ */
+const hasFatal = (issues) =>
+  issues.some((issue) => issue.severity === VALIDATION_SEVERITY.FATAL)
+
+/**
  * Builds a map from header names to their column indices
  *
  * Filters out null headers and EPR markers, returning only valid data headers.
@@ -162,35 +169,24 @@ const buildHeaderToIndexMap = (headers) => {
  *   tableName: string,
  *   headers: Array<string | null>,
  *   requiredHeaders: string[],
- *   location: CellLocation,
- *   issues: ValidationIssuesCollector
+ *   location: CellLocation
  * }} params
+ * @returns {ValidationIssue[]} A fatal issue for each missing required header
  */
-const validateHeaders = ({
-  tableName,
-  headers,
-  requiredHeaders,
-  location,
-  issues
-}) => {
+const validateHeaders = ({ tableName, headers, requiredHeaders, location }) => {
   const actualHeaders = headers.filter(
     (header) => header !== null && !isEprMarker(header)
   )
 
-  for (const requiredHeader of requiredHeaders) {
-    if (!actualHeaders.includes(requiredHeader)) {
-      issues.addFatal(
-        VALIDATION_CATEGORY.TECHNICAL,
-        `Missing required header '${requiredHeader}' in table '${tableName}'`,
-        VALIDATION_CODE.HEADER_REQUIRED,
-        {
-          location,
-          expected: requiredHeader,
-          actual: actualHeaders
-        }
-      )
-    }
-  }
+  return requiredHeaders
+    .filter((requiredHeader) => !actualHeaders.includes(requiredHeader))
+    .map((requiredHeader) => ({
+      severity: VALIDATION_SEVERITY.FATAL,
+      category: VALIDATION_CATEGORY.TECHNICAL,
+      message: `Missing required header '${requiredHeader}' in table '${tableName}'`,
+      code: VALIDATION_CODE.HEADER_REQUIRED,
+      context: { location, expected: requiredHeader, actual: actualHeaders }
+    }))
 }
 
 /**
@@ -292,33 +288,6 @@ const toApplicationIssue = ({
 }
 
 /**
- * Records each row-level issue onto the run-level issues collector, preserving
- * its severity (fatal vs error).
- *
- * @param {ValidationIssue[]} rowIssues
- * @param {ValidationIssuesCollector} issues
- */
-const recordIssues = (rowIssues, issues) => {
-  for (const rowIssue of rowIssues) {
-    if (rowIssue.severity === 'fatal') {
-      issues.addFatal(
-        rowIssue.category,
-        rowIssue.message,
-        rowIssue.code,
-        rowIssue.context
-      )
-    } else {
-      issues.addError(
-        rowIssue.category,
-        rowIssue.message,
-        rowIssue.code,
-        rowIssue.context
-      )
-    }
-  }
-}
-
-/**
  * Checks whether a row should be filtered out before validation.
  *
  * Rows are filtered when the row ID field contains template artefacts
@@ -359,20 +328,18 @@ const isTemplateRow = (rowObject, rowIdField) => {
  *   headerToIndexMap: Map<string, number>,
  *   rows: Array<{ rowNumber: number, values: Array<unknown> }>,
  *   domainSchema: TableSchema,
- *   location: CellLocation,
- *   issues: ValidationIssuesCollector
+ *   location: CellLocation
  * }} params
- * @returns {ValidatedRow[]}
+ * @returns {{ issues: ValidationIssue[], rows: ValidatedRow[] }}
  */
 const validateRows = ({
   tableName,
   headerToIndexMap,
   rows,
   domainSchema,
-  location,
-  issues
+  location
 }) => {
-  return rows.flatMap(({ rowNumber, values }) => {
+  const validatedRows = rows.flatMap(({ rowNumber, values }) => {
     /** @type {Record<string, unknown>} */
     const rowObject = {}
     for (const [headerName, colIndex] of headerToIndexMap) {
@@ -399,8 +366,6 @@ const validateRows = ({
       })
     )
 
-    recordIssues(rowIssues, issues)
-
     return [
       {
         data: rowObject,
@@ -410,6 +375,11 @@ const validateRows = ({
       }
     ]
   })
+
+  return {
+    issues: validatedRows.flatMap((row) => row.issues),
+    rows: validatedRows
+  }
 }
 
 /**
@@ -418,44 +388,40 @@ const validateRows = ({
  * @param {{
  *   tableName: string,
  *   tableData: DataSection,
- *   domainSchema: TableSchema,
- *   issues: ValidationIssuesCollector
+ *   domainSchema: TableSchema
  * }} params
- * @returns {ValidatedTableSection} Validated table data with rows converted to ValidatedRow[]
+ * @returns {{ issues: ValidationIssue[], table: ValidatedTableSection }} Validated table data (rows as ValidatedRow[]) and the issues it produced
  */
-const validateTable = ({ tableName, tableData, domainSchema, issues }) => {
+const validateTable = ({ tableName, tableData, domainSchema }) => {
   const { headers, rows, location } = tableData
 
-  validateHeaders({
+  const headerIssues = validateHeaders({
     tableName,
     headers,
     requiredHeaders: domainSchema.requiredHeaders,
-    location,
-    issues
+    location
   })
 
-  if (issues.isFatal()) {
-    return { ...tableData, rows: [] }
+  if (hasFatal(headerIssues)) {
+    return { table: { ...tableData, rows: [] }, issues: headerIssues }
   }
 
   const headerToIndexMap = buildHeaderToIndexMap(headers)
 
-  const validatedRows = validateRows({
+  const { rows: validatedRows, issues: rowIssues } = validateRows({
     tableName,
     headerToIndexMap,
     rows,
     domainSchema,
-    location,
-    issues
+    location
   })
 
-  if (issues.isFatal()) {
-    return { ...tableData, rows: [] }
-  }
-
   return {
-    ...tableData,
-    rows: validatedRows
+    table: {
+      ...tableData,
+      rows: hasFatal(rowIssues) ? [] : validatedRows
+    },
+    issues: [...headerIssues, ...rowIssues]
   }
 }
 
@@ -484,13 +450,13 @@ const validateTable = ({ tableName, tableData, domainSchema, issues }) => {
  * @returns {(parsed: ParsedSummaryLog) => DataSyntaxValidationResult} Validator function that takes parsed summary log
  */
 export const createDataSyntaxValidator = (schemaRegistry) => (parsed) => {
-  const issues = createValidationIssues()
-
   const data = parsed?.data || {}
   const processingType = parsed?.meta?.PROCESSING_TYPE?.value
   const getTableSchema = createTableSchemaGetter(processingType, schemaRegistry)
   /** @type {ValidatedSummaryLog['data']} */
   const validatedTables = {}
+  /** @type {ValidationIssue[]} */
+  const allIssues = []
 
   for (const [tableName, tableData] of Object.entries(data)) {
     const domainSchema = getTableSchema(tableName)
@@ -500,12 +466,13 @@ export const createDataSyntaxValidator = (schemaRegistry) => (parsed) => {
         ? { sheet: tableData.location.sheet, table: tableName }
         : { table: tableName }
 
-      issues.addFatal(
-        VALIDATION_CATEGORY.TECHNICAL,
-        `Unrecognised table '${tableName}' has no schema for this processing type`,
-        VALIDATION_CODE.TABLE_UNRECOGNISED,
-        { location }
-      )
+      allIssues.push({
+        severity: VALIDATION_SEVERITY.FATAL,
+        category: VALIDATION_CATEGORY.TECHNICAL,
+        message: `Unrecognised table '${tableName}' has no schema for this processing type`,
+        code: VALIDATION_CODE.TABLE_UNRECOGNISED,
+        context: { location }
+      })
 
       // Keep unvalidated tables as-is for downstream processing.
       validatedTables[tableName] = /** @type {ValidatedTableSection} */ (
@@ -514,16 +481,18 @@ export const createDataSyntaxValidator = (schemaRegistry) => (parsed) => {
       continue
     }
 
-    validatedTables[tableName] = validateTable({
+    const { issues: tableIssues, table } = validateTable({
       tableName,
       tableData,
-      domainSchema,
-      issues
+      domainSchema
     })
+
+    validatedTables[tableName] = table
+    allIssues.push(...tableIssues)
   }
 
   return {
-    issues,
+    issues: createValidationIssues(allIssues),
     validatedData: {
       ...parsed,
       data: validatedTables

--- a/src/application/summary-logs/validations/data-syntax.test.js
+++ b/src/application/summary-logs/validations/data-syntax.test.js
@@ -713,32 +713,54 @@ describe('createDataSyntaxValidator', () => {
       expect(result.issues.isValid()).toBe(true)
     })
 
-    it.for([
+    /**
+     * @type {Array<{
+     *   scenario: string,
+     *   tables: Record<string, Record<string, unknown>>,
+     *   expectedFatalTables: string[]
+     * }>}
+     */
+    const multiTableCases = [
       {
-        order: 'earlier-table-fatal-first',
+        scenario: 'two tables, earlier one fatal first',
         tables: {
           TEST_TABLE: { ROW_ID: 1000, TEXT_FIELD: 123, NUMBER_FIELD: 42 },
           DATE_TABLE: { ROW_ID: 1001, DATE_FIELD: 'not-a-date' }
-        }
+        },
+        expectedFatalTables: ['TEST_TABLE', 'DATE_TABLE']
       },
       {
-        order: 'later-table-fatal-first',
+        scenario: 'two tables, later one fatal first',
         tables: {
           DATE_TABLE: { ROW_ID: 1001, DATE_FIELD: 'not-a-date' },
           TEST_TABLE: { ROW_ID: 1000, TEXT_FIELD: 123, NUMBER_FIELD: 42 }
-        }
+        },
+        expectedFatalTables: ['TEST_TABLE', 'DATE_TABLE']
+      },
+      {
+        scenario:
+          'three tables on one sheet, a clean table before two failing ones',
+        tables: {
+          TEST_TABLE: { ROW_ID: 1000, TEXT_FIELD: 'valid', NUMBER_FIELD: 1 },
+          DATE_TABLE: { ROW_ID: 1001, DATE_FIELD: 'not-a-date' },
+          PATTERN_TABLE: { ROW_ID: 1002, CODE_FIELD: 'invalid' }
+        },
+        expectedFatalTables: ['DATE_TABLE', 'PATTERN_TABLE']
       }
-    ])(
-      'should report fatal cell errors in every table regardless of order ($order)',
-      ({ tables }) => {
-        const result = validateRows(tables)
+    ]
+
+    it.for(multiTableCases)(
+      'should report fatal cell errors for every failing table ($scenario)',
+      ({ tables, expectedFatalTables }) => {
+        const result = validateRows(tables, {
+          location: { sheet: 'Received', row: 7, column: 'A' }
+        })
 
         const fatalTables = result.issues
           .getIssuesBySeverity(VALIDATION_SEVERITY.FATAL)
           .map((issue) => issue.context?.location?.table)
 
-        expect(fatalTables).toContain('TEST_TABLE')
-        expect(fatalTables).toContain('DATE_TABLE')
+        expect(fatalTables).toEqual(expect.arrayContaining(expectedFatalTables))
       }
     )
   })

--- a/src/application/summary-logs/validations/data-syntax.test.js
+++ b/src/application/summary-logs/validations/data-syntax.test.js
@@ -712,6 +712,35 @@ describe('createDataSyntaxValidator', () => {
 
       expect(result.issues.isValid()).toBe(true)
     })
+
+    it.for([
+      {
+        order: 'earlier-table-fatal-first',
+        tables: {
+          TEST_TABLE: { ROW_ID: 1000, TEXT_FIELD: 123, NUMBER_FIELD: 42 },
+          DATE_TABLE: { ROW_ID: 1001, DATE_FIELD: 'not-a-date' }
+        }
+      },
+      {
+        order: 'later-table-fatal-first',
+        tables: {
+          DATE_TABLE: { ROW_ID: 1001, DATE_FIELD: 'not-a-date' },
+          TEST_TABLE: { ROW_ID: 1000, TEXT_FIELD: 123, NUMBER_FIELD: 42 }
+        }
+      }
+    ])(
+      'should report fatal cell errors in every table regardless of order ($order)',
+      ({ tables }) => {
+        const result = validateRows(tables)
+
+        const fatalTables = result.issues
+          .getIssuesBySeverity(VALIDATION_SEVERITY.FATAL)
+          .map((issue) => issue.context?.location?.table)
+
+        expect(fatalTables).toContain('TEST_TABLE')
+        expect(fatalTables).toContain('DATE_TABLE')
+      }
+    )
   })
 
   describe('unrecognised tables', () => {

--- a/src/common/validation/validation-issues.js
+++ b/src/common/validation/validation-issues.js
@@ -341,6 +341,7 @@ const createIssueTransformers = (
  * Collects and manages validation issues with support for different
  * severity levels and categorization
  *
+ * @param {ValidationIssue[]} [initialIssues] - Issues to seed the collector with
  * @returns {ValidationIssuesCollector}
  *
  * @example
@@ -350,9 +351,9 @@ const createIssueTransformers = (
  *   console.log(issues.getSummary())
  * }
  */
-export const createValidationIssues = () => {
+export const createValidationIssues = (initialIssues = []) => {
   /** @type {ValidationIssue[]} */
-  const issues = []
+  const issues = [...initialIssues]
   const result = /** @type {ValidationIssuesCollector} */ ({})
 
   const adders = createIssueAdders(issues, result)

--- a/src/common/validation/validation-issues.test.js
+++ b/src/common/validation/validation-issues.test.js
@@ -123,6 +123,7 @@ describe('Validation Issues', () => {
       const result = createValidationIssues()
 
       expect(() => {
+        // @ts-expect-error -- code intentionally omitted to test the runtime guard
         result.addIssue(
           VALIDATION_SEVERITY.ERROR,
           VALIDATION_CATEGORY.TECHNICAL,
@@ -579,9 +580,9 @@ describe('Validation Issues', () => {
       expect(byRow.size).toBe(2)
       expect(byRow.get(5)).toHaveLength(2)
       expect(byRow.get(10)).toHaveLength(1)
-      expect(byRow.get(5)[0].message).toBe('Error on row 5')
-      expect(byRow.get(5)[1].message).toBe('Warning on row 5')
-      expect(byRow.get(10)[0].message).toBe('Error on row 10')
+      expect(byRow.get(5)?.[0]?.message).toBe('Error on row 5')
+      expect(byRow.get(5)?.[1]?.message).toBe('Warning on row 5')
+      expect(byRow.get(10)?.[0]?.message).toBe('Error on row 10')
     })
 
     it('ignores issues without row context', () => {
@@ -677,7 +678,8 @@ describe('Validation Issues', () => {
       all.push({
         severity: VALIDATION_SEVERITY.WARNING,
         category: VALIDATION_CATEGORY.BUSINESS,
-        message: 'Added'
+        message: 'Added',
+        code: 'TEST_CODE'
       })
 
       expect(result.getAllIssues()).toHaveLength(1)
@@ -819,11 +821,13 @@ describe('Validation Issues', () => {
       )
 
       const issue = result.getAllIssues()[0]
-      expect(issue.context.row).toBe(42)
-      expect(issue.context.field).toBe('TONNAGE')
-      expect(issue.context.section).toBe('Section 1')
-      expect(issue.context.value).toBe('invalid')
-      expect(issue.context.reason).toBe('Must be a number')
+      expect(issue.context).toEqual({
+        row: 42,
+        field: 'TONNAGE',
+        section: 'Section 1',
+        value: 'invalid',
+        reason: 'Must be a number'
+      })
     })
   })
 
@@ -999,6 +1003,7 @@ describe('Validation Issues', () => {
         VALIDATION_CATEGORY.TECHNICAL,
         'System error',
         'TEST_CODE',
+        // @ts-expect-error -- null context intentionally passed to verify it is treated as no context
         null
       )
 
@@ -1015,9 +1020,10 @@ describe('Validation Issues', () => {
   describe('issueToErrorObject', () => {
     it('transforms a domain issue to HTTP format', () => {
       const domainIssue = {
-        severity: 'ERROR',
-        category: 'TECHNICAL',
+        severity: VALIDATION_SEVERITY.ERROR,
+        category: VALIDATION_CATEGORY.TECHNICAL,
         message: 'Invalid value',
+        code: 'TEST_CODE',
         context: {
           location: {
             sheet: 'Received',
@@ -1048,9 +1054,10 @@ describe('Validation Issues', () => {
     it('creates correct type from severity and category', () => {
       expect(
         issueToErrorObject({
-          severity: 'FATAL',
-          category: 'TECHNICAL',
-          message: 'Cannot parse'
+          severity: VALIDATION_SEVERITY.FATAL,
+          category: VALIDATION_CATEGORY.TECHNICAL,
+          message: 'Cannot parse',
+          code: 'TEST_CODE'
         })
       ).toEqual({
         type: 'TECHNICAL_FATAL'
@@ -1058,9 +1065,10 @@ describe('Validation Issues', () => {
 
       expect(
         issueToErrorObject({
-          severity: 'WARNING',
-          category: 'BUSINESS',
+          severity: VALIDATION_SEVERITY.WARNING,
+          category: VALIDATION_CATEGORY.BUSINESS,
           message: 'Low value',
+          code: 'TEST_CODE',
           context: { field: 'TONNAGE' }
         })
       ).toEqual({
@@ -1071,9 +1079,10 @@ describe('Validation Issues', () => {
 
     it('includes all context fields in meta', () => {
       const httpIssue = issueToErrorObject({
-        severity: 'ERROR',
-        category: 'TECHNICAL',
+        severity: VALIDATION_SEVERITY.ERROR,
+        category: VALIDATION_CATEGORY.TECHNICAL,
         message: 'Invalid',
+        code: 'TEST_CODE',
         context: {
           location: { header: 'FIELD' },
           actual: 'bad',
@@ -1093,9 +1102,10 @@ describe('Validation Issues', () => {
 
     it('omits meta when context only contains undefined values', () => {
       const httpIssue = issueToErrorObject({
-        severity: 'ERROR',
-        category: 'TECHNICAL',
+        severity: VALIDATION_SEVERITY.ERROR,
+        category: VALIDATION_CATEGORY.TECHNICAL,
         message: 'Invalid',
+        code: 'TEST_CODE',
         context: { field: undefined, value: undefined }
       })
 
@@ -1155,8 +1165,10 @@ describe('Validation Issues', () => {
       expect(issue.severity).toBe('error')
       expect(issue.category).toBe(VALIDATION_CATEGORY.TECHNICAL)
       expect(issue.message).toBe('Missing field')
-      expect(issue.context.location.row).toBe(5)
-      expect(issue.context.location.field).toBe('PROCESSING_TYPE')
+      expect(issue.context?.location).toEqual({
+        row: 5,
+        field: 'PROCESSING_TYPE'
+      })
     })
 
     it('merges empty result without errors', () => {
@@ -1201,9 +1213,13 @@ describe('Validation Issues', () => {
     it('throws TypeError when merging non-ValidationResult', () => {
       const result = createValidationIssues()
 
+      // @ts-expect-error -- {} is not a collector; testing the runtime guard
       expect(() => result.merge({})).toThrow(TypeError)
+      // @ts-expect-error -- null is not a collector; testing the runtime guard
       expect(() => result.merge(null)).toThrow(TypeError)
+      // @ts-expect-error -- [] is not a collector; testing the runtime guard
       expect(() => result.merge([])).toThrow(TypeError)
+      // @ts-expect-error -- string is not a collector; testing the runtime guard
       expect(() => result.merge('string')).toThrow(TypeError)
     })
 

--- a/src/common/validation/validation-issues.test.js
+++ b/src/common/validation/validation-issues.test.js
@@ -7,7 +7,68 @@ import {
   VALIDATION_CATEGORY
 } from '#common/enums/validation.js'
 
+/** @import {ValidationIssue} from './validation-issues.js' */
+
 describe('Validation Issues', () => {
+  describe('createValidationIssues seeding', () => {
+    /** @type {ValidationIssue[]} */
+    const seed = [
+      {
+        severity: VALIDATION_SEVERITY.FATAL,
+        category: VALIDATION_CATEGORY.TECHNICAL,
+        message: 'Seeded fatal',
+        code: 'ERR_SEED_FATAL',
+        context: { location: { row: 1 } }
+      },
+      {
+        severity: VALIDATION_SEVERITY.WARNING,
+        category: VALIDATION_CATEGORY.BUSINESS,
+        message: 'Seeded warning',
+        code: 'ERR_SEED_WARNING'
+      }
+    ]
+
+    it('should seed the collector with the provided issues', () => {
+      const result = createValidationIssues(seed)
+
+      expect(result.getAllIssues()).toEqual(seed)
+      expect(result.getCounts()).toMatchObject({
+        fatal: 1,
+        warning: 1,
+        total: 2
+      })
+      expect(result.isFatal()).toBe(true)
+    })
+
+    it('should copy the seed so later mutations do not leak in', () => {
+      const initial = [...seed]
+      const result = createValidationIssues(initial)
+
+      initial.push({
+        severity: VALIDATION_SEVERITY.ERROR,
+        category: VALIDATION_CATEGORY.TECHNICAL,
+        message: 'Added after construction',
+        code: 'ERR_LATE'
+      })
+
+      expect(result.getAllIssues()).toHaveLength(2)
+    })
+
+    it('should keep adding issues on top of the seed', () => {
+      const result = createValidationIssues(seed)
+
+      result.addError(VALIDATION_CATEGORY.BUSINESS, 'Added later', 'ERR_ADDED')
+
+      expect(result.getAllIssues()).toHaveLength(3)
+    })
+
+    it('should default to an empty collector when no seed is given', () => {
+      const result = createValidationIssues()
+
+      expect(result.getAllIssues()).toEqual([])
+    })
+  })
+
   describe('addIssue', () => {
     it('adds an issue with all properties', () => {
       const result = createValidationIssues()


### PR DESCRIPTION
Ticket: [PAE-1538](https://eaflood.atlassian.net/browse/PAE-1538)

bug: fatal errors were short-circuiting at the first table in a sheet - leading us to miscount the total number of fatal errors

[PAE-1538]: https://eaflood.atlassian.net/browse/PAE-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ