### PR TITLE
PAE-1382: Recover real summary-log submitter in waste-balance rebuild

### DIFF
--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
@@ -62,7 +62,7 @@ async function handler(request, h) {
   }
 
   const result = await promoteAccreditation(
-    { accreditationId, organisationId },
+    { accreditationId, organisationId, transactions: balance.transactions },
     {
       wasteBalancesRepository,
       streamRepository: request.streamRepository,

--- a/src/server/load-accreditation-sources.js
+++ b/src/server/load-accreditation-sources.js
@@ -1,6 +1,7 @@
 import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
+import { buildSummaryLogSubmitters } from '#waste-balances/application/summary-log-submitters.js'
 
 /** @type {Set<import('#domain/organisations/registration.js').Registration['status']>} */
 const ACTIVE_REGISTRATION_STATUSES = new Set([
@@ -35,9 +36,12 @@ export const toStreamSummaryLog = ({ summaryLog }) => ({
 /**
  * Load the organisation, registration, and accreditation for a balance row,
  * then fetch all authoritative sources needed to rebuild the event stream
- * or recompute totals.
+ * or recompute totals. The row's embedded waste-balance transactions recover
+ * the real submitting actor for each historical summary log, so the rebuilt
+ * stream attributes submissions to the person who made them rather than the
+ * backfill actor.
  *
- * @param {{ accreditationId: string, organisationId: string }} row
+ * @param {{ accreditationId: string, organisationId: string, transactions?: Array<import('#waste-balances/domain/model.js').WasteBalanceTransaction> }} row
  * @param {AccreditationSourceDeps} deps
  */
 export const loadAccreditationSources = async (row, deps) => {
@@ -87,11 +91,20 @@ export const loadAccreditationSources = async (row, deps) => {
     registration.id
   )
 
+  const submitters = buildSummaryLogSubmitters({
+    transactions: row.transactions,
+    wasteRecords
+  })
+
   const summaryLogs = summaryLogDocs
     .filter(
       ({ summaryLog }) => summaryLog.status === SUMMARY_LOG_STATUS.SUBMITTED
     )
     .map(toStreamSummaryLog)
+    .map((summaryLog) => {
+      const submittedBy = submitters.get(summaryLog.id)
+      return submittedBy ? { ...summaryLog, submittedBy } : summaryLog
+    })
 
   return {
     accreditation,

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -18,6 +18,7 @@ const LOCK_NAME = 'balance-divergence-diagnostic'
  * @property {string} organisationId
  * @property {number} amount
  * @property {number} availableAmount
+ * @property {Array<import('#waste-balances/domain/model.js').WasteBalanceTransaction>} [transactions]
  */
 
 /**
@@ -46,7 +47,8 @@ const findEmbeddedWasteBalances = async (db) => {
           accreditationId: 1,
           organisationId: 1,
           amount: 1,
-          availableAmount: 1
+          availableAmount: 1,
+          transactions: 1
         }
       }
     )

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -649,6 +649,68 @@ describe('runBalanceDivergenceDiagnostic', () => {
     })
   })
 
+  it('recovers the real submitter from the embedded transactions and threads it into computeRebuiltStream', async () => {
+    const accreditation = { id: 'acc-1', accreditationNumber: 'ACC-001' }
+    setEmbeddedBalances([
+      {
+        accreditationId: 'acc-1',
+        organisationId: 'org-1',
+        amount: 0,
+        availableAmount: 0,
+        transactions: [
+          {
+            createdBy: { id: 'user-9', name: 'real@example.com' },
+            entities: [{ currentVersionId: 'ver-1' }]
+          }
+        ]
+      }
+    ])
+    registrations['org-1'] = [
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: 'REG-1',
+        status: 'approved'
+      }
+    ]
+    accreditations['org-1'] = [accreditation]
+    summaryLogsRepository.findAllByOrgReg.mockResolvedValue([
+      {
+        id: 'doc-id-1',
+        version: 1,
+        summaryLog: {
+          status: 'submitted',
+          submittedAt: '2025-01-01T00:00:00Z',
+          file: { id: 'file-id-1', name: 'test.xlsx', uri: 's3://bucket/key' }
+        }
+      }
+    ])
+    const wasteRecords = [
+      {
+        rowId: 'r-1',
+        type: 'received',
+        versions: [{ id: 'ver-1', summaryLog: { id: 'file-id-1' } }]
+      }
+    ]
+    wasteRecordsRepository.findByRegistration.mockResolvedValue(wasteRecords)
+    prnRepository.findByAccreditation.mockResolvedValue([])
+
+    await runBalanceDivergenceDiagnostic(mockServer)
+
+    expect(computeRebuiltStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summaryLogs: [
+          {
+            id: 'file-id-1',
+            status: 'submitted',
+            submittedAt: '2025-01-01T00:00:00Z',
+            submittedBy: { id: 'user-9', name: 'real@example.com' }
+          }
+        ]
+      })
+    )
+  })
+
   it('filters out failure-status summary logs that may lack a file field before mapping', async () => {
     const accreditation = { id: 'acc-1', accreditationNumber: 'ACC-001' }
     setEmbeddedBalances([

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -48,12 +48,13 @@ const findEmbeddedBalances = async (db) => {
           _id: 0,
           accreditationId: 1,
           organisationId: 1,
-          registrationId: 1
+          registrationId: 1,
+          transactions: 1
         }
       }
     )
     .toArray()
-  return /** @type {{ accreditationId: string, organisationId: string, registrationId: string }[]} */ (
+  return /** @type {{ accreditationId: string, organisationId: string, registrationId: string, transactions?: Array<import('#waste-balances/domain/model.js').WasteBalanceTransaction> }[]} */ (
     /** @type {unknown} */ (docs)
   )
 }
@@ -70,7 +71,7 @@ const findEmbeddedBalances = async (db) => {
  */
 
 /**
- * @param {{ accreditationId: string, organisationId: string }} row
+ * @param {{ accreditationId: string, organisationId: string, transactions?: Array<import('#waste-balances/domain/model.js').WasteBalanceTransaction> }} row
  * @param {PromotionDependencies} deps
  * @returns {Promise<{ events: Array, registration: { id: string } }>}
  */
@@ -89,7 +90,7 @@ const rebuildEvents = async (row, deps) => {
 }
 
 /**
- * @param {{ accreditationId: string, organisationId: string }} row
+ * @param {{ accreditationId: string, organisationId: string, transactions?: Array<import('#waste-balances/domain/model.js').WasteBalanceTransaction> }} row
  * @param {PromotionDependencies} deps
  */
 export const promoteAccreditation = async (row, deps) => {

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -5,23 +5,18 @@ import {
 } from '#packaging-recycling-notes/domain/model.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 
-import { STREAM_EVENT_KIND, ZERO_BALANCE } from '../repository/stream-schema.js'
+import {
+  BACKFILL_ACTOR,
+  STREAM_EVENT_KIND,
+  ZERO_BALANCE
+} from '../repository/stream-schema.js'
 import {
   closingForSummaryLogSubmitted,
   closingForPrn
 } from './stream-closing-balance.js'
 import { getTargetAmount } from './target-amount.js'
 
-/**
- * Attribution for backfilled events with no recoverable real actor. The
- * submitting session for historical summary-log submissions is not persisted
- * on the summary-log document or the waste-record version, so a backfill
- * supplies it out of band where it can; absent that, events are attributed to
- * the system.
- *
- * @type {Readonly<import('../repository/stream-schema.js').StreamUserSummary>}
- */
-export const BACKFILL_ACTOR = Object.freeze({ id: 'system', name: 'backfill' })
+export { BACKFILL_ACTOR }
 
 /**
  * Reconstruct a waste record's data as it existed at a given submission

--- a/src/waste-balances/application/summary-log-submitters.js
+++ b/src/waste-balances/application/summary-log-submitters.js
@@ -1,0 +1,57 @@
+import { BACKFILL_ACTOR } from '../repository/stream-schema.js'
+
+/**
+ * Recover the real submitting actor for each historical summary log from the
+ * embedded waste-balance transactions. The submitting session is not persisted
+ * on the summary-log document or the waste-record version, but every embedded
+ * waste-balance transaction stamps `createdBy` with the submitting user and
+ * links the waste-record version it credited via `currentVersionId`. Each
+ * version carries the `summaryLog.id` of the submission that produced it, so
+ * the chain transaction.createdBy → currentVersionId → version → summaryLog.id
+ * yields a summary-log-id → actor map straight from authoritative sources.
+ *
+ * The system placeholder actor is rejected: it is the rebuild's own marker for
+ * "no real actor", so accepting it would falsely report a submission as
+ * recovered and hide the gap from the divergence diagnostic. Submissions that
+ * predate the SQS submit path may carry no recoverable actor at all; those are
+ * left to fall back to the backfill actor rather than be credited to a
+ * placeholder.
+ *
+ * Sourced from the embedded waste-balance document's `transactions` and the
+ * registration's waste records; typed structurally to the fields consumed.
+ *
+ * @param {Object} params
+ * @param {Array<{ createdBy?: { id: string, name: string }, entities?: Array<{ currentVersionId: string }> }>} [params.transactions]
+ * @param {Array<{ versions: Array<{ id: string, summaryLog: { id: string } }> }>} params.wasteRecords
+ * @returns {Map<string, import('../repository/stream-schema.js').StreamUserSummary>}
+ */
+export const buildSummaryLogSubmitters = ({ transactions, wasteRecords }) => {
+  const summaryLogIdByVersion = new Map()
+  for (const record of wasteRecords) {
+    for (const version of record.versions ?? []) {
+      summaryLogIdByVersion.set(version.id, version.summaryLog.id)
+    }
+  }
+
+  const submitters = new Map()
+  for (const transaction of transactions ?? []) {
+    if (
+      !transaction.createdBy ||
+      transaction.createdBy.id === BACKFILL_ACTOR.id
+    ) {
+      continue
+    }
+    for (const entity of transaction.entities ?? []) {
+      const summaryLogId = summaryLogIdByVersion.get(entity.currentVersionId)
+      if (summaryLogId === undefined || submitters.has(summaryLogId)) {
+        continue
+      }
+      submitters.set(summaryLogId, {
+        id: transaction.createdBy.id,
+        name: transaction.createdBy.name
+      })
+    }
+  }
+
+  return submitters
+}

--- a/src/waste-balances/application/summary-log-submitters.js
+++ b/src/waste-balances/application/summary-log-submitters.js
@@ -1,6 +1,20 @@
 import { BACKFILL_ACTOR } from '../repository/stream-schema.js'
 
 /**
+ * @param {Array<{ versions: Array<{ id: string, summaryLog: { id: string } }> }>} wasteRecords
+ * @returns {Map<string, string>}
+ */
+const indexSummaryLogIdByVersion = (wasteRecords) => {
+  const summaryLogIdByVersion = new Map()
+  for (const record of wasteRecords) {
+    for (const version of record.versions ?? []) {
+      summaryLogIdByVersion.set(version.id, version.summaryLog.id)
+    }
+  }
+  return summaryLogIdByVersion
+}
+
+/**
  * Recover the real submitting actor for each historical summary log from the
  * embedded waste-balance transactions. The submitting session is not persisted
  * on the summary-log document or the waste-record version, but every embedded
@@ -26,19 +40,12 @@ import { BACKFILL_ACTOR } from '../repository/stream-schema.js'
  * @returns {Map<string, import('../repository/stream-schema.js').StreamUserSummary>}
  */
 export const buildSummaryLogSubmitters = ({ transactions, wasteRecords }) => {
-  const summaryLogIdByVersion = new Map()
-  for (const record of wasteRecords) {
-    for (const version of record.versions ?? []) {
-      summaryLogIdByVersion.set(version.id, version.summaryLog.id)
-    }
-  }
+  const summaryLogIdByVersion = indexSummaryLogIdByVersion(wasteRecords)
 
   const submitters = new Map()
   for (const transaction of transactions ?? []) {
-    if (
-      !transaction.createdBy ||
-      transaction.createdBy.id === BACKFILL_ACTOR.id
-    ) {
+    const { createdBy } = transaction
+    if (createdBy === undefined || createdBy.id === BACKFILL_ACTOR.id) {
       continue
     }
     for (const entity of transaction.entities ?? []) {
@@ -47,8 +54,8 @@ export const buildSummaryLogSubmitters = ({ transactions, wasteRecords }) => {
         continue
       }
       submitters.set(summaryLogId, {
-        id: transaction.createdBy.id,
-        name: transaction.createdBy.name
+        id: createdBy.id,
+        name: createdBy.name
       })
     }
   }

--- a/src/waste-balances/application/summary-log-submitters.test.js
+++ b/src/waste-balances/application/summary-log-submitters.test.js
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+
+import { BACKFILL_ACTOR } from '../repository/stream-schema.js'
+import { buildSummaryLogSubmitters } from './summary-log-submitters.js'
+
+const versionWithSummaryLog = (versionId, summaryLogId) => ({
+  id: versionId,
+  summaryLog: { id: summaryLogId, uri: `s3://bucket/${summaryLogId}` },
+  data: {}
+})
+
+const wasteRecordWithVersions = (versions) => ({
+  rowId: 'row-1',
+  versions
+})
+
+const creditTransaction = (createdBy, currentVersionId) => ({
+  id: `txn-${currentVersionId}`,
+  type: 'credit',
+  createdBy,
+  entities: [
+    {
+      id: 'row-1',
+      currentVersionId,
+      previousVersionIds: [],
+      type: 'waste-record-received'
+    }
+  ]
+})
+
+describe('buildSummaryLogSubmitters', () => {
+  it('credits a summary log to the actor of the transaction that referenced its version', () => {
+    const wasteRecords = [
+      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
+    ]
+    const transactions = [
+      creditTransaction({ id: 'user-1', name: 'alice@example.com' }, 'v1')
+    ]
+
+    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
+
+    expect(submitters.get('sl-1')).toEqual({
+      id: 'user-1',
+      name: 'alice@example.com'
+    })
+  })
+
+  it('attributes each summary log to its own submitter across multiple submits', () => {
+    const wasteRecords = [
+      wasteRecordWithVersions([
+        versionWithSummaryLog('v1', 'sl-1'),
+        versionWithSummaryLog('v2', 'sl-2')
+      ])
+    ]
+    const transactions = [
+      creditTransaction({ id: 'user-1', name: 'alice@example.com' }, 'v1'),
+      creditTransaction({ id: 'user-2', name: 'bob@example.com' }, 'v2')
+    ]
+
+    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
+
+    expect(submitters.get('sl-1')).toEqual({
+      id: 'user-1',
+      name: 'alice@example.com'
+    })
+    expect(submitters.get('sl-2')).toEqual({
+      id: 'user-2',
+      name: 'bob@example.com'
+    })
+  })
+
+  it('skips system-generated transactions that name no actor', () => {
+    const wasteRecords = [
+      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
+    ]
+    const transactions = [creditTransaction(undefined, 'v1')]
+
+    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
+
+    expect(submitters.has('sl-1')).toBe(false)
+  })
+
+  it('rejects the system placeholder actor so it never masquerades as a real submitter', () => {
+    const wasteRecords = [
+      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
+    ]
+    const transactions = [
+      creditTransaction({ ...BACKFILL_ACTOR }, 'v1'),
+      creditTransaction({ id: 'system', name: 'system' }, 'v1')
+    ]
+
+    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
+
+    expect(submitters.has('sl-1')).toBe(false)
+  })
+
+  it('ignores entities whose version matches no waste record', () => {
+    const wasteRecords = [
+      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
+    ]
+    const transactions = [
+      creditTransaction({ id: 'user-1', name: 'alice@example.com' }, 'prn-v-9')
+    ]
+
+    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
+
+    expect(submitters.size).toBe(0)
+  })
+
+  it('keeps the first actor when two transactions reference the same summary log', () => {
+    const wasteRecords = [
+      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')]),
+      {
+        rowId: 'row-2',
+        versions: [versionWithSummaryLog('v2', 'sl-1')]
+      }
+    ]
+    const transactions = [
+      creditTransaction({ id: 'user-1', name: 'alice@example.com' }, 'v1'),
+      creditTransaction({ id: 'user-2', name: 'bob@example.com' }, 'v2')
+    ]
+
+    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
+
+    expect(submitters.get('sl-1')).toEqual({
+      id: 'user-1',
+      name: 'alice@example.com'
+    })
+  })
+
+  it('returns an empty map when there are no transactions', () => {
+    const wasteRecords = [
+      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
+    ]
+
+    const submitters = buildSummaryLogSubmitters({
+      transactions: [],
+      wasteRecords
+    })
+
+    expect(submitters.size).toBe(0)
+  })
+
+  it('tolerates a transaction that carries no entities', () => {
+    const wasteRecords = [
+      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
+    ]
+    const transactions = [
+      { createdBy: { id: 'user-1', name: 'alice@example.com' } }
+    ]
+
+    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
+
+    expect(submitters.size).toBe(0)
+  })
+
+  it('tolerates a balance document with no transactions array', () => {
+    const wasteRecords = [
+      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
+    ]
+
+    const submitters = buildSummaryLogSubmitters({
+      transactions: undefined,
+      wasteRecords
+    })
+
+    expect(submitters.size).toBe(0)
+  })
+})

--- a/src/waste-balances/repository/stream-schema.js
+++ b/src/waste-balances/repository/stream-schema.js
@@ -41,6 +41,18 @@ export const ZERO_BALANCE = Object.freeze({ amount: 0, availableAmount: 0 })
  */
 
 /**
+ * Attribution for events with no recoverable real actor. The submitting
+ * session for historical summary-log submissions is not persisted on the
+ * summary-log document or the waste-record version, so a rebuild supplies the
+ * real actor out of band where it can; absent that, events are attributed to
+ * the system. Its id is also the marker the submitter recovery rejects, so a
+ * placeholder can never masquerade as a recovered real actor.
+ *
+ * @type {Readonly<StreamUserSummary>}
+ */
+export const BACKFILL_ACTOR = Object.freeze({ id: 'system', name: 'backfill' })
+
+/**
  * @typedef {{ summaryLogId: string, creditTotal: number }} SummaryLogSubmittedPayload
  */
 


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## What and why

The event-sourced waste-balance rebuild reconstructs each accreditation's event stream from authoritative sources. Until now every historical `summary-log-submitted` event was attributed to a placeholder system actor, because the submitting user is not stored on the summary-log document or the waste-record version. Promoting that stream to the authoritative record at the ledger cutover would permanently bake the placeholder actor into the event history for the whole population, with no way to recover the real submitter afterwards.

This change sources the real submitter from data that already exists pre-cutover: the embedded waste-balance document's transactions. Each transaction stamps `createdBy` with the submitting user and links the waste-record version it credited via `currentVersionId`; each version carries the id of the summary log that produced it. Correlating `createdBy` → `currentVersionId` → version → `summaryLog.id` recovers the real submitter per summary log, and `loadAccreditationSources` now threads it into the rebuild so submissions are attributed to the person who made them rather than the backfill actor.

The recovery deliberately rejects the system placeholder identity, so a placeholder can never be mistaken for a recovered real actor. Submissions whose submitter cannot be recovered continue to fall back to the backfill actor and stay visible as genuine gaps in the boot divergence diagnostic, instead of being silently credited to a fake actor. Profiling the residual gap across the population (and identifying any alternative source for the oldest submissions) is tracked separately and gates the cutover.

## Changes

- Add `buildSummaryLogSubmitters` (`src/waste-balances/application/summary-log-submitters.js`): builds the `summaryLogId` → actor map from the embedded transactions and waste-record versions, rejecting the system placeholder and tolerating absent transactions/entities/versions.
- `loadAccreditationSources` attaches the recovered `submittedBy` to each submitted summary log before the rebuild consumes them.
- The balance-divergence diagnostic and stream-promotion sweeps now project the embedded `transactions`, and the dev promote-to-ledger route passes them through, so every rebuild caller supplies the data the correlation needs.
- Move `BACKFILL_ACTOR` to the stream-schema module (re-exported from its previous location) so the recovery can reference the placeholder marker without depending on the rebuild algorithm module.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ