### PR TITLE
PAE-1441: Collapse duplicate PRN status-history entry in rebuild

### DIFF
--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -201,8 +201,11 @@ const buildSummaryLogEvents = ({
 /**
  * Build the stream event for a single PRN status-history entry, or null when
  * the transition is a valid state-machine move that produces no balance event.
- * Throws when the transition cannot occur in the PRN state machine at all,
- * surfacing corrupt source history.
+ * An idempotent same-state repeat (a duplicate history entry left by a
+ * concurrent double-submit) collapses to a no-op — no PRN transition is a
+ * self-loop, so a repeat of the prior status carries no change. Throws when a
+ * move to a *different* state cannot occur in the PRN state machine, surfacing
+ * genuinely corrupt source history.
  *
  * @param {Object} params
  * @param {{ id: string, tonnage: number, status: { history: Array<{ status: string, at: Date, by?: { id: string, name: string } }> } }} params.prn
@@ -221,6 +224,11 @@ const prnTransitionEvent = ({
   const history = prn.status.history
   const prevStatus = index === 0 ? null : history[index - 1].status
   const newStatus = history[index].status
+
+  if (prevStatus !== null && prevStatus === newStatus) {
+    return null
+  }
+
   const kind = prnTransitionToStreamKind(prevStatus, newStatus)
 
   if (kind === null) {

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -857,6 +857,130 @@ describe('computeRebuiltStream', () => {
       expect(result.events).toHaveLength(0)
     })
 
+    it('collapses a duplicate same-state history entry to a single event', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        wasteRecords: [
+          {
+            organisationId: 'org-1',
+            registrationId: 'reg-1',
+            type: 'received',
+            data: { processingType: 'INPUT', tonnage: 100 },
+            versions: [
+              {
+                summaryLog: { id: 'sl-1' },
+                data: { processingType: 'INPUT', tonnage: 100 }
+              }
+            ],
+            excludedFromWasteBalance: false
+          }
+        ],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 30,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.DRAFT,
+                  at: new Date('2025-01-20T00:00:00.000Z')
+                },
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date('2025-01-21T00:00:00.000Z')
+                },
+                {
+                  status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                  at: new Date('2025-01-22T00:00:00.000Z')
+                },
+                {
+                  status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                  at: new Date('2025-01-23T00:00:00.000Z')
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: [
+          {
+            id: 'sl-1',
+            status: SUMMARY_LOG_STATUS.SUBMITTED,
+            submittedAt: '2025-01-15T10:00:00.000Z'
+          }
+        ]
+      })
+
+      const issued = result.events.filter(
+        (e) => e.kind === STREAM_EVENT_KIND.PRN_ISSUED
+      )
+      expect(issued).toHaveLength(1)
+      expect(result.amount).toBe(70)
+      expect(result.availableAmount).toBe(70)
+    })
+
+    it('collapses a duplicate awaiting_authorisation entry to a single PRN_CREATED', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        wasteRecords: [
+          {
+            organisationId: 'org-1',
+            registrationId: 'reg-1',
+            type: 'received',
+            data: { processingType: 'INPUT', tonnage: 100 },
+            versions: [
+              {
+                summaryLog: { id: 'sl-1' },
+                data: { processingType: 'INPUT', tonnage: 100 }
+              }
+            ],
+            excludedFromWasteBalance: false
+          }
+        ],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 30,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.DRAFT,
+                  at: new Date('2025-01-20T00:00:00.000Z')
+                },
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date('2025-01-21T00:00:00.000Z')
+                },
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date('2025-01-22T00:00:00.000Z')
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: [
+          {
+            id: 'sl-1',
+            status: SUMMARY_LOG_STATUS.SUBMITTED,
+            submittedAt: '2025-01-15T10:00:00.000Z'
+          }
+        ]
+      })
+
+      const created = result.events.filter(
+        (e) => e.kind === STREAM_EVENT_KIND.PRN_CREATED
+      )
+      expect(created).toHaveLength(1)
+      expect(result.amount).toBe(100)
+      expect(result.availableAmount).toBe(70)
+    })
+
     it('throws when a history entry transitions from an unrecognised status', () => {
       expect(() =>
         computeRebuiltStream({


### PR DESCRIPTION
Ticket: [PAE-1441](https://eaflood.atlassian.net/browse/PAE-1441)
## What

The migration startup rebuild (`computeRebuiltStream`) reconstructs an accreditation's waste-balance stream by folding each PRN's status history into events. A guard throws on any history move the PRN state machine cannot make, so genuinely corrupt source history surfaces rather than silently producing a wrong balance.

A concurrent double-submit (the "clicked too quickly" race) can leave a duplicate status-history entry, producing a same-state self-loop. The issuance-side case — a duplicate `awaiting_acceptance` entry — maps to no event but was caught by the impossible-transition guard, throwing and aborting the entire accreditation rebuild. The startup divergence diagnostic on prod reports this as the single rebuild failure, leaving that accreditation permanently unable to promote to the ledger.

This change collapses any idempotent same-state repeat (`prevStatus === newStatus`) to a no-op before resolving the event kind. No PRN transition is a self-loop, so a repeat of the prior status carries no change. The guard still throws on a move to a genuinely different impossible state, so real corruption is still caught.

## Why before-kind-resolution

The collapse runs ahead of the transition-to-event-kind lookup. This also covers the creation-side case: a duplicate `awaiting_authorisation` entry resolves to `PRN_CREATED` via the wildcard mapping, so a `kind === null` gate would miss it and emit a second `PRN_CREATED`, double-deducting the available balance. Placing the idempotency check first makes the invariant structural rather than dependent on which transitions happen to be mapped.

[PAE-1441]: https://eaflood.atlassian.net/browse/PAE-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ