### PR TITLE
PAE-1382: Add dev endpoint to promote single accreditation to ledger

### DIFF
--- a/src/routes/v1/dev/index.js
+++ b/src/routes/v1/dev/index.js
@@ -1,2 +1,3 @@
 export * from './form-submissions/index.js'
 export * from './organisations/index.js'
+export * from './waste-balances/index.js'

--- a/src/routes/v1/dev/waste-balances/index.js
+++ b/src/routes/v1/dev/waste-balances/index.js
@@ -1,0 +1,1 @@
+export * from './promote-to-ledger/index.js'

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/index.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/index.js
@@ -1,0 +1,1 @@
+export { devWasteBalancesPromoteToLedgerPost } from './post.js'

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
@@ -16,16 +16,15 @@ import { promoteAccreditation } from '#server/run-stream-promotion.js'
  *   wasteRecordsRepository: import('#repositories/waste-records/port.js').WasteRecordsRepository
  *   overseasSitesRepository: import('#overseas-sites/repository/port.js').OverseasSitesRepository
  *   summaryLogsRepository: import('#repositories/summary-logs/port.js').SummaryLogsRepository
- *   params: { organisationId: string, registrationId: string, accreditationId: string }
+ *   params: { organisationId: string, accreditationId: string }
  * }} PromoteToLedgerRequest
  */
 
 export const devWasteBalancesPromoteToLedgerPath =
-  '/v1/dev/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/promote-to-ledger'
+  '/v1/dev/organisations/{organisationId}/accreditations/{accreditationId}/promote-to-ledger'
 
 const params = Joi.object({
   organisationId: Joi.string().trim().min(1).required(),
-  registrationId: Joi.string().trim().min(1).required(),
   accreditationId: Joi.string().trim().min(1).required()
 }).messages({
   'any.required': '{#label} is required',
@@ -40,8 +39,8 @@ const params = Joi.object({
  * @param {Object} h - Hapi response toolkit
  */
 async function handler(request, h) {
-  const { organisationId, registrationId, accreditationId } = request.params
-  const { wasteBalancesRepository, streamRepository } = request
+  const { organisationId, accreditationId } = request.params
+  const { wasteBalancesRepository } = request
 
   const balance =
     await wasteBalancesRepository.findByAccreditationId(accreditationId)
@@ -66,7 +65,7 @@ async function handler(request, h) {
     { accreditationId, organisationId },
     {
       wasteBalancesRepository,
-      streamRepository,
+      streamRepository: request.streamRepository,
       organisationsRepository: request.organisationsRepository,
       prnRepository: request.packagingRecyclingNotesRepository,
       wasteRecordsRepository: request.wasteRecordsRepository,
@@ -81,13 +80,7 @@ async function handler(request, h) {
     )
   }
 
-  const latestEvent = await streamRepository.findLatestByPartition(
-    registrationId,
-    accreditationId
-  )
-  const eventCount = latestEvent?.number ?? 0
-
-  return h.response({ result: 'promoted', eventCount }).code(StatusCodes.OK)
+  return h.response({ result: 'promoted' }).code(StatusCodes.OK)
 }
 
 export const devWasteBalancesPromoteToLedgerPost = {

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
@@ -16,14 +16,16 @@ import { promoteAccreditation } from '#server/run-stream-promotion.js'
  *   wasteRecordsRepository: import('#repositories/waste-records/port.js').WasteRecordsRepository
  *   overseasSitesRepository: import('#overseas-sites/repository/port.js').OverseasSitesRepository
  *   summaryLogsRepository: import('#repositories/summary-logs/port.js').SummaryLogsRepository
- *   params: { accreditationId: string }
+ *   params: { organisationId: string, registrationId: string, accreditationId: string }
  * }} PromoteToLedgerRequest
  */
 
 export const devWasteBalancesPromoteToLedgerPath =
-  '/v1/dev/waste-balances/{accreditationId}/promote-to-ledger'
+  '/v1/dev/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/promote-to-ledger'
 
 const params = Joi.object({
+  organisationId: Joi.string().trim().min(1).required(),
+  registrationId: Joi.string().trim().min(1).required(),
   accreditationId: Joi.string().trim().min(1).required()
 }).messages({
   'any.required': '{#label} is required',
@@ -38,10 +40,9 @@ const params = Joi.object({
  * @param {Object} h - Hapi response toolkit
  */
 async function handler(request, h) {
-  const { accreditationId } = request.params
+  const { organisationId, registrationId, accreditationId } = request.params
   const { wasteBalancesRepository, streamRepository } = request
 
-  // Look up the waste balance
   const balance =
     await wasteBalancesRepository.findByAccreditationId(accreditationId)
 
@@ -51,40 +52,27 @@ async function handler(request, h) {
     )
   }
 
-  // Already promoted: idempotent no-op
   if (balance.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER) {
     return h.response({ result: 'already-promoted' }).code(StatusCodes.OK)
   }
 
-  // Stuck migrating: reset to embedded so promoteAccreditation can proceed
   if (balance.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING) {
     await wasteBalancesRepository.resetCanonicalSourceToEmbedded({
       accreditationId
     })
   }
 
-  const deps = {
-    wasteBalancesRepository,
-    streamRepository,
-    organisationsRepository: request.organisationsRepository,
-    prnRepository: request.packagingRecyclingNotesRepository,
-    wasteRecordsRepository: request.wasteRecordsRepository,
-    overseasSitesRepository: request.overseasSitesRepository,
-    summaryLogsRepository: request.summaryLogsRepository
-  }
-
-  // registrationId is not stored on the waste balance document, so we
-  // resolve it from the organisation to query the stream event count.
-  const organisation = await request.organisationsRepository.findById(
-    balance.organisationId
-  )
-  const registration = organisation?.registrations.find(
-    (r) => r.accreditationId === accreditationId
-  )
-
   const result = await promoteAccreditation(
-    { accreditationId, organisationId: balance.organisationId },
-    deps
+    { accreditationId, organisationId },
+    {
+      wasteBalancesRepository,
+      streamRepository,
+      organisationsRepository: request.organisationsRepository,
+      prnRepository: request.packagingRecyclingNotesRepository,
+      wasteRecordsRepository: request.wasteRecordsRepository,
+      overseasSitesRepository: request.overseasSitesRepository,
+      summaryLogsRepository: request.summaryLogsRepository
+    }
   )
 
   if (result !== 'promoted') {
@@ -93,17 +81,11 @@ async function handler(request, h) {
     )
   }
 
-  // Read the event count from the stream after promotion. When there is
-  // no active registration the sweep promotes with an empty stream, so
-  // there are no events to count.
-  let eventCount = 0
-  if (registration) {
-    const latestEvent = await streamRepository.findLatestByPartition(
-      registration.id,
-      accreditationId
-    )
-    eventCount = latestEvent?.number ?? 0
-  }
+  const latestEvent = await streamRepository.findLatestByPartition(
+    registrationId,
+    accreditationId
+  )
+  const eventCount = latestEvent?.number ?? 0
 
   return h.response({ result: 'promoted', eventCount }).code(StatusCodes.OK)
 }

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
@@ -92,13 +92,10 @@ async function handler(request, h) {
       ACTIVE_REGISTRATION_STATUSES.has(r.status)
   )
 
-  const row = {
-    accreditationId,
-    organisationId: balance.organisationId,
-    registrationId: registration?.id
-  }
-
-  const result = await promoteAccreditation(row, deps)
+  const result = await promoteAccreditation(
+    { accreditationId, organisationId: balance.organisationId },
+    deps
+  )
 
   if (result !== 'promoted') {
     throw Boom.internal(

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
@@ -4,14 +4,6 @@ import Joi from 'joi'
 
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import { promoteAccreditation } from '#server/run-stream-promotion.js'
-import { REG_ACC_STATUS } from '#domain/organisations/model.js'
-
-/** @type {Set<import('#domain/organisations/registration.js').Registration['status']>} */
-const ACTIVE_REGISTRATION_STATUSES = new Set([
-  REG_ACC_STATUS.APPROVED,
-  REG_ACC_STATUS.CANCELLED,
-  REG_ACC_STATUS.SUSPENDED
-])
 
 /** @import {HapiRequest} from '#common/hapi-types.js' */
 
@@ -82,14 +74,12 @@ async function handler(request, h) {
   }
 
   // registrationId is not stored on the waste balance document, so we
-  // resolve it from the organisation the same way the startup sweep does.
+  // resolve it from the organisation to query the stream event count.
   const organisation = await request.organisationsRepository.findById(
     balance.organisationId
   )
   const registration = organisation?.registrations.find(
-    (r) =>
-      r.accreditationId === accreditationId &&
-      ACTIVE_REGISTRATION_STATUSES.has(r.status)
+    (r) => r.accreditationId === accreditationId
   )
 
   const result = await promoteAccreditation(

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
@@ -1,0 +1,111 @@
+import Boom from '@hapi/boom'
+import { StatusCodes } from 'http-status-codes'
+import Joi from 'joi'
+
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { promoteAccreditation } from '#server/run-stream-promotion.js'
+
+/** @import {HapiRequest} from '#common/hapi-types.js' */
+
+/**
+ * @typedef {HapiRequest & {
+ *   wasteBalancesRepository: import('#waste-balances/repository/port.js').WasteBalancesRepository
+ *   streamRepository: import('#waste-balances/repository/stream-port.js').WasteBalanceStreamRepository
+ *   organisationsRepository: import('#repositories/organisations/port.js').OrganisationsRepository
+ *   packagingRecyclingNotesRepository: import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository
+ *   wasteRecordsRepository: import('#repositories/waste-records/port.js').WasteRecordsRepository
+ *   overseasSitesRepository: import('#overseas-sites/repository/port.js').OverseasSitesRepository
+ *   summaryLogsRepository: import('#repositories/summary-logs/port.js').SummaryLogsRepository
+ *   params: { accreditationId: string }
+ * }} PromoteToLedgerRequest
+ */
+
+export const devWasteBalancesPromoteToLedgerPath =
+  '/v1/dev/waste-balances/{accreditationId}/promote-to-ledger'
+
+const params = Joi.object({
+  accreditationId: Joi.string().trim().min(1).required()
+}).messages({
+  'any.required': '{#label} is required',
+  'string.empty': '{#label} cannot be empty',
+  'string.min': '{#label} cannot be empty'
+})
+
+/**
+ * Promote a single accreditation's waste balance from embedded to ledger.
+ *
+ * @param {PromoteToLedgerRequest} request
+ * @param {Object} h - Hapi response toolkit
+ */
+async function handler(request, h) {
+  const { accreditationId } = request.params
+  const { wasteBalancesRepository, streamRepository } = request
+
+  // Look up the waste balance
+  const balance =
+    await wasteBalancesRepository.findByAccreditationId(accreditationId)
+
+  if (!balance) {
+    throw Boom.notFound(
+      `No waste balance found for accreditation ${accreditationId}`
+    )
+  }
+
+  // Already promoted: idempotent no-op
+  if (balance.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER) {
+    return h.response({ result: 'already-promoted' }).code(StatusCodes.OK)
+  }
+
+  // Stuck migrating: reset to embedded so promoteAccreditation can proceed
+  if (balance.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING) {
+    await wasteBalancesRepository.resetCanonicalSourceToEmbedded({
+      accreditationId
+    })
+  }
+
+  const deps = {
+    wasteBalancesRepository,
+    streamRepository,
+    organisationsRepository: request.organisationsRepository,
+    prnRepository: request.packagingRecyclingNotesRepository,
+    wasteRecordsRepository: request.wasteRecordsRepository,
+    overseasSitesRepository: request.overseasSitesRepository,
+    summaryLogsRepository: request.summaryLogsRepository
+  }
+
+  const row = {
+    accreditationId,
+    organisationId: balance.organisationId,
+    registrationId: balance.registrationId
+  }
+
+  const result = await promoteAccreditation(row, deps)
+
+  if (result !== 'promoted') {
+    throw Boom.internal(
+      `Promotion failed for accreditation ${accreditationId}: ${result}`
+    )
+  }
+
+  // Read the event count from the stream after promotion
+  const latestEvent = await streamRepository.findLatestByPartition(
+    balance.registrationId,
+    accreditationId
+  )
+  const eventCount = latestEvent?.number ?? 0
+
+  return h.response({ result: 'promoted', eventCount }).code(StatusCodes.OK)
+}
+
+export const devWasteBalancesPromoteToLedgerPost = {
+  method: 'POST',
+  path: devWasteBalancesPromoteToLedgerPath,
+  options: {
+    auth: false,
+    tags: ['api'],
+    validate: {
+      params
+    }
+  },
+  handler
+}

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
@@ -4,6 +4,14 @@ import Joi from 'joi'
 
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import { promoteAccreditation } from '#server/run-stream-promotion.js'
+import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+
+/** @type {Set<import('#domain/organisations/registration.js').Registration['status']>} */
+const ACTIVE_REGISTRATION_STATUSES = new Set([
+  REG_ACC_STATUS.APPROVED,
+  REG_ACC_STATUS.CANCELLED,
+  REG_ACC_STATUS.SUSPENDED
+])
 
 /** @import {HapiRequest} from '#common/hapi-types.js' */
 
@@ -73,10 +81,21 @@ async function handler(request, h) {
     summaryLogsRepository: request.summaryLogsRepository
   }
 
+  // registrationId is not stored on the waste balance document, so we
+  // resolve it from the organisation the same way the startup sweep does.
+  const organisation = await request.organisationsRepository.findById(
+    balance.organisationId
+  )
+  const registration = organisation?.registrations.find(
+    (r) =>
+      r.accreditationId === accreditationId &&
+      ACTIVE_REGISTRATION_STATUSES.has(r.status)
+  )
+
   const row = {
     accreditationId,
     organisationId: balance.organisationId,
-    registrationId: balance.registrationId
+    registrationId: registration?.id
   }
 
   const result = await promoteAccreditation(row, deps)
@@ -87,12 +106,17 @@ async function handler(request, h) {
     )
   }
 
-  // Read the event count from the stream after promotion
-  const latestEvent = await streamRepository.findLatestByPartition(
-    balance.registrationId,
-    accreditationId
-  )
-  const eventCount = latestEvent?.number ?? 0
+  // Read the event count from the stream after promotion. When there is
+  // no active registration the sweep promotes with an empty stream, so
+  // there are no events to count.
+  let eventCount = 0
+  if (registration) {
+    const latestEvent = await streamRepository.findLatestByPartition(
+      registration.id,
+      accreditationId
+    )
+    eventCount = latestEvent?.number ?? 0
+  }
 
   return h.response({ result: 'promoted', eventCount }).code(StatusCodes.OK)
 }

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.test.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.test.js
@@ -34,7 +34,7 @@ import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
  * }} SetupServerOptions
  */
 
-describe('POST /v1/dev/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/promote-to-ledger', () => {
+describe('POST /v1/dev/organisations/{organisationId}/accreditations/{accreditationId}/promote-to-ledger', () => {
   setupAuthContext()
 
   const { VALID_FROM, VALID_TO } = getValidDateRange()
@@ -183,11 +183,10 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
   /**
    * @param {string} organisationId
-   * @param {string} registrationId
    * @param {string} accreditationId
    */
-  function url(organisationId, registrationId, accreditationId) {
-    return `/v1/dev/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/promote-to-ledger`
+  function url(organisationId, accreditationId) {
+    return `/v1/dev/organisations/${organisationId}/accreditations/${accreditationId}/promote-to-ledger`
   }
 
   /** @param {SetupServerOptions} [options] */
@@ -239,7 +238,7 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
       const response = await server.inject({
         method: 'POST',
-        url: url('org-1', 'reg-1', 'acc-1')
+        url: url('org-1', 'acc-1')
       })
 
       expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
@@ -252,7 +251,7 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
       const response = await server.inject({
         method: 'POST',
-        url: url('org-1', 'reg-1', '%20')
+        url: url('org-1', '%20')
       })
 
       expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
@@ -265,7 +264,7 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
       const response = await server.inject({
         method: 'POST',
-        url: url('org-1', 'reg-1', 'nonexistent')
+        url: url('org-1', 'nonexistent')
       })
 
       expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
@@ -274,8 +273,7 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
   describe('idempotency', () => {
     it('should return 200 with already-promoted when balance is already ledger', async () => {
-      const { organisation, accreditationId, registrationId, wasteBalance } =
-        buildTestData()
+      const { organisation, accreditationId, wasteBalance } = buildTestData()
       wasteBalance.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
 
       const server = await setupServer({
@@ -285,7 +283,7 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
       const response = await server.inject({
         method: 'POST',
-        url: url(organisation.id, registrationId, accreditationId)
+        url: url(organisation.id, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
@@ -299,7 +297,6 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
       const {
         organisation,
         accreditationId,
-        registrationId,
         summaryLog,
         summaryLogFileId,
         wasteRecord,
@@ -333,7 +330,7 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
       const response = await server.inject({
         method: 'POST',
-        url: url(organisation.id, registrationId, accreditationId)
+        url: url(organisation.id, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
@@ -342,8 +339,7 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
   describe('happy path', () => {
     it('should promote a zero-balance accreditation with no event history', async () => {
-      const { organisation, accreditationId, registrationId, wasteBalance } =
-        buildTestData()
+      const { organisation, accreditationId, wasteBalance } = buildTestData()
       wasteBalance.amount = 0
       wasteBalance.availableAmount = 0
 
@@ -354,20 +350,18 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
       const response = await server.inject({
         method: 'POST',
-        url: url(organisation.id, registrationId, accreditationId)
+        url: url(organisation.id, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       const body = JSON.parse(response.payload)
       expect(body.result).toBe('promoted')
-      expect(body.eventCount).toBe(0)
     })
 
     it('should promote an embedded balance to ledger with non-empty event history', async () => {
       const {
         organisation,
         accreditationId,
-        registrationId,
         summaryLog,
         summaryLogFileId,
         wasteRecord,
@@ -385,13 +379,12 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
       const response = await server.inject({
         method: 'POST',
-        url: url(organisation.id, registrationId, accreditationId)
+        url: url(organisation.id, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       const body = JSON.parse(response.payload)
       expect(body.result).toBe('promoted')
-      expect(body.eventCount).toBeGreaterThanOrEqual(3)
 
       const updatedBalance = await /** @type {any} */ (
         server.app.wasteBalancesRepository
@@ -405,7 +398,6 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
       const {
         organisation,
         accreditationId,
-        registrationId,
         summaryLog,
         summaryLogFileId,
         wasteRecord,
@@ -423,7 +415,7 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
       const response = await server.inject({
         method: 'POST',
-        url: url(organisation.id, registrationId, accreditationId)
+        url: url(organisation.id, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
@@ -433,7 +425,6 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
       const {
         organisation,
         accreditationId,
-        registrationId,
         summaryLog,
         summaryLogFileId,
         wasteRecord,
@@ -453,7 +444,7 @@ describe('POST /v1/dev/organisations/{organisationId}/registrations/{registratio
 
       const response = await server.inject({
         method: 'POST',
-        url: url(organisation.id, registrationId, accreditationId)
+        url: url(organisation.id, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.test.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.test.js
@@ -1,0 +1,459 @@
+import { randomUUID } from 'node:crypto'
+import { ObjectId } from 'mongodb'
+import { StatusCodes } from 'http-status-codes'
+import { vi } from 'vitest'
+
+import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
+import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
+import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
+import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
+import {
+  buildOrganisation,
+  buildRegistration,
+  buildAccreditation,
+  getValidDateRange
+} from '#repositories/organisations/contract/test-data.js'
+import { buildAwaitingAcceptancePrn } from '#packaging-recycling-notes/repository/contract/test-data.js'
+import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
+import { buildWasteRecord } from '#repositories/waste-records/contract/test-data.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { createTestServer } from '#test/create-test-server.js'
+import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+
+describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () => {
+  setupAuthContext()
+
+  const { VALID_FROM, VALID_TO } = getValidDateRange()
+
+  /**
+   * Build a realistic test scenario: an accreditation that has received a
+   * summary-log submission (crediting 200 tonnes) followed by a PRN issuance
+   * (debiting 50 tonnes), giving a net positive balance. This ensures the
+   * migrated event history is non-empty and realistic.
+   */
+  function buildTestData() {
+    const accreditationId = new ObjectId().toString()
+    const registrationId = new ObjectId().toString()
+    const summaryLogFileId = `file-${randomUUID()}`
+
+    const accreditation = buildAccreditation({
+      id: accreditationId,
+      wasteProcessingType: 'reprocessor',
+      material: 'plastic',
+      validFrom: VALID_FROM,
+      validTo: VALID_TO,
+      statusHistory: [
+        { status: 'created', updatedAt: new Date('2025-01-01') },
+        { status: 'approved', updatedAt: new Date('2025-02-01') }
+      ]
+    })
+
+    const registration = buildRegistration({
+      id: registrationId,
+      accreditationId,
+      wasteProcessingType: 'reprocessor',
+      material: 'plastic',
+      statusHistory: [
+        { status: 'created', updatedAt: new Date('2025-01-01') },
+        { status: 'approved', updatedAt: new Date('2025-02-01') }
+      ]
+    })
+
+    const organisation = buildOrganisation({
+      registrations: [registration],
+      accreditations: [accreditation]
+    })
+
+    // A submitted summary log that will produce a credit event
+    const summaryLog = summaryLogFactory.submitted({
+      organisationId: organisation.id,
+      registrationId,
+      submittedAt: '2025-06-15T10:00:00.000Z',
+      file: { id: summaryLogFileId }
+    })
+
+    // A waste record whose version references the summary log, with enough
+    // fields filled for classifyForWasteBalance to return INCLUDED with 200t
+    const wasteRecord = buildWasteRecord({
+      organisationId: organisation.id,
+      registrationId,
+      type: WASTE_RECORD_TYPE.RECEIVED,
+      data: {
+        processingType: 'REPROCESSOR_INPUT',
+        ROW_ID: 'R001',
+        DATE_RECEIVED_FOR_REPROCESSING: VALID_FROM,
+        EWC_CODE: '02 01 04',
+        DESCRIPTION_WASTE: 'Plastic packaging waste',
+        WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+        GROSS_WEIGHT: 220,
+        TARE_WEIGHT: 10,
+        PALLET_WEIGHT: 5,
+        NET_WEIGHT: 205,
+        BAILING_WIRE_PROTOCOL: 'No',
+        HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Visual assessment',
+        WEIGHT_OF_NON_TARGET_MATERIALS: 5,
+        RECYCLABLE_PROPORTION_PERCENTAGE: 100,
+        TONNAGE_RECEIVED_FOR_RECYCLING: 200
+      },
+      versions: [
+        {
+          id: randomUUID(),
+          createdAt: '2025-06-15T10:00:00.000Z',
+          status: 'created',
+          summaryLog: { id: summaryLogFileId, uri: 's3://bucket/key' },
+          data: {
+            processingType: 'REPROCESSOR_INPUT',
+            ROW_ID: 'R001',
+            DATE_RECEIVED_FOR_REPROCESSING: VALID_FROM,
+            EWC_CODE: '02 01 04',
+            DESCRIPTION_WASTE: 'Plastic packaging waste',
+            WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+            GROSS_WEIGHT: 220,
+            TARE_WEIGHT: 10,
+            PALLET_WEIGHT: 5,
+            NET_WEIGHT: 205,
+            BAILING_WIRE_PROTOCOL: 'No',
+            HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Visual assessment',
+            WEIGHT_OF_NON_TARGET_MATERIALS: 5,
+            RECYCLABLE_PROPORTION_PERCENTAGE: 100,
+            TONNAGE_RECEIVED_FOR_RECYCLING: 200
+          }
+        }
+      ]
+    })
+
+    // A PRN that has been issued (draft → awaiting_authorisation → awaiting_acceptance),
+    // debiting 50 tonnes from the available balance
+    const prn = {
+      ...buildAwaitingAcceptancePrn({
+        organisation: {
+          id: String(organisation.orgId),
+          name: organisation.name,
+          tradingName: organisation.name
+        },
+        registrationId,
+        accreditation: {
+          id: accreditationId,
+          accreditationNumber: `ACC-${accreditationId}`,
+          accreditationYear: 2026,
+          material: 'plastic',
+          submittedToRegulator: 'ea',
+          siteAddress: { line1: '1 Test Street', postcode: 'SW1A 1AA' }
+        },
+        tonnage: 50
+      }),
+      id: new ObjectId().toHexString()
+    }
+
+    // Embedded balance reflecting the above: 200 credited, 50 deducted from available
+    const wasteBalance = {
+      id: new ObjectId().toString(),
+      organisationId: organisation.id,
+      accreditationId,
+      registrationId,
+      schemaVersion: 1,
+      version: 1,
+      amount: 200,
+      availableAmount: 150,
+      transactions: [],
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+    }
+
+    return {
+      organisation,
+      accreditationId,
+      registrationId,
+      summaryLog,
+      summaryLogFileId,
+      wasteRecord,
+      prn,
+      wasteBalance
+    }
+  }
+
+  function url(accreditationId) {
+    return `/v1/dev/waste-balances/${accreditationId}/promote-to-ledger`
+  }
+
+  async function setupServer({
+    featureFlagOverrides = {},
+    organisations = [],
+    prns = [],
+    wasteRecords = [],
+    wasteBalances = [],
+    summaryLogs = []
+  } = {}) {
+    const featureFlags = createInMemoryFeatureFlags({
+      devEndpoints: true,
+      ...featureFlagOverrides
+    })
+
+    const organisationsFactory =
+      createInMemoryOrganisationsRepository(organisations)
+    const prnFactory = createInMemoryPackagingRecyclingNotesRepository(prns)
+    const wasteRecordsFactory =
+      createInMemoryWasteRecordsRepository(wasteRecords)
+
+    const server = await createTestServer({
+      repositories: {
+        organisationsRepository: organisationsFactory,
+        packagingRecyclingNotesRepository: prnFactory,
+        wasteRecordsRepository: wasteRecordsFactory
+      },
+      featureFlags
+    })
+
+    // Seed waste balances into the in-memory store
+    const storage = server.app.wasteBalancesRepository._getStorageForTesting()
+    for (const wb of wasteBalances) {
+      storage.push(wb)
+    }
+
+    // Seed summary logs via the repository insert method
+    for (const { id, summaryLog } of summaryLogs) {
+      await server.app.summaryLogsRepository.insert(id, summaryLog)
+    }
+
+    return server
+  }
+
+  describe('feature flag disabled', () => {
+    it('should return 404 when devEndpoints feature flag is disabled', async () => {
+      const server = await setupServer({
+        featureFlagOverrides: { devEndpoints: false }
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: url('abc123')
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    })
+  })
+
+  describe('validation', () => {
+    it('should return 422 when accreditationId is empty', async () => {
+      const server = await setupServer()
+
+      const response = await server.inject({
+        method: 'POST',
+        url: url('%20')
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+    })
+  })
+
+  describe('not found', () => {
+    it('should return 404 when no waste balance exists for the accreditation', async () => {
+      const server = await setupServer()
+
+      const response = await server.inject({
+        method: 'POST',
+        url: url('nonexistent-accreditation-id')
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    })
+  })
+
+  describe('idempotency', () => {
+    it('should return 200 with already-promoted when balance is already ledger', async () => {
+      const { organisation, accreditationId, wasteBalance } = buildTestData()
+      wasteBalance.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+
+      const server = await setupServer({
+        organisations: [organisation],
+        wasteBalances: [wasteBalance]
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: url(accreditationId)
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const body = JSON.parse(response.payload)
+      expect(body.result).toBe('already-promoted')
+    })
+  })
+
+  describe('promotion failure', () => {
+    it('should return 500 when promotion is skipped due to version conflict', async () => {
+      const {
+        organisation,
+        accreditationId,
+        summaryLog,
+        summaryLogFileId,
+        wasteRecord,
+        prn,
+        wasteBalance
+      } = buildTestData()
+
+      const server = await setupServer({
+        organisations: [organisation],
+        prns: [prn],
+        wasteRecords: [wasteRecord],
+        wasteBalances: [wasteBalance],
+        summaryLogs: [{ id: summaryLogFileId, summaryLog }]
+      })
+
+      // Simulate a version conflict by bumping the balance version
+      // after the handler reads it but before promoteAccreditation flips
+      const storage = server.app.wasteBalancesRepository._getStorageForTesting()
+      const original = storage.find(
+        (wb) => wb.accreditationId === accreditationId
+      )
+
+      // Intercept flipCanonicalSourceToMigrating to bump version first
+      const originalFlip =
+        server.app.wasteBalancesRepository.flipCanonicalSourceToMigrating
+      vi.spyOn(
+        server.app.wasteBalancesRepository,
+        'flipCanonicalSourceToMigrating'
+      ).mockImplementation(async (params) => {
+        // Bump the version so the optimistic lock misses
+        original.version += 1
+        return originalFlip(params)
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: url(accreditationId)
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+    })
+  })
+
+  describe('happy path', () => {
+    it('should promote a zero-balance accreditation with no event history', async () => {
+      const { organisation, accreditationId, wasteBalance } = buildTestData()
+      wasteBalance.amount = 0
+      wasteBalance.availableAmount = 0
+
+      const server = await setupServer({
+        organisations: [organisation],
+        wasteBalances: [wasteBalance]
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: url(accreditationId)
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const body = JSON.parse(response.payload)
+      expect(body.result).toBe('promoted')
+      expect(body.eventCount).toBe(0)
+    })
+
+    it('should promote an embedded balance to ledger with non-empty event history', async () => {
+      const {
+        organisation,
+        accreditationId,
+        summaryLog,
+        summaryLogFileId,
+        wasteRecord,
+        prn,
+        wasteBalance
+      } = buildTestData()
+
+      const server = await setupServer({
+        organisations: [organisation],
+        prns: [prn],
+        wasteRecords: [wasteRecord],
+        wasteBalances: [wasteBalance],
+        summaryLogs: [{ id: summaryLogFileId, summaryLog }]
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: url(accreditationId)
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const body = JSON.parse(response.payload)
+      expect(body.result).toBe('promoted')
+      // Summary log submission + PRN created + PRN issued = 3 events
+      expect(body.eventCount).toBeGreaterThanOrEqual(3)
+
+      // Verify the canonical source flipped to ledger
+      const updatedBalance =
+        await server.app.wasteBalancesRepository.findByAccreditationId(
+          accreditationId
+        )
+      expect(updatedBalance.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      )
+    })
+
+    it('should not require authentication', async () => {
+      const {
+        organisation,
+        accreditationId,
+        summaryLog,
+        summaryLogFileId,
+        wasteRecord,
+        prn,
+        wasteBalance
+      } = buildTestData()
+
+      const server = await setupServer({
+        organisations: [organisation],
+        prns: [prn],
+        wasteRecords: [wasteRecord],
+        wasteBalances: [wasteBalance],
+        summaryLogs: [{ id: summaryLogFileId, summaryLog }]
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: url(accreditationId)
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+
+    it('should recover a stuck migrating balance before promoting', async () => {
+      const {
+        organisation,
+        accreditationId,
+        summaryLog,
+        summaryLogFileId,
+        wasteRecord,
+        prn,
+        wasteBalance
+      } = buildTestData()
+      wasteBalance.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      wasteBalance.migratingSince = new Date().toISOString()
+
+      const server = await setupServer({
+        organisations: [organisation],
+        prns: [prn],
+        wasteRecords: [wasteRecord],
+        wasteBalances: [wasteBalance],
+        summaryLogs: [{ id: summaryLogFileId, summaryLog }]
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: url(accreditationId)
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const body = JSON.parse(response.payload)
+      expect(body.result).toBe('promoted')
+
+      const updatedBalance =
+        await server.app.wasteBalancesRepository.findByAccreditationId(
+          accreditationId
+        )
+      expect(updatedBalance.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      )
+    })
+  })
+})

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.test.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.test.js
@@ -21,7 +21,20 @@ import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createTestServer } from '#test/create-test-server.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 
-describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () => {
+/** @import {WasteBalance} from '#waste-balances/domain/model.js' */
+
+/**
+ * @typedef {{
+ *   featureFlagOverrides?: Record<string, boolean>
+ *   organisations?: object[]
+ *   prns?: object[]
+ *   wasteRecords?: object[]
+ *   wasteBalances?: Partial<WasteBalance>[]
+ *   summaryLogs?: { id: string, summaryLog: object }[]
+ * }} SetupServerOptions
+ */
+
+describe('POST /v1/dev/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/promote-to-ledger', () => {
   setupAuthContext()
 
   const { VALID_FROM, VALID_TO } = getValidDateRange()
@@ -65,7 +78,6 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
       accreditations: [accreditation]
     })
 
-    // A submitted summary log that will produce a credit event
     const summaryLog = summaryLogFactory.submitted({
       organisationId: organisation.id,
       registrationId,
@@ -73,8 +85,6 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
       file: { id: summaryLogFileId }
     })
 
-    // A waste record whose version references the summary log, with enough
-    // fields filled for classifyForWasteBalance to return INCLUDED with 200t
     const wasteRecord = buildWasteRecord({
       organisationId: organisation.id,
       registrationId,
@@ -123,14 +133,12 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
       ]
     })
 
-    // A PRN that has been issued (draft → awaiting_authorisation → awaiting_acceptance),
-    // debiting 50 tonnes from the available balance
     const prn = {
       ...buildAwaitingAcceptancePrn({
         organisation: {
           id: String(organisation.orgId),
-          name: organisation.name,
-          tradingName: organisation.name
+          name: 'Test Organisation',
+          tradingName: 'Test Organisation'
         },
         registrationId,
         accreditation: {
@@ -146,9 +154,9 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
       id: new ObjectId().toHexString()
     }
 
-    // Embedded balance reflecting the above: 200 credited, 50 deducted from
-    // available. Note: registrationId is intentionally absent — production
-    // waste balance documents never have it (see createNewWasteBalance).
+    // Note: registrationId is intentionally absent — production waste balance
+    // documents never have it (see createNewWasteBalance).
+    /** @type {Partial<WasteBalance>} */
     const wasteBalance = {
       id: new ObjectId().toString(),
       organisationId: organisation.id,
@@ -173,10 +181,16 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
     }
   }
 
-  function url(accreditationId) {
-    return `/v1/dev/waste-balances/${accreditationId}/promote-to-ledger`
+  /**
+   * @param {string} organisationId
+   * @param {string} registrationId
+   * @param {string} accreditationId
+   */
+  function url(organisationId, registrationId, accreditationId) {
+    return `/v1/dev/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/promote-to-ledger`
   }
 
+  /** @param {SetupServerOptions} [options] */
   async function setupServer({
     featureFlagOverrides = {},
     organisations = [],
@@ -206,14 +220,12 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
     })
 
     // Seed waste balances into the in-memory store
-    const storage = server.app.wasteBalancesRepository._getStorageForTesting()
-    for (const wb of wasteBalances) {
-      storage.push(wb)
-    }
+    const wbRepo = /** @type {any} */ (server.app.wasteBalancesRepository)
+    wbRepo._getStorageForTesting().push(...wasteBalances)
 
-    // Seed summary logs via the repository insert method
+    const slRepo = /** @type {any} */ (server.app.summaryLogsRepository)
     for (const { id, summaryLog } of summaryLogs) {
-      await server.app.summaryLogsRepository.insert(id, summaryLog)
+      await slRepo.insert(id, summaryLog)
     }
 
     return server
@@ -227,7 +239,7 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
 
       const response = await server.inject({
         method: 'POST',
-        url: url('abc123')
+        url: url('org-1', 'reg-1', 'acc-1')
       })
 
       expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
@@ -240,7 +252,7 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
 
       const response = await server.inject({
         method: 'POST',
-        url: url('%20')
+        url: url('org-1', 'reg-1', '%20')
       })
 
       expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
@@ -253,7 +265,7 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
 
       const response = await server.inject({
         method: 'POST',
-        url: url('nonexistent-accreditation-id')
+        url: url('org-1', 'reg-1', 'nonexistent')
       })
 
       expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
@@ -262,7 +274,8 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
 
   describe('idempotency', () => {
     it('should return 200 with already-promoted when balance is already ledger', async () => {
-      const { organisation, accreditationId, wasteBalance } = buildTestData()
+      const { organisation, accreditationId, registrationId, wasteBalance } =
+        buildTestData()
       wasteBalance.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
 
       const server = await setupServer({
@@ -272,7 +285,7 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
 
       const response = await server.inject({
         method: 'POST',
-        url: url(accreditationId)
+        url: url(organisation.id, registrationId, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
@@ -286,6 +299,7 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
       const {
         organisation,
         accreditationId,
+        registrationId,
         summaryLog,
         summaryLogFileId,
         wasteRecord,
@@ -303,26 +317,23 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
 
       // Simulate a version conflict by bumping the balance version
       // after the handler reads it but before promoteAccreditation flips
-      const storage = server.app.wasteBalancesRepository._getStorageForTesting()
+      const repo = /** @type {any} */ (server.app.wasteBalancesRepository)
+      const storage = repo._getStorageForTesting()
       const original = storage.find(
-        (wb) => wb.accreditationId === accreditationId
+        (/** @type {any} */ wb) => wb.accreditationId === accreditationId
       )
 
-      // Intercept flipCanonicalSourceToMigrating to bump version first
-      const originalFlip =
-        server.app.wasteBalancesRepository.flipCanonicalSourceToMigrating
-      vi.spyOn(
-        server.app.wasteBalancesRepository,
-        'flipCanonicalSourceToMigrating'
-      ).mockImplementation(async (params) => {
-        // Bump the version so the optimistic lock misses
-        original.version += 1
-        return originalFlip(params)
-      })
+      const originalFlip = repo.flipCanonicalSourceToMigrating
+      vi.spyOn(repo, 'flipCanonicalSourceToMigrating').mockImplementation(
+        async (/** @type {any} */ params) => {
+          original.version += 1
+          return originalFlip(params)
+        }
+      )
 
       const response = await server.inject({
         method: 'POST',
-        url: url(accreditationId)
+        url: url(organisation.id, registrationId, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
@@ -331,7 +342,8 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
 
   describe('happy path', () => {
     it('should promote a zero-balance accreditation with no event history', async () => {
-      const { organisation, accreditationId, wasteBalance } = buildTestData()
+      const { organisation, accreditationId, registrationId, wasteBalance } =
+        buildTestData()
       wasteBalance.amount = 0
       wasteBalance.availableAmount = 0
 
@@ -342,53 +354,7 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
 
       const response = await server.inject({
         method: 'POST',
-        url: url(accreditationId)
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.OK)
-      const body = JSON.parse(response.payload)
-      expect(body.result).toBe('promoted')
-      expect(body.eventCount).toBe(0)
-    })
-
-    it('should promote when no active registration links to the accreditation', async () => {
-      const accreditationId = new ObjectId().toString()
-
-      const accreditation = buildAccreditation({
-        id: accreditationId,
-        wasteProcessingType: 'reprocessor',
-        statusHistory: [
-          { status: 'created', updatedAt: new Date('2025-01-01') },
-          { status: 'approved', updatedAt: new Date('2025-02-01') }
-        ]
-      })
-
-      // Organisation has the accreditation but no registration linked to it
-      const organisation = buildOrganisation({
-        registrations: [],
-        accreditations: [accreditation]
-      })
-
-      const wasteBalance = {
-        id: new ObjectId().toString(),
-        organisationId: organisation.id,
-        accreditationId,
-        schemaVersion: 1,
-        version: 1,
-        amount: 0,
-        availableAmount: 0,
-        transactions: [],
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
-      }
-
-      const server = await setupServer({
-        organisations: [organisation],
-        wasteBalances: [wasteBalance]
-      })
-
-      const response = await server.inject({
-        method: 'POST',
-        url: url(accreditationId)
+        url: url(organisation.id, registrationId, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
@@ -401,6 +367,7 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
       const {
         organisation,
         accreditationId,
+        registrationId,
         summaryLog,
         summaryLogFileId,
         wasteRecord,
@@ -418,20 +385,17 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
 
       const response = await server.inject({
         method: 'POST',
-        url: url(accreditationId)
+        url: url(organisation.id, registrationId, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       const body = JSON.parse(response.payload)
       expect(body.result).toBe('promoted')
-      // Summary log submission + PRN created + PRN issued = 3 events
       expect(body.eventCount).toBeGreaterThanOrEqual(3)
 
-      // Verify the canonical source flipped to ledger
-      const updatedBalance =
-        await server.app.wasteBalancesRepository.findByAccreditationId(
-          accreditationId
-        )
+      const updatedBalance = await /** @type {any} */ (
+        server.app.wasteBalancesRepository
+      ).findByAccreditationId(accreditationId)
       expect(updatedBalance.canonicalSource).toBe(
         WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       )
@@ -441,6 +405,7 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
       const {
         organisation,
         accreditationId,
+        registrationId,
         summaryLog,
         summaryLogFileId,
         wasteRecord,
@@ -458,7 +423,7 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
 
       const response = await server.inject({
         method: 'POST',
-        url: url(accreditationId)
+        url: url(organisation.id, registrationId, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
@@ -468,6 +433,7 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
       const {
         organisation,
         accreditationId,
+        registrationId,
         summaryLog,
         summaryLogFileId,
         wasteRecord,
@@ -487,17 +453,16 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
 
       const response = await server.inject({
         method: 'POST',
-        url: url(accreditationId)
+        url: url(organisation.id, registrationId, accreditationId)
       })
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       const body = JSON.parse(response.payload)
       expect(body.result).toBe('promoted')
 
-      const updatedBalance =
-        await server.app.wasteBalancesRepository.findByAccreditationId(
-          accreditationId
-        )
+      const updatedBalance = await /** @type {any} */ (
+        server.app.wasteBalancesRepository
+      ).findByAccreditationId(accreditationId)
       expect(updatedBalance.canonicalSource).toBe(
         WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       )

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.test.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.test.js
@@ -146,12 +146,13 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
       id: new ObjectId().toHexString()
     }
 
-    // Embedded balance reflecting the above: 200 credited, 50 deducted from available
+    // Embedded balance reflecting the above: 200 credited, 50 deducted from
+    // available. Note: registrationId is intentionally absent — production
+    // waste balance documents never have it (see createNewWasteBalance).
     const wasteBalance = {
       id: new ObjectId().toString(),
       organisationId: organisation.id,
       accreditationId,
-      registrationId,
       schemaVersion: 1,
       version: 1,
       amount: 200,
@@ -333,6 +334,52 @@ describe('POST /v1/dev/waste-balances/{accreditationId}/promote-to-ledger', () =
       const { organisation, accreditationId, wasteBalance } = buildTestData()
       wasteBalance.amount = 0
       wasteBalance.availableAmount = 0
+
+      const server = await setupServer({
+        organisations: [organisation],
+        wasteBalances: [wasteBalance]
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: url(accreditationId)
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const body = JSON.parse(response.payload)
+      expect(body.result).toBe('promoted')
+      expect(body.eventCount).toBe(0)
+    })
+
+    it('should promote when no active registration links to the accreditation', async () => {
+      const accreditationId = new ObjectId().toString()
+
+      const accreditation = buildAccreditation({
+        id: accreditationId,
+        wasteProcessingType: 'reprocessor',
+        statusHistory: [
+          { status: 'created', updatedAt: new Date('2025-01-01') },
+          { status: 'approved', updatedAt: new Date('2025-02-01') }
+        ]
+      })
+
+      // Organisation has the accreditation but no registration linked to it
+      const organisation = buildOrganisation({
+        registrations: [],
+        accreditations: [accreditation]
+      })
+
+      const wasteBalance = {
+        id: new ObjectId().toString(),
+        organisationId: organisation.id,
+        accreditationId,
+        schemaVersion: 1,
+        version: 1,
+        amount: 0,
+        availableAmount: 0,
+        transactions: [],
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+      }
 
       const server = await setupServer({
         organisations: [organisation],

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -92,7 +92,7 @@ const rebuildEvents = async (row, deps) => {
  * @param {{ accreditationId: string, organisationId: string, registrationId: string }} row
  * @param {PromotionDependencies} deps
  */
-const promoteAccreditation = async (row, deps) => {
+export const promoteAccreditation = async (row, deps) => {
   const { wasteBalancesRepository, streamRepository } = deps
 
   // Capture version BEFORE rebuilding events. A submission that writes waste

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -89,7 +89,7 @@ const rebuildEvents = async (row, deps) => {
 }
 
 /**
- * @param {{ accreditationId: string, organisationId: string, registrationId: string }} row
+ * @param {{ accreditationId: string, organisationId: string }} row
  * @param {PromotionDependencies} deps
  */
 export const promoteAccreditation = async (row, deps) => {

--- a/src/waste-balances/repository/inmemory.plugin.js
+++ b/src/waste-balances/repository/inmemory.plugin.js
@@ -22,6 +22,7 @@ export function createInMemoryWasteBalancesRepositoryPlugin(
       )
       const repository = factory()
       registerRepository(server, 'wasteBalancesRepository', () => repository)
+      registerRepository(server, 'streamRepository', () => streamRepository)
     }
   }
 }

--- a/src/waste-balances/repository/mongodb.plugin.js
+++ b/src/waste-balances/repository/mongodb.plugin.js
@@ -18,5 +18,6 @@ export const mongoWasteBalancesRepositoryPlugin = {
     const repository = factory()
 
     registerRepository(server, 'wasteBalancesRepository', () => repository)
+    registerRepository(server, 'streamRepository', () => streamRepository)
   }
 }


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

Adds a dev-only endpoint to trigger the embedded-to-ledger waste balance migration for a single accreditation, without waiting for the full startup sweep.

**Route:** `POST /v1/dev/organisations/{organisationId}/accreditations/{accreditationId}/promote-to-ledger`

### Behaviour

- **Embedded** balance: rebuilds the full event history from authoritative sources (summary logs, PRNs, waste records), writes events to the stream, and flips `canonicalSource` to `ledger`. Returns `{ result: 'promoted' }`.
- **Already ledger**: idempotent no-op, returns `{ result: 'already-promoted' }`.
- **Stuck migrating**: resets to `embedded` first (matching the startup sweep's recovery logic), then promotes.
- **Not found**: 404.
- **Version conflict**: 500 (concurrent mutation detected during promotion).

### What changed

- New route handler at `src/routes/v1/dev/waste-balances/promote-to-ledger/post.js`, wired into the existing dev routes barrel. Same triple gate as other dev endpoints (feature flag, router check, isProduction refusal).
- Reuses the existing `promoteAccreditation` function (exported in #1233) and `streamRepository` (registered on the Hapi request object in #1233).

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ