### PR TITLE
PAE-1382: Pin registered-only partition isolation in deleteByPartition contract

### DIFF
--- a/src/waste-balances/repository/stream-contract/deleteByPartition.contract.js
+++ b/src/waste-balances/repository/stream-contract/deleteByPartition.contract.js
@@ -2,13 +2,21 @@ import { describe, beforeEach, expect } from 'vitest'
 
 import { buildStreamEvent } from '../stream-test-data.js'
 
+/**
+ * @typedef {object} StreamContractContext
+ * @property {import('../stream-port.js').WasteBalanceStreamRepositoryFactory} streamRepository
+ */
+
 export const testDeleteByPartitionBehaviour = (it) => {
   describe('deleteByPartition (@migration PAE-1382)', () => {
+    /** @type {import('../stream-port.js').WasteBalanceStreamRepository} */
     let repository
 
-    beforeEach(async ({ streamRepository }) => {
-      repository = await streamRepository()
-    })
+    beforeEach(
+      async (/** @type {StreamContractContext} */ { streamRepository }) => {
+        repository = await streamRepository()
+      }
+    )
 
     it('deletes all events for the given partition and returns the count', async () => {
       await repository.appendEvent(
@@ -67,7 +75,43 @@ export const testDeleteByPartitionBehaviour = (it) => {
         'acc-keep'
       )
       expect(kept).not.toBeNull()
-      expect(kept.registrationId).toBe('reg-keep')
+      expect(kept?.registrationId).toBe('reg-keep')
+    })
+
+    it("deletes one accreditation's partition without touching the same registration's registered-only stream", async () => {
+      await repository.appendEvent(
+        buildStreamEvent({
+          registrationId: 'reg-shared',
+          accreditationId: 'acc-1',
+          number: 1
+        })
+      )
+      await repository.appendEvent(
+        buildStreamEvent({
+          registrationId: 'reg-shared',
+          accreditationId: null,
+          number: 1,
+          payload: { summaryLogId: 'reg-only-log', creditTotal: 0 },
+          closingBalance: { amount: 0, availableAmount: 0 }
+        })
+      )
+
+      const count = await repository.deleteByPartition('reg-shared', 'acc-1')
+
+      expect(count).toBe(1)
+
+      const accreditationStream = await repository.findLatestByPartition(
+        'reg-shared',
+        'acc-1'
+      )
+      expect(accreditationStream).toBeNull()
+
+      const registeredOnlyStream = await repository.findLatestByPartition(
+        'reg-shared',
+        null
+      )
+      expect(registeredOnlyStream).not.toBeNull()
+      expect(registeredOnlyStream?.accreditationId).toBeNull()
     })
   })
 }


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
The waste-balance event stream uses a shared `(registrationId, null)` "registered-only" partition for submissions made before a registration's accreditation is granted. That stream is shared across all of a registration's accreditations, so the migration sweep's per-accreditation delete primitive `deleteByPartition(registrationId, accreditationId)` must scope strictly to the given partition and must never clear the registered-only stream — doing so would corrupt sibling accreditations' replay.

Both adapters already scope correctly (the in-memory adapter matches on both keys by strict equality; the MongoDB adapter deletes on `{ registrationId, accreditationId }`), but the contract suite only proved isolation between different *registrations*. It did not pin the subtler invariant that deleting one accreditation's partition leaves the *same* registration's `(registrationId, null)` stream intact.

This adds a contract case covering exactly that: it appends an event to an accreditation partition and one to the same registration's registered-only partition, deletes the accreditation partition, and asserts the delete count is 1, the accreditation partition is gone, and the registered-only stream survives. The case runs against both the in-memory and MongoDB adapters via the shared stream port contract.

The contract's `beforeEach` fixture context is given a precise type (`WasteBalanceStreamRepositoryFactory`) rather than `any`, so the repository handle and every assertion in the file are type-checked. This surfaced two genuinely nullable `findLatestByPartition` results that were previously masked; both are guarded with optional chaining so the assertions still fail if a stream is wrongly absent.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ