### PR TITLE
PAE-1382: Route summary-log writes on canonicalSource, not feature flag

### DIFF
--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-ledger.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-ledger.test.js
@@ -22,7 +22,7 @@ import {
   EXPORTER_HEADERS
 } from './integration-test-helpers.js'
 
-describe('Waste balance stream (Exporter, flag ON)', () => {
+describe('Waste balance stream (Exporter, canonicalSource ledger)', () => {
   const { getServer } = setupAuthContext()
 
   beforeEach(() => {
@@ -125,7 +125,6 @@ describe('Waste balance stream (Exporter, flag ON)', () => {
       processingType: 'exporter',
       organisationId,
       registrationId,
-      featureFlagOverrides: { wasteBalanceLedger: true },
       // @ts-expect-error -- TypeScript infers existingWasteBalances as never[] from the default [], WasteBalance[] is correct at runtime
       existingWasteBalances
     })

--- a/src/waste-balances/repository/helpers.js
+++ b/src/waste-balances/repository/helpers.js
@@ -169,12 +169,11 @@ const dispatchToStream = async ({
 /**
  * Shared logic for updating waste balance transactions.
  *
- * Dispatches on the `wasteBalanceLedger` feature flag and the
- * per-accreditation `canonicalSource` marker:
- * - flag OFF — embedded `transactions[]` array
- * - flag ON, marker `'ledger'` — event stream path
- * - flag ON, marker `'embedded'`, `'migrating'`, or no balance yet — embedded
- *   `transactions[]` array
+ * Dispatches on the per-accreditation `canonicalSource` marker, gated by
+ * `streamRepository` presence (matching the PRN write paths in helpers-prn):
+ * - marker `'ledger'` and streamRepository available — event stream path
+ * - marker `'embedded'`, `'migrating'`, no balance yet, or no streamRepository
+ *   — embedded `transactions[]` array
  *
  * `'migrating'` deliberately routes to the embedded path: a per-accreditation
  * rebuild that flipped the marker via `flipCanonicalSourceToMigrating` keeps
@@ -191,7 +190,6 @@ const dispatchToStream = async ({
  * @param {Object} params.dependencies
  * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [params.dependencies.systemLogsRepository]
  * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} [params.dependencies.streamRepository]
- * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [params.dependencies.featureFlags]
  * @param {(accreditationId: string) => Promise<import('../domain/model.js').WasteBalance | null>} params.findBalance
  * @param {(balance: import('../domain/model.js').WasteBalance, newTransactions: any[], user?: any) => Promise<void>} params.saveBalance
  * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} [params.user]
@@ -216,7 +214,7 @@ export const performUpdateWasteBalanceTransactions = async ({
 
   const validatedAccreditationId = validateAccreditationId(accreditation.id)
 
-  if (dependencies.featureFlags?.isWasteBalanceLedgerEnabled()) {
+  if (dependencies.streamRepository) {
     const existingBalance = await findBalance(validatedAccreditationId)
     if (
       existingBalance?.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -438,8 +438,8 @@ describe('src/waste-balances/repository/helpers.js', () => {
       expect(result).toBeUndefined()
     })
 
-    describe('feature flag dispatch', () => {
-      it('uses the stream path when flag is ON, canonicalSource is ledger, and streamRepository is provided', async () => {
+    describe('canonical source dispatch', () => {
+      it('uses the stream path when canonicalSource is ledger and streamRepository is provided', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -469,7 +469,6 @@ describe('src/waste-balances/repository/helpers.js', () => {
           wasteRecords,
           accreditation,
           dependencies: {
-            featureFlags: { isWasteBalanceLedgerEnabled: () => true },
             streamRepository
           },
           findBalance,
@@ -490,7 +489,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(findBalance).toHaveBeenCalledTimes(1)
       })
 
-      it('uses the embedded path when flag is ON but the existing balance has no marker (legacy doc)', async () => {
+      it('uses the embedded path when the existing balance has no marker (legacy doc)', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -520,8 +519,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           wasteRecords,
           accreditation,
           dependencies: {
-            featureFlags: { isWasteBalanceLedgerEnabled: () => true },
-            ledgerRepository: { insertTransactions: vi.fn() }
+            streamRepository: { appendEvent: vi.fn() }
           },
           findBalance,
           saveBalance,
@@ -532,7 +530,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(saveBalance).toHaveBeenCalledTimes(1)
       })
 
-      it('uses the embedded path when flag is ON and canonicalSource is migrating — PRN writes during a rebuild treat migrating as embedded', async () => {
+      it('uses the embedded path when canonicalSource is migrating', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -564,8 +562,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           wasteRecords,
           accreditation,
           dependencies: {
-            featureFlags: { isWasteBalanceLedgerEnabled: () => true },
-            ledgerRepository: { insertTransactions: vi.fn() }
+            streamRepository: { appendEvent: vi.fn() }
           },
           findBalance,
           saveBalance,
@@ -577,7 +574,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(saveBalance).toHaveBeenCalledTimes(1)
       })
 
-      it('uses the embedded path when flag is ON but canonicalSource is still embedded', async () => {
+      it('uses the embedded path when canonicalSource is still embedded', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -608,8 +605,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           wasteRecords,
           accreditation,
           dependencies: {
-            featureFlags: { isWasteBalanceLedgerEnabled: () => true },
-            ledgerRepository: { insertTransactions: vi.fn() }
+            streamRepository: { appendEvent: vi.fn() }
           },
           findBalance,
           saveBalance,
@@ -621,7 +617,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(saveBalance).toHaveBeenCalledTimes(1)
       })
 
-      it('uses the embedded path when flag is ON and no balance exists yet', async () => {
+      it('uses the embedded path when no balance exists yet', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -643,8 +639,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           wasteRecords,
           accreditation,
           dependencies: {
-            featureFlags: { isWasteBalanceLedgerEnabled: () => true },
-            ledgerRepository: { insertTransactions: vi.fn() }
+            streamRepository: { appendEvent: vi.fn() }
           },
           findBalance,
           saveBalance,
@@ -659,7 +654,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         )
       })
 
-      it('uses the embedded-array path when flag is OFF', async () => {
+      it('uses the embedded path when canonicalSource is ledger but no streamRepository is provided', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -674,49 +669,8 @@ describe('src/waste-balances/repository/helpers.js', () => {
           amount: 0,
           availableAmount: 0,
           transactions: [],
-          version: 0
-        }
-        const findBalance = vi.fn().mockResolvedValue(wasteBalance)
-        const saveBalance = vi.fn().mockResolvedValue(undefined)
-        vi.mocked(calculateWasteBalanceUpdates).mockClear()
-        vi.mocked(calculateWasteBalanceUpdates).mockReturnValue({
-          newTransactions: [{ id: 't1' }],
-          newAmount: 100,
-          newAvailableAmount: 100
-        })
-
-        await callPerformUpdate({
-          wasteRecords,
-          accreditation,
-          dependencies: {
-            featureFlags: { isWasteBalanceLedgerEnabled: () => false }
-          },
-          findBalance,
-          saveBalance,
-          user: { id: 'user-1' },
-          overseasSites: ORS_VALIDATION_DISABLED
-        })
-
-        expect(calculateWasteBalanceUpdates).toHaveBeenCalledTimes(1)
-        expect(saveBalance).toHaveBeenCalledTimes(1)
-      })
-
-      it('uses the v1 path when no featureFlags dependency is provided', async () => {
-        const wasteRecords = [
-          {
-            id: 'rec-1',
-            organisationId: 'org-1',
-            data: {}
-          }
-        ]
-        const accreditation = { id: 'acc-1' }
-        const wasteBalance = {
-          id: 'bal-1',
-          accreditationId: 'acc-1',
-          amount: 0,
-          availableAmount: 0,
-          transactions: [],
-          version: 0
+          version: 1,
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
         }
         const findBalance = vi.fn().mockResolvedValue(wasteBalance)
         const saveBalance = vi.fn().mockResolvedValue(undefined)
@@ -737,6 +691,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           overseasSites: ORS_VALIDATION_DISABLED
         })
 
+        expect(calculateWasteBalanceUpdates).toHaveBeenCalledTimes(1)
         expect(saveBalance).toHaveBeenCalledTimes(1)
       })
     })

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -1246,7 +1246,9 @@ describe('src/waste-balances/repository/helpers.js', () => {
           appendEvent: vi.fn(),
           findLatestByPartition: vi.fn(),
           findLatestByPartitionAndKind: vi.fn(),
-          findEventsByPrnIdAfter: vi.fn()
+          findEventsByPrnIdAfter: vi.fn(),
+          deleteByPartition: vi.fn(),
+          bulkAppendEvents: vi.fn()
         })
       const findBalance = vi.fn().mockResolvedValue(existingBalance)
       const saveBalance = vi.fn()
@@ -1477,7 +1479,9 @@ describe('src/waste-balances/repository/helpers.js', () => {
           appendEvent: vi.fn(),
           findLatestByPartition: vi.fn(),
           findLatestByPartitionAndKind: vi.fn(),
-          findEventsByPrnIdAfter: vi.fn()
+          findEventsByPrnIdAfter: vi.fn(),
+          deleteByPartition: vi.fn(),
+          bulkAppendEvents: vi.fn()
         })
       const findBalance = vi.fn().mockResolvedValue(existingBalance)
       const saveBalance = vi.fn()
@@ -1711,7 +1715,9 @@ describe('src/waste-balances/repository/helpers.js', () => {
           appendEvent: vi.fn(),
           findLatestByPartition: vi.fn(),
           findLatestByPartitionAndKind: vi.fn(),
-          findEventsByPrnIdAfter: vi.fn()
+          findEventsByPrnIdAfter: vi.fn(),
+          deleteByPartition: vi.fn(),
+          bulkAppendEvents: vi.fn()
         })
       const findBalance = vi.fn().mockResolvedValue(existingBalance)
       const saveBalance = vi.fn()
@@ -1902,7 +1908,9 @@ describe('src/waste-balances/repository/helpers.js', () => {
           appendEvent: vi.fn(),
           findLatestByPartition: vi.fn(),
           findLatestByPartitionAndKind: vi.fn(),
-          findEventsByPrnIdAfter: vi.fn()
+          findEventsByPrnIdAfter: vi.fn(),
+          deleteByPartition: vi.fn(),
+          bulkAppendEvents: vi.fn()
         })
       const findBalance = vi.fn().mockResolvedValue(existingBalance)
       const saveBalance = vi.fn()


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

The summary-log write path in `helpers.js` was the only waste-balance dispatch point that checked the `wasteBalanceLedger` feature flag before consulting the per-accreditation `canonicalSource` marker. This meant a ledger-migrated accreditation would incorrectly use the embedded write path if the flag was off.

All other write paths (PRN creation, PRN issuance, PRN cancellation in `helpers-prn.js`; PRN accept/reject in `update-status.js`) and the read path (`marker-aware-read.js`) already dispatch on `canonicalSource` alone, gated only by `streamRepository` presence.

This change aligns the summary-log path with the rest: `canonicalSource` is now the sole runtime routing condition. The feature flag remains wired through the repository layer for the startup migration sweep, but no longer influences per-request dispatch.

## Changes

- **`helpers.js`**: Replace `dependencies.featureFlags?.isWasteBalanceLedgerEnabled()` guard with `dependencies.streamRepository` presence check, matching the PRN pattern
- **`helpers.test.js`**: Rewrite dispatch tests to reflect canonicalSource-driven routing; add coverage for the "ledger marker but no streamRepository" fallback; remove obsolete flag-on/flag-off tests; add missing `deleteByPartition`/`bulkAppendEvents` mock methods to stream repository casts
- **`integration.waste-balance-ledger.test.js`**: Remove `featureFlagOverrides` from test setup since the seeded `canonicalSource: LEDGER` marker is now sufficient

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ