### PR TITLE
PAE-1382: Persist registrationId on promotion to ledger

### DIFF
--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -72,8 +72,7 @@ const findEmbeddedBalances = async (db) => {
 /**
  * @param {{ accreditationId: string, organisationId: string }} row
  * @param {PromotionDependencies} deps
- * @returns {Promise<{ events: Array, registration: { id: string } } | null>}
- *   null when the accreditation has no active registration (nothing to rebuild)
+ * @returns {Promise<{ events: Array, registration: { id: string } }>}
  */
 const rebuildEvents = async (row, deps) => {
   const sources = await loadAccreditationSources(row, deps)

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -177,6 +177,7 @@ const promoteAccreditation = async (row, deps) => {
   const ledgerResult =
     await wasteBalancesRepository.flipCanonicalSourceToLedger({
       accreditationId: row.accreditationId,
+      registrationId: rebuildResult?.registration.id,
       capturedVersion: captured.version
     })
 

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -76,15 +76,7 @@ const findEmbeddedBalances = async (db) => {
  *   null when the accreditation has no active registration (nothing to rebuild)
  */
 const rebuildEvents = async (row, deps) => {
-  let sources
-  try {
-    sources = await loadAccreditationSources(row, deps)
-  } catch (error) {
-    if (error.message?.startsWith('No registration links to accreditation')) {
-      return null
-    }
-    throw error
-  }
+  const sources = await loadAccreditationSources(row, deps)
   const { events } = computeRebuiltStream({
     accreditation: sources.accreditation,
     registrationId: sources.registration.id,
@@ -119,22 +111,17 @@ const promoteAccreditation = async (row, deps) => {
   const rebuildResult = await rebuildEvents(row, deps)
 
   // Invariant: a non-zero embedded balance must reconstruct to a non-empty
-  // stream. An empty rebuild — whether from no active registration, or from
-  // authoritative sources that don't account for the balance (e.g. a summary
-  // log submitted against a non-approved registration the rebuild can't see) —
-  // would flip to ledger and read back zero. Abort loudly and leave the
-  // accreditation embedded for the next boot rather than silently zeroing a
-  // real balance.
+  // stream. An empty rebuild from authoritative sources that don't account
+  // for the balance (e.g. a summary log submitted against a non-approved
+  // registration the rebuild can't see) would flip to ledger and read back
+  // zero. Abort loudly and leave the accreditation embedded for the next
+  // boot rather than silently zeroing a real balance.
   const capturedNonZero =
     captured.amount !== 0 || captured.availableAmount !== 0
-  const rebuiltStreamEmpty = !rebuildResult || rebuildResult.events.length === 0
 
-  if (capturedNonZero && rebuiltStreamEmpty) {
-    const cause = rebuildResult
-      ? 'rebuilds to an empty stream'
-      : 'has no active registration'
+  if (capturedNonZero && rebuildResult.events.length === 0) {
     throw new Error(
-      `Accreditation ${row.accreditationId} has a non-zero balance (amount=${captured.amount}, availableAmount=${captured.availableAmount}) but ${cause}`
+      `Accreditation ${row.accreditationId} has a non-zero balance (amount=${captured.amount}, availableAmount=${captured.availableAmount}) but rebuilds to an empty stream`
     )
   }
 
@@ -151,24 +138,18 @@ const promoteAccreditation = async (row, deps) => {
     return 'skipped'
   }
 
-  if (rebuildResult) {
-    const { events, registration } = rebuildResult
-    // Idempotency: if a previous boot crashed between bulkAppendEvents and
-    // flipCanonicalSourceToLedger, stale events may exist. Deleting first
-    // means a restart always replays from the authoritative sources rather
-    // than appending on top of a partial write. An alternative would be to
-    // skip the delete and let bulkAppendEvents fail on a sequence conflict,
-    // but that turns a recoverable restart into a stuck accreditation.
-    await streamRepository.deleteByPartition(
-      registration.id,
-      row.accreditationId
-    )
-    await streamRepository.bulkAppendEvents(events)
-  } else {
-    logger.info({
-      message: `Stream promotion: no active registration for accreditation ${row.accreditationId}, promoting with empty stream`
-    })
-  }
+  const { events, registration } = rebuildResult
+  // Idempotency: if a previous boot crashed between bulkAppendEvents and
+  // flipCanonicalSourceToLedger, stale events may exist. Deleting first
+  // means a restart always replays from the authoritative sources rather
+  // than appending on top of a partial write. An alternative would be to
+  // skip the delete and let bulkAppendEvents fail on a sequence conflict,
+  // but that turns a recoverable restart into a stuck accreditation.
+  await streamRepository.deleteByPartition(
+    registration.id,
+    row.accreditationId
+  )
+  await streamRepository.bulkAppendEvents(events)
 
   // Use the ORIGINAL captured version, not a re-read. If a concurrent
   // mutation (PRN op or summary log upload) bumped version while we were
@@ -177,7 +158,7 @@ const promoteAccreditation = async (row, deps) => {
   const ledgerResult =
     await wasteBalancesRepository.flipCanonicalSourceToLedger({
       accreditationId: row.accreditationId,
-      registrationId: rebuildResult?.registration.id,
+      registrationId: registration.id,
       capturedVersion: captured.version
     })
 

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -145,10 +145,7 @@ const promoteAccreditation = async (row, deps) => {
   // than appending on top of a partial write. An alternative would be to
   // skip the delete and let bulkAppendEvents fail on a sequence conflict,
   // but that turns a recoverable restart into a stuck accreditation.
-  await streamRepository.deleteByPartition(
-    registration.id,
-    row.accreditationId
-  )
+  await streamRepository.deleteByPartition(registration.id, row.accreditationId)
   await streamRepository.bulkAppendEvents(events)
 
   // Use the ORIGINAL captured version, not a re-read. If a concurrent

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -308,11 +308,12 @@ describe('runStreamPromotion', () => {
     // Step f: bulk append rebuilt events
     expect(streamRepository.bulkAppendEvents).toHaveBeenCalledWith(builtEvents)
 
-    // Step h: flip migrating -> ledger
+    // Step h: flip migrating -> ledger (persists registrationId)
     expect(
       wasteBalancesRepository.flipCanonicalSourceToLedger
     ).toHaveBeenCalledWith({
       accreditationId: 'acc-1',
+      registrationId: 'reg-1',
       capturedVersion: 1
     })
 
@@ -382,6 +383,7 @@ describe('runStreamPromotion', () => {
       wasteBalancesRepository.flipCanonicalSourceToLedger
     ).toHaveBeenCalledWith({
       accreditationId: 'acc-race',
+      registrationId: 'reg-1',
       capturedVersion: 1
     })
 
@@ -566,11 +568,12 @@ describe('runStreamPromotion', () => {
     expect(streamRepository.deleteByPartition).not.toHaveBeenCalled()
     expect(streamRepository.bulkAppendEvents).not.toHaveBeenCalled()
 
-    // Still flips to ledger
+    // Still flips to ledger (no registrationId available)
     expect(
       wasteBalancesRepository.flipCanonicalSourceToLedger
     ).toHaveBeenCalledWith({
       accreditationId: 'acc-noreg',
+      registrationId: undefined,
       capturedVersion: 1
     })
 

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -532,7 +532,7 @@ describe('runStreamPromotion', () => {
     )
   })
 
-  it('promotes with empty stream when no active registration exists', async () => {
+  it('counts as failed when no active registration exists', async () => {
     const migratingToArray = vi.fn().mockResolvedValue([])
     const embeddedToArray = vi.fn().mockResolvedValue([
       {
@@ -564,79 +564,11 @@ describe('runStreamPromotion', () => {
 
     await runStreamPromotion(mockServer)
 
-    // No stream writes for accreditations without active registrations
-    expect(streamRepository.deleteByPartition).not.toHaveBeenCalled()
-    expect(streamRepository.bulkAppendEvents).not.toHaveBeenCalled()
-
-    // Still flips to ledger (no registrationId available)
-    expect(
-      wasteBalancesRepository.flipCanonicalSourceToLedger
-    ).toHaveBeenCalledWith({
-      accreditationId: 'acc-noreg',
-      registrationId: undefined,
-      capturedVersion: 1
-    })
-
-    expect(logger.info).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining('no active registration')
-      })
-    )
-    expect(logger.info).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining('promoted=1')
-      })
-    )
-  })
-
-  it('aborts promotion when no active registration but balance is non-zero', async () => {
-    const migratingToArray = vi.fn().mockResolvedValue([])
-    const embeddedToArray = vi.fn().mockResolvedValue([
-      {
-        accreditationId: 'acc-surprise',
-        organisationId: 'org-1',
-        registrationId: 'reg-1'
-      }
-    ])
-
-    mockFindBalances
-      .mockReturnValueOnce({ toArray: migratingToArray })
-      .mockReturnValueOnce({ toArray: embeddedToArray })
-
-    wasteBalancesRepository.findByAccreditationId.mockResolvedValue({
-      accreditationId: 'acc-surprise',
-      version: 1,
-      amount: 50,
-      availableAmount: 50,
-      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
-    })
-
-    organisationsRepository.findById.mockResolvedValue({
-      id: 'org-1',
-      registrations: [],
-      accreditations: [
-        {
-          id: 'acc-surprise',
-          accreditationNumber: 'CBDA1',
-          status: 'approved'
-        }
-      ]
-    })
-
-    await runStreamPromotion(mockServer)
-
-    // Should not promote: marker never touched, no stream writes
     expect(
       wasteBalancesRepository.flipCanonicalSourceToMigrating
     ).not.toHaveBeenCalled()
     expect(streamRepository.deleteByPartition).not.toHaveBeenCalled()
 
-    // Counted as failed with an error log
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining('non-zero balance')
-      })
-    )
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining('failed=1')

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
@@ -47,6 +47,36 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
       expect(after.migratingSince).toBeUndefined()
     })
 
+    it('persists registrationId to the balance document when provided', async ({
+      insertWasteBalance,
+      streamRepository
+    }) => {
+      const balance = buildWasteBalance({
+        accreditationId: 'acc-flip-regid',
+        version: 3,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING,
+        migratingSince: '2025-01-01T00:00:00.000Z'
+      })
+      await insertWasteBalance(balance)
+      await streamRepository.appendEvent(
+        buildStreamEvent({
+          accreditationId: 'acc-flip-regid',
+          registrationId: 'reg-resolved',
+          number: 1,
+          closingBalance: { amount: 0, availableAmount: 0 }
+        })
+      )
+
+      await repository.flipCanonicalSourceToLedger({
+        accreditationId: 'acc-flip-regid',
+        registrationId: 'reg-resolved',
+        capturedVersion: 3
+      })
+
+      const after = await repository.findByAccreditationId('acc-flip-regid')
+      expect(after.registrationId).toBe('reg-resolved')
+    })
+
     it('returns the migrating post-state and leaves the marker alone when versions diverge', async ({
       insertWasteBalance
     }) => {

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -116,7 +116,7 @@ const performFlipCanonicalSourceToMigrating =
 
 const performFlipCanonicalSourceToLedger =
   (wasteBalanceStorage) =>
-  async ({ accreditationId, capturedVersion }) => {
+  async ({ accreditationId, registrationId, capturedVersion }) => {
     const validatedAccreditationId = validateAccreditationId(accreditationId)
     const current = wasteBalanceStorage.find(
       (b) => b.accreditationId === validatedAccreditationId
@@ -130,6 +130,9 @@ const performFlipCanonicalSourceToLedger =
     ) {
       current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       delete current.migratingSince
+      if (registrationId !== undefined) {
+        current.registrationId = registrationId
+      }
     }
     return { canonicalSource: current.canonicalSource }
   }

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -130,9 +130,7 @@ const performFlipCanonicalSourceToLedger =
     ) {
       current.canonicalSource = WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
       delete current.migratingSince
-      if (registrationId !== undefined) {
-        current.registrationId = registrationId
-      }
+      current.registrationId = registrationId
     }
     return { canonicalSource: current.canonicalSource }
   }

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -106,7 +106,7 @@ const performFlipCanonicalSourceToLedger =
     const collection = db.collection(WASTE_BALANCE_COLLECTION_NAME)
     const $set = {
       canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
-      ...(registrationId !== undefined && { registrationId })
+      registrationId
     }
     const updated = await collection.findOneAndUpdate(
       {

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -101,9 +101,13 @@ const performFlipCanonicalSourceToMigrating =
 
 const performFlipCanonicalSourceToLedger =
   (db) =>
-  async ({ accreditationId, capturedVersion }) => {
+  async ({ accreditationId, registrationId, capturedVersion }) => {
     const validatedAccreditationId = validateAccreditationId(accreditationId)
     const collection = db.collection(WASTE_BALANCE_COLLECTION_NAME)
+    const $set = {
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER,
+      ...(registrationId !== undefined && { registrationId })
+    }
     const updated = await collection.findOneAndUpdate(
       {
         accreditationId: validatedAccreditationId,
@@ -111,7 +115,7 @@ const performFlipCanonicalSourceToLedger =
         canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
       },
       {
-        $set: { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER },
+        $set,
         $unset: { migratingSince: '' }
       },
       { returnDocument: 'after' }

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -76,6 +76,10 @@
 /**
  * @typedef {Object} FlipCanonicalSourceToLedgerParams
  * @property {string} accreditationId
+ * @property {string} [registrationId] - Resolved during the promotion sweep
+ *   from the organisation's registration. Persisted to the balance document
+ *   so the ledger read path can look up stream events by partition. Not
+ *   required when the caller is not the promotion sweep (e.g. tests).
  * @property {number} capturedVersion - The `version` observed on the
  *   `'migrating'` doc at the start of step 3 of a per-accreditation rebuild
  *   (after authoritative history has been replayed into the ledger). The flip

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -76,10 +76,9 @@
 /**
  * @typedef {Object} FlipCanonicalSourceToLedgerParams
  * @property {string} accreditationId
- * @property {string} [registrationId] - Resolved during the promotion sweep
+ * @property {string} registrationId - Resolved during the promotion sweep
  *   from the organisation's registration. Persisted to the balance document
- *   so the ledger read path can look up stream events by partition. Not
- *   required when the caller is not the promotion sweep (e.g. tests).
+ *   so the ledger read path can look up stream events by partition.
  * @property {number} capturedVersion - The `version` observed on the
  *   `'migrating'` doc at the start of step 3 of a per-accreditation rebuild
  *   (after authoritative history has been replayed into the ledger). The flip


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)

## Summary

When the stream promotion sweep flips an accreditation from `embedded` to `ledger`, it now writes `registrationId` to the waste-balance document. This ensures the ledger read path (`resolveBalanceAmounts`) can look up stream events by partition, since `findLatestByPartition` requires `registrationId`.

### Root cause

`saveBalance` never persisted `registrationId` to the `waste-balances` collection, so all existing balance documents lack it. When the read path casts `balance.registrationId` to string, `undefined` becomes `"undefined"`, the stream query matches nothing, and the balance falls through to zero.

### Why fix at the migration layer, not the read layer

The promotion sweep already resolves each accreditation's registration via `loadAccreditationSources`. Writing `registrationId` during the `flipCanonicalSourceToLedger` step fixes the data at source. This avoids teaching `findLatestByPartition` to tolerate `undefined` and keeps the stream query contract clean.

`saveBalance` does not need updating because once an accreditation is on `ledger`, the write path uses event appends, not `saveBalance`.

### What this PR does

- `flipCanonicalSourceToLedger` accepts an optional `registrationId` and writes it to the balance document via `$set` alongside `canonicalSource`. When `registrationId` is `undefined` (e.g. no active registration), it is omitted from the update.
- `promoteAccreditation` passes `registration.id` through to the flip.
- Port type updated to include `registrationId` on `FlipCanonicalSourceToLedgerParams`.
- Test assertions updated to verify `registrationId` is passed through in all promotion scenarios.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ