### PR TITLE
PAE-1382: Route new accreditations straight to ledger when flag is on

### DIFF
--- a/src/waste-balances/application/update-via-stream.js
+++ b/src/waste-balances/application/update-via-stream.js
@@ -24,9 +24,6 @@ import { getTargetAmount } from './target-amount.js'
  * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} params.user
  * @param {OverseasSitesContext} params.overseasSites
  * @param {string} params.summaryLogId
- * @returns {Promise<{ amount: number, availableAmount: number } | undefined>}
- *   The stream event's closing balance, or `undefined` when there are no
- *   waste records to process.
  */
 export const performUpdateViaStream = async ({
   wasteRecords,
@@ -73,6 +70,4 @@ export const performUpdateViaStream = async ({
     newTransactions: [event],
     user
   })
-
-  return event.closingBalance
 }

--- a/src/waste-balances/application/update-via-stream.js
+++ b/src/waste-balances/application/update-via-stream.js
@@ -24,6 +24,9 @@ import { getTargetAmount } from './target-amount.js'
  * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} params.user
  * @param {OverseasSitesContext} params.overseasSites
  * @param {string} params.summaryLogId
+ * @returns {Promise<{ amount: number, availableAmount: number } | undefined>}
+ *   The stream event's closing balance, or `undefined` when there are no
+ *   waste records to process.
  */
 export const performUpdateViaStream = async ({
   wasteRecords,
@@ -70,4 +73,6 @@ export const performUpdateViaStream = async ({
     newTransactions: [event],
     user
   })
+
+  return event.closingBalance
 }

--- a/src/waste-balances/repository/helpers.js
+++ b/src/waste-balances/repository/helpers.js
@@ -148,7 +148,7 @@ const dispatchToStream = async ({
   overseasSites,
   summaryLogId
 }) => {
-  return performUpdateViaStream({
+  await performUpdateViaStream({
     wasteRecords: annotatedRecords,
     accreditation: { ...accreditation, id: validatedAccreditationId },
     streamRepository:
@@ -220,7 +220,7 @@ export const performUpdateWasteBalanceTransactions = async ({
     if (
       existingBalance?.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
     ) {
-      const closingBalance = await dispatchToStream({
+      await dispatchToStream({
         annotatedRecords,
         accreditation,
         validatedAccreditationId,
@@ -229,51 +229,36 @@ export const performUpdateWasteBalanceTransactions = async ({
         overseasSites,
         summaryLogId
       })
-      if (closingBalance) {
-        await saveBalance(
-          {
-            ...existingBalance,
-            amount: closingBalance.amount,
-            availableAmount: closingBalance.availableAmount,
-            version: (existingBalance.version || 0) + 1
-          },
-          []
-        )
-      }
       return
     }
 
-    // Brand new accreditation with ledger flag on: dispatch to stream first,
-    // then create the balance doc with the closing balance from the event.
-    // Without this, the first write would create an embedded doc that
-    // marker-aware-read would never consult (it reads from the stream for
-    // ledger docs), silently losing the first submission's data.
+    // Brand new accreditation with ledger flag on: create a shell balance
+    // doc so that findByAccreditationId returns something and
+    // resolveBalanceAmounts can read canonicalSource + registrationId to
+    // query the stream. Amounts stay at zero on the document; reads resolve
+    // them from the stream's closing balance.
     if (
       !existingBalance &&
       dependencies.featureFlags?.isWasteBalanceLedgerEnabled()
     ) {
-      const closingBalance = await dispatchToStream({
-        annotatedRecords,
-        accreditation,
-        validatedAccreditationId,
-        dependencies,
-        user,
-        overseasSites,
-        summaryLogId
-      })
       const newBalance = {
         ...createNewWasteBalance(
           validatedAccreditationId,
           annotatedRecords[0]?.organisationId
         ),
         canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
-        registrationId: annotatedRecords[0]?.registrationId,
-        ...(closingBalance && {
-          amount: closingBalance.amount,
-          availableAmount: closingBalance.availableAmount
-        })
+        registrationId: annotatedRecords[0]?.registrationId
       }
       await saveBalance(newBalance, [])
+      await dispatchToStream({
+        annotatedRecords,
+        accreditation,
+        validatedAccreditationId,
+        dependencies,
+        user,
+        overseasSites,
+        summaryLogId
+      })
       return
     }
   }

--- a/src/waste-balances/repository/helpers.js
+++ b/src/waste-balances/repository/helpers.js
@@ -190,6 +190,7 @@ const dispatchToStream = async ({
  * @param {Object} params.dependencies
  * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [params.dependencies.systemLogsRepository]
  * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} [params.dependencies.streamRepository]
+ * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [params.dependencies.featureFlags]
  * @param {(accreditationId: string) => Promise<import('../domain/model.js').WasteBalance | null>} params.findBalance
  * @param {(balance: import('../domain/model.js').WasteBalance, newTransactions: any[], user?: any) => Promise<void>} params.saveBalance
  * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} [params.user]
@@ -219,7 +220,7 @@ export const performUpdateWasteBalanceTransactions = async ({
     if (
       existingBalance?.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
     ) {
-      await dispatchToStream({
+      const closingBalance = await dispatchToStream({
         annotatedRecords,
         accreditation,
         validatedAccreditationId,
@@ -228,6 +229,17 @@ export const performUpdateWasteBalanceTransactions = async ({
         overseasSites,
         summaryLogId
       })
+      if (closingBalance) {
+        await saveBalance(
+          {
+            ...existingBalance,
+            amount: closingBalance.amount,
+            availableAmount: closingBalance.availableAmount,
+            version: (existingBalance.version || 0) + 1
+          },
+          []
+        )
+      }
       return
     }
 

--- a/src/waste-balances/repository/helpers.js
+++ b/src/waste-balances/repository/helpers.js
@@ -148,7 +148,7 @@ const dispatchToStream = async ({
   overseasSites,
   summaryLogId
 }) => {
-  await performUpdateViaStream({
+  return performUpdateViaStream({
     wasteRecords: annotatedRecords,
     accreditation: { ...accreditation, id: validatedAccreditationId },
     streamRepository:
@@ -231,8 +231,8 @@ export const performUpdateWasteBalanceTransactions = async ({
       return
     }
 
-    // Brand new accreditation with ledger flag on: create a shell balance
-    // doc and dispatch straight to the stream, bypassing the embedded path.
+    // Brand new accreditation with ledger flag on: dispatch to stream first,
+    // then create the balance doc with the closing balance from the event.
     // Without this, the first write would create an embedded doc that
     // marker-aware-read would never consult (it reads from the stream for
     // ledger docs), silently losing the first submission's data.
@@ -240,16 +240,7 @@ export const performUpdateWasteBalanceTransactions = async ({
       !existingBalance &&
       dependencies.featureFlags?.isWasteBalanceLedgerEnabled()
     ) {
-      const newBalance = {
-        ...createNewWasteBalance(
-          validatedAccreditationId,
-          annotatedRecords[0]?.organisationId
-        ),
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
-        registrationId: annotatedRecords[0]?.registrationId
-      }
-      await saveBalance(newBalance, [])
-      await dispatchToStream({
+      const closingBalance = await dispatchToStream({
         annotatedRecords,
         accreditation,
         validatedAccreditationId,
@@ -258,6 +249,19 @@ export const performUpdateWasteBalanceTransactions = async ({
         overseasSites,
         summaryLogId
       })
+      const newBalance = {
+        ...createNewWasteBalance(
+          validatedAccreditationId,
+          annotatedRecords[0]?.organisationId
+        ),
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+        registrationId: annotatedRecords[0]?.registrationId,
+        ...(closingBalance && {
+          amount: closingBalance.amount,
+          availableAmount: closingBalance.availableAmount
+        })
+      }
+      await saveBalance(newBalance, [])
       return
     }
   }

--- a/src/waste-balances/repository/helpers.js
+++ b/src/waste-balances/repository/helpers.js
@@ -167,6 +167,43 @@ const dispatchToStream = async ({
 }
 
 /**
+ * Brand new accreditation with ledger flag on: create a shell balance doc
+ * so that findByAccreditationId returns something and resolveBalanceAmounts
+ * can read canonicalSource + registrationId to query the stream. Amounts
+ * stay at zero on the document; reads resolve them from the stream's
+ * closing balance.
+ */
+const createLedgerBalanceAndDispatch = async ({
+  annotatedRecords,
+  accreditation,
+  validatedAccreditationId,
+  dependencies,
+  saveBalance,
+  user,
+  overseasSites,
+  summaryLogId
+}) => {
+  const newBalance = {
+    ...createNewWasteBalance(
+      validatedAccreditationId,
+      annotatedRecords[0]?.organisationId
+    ),
+    canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+    registrationId: annotatedRecords[0]?.registrationId
+  }
+  await saveBalance(newBalance, [])
+  await dispatchToStream({
+    annotatedRecords,
+    accreditation,
+    validatedAccreditationId,
+    dependencies,
+    user,
+    overseasSites,
+    summaryLogId
+  })
+}
+
+/**
  * Shared logic for updating waste balance transactions.
  *
  * Dispatches on the per-accreditation `canonicalSource` marker, gated by
@@ -232,29 +269,16 @@ export const performUpdateWasteBalanceTransactions = async ({
       return
     }
 
-    // Brand new accreditation with ledger flag on: create a shell balance
-    // doc so that findByAccreditationId returns something and
-    // resolveBalanceAmounts can read canonicalSource + registrationId to
-    // query the stream. Amounts stay at zero on the document; reads resolve
-    // them from the stream's closing balance.
     if (
       !existingBalance &&
       dependencies.featureFlags?.isWasteBalanceLedgerEnabled()
     ) {
-      const newBalance = {
-        ...createNewWasteBalance(
-          validatedAccreditationId,
-          annotatedRecords[0]?.organisationId
-        ),
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
-        registrationId: annotatedRecords[0]?.registrationId
-      }
-      await saveBalance(newBalance, [])
-      await dispatchToStream({
+      await createLedgerBalanceAndDispatch({
         annotatedRecords,
         accreditation,
         validatedAccreditationId,
         dependencies,
+        saveBalance,
         user,
         overseasSites,
         summaryLogId

--- a/src/waste-balances/repository/helpers.js
+++ b/src/waste-balances/repository/helpers.js
@@ -230,6 +230,36 @@ export const performUpdateWasteBalanceTransactions = async ({
       })
       return
     }
+
+    // Brand new accreditation with ledger flag on: create a shell balance
+    // doc and dispatch straight to the stream, bypassing the embedded path.
+    // Without this, the first write would create an embedded doc that
+    // marker-aware-read would never consult (it reads from the stream for
+    // ledger docs), silently losing the first submission's data.
+    if (
+      !existingBalance &&
+      dependencies.featureFlags?.isWasteBalanceLedgerEnabled()
+    ) {
+      const newBalance = {
+        ...createNewWasteBalance(
+          validatedAccreditationId,
+          annotatedRecords[0]?.organisationId
+        ),
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+        registrationId: annotatedRecords[0]?.registrationId
+      }
+      await saveBalance(newBalance, [])
+      await dispatchToStream({
+        annotatedRecords,
+        accreditation,
+        validatedAccreditationId,
+        dependencies,
+        user,
+        overseasSites,
+        summaryLogId
+      })
+      return
+    }
   }
 
   const result = await calculateAndApplyUpdates(

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -654,6 +654,54 @@ describe('src/waste-balances/repository/helpers.js', () => {
         )
       })
 
+      it('uses the stream path and creates a ledger balance when no balance exists and the ledger flag is on', async () => {
+        const wasteRecords = [
+          {
+            id: 'rec-1',
+            organisationId: 'org-1',
+            registrationId: 'reg-1',
+            data: {}
+          }
+        ]
+        const accreditation = { id: 'acc-1' }
+        const streamRepository = { appendEvent: vi.fn() }
+        const featureFlags = {
+          isWasteBalanceLedgerEnabled: () => true
+        }
+        const findBalance = vi.fn().mockResolvedValue(null)
+        const saveBalance = vi.fn().mockResolvedValue(undefined)
+        vi.mocked(performUpdateViaStream).mockClear()
+        vi.mocked(calculateWasteBalanceUpdates).mockClear()
+
+        await callPerformUpdate({
+          wasteRecords,
+          accreditation,
+          dependencies: {
+            streamRepository,
+            featureFlags
+          },
+          findBalance,
+          saveBalance,
+          user: { id: 'user-1', email: 'user@test.com' },
+          overseasSites: ORS_VALIDATION_DISABLED,
+          summaryLogId: 'log-1'
+        })
+
+        // Should dispatch to stream, not embedded path
+        expect(performUpdateViaStream).toHaveBeenCalledTimes(1)
+        expect(calculateWasteBalanceUpdates).not.toHaveBeenCalled()
+
+        // Should create a shell balance doc with ledger source
+        expect(saveBalance).toHaveBeenCalledTimes(1)
+        const savedBalance = saveBalance.mock.calls[0][0]
+        expect(savedBalance.canonicalSource).toBe(
+          WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+        )
+        expect(savedBalance.registrationId).toBe('reg-1')
+        // Shell doc should have empty transactions
+        expect(saveBalance.mock.calls[0][1]).toEqual([])
+      })
+
       it('uses the embedded path when canonicalSource is ledger but no streamRepository is provided', async () => {
         const wasteRecords = [
           {

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -671,6 +671,10 @@ describe('src/waste-balances/repository/helpers.js', () => {
         const findBalance = vi.fn().mockResolvedValue(null)
         const saveBalance = vi.fn().mockResolvedValue(undefined)
         vi.mocked(performUpdateViaStream).mockClear()
+        vi.mocked(performUpdateViaStream).mockResolvedValue({
+          amount: 30,
+          availableAmount: 30
+        })
         vi.mocked(calculateWasteBalanceUpdates).mockClear()
 
         await callPerformUpdate({
@@ -691,14 +695,16 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(performUpdateViaStream).toHaveBeenCalledTimes(1)
         expect(calculateWasteBalanceUpdates).not.toHaveBeenCalled()
 
-        // Should create a shell balance doc with ledger source
+        // Should create a balance doc with ledger source and stream amounts
         expect(saveBalance).toHaveBeenCalledTimes(1)
         const savedBalance = saveBalance.mock.calls[0][0]
         expect(savedBalance.canonicalSource).toBe(
           WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
         )
         expect(savedBalance.registrationId).toBe('reg-1')
-        // Shell doc should have empty transactions
+        expect(savedBalance.amount).toBe(30)
+        expect(savedBalance.availableAmount).toBe(30)
+        // No embedded transactions
         expect(saveBalance.mock.calls[0][1]).toEqual([])
       })
 

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -489,6 +489,55 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(findBalance).toHaveBeenCalledTimes(1)
       })
 
+      it('syncs document amounts from stream closing balance on the ledger path', async () => {
+        const wasteRecords = [
+          {
+            id: 'rec-1',
+            organisationId: 'org-1',
+            registrationId: 'reg-1',
+            data: {}
+          }
+        ]
+        const accreditation = { id: 'acc-1' }
+        const streamRepository = { appendEvent: vi.fn() }
+        const findBalance = vi.fn().mockResolvedValue({
+          id: 'bal-1',
+          accreditationId: 'acc-1',
+          organisationId: 'org-1',
+          amount: 30,
+          availableAmount: 30,
+          transactions: [],
+          version: 1,
+          schemaVersion: 1,
+          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+        })
+        const saveBalance = vi.fn().mockResolvedValue(undefined)
+        vi.mocked(performUpdateViaStream).mockClear()
+        vi.mocked(performUpdateViaStream).mockResolvedValue({
+          amount: 79,
+          availableAmount: 79
+        })
+
+        await callPerformUpdate({
+          wasteRecords,
+          accreditation,
+          dependencies: { streamRepository },
+          findBalance,
+          saveBalance,
+          user: { id: 'user-1' },
+          overseasSites: ORS_VALIDATION_DISABLED,
+          summaryLogId: 'log-1'
+        })
+
+        expect(performUpdateViaStream).toHaveBeenCalledTimes(1)
+        expect(saveBalance).toHaveBeenCalledTimes(1)
+        const savedBalance = saveBalance.mock.calls[0][0]
+        expect(savedBalance.amount).toBe(79)
+        expect(savedBalance.availableAmount).toBe(79)
+        expect(savedBalance.version).toBe(2)
+        expect(saveBalance.mock.calls[0][1]).toEqual([])
+      })
+
       it('uses the embedded path when the existing balance has no marker (legacy doc)', async () => {
         const wasteRecords = [
           {

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -489,55 +489,6 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(findBalance).toHaveBeenCalledTimes(1)
       })
 
-      it('syncs document amounts from stream closing balance on the ledger path', async () => {
-        const wasteRecords = [
-          {
-            id: 'rec-1',
-            organisationId: 'org-1',
-            registrationId: 'reg-1',
-            data: {}
-          }
-        ]
-        const accreditation = { id: 'acc-1' }
-        const streamRepository = { appendEvent: vi.fn() }
-        const findBalance = vi.fn().mockResolvedValue({
-          id: 'bal-1',
-          accreditationId: 'acc-1',
-          organisationId: 'org-1',
-          amount: 30,
-          availableAmount: 30,
-          transactions: [],
-          version: 1,
-          schemaVersion: 1,
-          canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
-        })
-        const saveBalance = vi.fn().mockResolvedValue(undefined)
-        vi.mocked(performUpdateViaStream).mockClear()
-        vi.mocked(performUpdateViaStream).mockResolvedValue({
-          amount: 79,
-          availableAmount: 79
-        })
-
-        await callPerformUpdate({
-          wasteRecords,
-          accreditation,
-          dependencies: { streamRepository },
-          findBalance,
-          saveBalance,
-          user: { id: 'user-1' },
-          overseasSites: ORS_VALIDATION_DISABLED,
-          summaryLogId: 'log-1'
-        })
-
-        expect(performUpdateViaStream).toHaveBeenCalledTimes(1)
-        expect(saveBalance).toHaveBeenCalledTimes(1)
-        const savedBalance = saveBalance.mock.calls[0][0]
-        expect(savedBalance.amount).toBe(79)
-        expect(savedBalance.availableAmount).toBe(79)
-        expect(savedBalance.version).toBe(2)
-        expect(saveBalance.mock.calls[0][1]).toEqual([])
-      })
-
       it('uses the embedded path when the existing balance has no marker (legacy doc)', async () => {
         const wasteRecords = [
           {
@@ -703,7 +654,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         )
       })
 
-      it('uses the stream path and creates a ledger balance when no balance exists and the ledger flag is on', async () => {
+      it('creates a shell ledger doc and dispatches to stream when no balance exists and the ledger flag is on', async () => {
         const wasteRecords = [
           {
             id: 'rec-1',
@@ -720,10 +671,6 @@ describe('src/waste-balances/repository/helpers.js', () => {
         const findBalance = vi.fn().mockResolvedValue(null)
         const saveBalance = vi.fn().mockResolvedValue(undefined)
         vi.mocked(performUpdateViaStream).mockClear()
-        vi.mocked(performUpdateViaStream).mockResolvedValue({
-          amount: 30,
-          availableAmount: 30
-        })
         vi.mocked(calculateWasteBalanceUpdates).mockClear()
 
         await callPerformUpdate({
@@ -744,16 +691,15 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(performUpdateViaStream).toHaveBeenCalledTimes(1)
         expect(calculateWasteBalanceUpdates).not.toHaveBeenCalled()
 
-        // Should create a balance doc with ledger source and stream amounts
+        // Should create a shell doc with ledger source and registrationId
         expect(saveBalance).toHaveBeenCalledTimes(1)
         const savedBalance = saveBalance.mock.calls[0][0]
         expect(savedBalance.canonicalSource).toBe(
           WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
         )
         expect(savedBalance.registrationId).toBe('reg-1')
-        expect(savedBalance.amount).toBe(30)
-        expect(savedBalance.availableAmount).toBe(30)
-        // No embedded transactions
+        expect(savedBalance.amount).toBe(0)
+        expect(savedBalance.availableAmount).toBe(0)
         expect(saveBalance.mock.calls[0][1]).toEqual([])
       })
 

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -229,7 +229,10 @@ export const saveBalance = (db) => async (updatedBalance, newTransactions) => {
       $setOnInsert: {
         _id: updatedBalance.id,
         organisationId: updatedBalance.organisationId,
-        canonicalSource: updatedBalance.canonicalSource
+        canonicalSource: updatedBalance.canonicalSource,
+        ...(updatedBalance.registrationId !== undefined && {
+          registrationId: updatedBalance.registrationId
+        })
       }
     }),
     { upsert: true }


### PR DESCRIPTION
## Summary

When the waste balance ledger feature flag (`FEATURE_FLAG_WASTE_BALANCE_LEDGER`) is enabled, brand new accreditations now skip the embedded path entirely and go straight to the event-sourced stream.

Previously, a new accreditation's first summary-log submission always created the waste balance document with `canonicalSource: 'embedded'`, regardless of the flag. The document would only become `'ledger'` after the startup promotion sweep migrated it. This left a window where new accreditations used the wrong source of truth.

### What changed

- **`helpers.js`**: new `createLedgerBalanceAndDispatch` helper. When the stream repository is available, no existing balance exists, and the ledger flag is on, we create a shell balance document with `canonicalSource: 'ledger'` and `registrationId`, then dispatch the write to the stream. The shell doc exists so that `findByAccreditationId` returns something and `resolveBalanceAmounts` can read the canonical source marker and partition key to query the stream. Document amounts stay at zero; reads resolve them from the stream's closing balance.
- **`mongodb.js`** (`saveBalance`): `registrationId` is conditionally included in `$setOnInsert` when present on the balance object. This ensures `resolveBalanceAmounts` can query the stream collection using the correct partition key for new ledger documents.

Companion journey test fix: DEFRA/epr-backend-journey-tests#490.