### PR TITLE
PAE-1382: Log empty-stream ledger zeroing at info

### DIFF
--- a/src/waste-balances/repository/marker-aware-read.js
+++ b/src/waste-balances/repository/marker-aware-read.js
@@ -1,3 +1,5 @@
+import { logger } from '#common/helpers/logging/logger.js'
+
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
 import { ZERO_BALANCE } from './stream-schema.js'
 
@@ -9,9 +11,11 @@ import { ZERO_BALANCE } from './stream-schema.js'
  * the embedded write path is still authoritative for them.
  *
  * An empty stream under a `'ledger'` marker means the accreditation was
- * promoted with zero activity. This is legitimate for accreditations that
- * never received waste records, so the function returns zero balances
- * instead of throwing.
+ * promoted before any summary log was submitted, so it has no events yet. This
+ * is correct behaviour, and the function returns zero balances rather than
+ * throwing. An info-level log makes the zeroing observable in the read path
+ * without implying a fault: a populated accreditation resolving to zero would
+ * be a problem, but that is caught at promotion time, not here.
  *
  * @param {import('../domain/model.js').WasteBalance} balance
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} streamRepository
@@ -28,6 +32,13 @@ export const resolveBalanceAmounts = async (balance, streamRepository) => {
   )
 
   if (!latest) {
+    logger.info({
+      message:
+        `Ledger marker resolved against empty stream, returning zero balance:` +
+        ` registrationId=${balance.registrationId}` +
+        ` accreditationId=${balance.accreditationId}`
+    })
+
     return {
       ...balance,
       ...ZERO_BALANCE

--- a/src/waste-balances/repository/marker-aware-read.test.js
+++ b/src/waste-balances/repository/marker-aware-read.test.js
@@ -1,7 +1,14 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { logger } from '#common/helpers/logging/logger.js'
 
 import { resolveBalanceAmounts } from './marker-aware-read.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn()
+  }
+}))
 
 const buildBalance = (overrides = {}) => ({
   id: 'bal-1',
@@ -39,6 +46,10 @@ const buildStream = (latest) => ({
 })
 
 describe('resolveBalanceAmounts', () => {
+  beforeEach(() => {
+    vi.mocked(logger.info).mockClear()
+  })
+
   it('leaves an embedded balance unchanged', async () => {
     const balance = buildBalance({
       canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED,
@@ -89,6 +100,7 @@ describe('resolveBalanceAmounts', () => {
     )
     expect(result.amount).toBe(200)
     expect(result.availableAmount).toBe(175)
+    expect(logger.info).not.toHaveBeenCalled()
   })
 
   it('returns zero balances when marker is ledger but stream is empty', async () => {
@@ -105,6 +117,32 @@ describe('resolveBalanceAmounts', () => {
 
     expect(result.amount).toBe(0)
     expect(result.availableAmount).toBe(0)
+  })
+
+  it('logs at info when a ledger marker resolves against an empty stream', async () => {
+    const balance = buildBalance({
+      accreditationId: 'acc-empty',
+      registrationId: 'reg-empty',
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+    })
+    const stream = buildStream(null)
+
+    await resolveBalanceAmounts(balance, stream)
+
+    expect(logger.info).toHaveBeenCalledTimes(1)
+    const { message } = vi.mocked(logger.info).mock.calls[0][0]
+    expect(message).toContain('accreditationId=acc-empty')
+    expect(message).toContain('registrationId=reg-empty')
+  })
+
+  it('does not log on the embedded path', async () => {
+    const balance = buildBalance({
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+    })
+
+    await resolveBalanceAmounts(balance, buildStream(null))
+
+    expect(logger.info).not.toHaveBeenCalled()
   })
 
   it('preserves all non-amount fields', async () => {

--- a/src/waste-balances/repository/marker-aware-read.test.js
+++ b/src/waste-balances/repository/marker-aware-read.test.js
@@ -77,6 +77,7 @@ describe('resolveBalanceAmounts', () => {
     expect(result.amount).toBe(50)
     expect(result.availableAmount).toBe(30)
     expect(stream.findLatestByPartition).not.toHaveBeenCalled()
+    expect(logger.info).not.toHaveBeenCalled()
   })
 
   it('substitutes amounts from the latest stream event when marker is ledger', async () => {
@@ -131,6 +132,7 @@ describe('resolveBalanceAmounts', () => {
 
     expect(logger.info).toHaveBeenCalledTimes(1)
     const { message } = vi.mocked(logger.info).mock.calls[0][0]
+    expect(message).toContain('Ledger marker resolved against empty stream')
     expect(message).toContain('accreditationId=acc-empty')
     expect(message).toContain('registrationId=reg-empty')
   })


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
When a waste-balance document is marked `canonicalSource='ledger'` but its event stream contains no events, `resolveBalanceAmounts` returns a zero balance. This is correct behaviour — an accreditation promoted to the ledger before any summary log has been submitted legitimately has no events yet — but until now the zeroing was invisible in the read path.

This adds an `info`-level log carrying `registrationId` and `accreditationId` (as searchable `key=value` pairs in the message, matching the existing waste-balance growth-observability convention) whenever an empty stream under a ledger marker resolves to zero. The zero-return behaviour is unchanged; this is observability only.

The level is deliberately `info`, not `warn` or `error`: an empty stream here is a normal steady state for pre-submission accreditations, so a warning would be routine noise and an error would page on-call (Defra services alert on `log.level=error`). A genuinely wrongly-zeroed accreditation — one that should carry a balance but resolves to zero — is a promotion-time concern, caught where the stream is rebuilt, not on this read path.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ