### PR TITLE
PAE-1382: Break down rebuild backfill count by event kind

### DIFF
--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -185,7 +185,7 @@ const formatErrorLine = (embedded, error) =>
 
 const formatBackfillByKind = (byKind) =>
   Object.keys(byKind)
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .map((kind) => `${kind}:${byKind[kind]}`)
     .join(',')
 

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -139,7 +139,8 @@ const buildComparison = (
     stream.availableAmount
   ),
   streamEventCount: stream.events.length,
-  backfilledActorCount: stream.backfilledActorCount
+  backfilledActorCount: stream.backfilledActorCount,
+  backfilledActorCountByKind: stream.backfilledActorCountByKind ?? {}
 })
 
 const isDivergent = (comparison) =>
@@ -182,6 +183,12 @@ const formatErrorLine = (embedded, error) =>
     `error="${error.message}"`
   ].join(' ')
 
+const formatBackfillByKind = (byKind) =>
+  Object.keys(byKind)
+    .sort()
+    .map((kind) => `${kind}:${byKind[kind]}`)
+    .join(',')
+
 const formatBackfillLine = (comparison) =>
   [
     'Waste-balance rebuild used backfill actor:',
@@ -189,6 +196,7 @@ const formatBackfillLine = (comparison) =>
     `registrationNumber=${comparison.registrationNumber}`,
     `accreditationNumber=${comparison.accreditationNumber}`,
     `backfilledActorCount=${comparison.backfilledActorCount}`,
+    `backfilledActorCountByKind=${formatBackfillByKind(comparison.backfilledActorCountByKind)}`,
     `streamEventCount=${comparison.streamEventCount}`
   ].join(' ')
 

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -140,7 +140,7 @@ const buildComparison = (
   ),
   streamEventCount: stream.events.length,
   backfilledActorCount: stream.backfilledActorCount,
-  backfilledActorCountByKind: stream.backfilledActorCountByKind ?? {}
+  backfilledActorCountByKind: stream.backfilledActorCountByKind
 })
 
 const isDivergent = (comparison) =>

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -770,14 +770,18 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [buildStreamEvent(), buildStreamEvent(), buildStreamEvent()],
       amount: 0,
       availableAmount: 0,
-      backfilledActorCount: 2
+      backfilledActorCount: 2,
+      backfilledActorCountByKind: {
+        'summary-log-submitted': 1,
+        'prn-created': 1
+      }
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
     expect(logger.warn).toHaveBeenCalledWith({
       message:
-        'Waste-balance rebuild used backfill actor: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-1 backfilledActorCount=2 streamEventCount=3'
+        'Waste-balance rebuild used backfill actor: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-1 backfilledActorCount=2 backfilledActorCountByKind=prn-created:1,summary-log-submitted:1 streamEventCount=3'
     })
   })
 

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -136,7 +136,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 0,
       availableAmount: 0,
-      backfilledActorCount: 0
+      backfilledActorCount: 0,
+      backfilledActorCountByKind: {}
     })
     vi.mocked(resolveOverseasSites).mockResolvedValue({})
   })
@@ -217,7 +218,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 7,
       availableAmount: 5,
-      backfilledActorCount: 0
+      backfilledActorCount: 0,
+      backfilledActorCountByKind: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -267,7 +269,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 95,
       availableAmount: 80,
-      backfilledActorCount: 0
+      backfilledActorCount: 0,
+      backfilledActorCountByKind: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -392,7 +395,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 7,
       availableAmount: 7,
-      backfilledActorCount: 0
+      backfilledActorCount: 0,
+      backfilledActorCountByKind: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -541,7 +545,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 5,
       availableAmount: 5,
-      backfilledActorCount: 0
+      backfilledActorCount: 0,
+      backfilledActorCountByKind: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -728,7 +733,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 95,
       availableAmount: 75,
-      backfilledActorCount: 0
+      backfilledActorCount: 0,
+      backfilledActorCountByKind: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -809,7 +815,8 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [buildStreamEvent()],
       amount: 0,
       availableAmount: 0,
-      backfilledActorCount: 0
+      backfilledActorCount: 0,
+      backfilledActorCountByKind: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -123,6 +123,52 @@ const actorOf = (actor) =>
   actor ? { id: actor.id, name: actor.name } : { ...BACKFILL_ACTOR }
 
 /**
+ * Sparse count of backfilled-actor events keyed by the stream event kind that
+ * fell back. Only kinds with at least one fallback appear.
+ *
+ * @typedef {Partial<Record<import('../repository/stream-schema.js').StreamEventKind, number>>} BackfillTally
+ */
+
+/**
+ * Record one event-kind's fallback to the backfill actor in a per-kind tally.
+ *
+ * @param {BackfillTally} byKind
+ * @param {import('../repository/stream-schema.js').StreamEventKind} kind
+ */
+const tallyBackfill = (byKind, kind) => {
+  byKind[kind] = (byKind[kind] ?? 0) + 1
+}
+
+/**
+ * Combine per-kind backfill tallies, summing counts for shared kinds.
+ *
+ * @param {BackfillTally[]} tallies
+ * @returns {BackfillTally}
+ */
+const mergeBackfillTallies = (tallies) => {
+  const merged = /** @type {BackfillTally} */ ({})
+  for (const tally of tallies) {
+    for (const [rawKind, count] of Object.entries(tally)) {
+      const kind =
+        /** @type {import('../repository/stream-schema.js').StreamEventKind} */ (
+          rawKind
+        )
+      merged[kind] = (merged[kind] ?? 0) + count
+    }
+  }
+  return merged
+}
+
+/**
+ * Total backfilled-actor events across every kind in a tally.
+ *
+ * @param {BackfillTally} byKind
+ * @returns {number}
+ */
+const totalBackfilled = (byKind) =>
+  Object.values(byKind).reduce((sum, count) => sum + count, 0)
+
+/**
  * Build summary-log-submitted events, threading the running set of seen
  * summary-log ids so each submission credits the waste-record data as it
  * stood at that point.
@@ -155,7 +201,7 @@ const buildSummaryLogEvents = ({
 
   const seenSummaryLogIds = new Set()
   const events = []
-  let backfilledActorCount = 0
+  const backfilledActorCountByKind = /** @type {BackfillTally} */ ({})
 
   for (const summaryLog of submitted) {
     seenSummaryLogIds.add(summaryLog.id)
@@ -181,7 +227,10 @@ const buildSummaryLogEvents = ({
     // exactly one backfilled event — no need to gate on emission as the PRN
     // builder does.
     if (!summaryLog.submittedBy) {
-      backfilledActorCount += 1
+      tallyBackfill(
+        backfilledActorCountByKind,
+        STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED
+      )
     }
 
     events.push({
@@ -195,7 +244,7 @@ const buildSummaryLogEvents = ({
     })
   }
 
-  return { events, backfilledActorCount }
+  return { events, backfilledActorCountByKind }
 }
 
 /**
@@ -272,7 +321,7 @@ const buildPrnHistoryEvents = ({
 }) => {
   const history = prn.status.history
   const events = []
-  let backfilledActorCount = 0
+  const backfilledActorCountByKind = /** @type {BackfillTally} */ ({})
 
   for (let i = 0; i < history.length; i++) {
     const event = prnTransitionEvent({
@@ -287,11 +336,11 @@ const buildPrnHistoryEvents = ({
     }
     events.push(event)
     if (!history[i].by) {
-      backfilledActorCount += 1
+      tallyBackfill(backfilledActorCountByKind, event.kind)
     }
   }
 
-  return { events, backfilledActorCount }
+  return { events, backfilledActorCountByKind }
 }
 
 /**
@@ -320,9 +369,8 @@ const buildPrnEvents = ({
 
   return {
     events: perPrn.flatMap(({ events }) => events),
-    backfilledActorCount: perPrn.reduce(
-      (sum, { backfilledActorCount }) => sum + backfilledActorCount,
-      0
+    backfilledActorCountByKind: mergeBackfillTallies(
+      perPrn.map(({ backfilledActorCountByKind }) => backfilledActorCountByKind)
     )
   }
 }
@@ -346,8 +394,10 @@ const buildChronologicalEvents = (params) => {
 
   return {
     events: [...summaryLog.events, ...prn.events],
-    backfilledActorCount:
-      summaryLog.backfilledActorCount + prn.backfilledActorCount
+    backfilledActorCountByKind: mergeBackfillTallies([
+      summaryLog.backfilledActorCountByKind,
+      prn.backfilledActorCountByKind
+    ])
   }
 }
 
@@ -439,8 +489,9 @@ const byStreamOrder = (a, b) =>
  * source history that violates the PRN state machine — so the sequence is
  * seedable into the stream store, not only a totals cross-check. Also reports
  * `backfilledActorCount`: how many events fell back to the backfill actor
- * because no real actor was recoverable, so callers can surface attribution
- * gaps.
+ * because no real actor was recoverable, and `backfilledActorCountByKind`: the
+ * same total broken down by stream event kind, so callers can surface
+ * attribution gaps and see which event kinds drive them.
  *
  * @param {Object} params
  * @param {{ id: string }} params.accreditation
@@ -460,22 +511,30 @@ export const computeRebuiltStream = ({
   overseasSites,
   summaryLogs
 }) => {
-  const { events: unsorted, backfilledActorCount } = buildChronologicalEvents({
-    accreditation,
-    registrationId,
-    organisationId,
-    wasteRecords,
-    prns,
-    overseasSites,
-    summaryLogs
-  })
+  const { events: unsorted, backfilledActorCountByKind } =
+    buildChronologicalEvents({
+      accreditation,
+      registrationId,
+      organisationId,
+      wasteRecords,
+      prns,
+      overseasSites,
+      summaryLogs
+    })
+
+  const backfilledActorCount = totalBackfilled(backfilledActorCountByKind)
 
   unsorted.sort(byStreamOrder)
 
   const events = replayStream(unsorted)
 
   if (events.length === 0) {
-    return { events, ...ZERO_BALANCE, backfilledActorCount }
+    return {
+      events,
+      ...ZERO_BALANCE,
+      backfilledActorCount,
+      backfilledActorCountByKind
+    }
   }
 
   const finalBalance =
@@ -487,6 +546,7 @@ export const computeRebuiltStream = ({
     events,
     amount: finalBalance.amount,
     availableAmount: finalBalance.availableAmount,
-    backfilledActorCount
+    backfilledActorCount,
+    backfilledActorCountByKind
   }
 }

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -56,7 +56,8 @@ describe('computeRebuiltStream', () => {
       events: [],
       amount: 0,
       availableAmount: 0,
-      backfilledActorCount: 0
+      backfilledActorCount: 0,
+      backfilledActorCountByKind: {}
     })
   })
 
@@ -1115,6 +1116,7 @@ describe('computeRebuiltStream', () => {
       })
 
       expect(result.backfilledActorCount).toBe(0)
+      expect(result.backfilledActorCountByKind).toEqual({})
     })
 
     it('counts a summary-log event with no submitter', () => {
@@ -1129,6 +1131,9 @@ describe('computeRebuiltStream', () => {
       })
 
       expect(result.backfilledActorCount).toBe(1)
+      expect(result.backfilledActorCountByKind).toEqual({
+        [STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED]: 1
+      })
     })
 
     it('counts a PRN event whose history entry has no actor', () => {
@@ -1143,9 +1148,12 @@ describe('computeRebuiltStream', () => {
       })
 
       expect(result.backfilledActorCount).toBe(1)
+      expect(result.backfilledActorCountByKind).toEqual({
+        [STREAM_EVENT_KIND.PRN_CREATED]: 1
+      })
     })
 
-    it('sums backfilled summary-log and PRN events', () => {
+    it('breaks the backfilled count down by event type', () => {
       const result = computeRebuiltStream({
         accreditation,
         registrationId,
@@ -1157,6 +1165,27 @@ describe('computeRebuiltStream', () => {
       })
 
       expect(result.backfilledActorCount).toBe(2)
+      expect(result.backfilledActorCountByKind).toEqual({
+        [STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED]: 1,
+        [STREAM_EVENT_KIND.PRN_CREATED]: 1
+      })
+    })
+
+    it('tallies repeated backfills of the same event type', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [],
+        prns: [createdPrn('prn-1'), createdPrn('prn-2')],
+        overseasSites,
+        summaryLogs: []
+      })
+
+      expect(result.backfilledActorCount).toBe(2)
+      expect(result.backfilledActorCountByKind).toEqual({
+        [STREAM_EVENT_KIND.PRN_CREATED]: 2
+      })
     })
 
     it('reports zero for an empty stream', () => {
@@ -1171,6 +1200,7 @@ describe('computeRebuiltStream', () => {
       })
 
       expect(result.backfilledActorCount).toBe(0)
+      expect(result.backfilledActorCountByKind).toEqual({})
     })
   })
 })

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -1171,6 +1171,41 @@ describe('computeRebuiltStream', () => {
       })
     })
 
+    it('keys each transition in one PRN history by its own event type', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 10,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date('2025-01-21T00:00:00.000Z')
+                },
+                {
+                  status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                  at: new Date('2025-01-22T00:00:00.000Z')
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: []
+      })
+
+      expect(result.backfilledActorCount).toBe(2)
+      expect(result.backfilledActorCountByKind).toEqual({
+        [STREAM_EVENT_KIND.PRN_CREATED]: 1,
+        [STREAM_EVENT_KIND.PRN_ISSUED]: 1
+      })
+    })
+
     it('tallies repeated backfills of the same event type', () => {
       const result = computeRebuiltStream({
         accreditation,


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
When the waste-balance rebuild reconstructs an accreditation's event stream, it attributes each event to a real actor and falls back to a placeholder "backfill" actor when none is recoverable. The rebuild reported a single scalar count of these fallbacks, which conflated two independent attribution gaps — summary-log submissions with no recorded submitter, and PRN status-history entries with no recorded actor — and gave no visibility into which event kinds drive them.

This change breaks that count down by stream event kind. `computeRebuiltStream` now returns `backfilledActorCountByKind` (a sparse map keyed by stream event kind) alongside the existing total `backfilledActorCount`, and the startup balance-divergence diagnostic logs the per-kind breakdown in its "rebuild used backfill actor" warning line.

The per-kind tally is built in each event builder and merged once on the way up, so the scalar total is now derived from the breakdown rather than carried as a parallel counter — the breakdown is the single source of truth. The breakdown is keyed by the `StreamEventKind` union, so a count under a non-existent kind is unrepresentable.

This visibility is needed for the ledger cutover: startup diagnostics show that a large majority of reconstructed events fall back to the placeholder actor across nearly every accreditation. Splitting the count by event kind shows how much of that is summary-log attribution versus PRN attribution, which scopes the historical-submitter sourcing work and reveals whether PRN history — expected to already carry an actor — has an attribution gap of its own.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ