### PR TITLE
PAE-1382: Run journey tests with the waste balance ledger flag both ways

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -99,10 +99,14 @@ jobs:
           fail-on-severity: moderate
 
   test-journey:
-    name: Run Journey Tests
+    name: Run Journey Tests (ledger=${{ matrix.ledger }})
     runs-on: ubuntu-latest
     needs: pr-prep
     if: needs.pr-prep.outputs.docs-only != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        ledger: [false, true]
     steps:
       - uses: actions/checkout@v6
 
@@ -131,6 +135,8 @@ jobs:
         with:
           epr-backend: ${{github.sha}}
           branch: ${{ steps.journey-branch.outputs.ref }}
+          waste-balance-ledger: ${{ matrix.ledger }}
+          artifact-suffix: -ledger-${{ matrix.ledger }}
 
       - name: Write journey test summary
         if: always()

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -191,3 +191,18 @@ jobs:
           EOF
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  journey-tests:
+    name: Run Journey Tests
+    runs-on: ubuntu-latest
+    needs: test-journey
+    if: always()
+    steps:
+      - name: Check journey test results
+        run: |
+          RESULT="${{ needs.test-journey.result }}"
+          if [ "$RESULT" = "failure" ] || [ "$RESULT" = "cancelled" ]; then
+            echo "Journey tests reported '$RESULT'"
+            exit 1
+          fi
+          echo "Journey tests reported '$RESULT'"


### PR DESCRIPTION
## What

Adds a `[false, true]` matrix to the `test-journey` job so every epr-backend PR runs the journey suite twice — once with `FEATURE_FLAG_WASTE_BALANCE_LEDGER=false` (today's default path) and once with `=true` (the event-sourced ledger path) — passing the flag value and a per-leg artifact suffix to the `run-journey-tests` action. No feature files or step definitions change.

## Why

[PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382) moves PRN status and waste balances onto an event-sourced ledger as the canonical source. The journey suite is the externally-observable behavioural contract: the `false` leg reproduces today's run, the `true` leg exercises the ledger, and identical pass results from one unchanged contract against both implementations are the evidence that the migration preserves behaviour.

## Depends on

The action inputs this matrix passes (`waste-balance-ledger`, `artifact-suffix`) are added in [DEFRA/epr-backend-journey-tests#487](https://github.com/DEFRA/epr-backend-journey-tests/pull/487). **That PR must merge to `main` first** — this workflow pins the action at `@main`, so until #487 lands the new inputs don't exist and both legs would run the legacy path. Treat this PR's own `Run Journey Tests (ledger=…)` checks as meaningless until #487 has merged.

## Before merge

This renames the check from `Run Journey Tests` to `Run Journey Tests (ledger=false)` and `Run Journey Tests (ledger=true)`. If `Run Journey Tests` is a required status check on the protected branch, branch protection must be updated to require the two new names, otherwise the old name will block every PR.

## Note

This is migration scaffolding. The `false` leg becomes redundant once the ledger is the canonical source and the legacy path is removed, at which point the matrix comes back out.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ