### PR TITLE
PAE-250: Override axios to 1.16.1 to fix SSRF and prototype pollution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5923,14 +5923,40 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/b4a": {
@@ -10174,9 +10200,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"

--- a/package.json
+++ b/package.json
@@ -105,12 +105,9 @@
     "unzipper": "0.10.14"
   },
   "overrides": {
-    "@hapi/content": "6.0.2",
-    "@hapi/wreck": "18.1.1",
+    "axios": "1.16.1",
     "fast-xml-parser": "5.7.3",
     "glob": "11.1.0",
-    "protobufjs": "7.5.9",
-    "tmp": "0.2.6",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## What

`axios` reached the dependency tree at 1.15.2 via `notifications-node-client@8.3.0`, carrying a cluster of high-severity issues:

- **SSRF** — `axios` follows requests in a way that allows server-side request forgery (SNYK-JS-AXIOS-17111062).
- **Prototype pollution** — multiple gadgets allowing pollution that escalates to DoS, header injection and proxy-auth header leakage (GHSA-898c-q2cr-xwhg, GHSA-654m-c8p4-x5fp, GHSA-35jp-ww65-95wh; SNYK-JS-AXIOS-17111079/081/086).
- **`NO_PROXY` bypass** — IPv4-mapped IPv6 addresses are not recognised, allowing proxy bypass (GHSA-pjwm-pj3p-43mv).

All are fixed in `axios` 1.16.0. `notifications-node-client` hasn't yet shipped a release that pulls the patched line, so this pins it via an `overrides` entry to **1.16.1** (latest), which sits within the parent's semver range. `npm audit` and `snyk test` are both clean afterwards.

## Also in this change

While in the file, four `overrides` entries were tested for staleness by removing them and re-resolving — the dependency tree now resolves to safe versions without them, so they've been dropped: `@hapi/content`, `@hapi/wreck`, `protobufjs`, `tmp`. The `fast-xml-parser`, `glob` and `uuid` overrides are still load-bearing (removing them reintroduces vulnerabilities) and are retained.


[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ