### PR TITLE
PAE-1382: Add per-kind idempotency indexes to the waste-balance stream

### DIFF
--- a/src/waste-balances/repository/stream-mongodb.js
+++ b/src/waste-balances/repository/stream-mongodb.js
@@ -53,6 +53,29 @@ export async function ensureStreamCollection(db) {
     { name: 'prn_watermark_catchup' }
   )
 
+  await collection.createIndex(
+    { registrationId: 1, accreditationId: 1, kind: 1, 'payload.prnId': 1 },
+    {
+      name: 'prn_idempotency',
+      unique: true,
+      partialFilterExpression: { 'payload.prnId': { $exists: true } }
+    }
+  )
+
+  await collection.createIndex(
+    {
+      registrationId: 1,
+      accreditationId: 1,
+      kind: 1,
+      'payload.summaryLogId': 1
+    },
+    {
+      name: 'summary_log_idempotency',
+      unique: true,
+      partialFilterExpression: { 'payload.summaryLogId': { $exists: true } }
+    }
+  )
+
   return collection
 }
 
@@ -68,8 +91,14 @@ const toStreamEvent = (doc) => {
  * Classify a MongoDB E11000 duplicate key error by inspecting the
  * `keyPattern` on the write error to determine which index was violated.
  *
+ * The slot index `(registrationId, accreditationId, number)` maps to a
+ * `StreamSlotConflictError`. The per-kind natural-key indexes
+ * (`payload.prnId` / `payload.summaryLogId`) signal that the same logical
+ * event is already persisted, so the append is a safe no-op.
+ *
  * @param {unknown} error
  * @param {StreamEventInsert} event
+ * @returns {StreamSlotConflictError | { naturalKeyConflict: true } | undefined}
  */
 const classifyDuplicateKeyError = (error, event) => {
   const writeError = findDuplicateKeyWriteError(error)
@@ -83,6 +112,13 @@ const classifyDuplicateKeyError = (error, event) => {
       event.accreditationId,
       event.number
     )
+  }
+
+  if (
+    writeError.keyPattern?.['payload.prnId'] ||
+    writeError.keyPattern?.['payload.summaryLogId']
+  ) {
+    return { naturalKeyConflict: true }
   }
 
   return undefined
@@ -158,11 +194,39 @@ const performAppendEvent = (collection) => async (event) => {
     return toStreamEvent({ _id: result.insertedId, ...validated })
   } catch (error) {
     const classified = classifyDuplicateKeyError(error, validated)
-    if (classified) {
+    if (classified instanceof StreamSlotConflictError) {
       throw classified
+    }
+    if (classified) {
+      return findEventByNaturalKey(collection, validated)
     }
     throw error
   }
+}
+
+/**
+ * Fetch the event already persisted under the same per-kind natural key.
+ *
+ * @param {Collection} collection
+ * @param {StreamEventInsert} event
+ * @returns {Promise<StreamEvent>}
+ */
+const findEventByNaturalKey = async (collection, event) => {
+  const payloadIdField =
+    'prnId' in event.payload ? 'payload.prnId' : 'payload.summaryLogId'
+  const payloadIdValue =
+    'prnId' in event.payload
+      ? event.payload.prnId
+      : event.payload.summaryLogId
+
+  const doc = await collection.findOne({
+    registrationId: event.registrationId,
+    accreditationId: event.accreditationId,
+    kind: event.kind,
+    [payloadIdField]: payloadIdValue
+  })
+
+  return toStreamEvent(doc)
 }
 
 /**

--- a/src/waste-balances/repository/stream-mongodb.test.js
+++ b/src/waste-balances/repository/stream-mongodb.test.js
@@ -7,7 +7,10 @@ import {
   ensureStreamCollection,
   WASTE_BALANCE_EVENTS_COLLECTION_NAME
 } from './stream-mongodb.js'
-import { buildStreamEvent } from './stream-test-data.js'
+import {
+  buildStreamEvent,
+  buildPrnCreatedEvent
+} from './stream-test-data.js'
 import { testStreamRepositoryContract } from './stream-port.contract.js'
 
 const DATABASE_NAME = 'epr-backend'
@@ -85,6 +88,44 @@ describe('ensureStreamCollection', () => {
         number: 1
       })
     })
+
+    it('creates the prn_idempotency partial-unique index scoped to PRN events', async (/** @type {*} */ {
+      streamCollection
+    }) => {
+      const indexes = await streamCollection.indexes()
+      expect(indexKeyFor(indexes, 'prn_idempotency')).toEqual({
+        registrationId: 1,
+        accreditationId: 1,
+        kind: 1,
+        'payload.prnId': 1
+      })
+      expect(indexOptionFor(indexes, 'prn_idempotency', 'unique')).toBe(true)
+      expect(
+        indexOptionFor(indexes, 'prn_idempotency', 'partialFilterExpression')
+      ).toEqual({ 'payload.prnId': { $exists: true } })
+    })
+
+    it('creates the summary_log_idempotency partial-unique index scoped to summary-log events', async (/** @type {*} */ {
+      streamCollection
+    }) => {
+      const indexes = await streamCollection.indexes()
+      expect(indexKeyFor(indexes, 'summary_log_idempotency')).toEqual({
+        registrationId: 1,
+        accreditationId: 1,
+        kind: 1,
+        'payload.summaryLogId': 1
+      })
+      expect(
+        indexOptionFor(indexes, 'summary_log_idempotency', 'unique')
+      ).toBe(true)
+      expect(
+        indexOptionFor(
+          indexes,
+          'summary_log_idempotency',
+          'partialFilterExpression'
+        )
+      ).toEqual({ 'payload.summaryLogId': { $exists: true } })
+    })
   })
 
   describe('idempotency', () => {
@@ -112,6 +153,44 @@ describe('MongoDB stream repository', () => {
 
   describe('stream repository contract', () => {
     testStreamRepositoryContract(it)
+  })
+
+  describe('appendEvent idempotency', () => {
+    it('returns the persisted event when a PRN natural key is re-appended', async (/** @type {*} */ {
+      streamRepository,
+      streamCollection
+    }) => {
+      const repository = streamRepository()
+      const first = await repository.appendEvent(
+        buildPrnCreatedEvent({ number: 1 })
+      )
+
+      const retried = await repository.appendEvent(
+        buildPrnCreatedEvent({ number: 2 })
+      )
+
+      expect(retried.id).toBe(first.id)
+      expect(retried.number).toBe(1)
+      expect(await streamCollection.countDocuments({})).toBe(1)
+    })
+
+    it('returns the persisted event when a summary-log natural key is re-appended', async (/** @type {*} */ {
+      streamRepository,
+      streamCollection
+    }) => {
+      const repository = streamRepository()
+      const first = await repository.appendEvent(
+        buildStreamEvent({ number: 1 })
+      )
+
+      const retried = await repository.appendEvent(
+        buildStreamEvent({ number: 2 })
+      )
+
+      expect(retried.id).toBe(first.id)
+      expect(retried.number).toBe(1)
+      expect(await streamCollection.countDocuments({})).toBe(1)
+    })
   })
 
   describe('appendEvent error translation', () => {


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
Adds per-kind partial-unique indexes to the event-sourced waste-balance stream so event writes are at-most-once and retries / backfill re-runs are idempotent.

## What this adds

- Two partial-unique indexes on the stream collection: `(registrationId, accreditationId, kind, payload.prnId)` partial on PRN kinds, and `(registrationId, accreditationId, kind, payload.summaryLogId)` partial on `summary-log-submitted`. The partial filter keys on `$exists` of the respective payload id — only PRN events carry `payload.prnId` and only summary-log events carry `payload.summaryLogId` — and `kind` stays in the key so each PRN transition for a given PRN gets its own slot.
- `classifyDuplicateKeyError` now distinguishes the slot index (still a `StreamSlotConflictError`) from a natural-key index, which signals the same logical event is already persisted.
- On a natural-key duplicate, `appendEvent` fetches and returns the already-persisted event rather than throwing, so a retried or replayed operation is a safe no-op.

Tests cover a duplicate append being a no-op against a real in-memory MongoDB; the indexes genuinely trigger E11000 and resolve via fetch-and-return.

## Scope notes

- Bulk append (`bulkAppendEvents`, the backfill path) is not made idempotent here — a natural-key collision inside `insertMany` still surfaces E11000. Tracked separately.
- The no-op fetch assumes the event still exists; a concurrent partition delete racing the append is out of scope and tracked separately.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ