### PR TITLE
PAE-1382: Add canonicalSource population census diagnostic

### DIFF
--- a/src/server/run-canonical-source-census.js
+++ b/src/server/run-canonical-source-census.js
@@ -1,0 +1,101 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+
+const WASTE_BALANCES_COLLECTION = 'waste-balances'
+const LOCK_NAME = 'canonical-source-census'
+
+const CENSUS_PIPELINE = [
+  { $group: { _id: '$canonicalSource', count: { $sum: 1 } } }
+]
+
+/**
+ * @typedef {Object} CanonicalSourceCount
+ * @property {string|null} _id
+ * @property {number} count
+ */
+
+/**
+ * @param {import('mongodb').Db} db
+ * @returns {Promise<CanonicalSourceCount[]>}
+ */
+export const countWasteBalancesByCanonicalSource = async (db) => {
+  const docs = await db
+    .collection(WASTE_BALANCES_COLLECTION)
+    .aggregate(CENSUS_PIPELINE, { allowDiskUse: true })
+    .toArray()
+  return /** @type {CanonicalSourceCount[]} */ (/** @type {unknown} */ (docs))
+}
+
+/**
+ * @param {CanonicalSourceCount[]} rows
+ */
+const formatCensusLine = (rows) => {
+  const known = {
+    [WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED]: 0,
+    [WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING]: 0,
+    [WASTE_BALANCE_CANONICAL_SOURCE.LEDGER]: 0
+  }
+  let unknown = 0
+
+  for (const row of rows) {
+    if (row._id !== null && Object.hasOwn(known, row._id)) {
+      known[row._id] += row.count
+    } else {
+      unknown += row.count
+    }
+  }
+
+  const embedded = known[WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED]
+  const migrating = known[WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING]
+  const ledger = known[WASTE_BALANCE_CANONICAL_SOURCE.LEDGER]
+  const total = embedded + migrating + ledger + unknown
+
+  return [
+    'Waste balance canonicalSource census:',
+    `embedded=${embedded}`,
+    `migrating=${migrating}`,
+    `ledger=${ledger}`,
+    `unknown=${unknown}`,
+    `total=${total}`
+  ].join(' ')
+}
+
+const runCensus = async (server) => {
+  const rows = await countWasteBalancesByCanonicalSource(server.db)
+  logger.info({ message: formatCensusLine(rows) })
+}
+
+/**
+ * One-shot startup diagnostic that logs a single line counting waste-balance
+ * documents by `canonicalSource`. Unlike `runStreamPromotion` (which reports
+ * only what it promoted this run) and the size/divergence diagnostics (which
+ * filter to non-ledger docs), this emits the cumulative population split —
+ * embedded / migrating / ledger — turning ledger-migration progress into a
+ * plottable burn-down across deploys.
+ *
+ * Read-only, safe under live traffic. Runs under a cross-instance lock so a
+ * single pod per deploy executes the scan. Info level only.
+ *
+ * @param {Object} server - Hapi server instance
+ */
+export const runCanonicalSourceCensus = async (server) => {
+  try {
+    const lock = await server.locker.lock(LOCK_NAME)
+    if (!lock) {
+      logger.info({
+        message: 'Unable to obtain lock, skipping canonical-source census'
+      })
+      return
+    }
+    try {
+      await runCensus(server)
+    } finally {
+      await lock.free()
+    }
+  } catch (error) {
+    logger.error({
+      err: error,
+      message: 'Failed to run canonical-source census'
+    })
+  }
+}

--- a/src/server/run-canonical-source-census.js
+++ b/src/server/run-canonical-source-census.js
@@ -27,35 +27,34 @@ export const countWasteBalancesByCanonicalSource = async (db) => {
 }
 
 /**
+ * Documents written before `canonicalSource` was introduced have no value, but
+ * the read path treats anything that isn't `ledger` as embedded — so a missing
+ * or unrecognised value counts as embedded here too.
+ *
  * @param {CanonicalSourceCount[]} rows
  */
 const formatCensusLine = (rows) => {
-  const known = {
-    [WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED]: 0,
-    [WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING]: 0,
-    [WASTE_BALANCE_CANONICAL_SOURCE.LEDGER]: 0
-  }
-  let unknown = 0
+  let embedded = 0
+  let migrating = 0
+  let ledger = 0
 
   for (const row of rows) {
-    if (row._id !== null && Object.hasOwn(known, row._id)) {
-      known[row._id] += row.count
+    if (row._id === WASTE_BALANCE_CANONICAL_SOURCE.LEDGER) {
+      ledger += row.count
+    } else if (row._id === WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING) {
+      migrating += row.count
     } else {
-      unknown += row.count
+      embedded += row.count
     }
   }
 
-  const embedded = known[WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED]
-  const migrating = known[WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING]
-  const ledger = known[WASTE_BALANCE_CANONICAL_SOURCE.LEDGER]
-  const total = embedded + migrating + ledger + unknown
+  const total = embedded + migrating + ledger
 
   return [
     'Waste balance canonicalSource census:',
     `embedded=${embedded}`,
     `migrating=${migrating}`,
     `ledger=${ledger}`,
-    `unknown=${unknown}`,
     `total=${total}`
   ].join(' ')
 }

--- a/src/server/run-canonical-source-census.js
+++ b/src/server/run-canonical-source-census.js
@@ -21,7 +21,7 @@ const CENSUS_PIPELINE = [
 export const countWasteBalancesByCanonicalSource = async (db) => {
   const docs = await db
     .collection(WASTE_BALANCES_COLLECTION)
-    .aggregate(CENSUS_PIPELINE, { allowDiskUse: true })
+    .aggregate(CENSUS_PIPELINE)
     .toArray()
   return /** @type {CanonicalSourceCount[]} */ (/** @type {unknown} */ (docs))
 }

--- a/src/server/run-canonical-source-census.test.js
+++ b/src/server/run-canonical-source-census.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { runCanonicalSourceCensus } from './run-canonical-source-census.js'
+import { logger } from '#common/helpers/logging/logger.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+describe('runCanonicalSourceCensus', () => {
+  let mockServer
+  let mockLock
+  let mockAggregate
+  let mockToArray
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockLock = { free: vi.fn().mockResolvedValue(undefined) }
+
+    mockToArray = vi.fn().mockResolvedValue([])
+    mockAggregate = vi.fn().mockReturnValue({ toArray: mockToArray })
+    const db = {
+      collection: vi.fn().mockReturnValue({ aggregate: mockAggregate })
+    }
+
+    mockServer = {
+      db,
+      locker: {
+        lock: vi.fn().mockResolvedValue(mockLock)
+      }
+    }
+  })
+
+  it('acquires a lock scoped to the census and releases it afterwards', async () => {
+    await runCanonicalSourceCensus(mockServer)
+
+    expect(mockServer.locker.lock).toHaveBeenCalledWith(
+      'canonical-source-census'
+    )
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('skips running when the lock is held by another instance', async () => {
+    mockServer.locker.lock.mockResolvedValue(null)
+
+    await runCanonicalSourceCensus(mockServer)
+
+    expect(mockServer.db.collection).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Unable to obtain lock, skipping canonical-source census'
+    })
+  })
+
+  it('groups the waste-balances collection by canonicalSource', async () => {
+    await runCanonicalSourceCensus(mockServer)
+
+    expect(mockServer.db.collection).toHaveBeenCalledWith('waste-balances')
+    const [pipeline] = mockAggregate.mock.calls[0]
+    expect(pipeline).toEqual([
+      { $group: { _id: '$canonicalSource', count: { $sum: 1 } } }
+    ])
+  })
+
+  it('emits a single census line with each bucket count and the total', async () => {
+    mockToArray.mockResolvedValue([
+      { _id: 'embedded', count: 10 },
+      { _id: 'migrating', count: 3 },
+      { _id: 'ledger', count: 7 }
+    ])
+
+    await runCanonicalSourceCensus(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste balance canonicalSource census: embedded=10 migrating=3 ledger=7 unknown=0 total=20'
+    })
+  })
+
+  it('buckets missing or unrecognised canonicalSource values as unknown and includes them in the total', async () => {
+    mockToArray.mockResolvedValue([
+      { _id: 'embedded', count: 5 },
+      { _id: null, count: 2 },
+      { _id: 'legacy', count: 1 }
+    ])
+
+    await runCanonicalSourceCensus(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste balance canonicalSource census: embedded=5 migrating=0 ledger=0 unknown=3 total=8'
+    })
+  })
+
+  it('reports zeroes across all buckets when the collection is empty', async () => {
+    mockToArray.mockResolvedValue([])
+
+    await runCanonicalSourceCensus(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste balance canonicalSource census: embedded=0 migrating=0 ledger=0 unknown=0 total=0'
+    })
+  })
+
+  it('releases the lock and logs an error when the aggregation throws', async () => {
+    const error = new Error('aggregate exploded')
+    mockAggregate.mockImplementation(() => {
+      throw error
+    })
+
+    await runCanonicalSourceCensus(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run canonical-source census'
+    })
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('tolerates the locker itself throwing', async () => {
+    const error = new Error('locker unavailable')
+    mockServer.locker.lock.mockRejectedValue(error)
+
+    await runCanonicalSourceCensus(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run canonical-source census'
+    })
+  })
+})

--- a/src/server/run-canonical-source-census.test.js
+++ b/src/server/run-canonical-source-census.test.js
@@ -75,11 +75,11 @@ describe('runCanonicalSourceCensus', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste balance canonicalSource census: embedded=10 migrating=3 ledger=7 unknown=0 total=20'
+        'Waste balance canonicalSource census: embedded=10 migrating=3 ledger=7 total=20'
     })
   })
 
-  it('buckets missing or unrecognised canonicalSource values as unknown and includes them in the total', async () => {
+  it('counts docs with a missing or unrecognised canonicalSource as embedded', async () => {
     mockToArray.mockResolvedValue([
       { _id: 'embedded', count: 5 },
       { _id: null, count: 2 },
@@ -90,7 +90,7 @@ describe('runCanonicalSourceCensus', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste balance canonicalSource census: embedded=5 migrating=0 ledger=0 unknown=3 total=8'
+        'Waste balance canonicalSource census: embedded=8 migrating=0 ledger=0 total=8'
     })
   })
 
@@ -101,7 +101,7 @@ describe('runCanonicalSourceCensus', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste balance canonicalSource census: embedded=0 migrating=0 ledger=0 unknown=0 total=0'
+        'Waste balance canonicalSource census: embedded=0 migrating=0 ledger=0 total=0'
     })
   })
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -44,6 +44,7 @@ import { runFormsDataMigration } from '#server/run-forms-data-migration.js'
 import { copyFormFilesToS3 } from '#server/copy-form-files-to-s3.js'
 import { runBalanceDivergenceDiagnostic } from '#server/run-balance-divergence-diagnostic.js'
 import { runBalanceSizeDiagnostic } from '#server/run-balance-size-diagnostic.js'
+import { runCanonicalSourceCensus } from '#server/run-canonical-source-census.js'
 import { runRowIdCollisionDiagnostic } from '#server/run-row-id-collision-diagnostic.js'
 import { runStreamPromotion } from '#server/run-stream-promotion.js'
 
@@ -227,6 +228,7 @@ async function createServer(options = {}) {
     runRowIdCollisionDiagnostic(server)
     runBalanceDivergenceDiagnostic(server)
     runBalanceSizeDiagnostic(server)
+    runCanonicalSourceCensus(server)
     runStreamPromotion(server)
   })
 


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
Adds a boot-time diagnostic that emits a single info-level log line counting `waste-balances` documents by `canonicalSource`, so progress migrating accreditations onto the ledger becomes a plottable burn-down across deploys.

Until now no signal reported the cumulative population split. The stream promotion run logs only what it promoted that run (`promoted=/skipped=/failed=`), and the size and divergence diagnostics both filter to non-ledger documents, so there was no "of N accreditations, X embedded / Y migrating / Z ledger" view to track migration over time.

The census runs a cheap `$group` aggregation over the `waste-balances` collection and logs one line of the form `Waste balance canonicalSource census: embedded=… migrating=… ledger=… total=…`. Documents whose `canonicalSource` is missing or unrecognised count as embedded — they predate the property but the read path treats anything that isn't `ledger` as embedded — so the buckets always sum to `total`. Fields are encoded as key=value pairs inside the log message to match the indexed-log schema and stay searchable in OpenSearch.

It follows the existing diagnostic pattern: one-shot on `onPostStart`, read-only, guarded by a cross-instance lock so a single pod per deploy runs the scan, and wired into `server.js` alongside the other diagnostics. It logs at info level only — the sole error line is the catch-all wrapper failure shared by every diagnostic — so it does not trip the error-log alert that pages on `log.level=error`.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ