### PR TITLE
PAE-1382: Guard stream promotion against silently zeroing a balance

### DIFF
--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -118,16 +118,23 @@ const promoteAccreditation = async (row, deps) => {
 
   const rebuildResult = await rebuildEvents(row, deps)
 
-  // Guard: if there's no active registration but the embedded balance is
-  // non-zero, something unexpected happened (e.g. a summary log submitted
-  // against a non-approved registration). Abort rather than silently
-  // promoting to an empty stream that would read back zero.
-  if (
-    !rebuildResult &&
-    (captured.amount !== 0 || captured.availableAmount !== 0)
-  ) {
+  // Invariant: a non-zero embedded balance must reconstruct to a non-empty
+  // stream. An empty rebuild — whether from no active registration, or from
+  // authoritative sources that don't account for the balance (e.g. a summary
+  // log submitted against a non-approved registration the rebuild can't see) —
+  // would flip to ledger and read back zero. Abort loudly and leave the
+  // accreditation embedded for the next boot rather than silently zeroing a
+  // real balance.
+  const capturedNonZero =
+    captured.amount !== 0 || captured.availableAmount !== 0
+  const rebuiltStreamEmpty = !rebuildResult || rebuildResult.events.length === 0
+
+  if (capturedNonZero && rebuiltStreamEmpty) {
+    const cause = rebuildResult
+      ? 'rebuilds to an empty stream'
+      : 'has no active registration'
     throw new Error(
-      `Accreditation ${row.accreditationId} has no active registration but a non-zero balance (amount=${captured.amount}, availableAmount=${captured.availableAmount})`
+      `Accreditation ${row.accreditationId} has a non-zero balance (amount=${captured.amount}, availableAmount=${captured.availableAmount}) but ${cause}`
     )
   }
 

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -359,6 +359,8 @@ describe('runStreamPromotion', () => {
       .mockResolvedValueOnce({
         accreditationId: 'acc-race',
         version: 1,
+        amount: 0,
+        availableAmount: 0,
         canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
       })
       .mockResolvedValueOnce({
@@ -422,6 +424,8 @@ describe('runStreamPromotion', () => {
     wasteBalancesRepository.findByAccreditationId.mockResolvedValue({
       accreditationId: 'acc-ledger',
       version: 3,
+      amount: 0,
+      availableAmount: 0,
       canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
     })
 
@@ -473,6 +477,8 @@ describe('runStreamPromotion', () => {
       .mockResolvedValueOnce({
         accreditationId: 'acc-empty',
         version: 1,
+        amount: 0,
+        availableAmount: 0,
         canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
       })
       .mockResolvedValueOnce({
@@ -635,6 +641,73 @@ describe('runStreamPromotion', () => {
     )
   })
 
+  it('aborts promotion when rebuilt stream is empty but balance is non-zero', async () => {
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([
+      {
+        accreditationId: 'acc-divergent',
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+    ])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    wasteBalancesRepository.findByAccreditationId.mockResolvedValue({
+      accreditationId: 'acc-divergent',
+      version: 1,
+      amount: 75,
+      availableAmount: 75,
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+    })
+
+    organisationsRepository.findById.mockResolvedValue({
+      id: 'org-1',
+      registrations: [
+        {
+          id: 'reg-1',
+          accreditationId: 'acc-divergent',
+          registrationNumber: 'CBDU1',
+          status: 'approved'
+        }
+      ],
+      accreditations: [
+        {
+          id: 'acc-divergent',
+          accreditationNumber: 'CBDA1',
+          status: 'approved'
+        }
+      ]
+    })
+
+    // Active registration resolves, but the rebuild produces no events
+    // (default computeRebuiltStream mock returns events: []). Promoting would
+    // flip to ledger and read back zero, masking the non-zero balance.
+
+    await runStreamPromotion(mockServer)
+
+    // Should not promote: marker never touched, no stream writes
+    expect(
+      wasteBalancesRepository.flipCanonicalSourceToMigrating
+    ).not.toHaveBeenCalled()
+    expect(streamRepository.deleteByPartition).not.toHaveBeenCalled()
+    expect(streamRepository.bulkAppendEvents).not.toHaveBeenCalled()
+
+    // Counted as failed with an error log
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('non-zero balance')
+      })
+    )
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('failed=1')
+      })
+    )
+  })
+
   it('counts as failed when no waste balance exists for accreditation', async () => {
     const migratingToArray = vi.fn().mockResolvedValue([])
     const embeddedToArray = vi.fn().mockResolvedValue([
@@ -707,6 +780,8 @@ describe('runStreamPromotion', () => {
     wasteBalancesRepository.findByAccreditationId.mockResolvedValue({
       accreditationId: 'acc-nolift',
       version: 1,
+      amount: 0,
+      availableAmount: 0,
       canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
     })
 


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
The startup stream-promotion sweep flips each embedded accreditation onto the event-sourced ledger and then serves the stream-derived balance. An accreditation whose embedded balance is non-zero but whose rebuilt stream comes back empty would be promoted to the `ledger` marker and then read back as zero, silently losing the balance. The two reconstructions involved are independent and can diverge: the stream rebuild credits only via submitted summary logs, whereas the embedded write path credits each waste record directly.

The promotion guard previously only caught the case where an accreditation had no active registration. This extends it to the general invariant: a non-zero embedded balance must reconstruct to a non-empty stream. When it does not, the promotion aborts for that accreditation — the canonical-source marker is left untouched, the failure is logged at error and counted, and the accreditation stays `embedded` to be retried on the next boot.

This turns a silent data-loss path into a loud, recoverable failure, without reverting the deliberate behaviour of reading an empty `ledger` stream as a zero balance for accreditations that legitimately have no activity.

The narrower case where the rebuilt stream is non-empty but its total differs from the embedded balance is tracked separately.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ