### PR TITLE
PAE-1382: Recover summary-log submitters from system-logs instead of embedded transactions

### DIFF
--- a/src/repositories/system-logs/contract/test-data.js
+++ b/src/repositories/system-logs/contract/test-data.js
@@ -27,3 +27,34 @@ export const buildSystemLog = ({
     ...(id !== undefined && { id })
   }
 })
+
+/**
+ * @param {object} params
+ * @param {string} params.summaryLogId
+ * @param {string} [params.organisationId]
+ * @param {string} [params.registrationId]
+ * @param {string} [params.userId]
+ * @param {string} [params.email]
+ * @param {Date} [params.createdAt]
+ */
+export const buildSummaryLogSubmitEvent = ({
+  summaryLogId,
+  organisationId = 'org-1',
+  registrationId = 'reg-1',
+  userId = 'user-001',
+  email = 'user@email.com',
+  createdAt = new Date()
+}) => ({
+  createdAt,
+  createdBy: { id: userId, email, scope: [] },
+  event: {
+    category: 'waste-reporting',
+    subCategory: 'summary-log',
+    action: 'submit'
+  },
+  context: {
+    summaryLogId,
+    organisationId,
+    registrationId
+  }
+})

--- a/src/repositories/system-logs/inmemory.js
+++ b/src/repositories/system-logs/inmemory.js
@@ -95,9 +95,12 @@ export function createSystemLogsRepository() {
             item.event?.action === 'submit' &&
             idSet.has(item.context?.summaryLogId)
           ) {
+            const createdBy = /** @type {Record<string, string>} */ (
+              item.createdBy
+            )
             submitters.set(item.context.summaryLogId, {
-              id: item.createdBy.id,
-              name: item.createdBy.email ?? item.createdBy.name
+              id: createdBy.id,
+              name: createdBy.email ?? createdBy.name
             })
           }
         }

--- a/src/repositories/system-logs/inmemory.js
+++ b/src/repositories/system-logs/inmemory.js
@@ -80,6 +80,28 @@ export function createSystemLogsRepository() {
           nextCursor,
           prevCursor
         }
+      },
+
+      async findSubmittersBySummaryLogIds(summaryLogIds) {
+        /** @type {Map<string, import('./port.js').SystemLogSubmitter>} */
+        const submitters = new Map()
+        if (summaryLogIds.length === 0) {
+          return submitters
+        }
+        const idSet = new Set(summaryLogIds)
+        for (const item of storage) {
+          if (
+            item.event?.subCategory === 'summary-log' &&
+            item.event?.action === 'submit' &&
+            idSet.has(item.context?.summaryLogId)
+          ) {
+            submitters.set(item.context.summaryLogId, {
+              id: item.createdBy.id,
+              name: item.createdBy.email ?? item.createdBy.name
+            })
+          }
+        }
+        return submitters
       }
     }
   }

--- a/src/repositories/system-logs/mongodb.js
+++ b/src/repositories/system-logs/mongodb.js
@@ -95,6 +95,38 @@ export const createSystemLogsRepository = async (db) => {
         nextCursor,
         prevCursor
       }
+    },
+
+    async findSubmittersBySummaryLogIds(summaryLogIds) {
+      /** @type {Map<string, import('./port.js').SystemLogSubmitter>} */
+      const submitters = new Map()
+      if (summaryLogIds.length === 0) {
+        return submitters
+      }
+
+      const docs = await db
+        .collection(SYSTEM_LOGS_COLLECTION_NAME)
+        .find({
+          'context.summaryLogId': { $in: summaryLogIds },
+          'event.subCategory': 'summary-log',
+          'event.action': 'submit'
+        })
+        .project({
+          'context.summaryLogId': 1,
+          'createdBy.id': 1,
+          'createdBy.email': 1,
+          'createdBy.name': 1
+        })
+        .toArray()
+
+      for (const doc of docs) {
+        submitters.set(doc.context.summaryLogId, {
+          id: doc.createdBy.id,
+          name: doc.createdBy.email ?? doc.createdBy.name
+        })
+      }
+
+      return submitters
     }
   })
 }

--- a/src/repositories/system-logs/port.contract.js
+++ b/src/repositories/system-logs/port.contract.js
@@ -1,7 +1,10 @@
 import { describe, expect } from 'vitest'
 import { randomUUID } from 'crypto'
 
-import { buildSystemLog } from './contract/test-data.js'
+import {
+  buildSystemLog,
+  buildSummaryLogSubmitEvent
+} from './contract/test-data.js'
 
 /** @import {SystemLogsRepository} from './port.js' */
 
@@ -453,6 +456,110 @@ export const testSystemLogsRepositoryContract = (it) => {
         expect(result.nextCursor).toBeNull()
         expect(result.prevCursor).toBeNull()
       })
+    })
+  })
+
+  describe('findSubmittersBySummaryLogIds', () => {
+    it('returns the submitter for each summary log ID', async ({
+      systemLogsRepository
+    }) => {
+      /** @type {SystemLogsRepository} */
+      const repository = systemLogsRepository()
+
+      await repository.insert(
+        buildSummaryLogSubmitEvent({
+          summaryLogId: 'sl-1',
+          userId: 'user-a',
+          email: 'alice@example.com'
+        })
+      )
+      await repository.insert(
+        buildSummaryLogSubmitEvent({
+          summaryLogId: 'sl-2',
+          userId: 'user-b',
+          email: 'bob@example.com'
+        })
+      )
+
+      const result = await repository.findSubmittersBySummaryLogIds([
+        'sl-1',
+        'sl-2'
+      ])
+
+      expect(result.get('sl-1')).toEqual({
+        id: 'user-a',
+        name: 'alice@example.com'
+      })
+      expect(result.get('sl-2')).toEqual({
+        id: 'user-b',
+        name: 'bob@example.com'
+      })
+    })
+
+    it('ignores non-submit events for the same summary log ID', async ({
+      systemLogsRepository
+    }) => {
+      /** @type {SystemLogsRepository} */
+      const repository = systemLogsRepository()
+
+      const uniqueId = `sl-download-only-${randomUUID()}`
+      await repository.insert({
+        createdAt: new Date(),
+        createdBy: { id: 'user-a', email: 'alice@example.com', scope: [] },
+        event: {
+          category: 'waste-reporting',
+          subCategory: 'summary-log',
+          action: 'download'
+        },
+        context: { summaryLogId: uniqueId }
+      })
+
+      const result = await repository.findSubmittersBySummaryLogIds([uniqueId])
+
+      expect(result.size).toBe(0)
+    })
+
+    it('returns an empty map when no IDs match', async ({
+      systemLogsRepository
+    }) => {
+      /** @type {SystemLogsRepository} */
+      const repository = systemLogsRepository()
+
+      const result = await repository.findSubmittersBySummaryLogIds([
+        'no-such-id'
+      ])
+
+      expect(result.size).toBe(0)
+    })
+
+    it('returns an empty map for an empty input array', async ({
+      systemLogsRepository
+    }) => {
+      /** @type {SystemLogsRepository} */
+      const repository = systemLogsRepository()
+
+      const result = await repository.findSubmittersBySummaryLogIds([])
+
+      expect(result.size).toBe(0)
+    })
+
+    it('excludes summary log IDs not in the requested set', async ({
+      systemLogsRepository
+    }) => {
+      /** @type {SystemLogsRepository} */
+      const repository = systemLogsRepository()
+
+      await repository.insert(
+        buildSummaryLogSubmitEvent({ summaryLogId: 'sl-1', userId: 'user-a' })
+      )
+      await repository.insert(
+        buildSummaryLogSubmitEvent({ summaryLogId: 'sl-2', userId: 'user-b' })
+      )
+
+      const result = await repository.findSubmittersBySummaryLogIds(['sl-1'])
+
+      expect(result.size).toBe(1)
+      expect(result.has('sl-1')).toBe(true)
     })
   })
 }

--- a/src/repositories/system-logs/port.js
+++ b/src/repositories/system-logs/port.js
@@ -37,9 +37,14 @@
  */
 
 /**
+ * @typedef {{ id: string, name: string }} SystemLogSubmitter
+ */
+
+/**
  * @typedef {{
  *   insert: (systemLog: SystemLog) => Promise<void>
  *   find: (params: FindParams) => Promise<PaginatedSystemLogs>
+ *   findSubmittersBySummaryLogIds: (summaryLogIds: string[]) => Promise<Map<string, SystemLogSubmitter>>
  * }} SystemLogsRepository
  */
 

--- a/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
+++ b/src/routes/v1/dev/waste-balances/promote-to-ledger/post.js
@@ -62,7 +62,7 @@ async function handler(request, h) {
   }
 
   const result = await promoteAccreditation(
-    { accreditationId, organisationId, transactions: balance.transactions },
+    { accreditationId, organisationId },
     {
       wasteBalancesRepository,
       streamRepository: request.streamRepository,
@@ -70,7 +70,8 @@ async function handler(request, h) {
       prnRepository: request.packagingRecyclingNotesRepository,
       wasteRecordsRepository: request.wasteRecordsRepository,
       overseasSitesRepository: request.overseasSitesRepository,
-      summaryLogsRepository: request.summaryLogsRepository
+      summaryLogsRepository: request.summaryLogsRepository,
+      systemLogsRepository: request.systemLogsRepository
     }
   )
 

--- a/src/server/load-accreditation-sources.js
+++ b/src/server/load-accreditation-sources.js
@@ -31,17 +31,18 @@ export const toStreamSummaryLog = ({ summaryLog }) => ({
  * @property {import('#repositories/waste-records/port.js').WasteRecordsRepository} wasteRecordsRepository
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
  * @property {import('#repositories/summary-logs/port.js').SummaryLogsRepository} summaryLogsRepository
+ * @property {import('#repositories/system-logs/port.js').SystemLogsRepository} systemLogsRepository
  */
 
 /**
  * Load the organisation, registration, and accreditation for a balance row,
  * then fetch all authoritative sources needed to rebuild the event stream
- * or recompute totals. The row's embedded waste-balance transactions recover
- * the real submitting actor for each historical summary log, so the rebuilt
- * stream attributes submissions to the person who made them rather than the
+ * or recompute totals. Recovers the real submitting actor for each historical
+ * summary log from the system-logs audit trail, so the rebuilt stream
+ * attributes submissions to the person who made them rather than the
  * backfill actor.
  *
- * @param {{ accreditationId: string, organisationId: string, transactions?: Array<import('#waste-balances/domain/model.js').WasteBalanceTransaction> }} row
+ * @param {{ accreditationId: string, organisationId: string }} row
  * @param {AccreditationSourceDeps} deps
  */
 export const loadAccreditationSources = async (row, deps) => {
@@ -50,7 +51,8 @@ export const loadAccreditationSources = async (row, deps) => {
     prnRepository,
     wasteRecordsRepository,
     overseasSitesRepository,
-    summaryLogsRepository
+    summaryLogsRepository,
+    systemLogsRepository
   } = deps
 
   const organisation = await organisationsRepository.findById(
@@ -91,9 +93,13 @@ export const loadAccreditationSources = async (row, deps) => {
     registration.id
   )
 
+  const summaryLogDocIds = summaryLogDocs.map((doc) => String(doc.id))
+  const systemLogSubmitters =
+    await systemLogsRepository.findSubmittersBySummaryLogIds(summaryLogDocIds)
+
   const submitters = buildSummaryLogSubmitters({
-    transactions: row.transactions,
-    wasteRecords
+    systemLogSubmitters,
+    summaryLogDocs
   })
 
   const summaryLogs = summaryLogDocs

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -3,6 +3,7 @@ import { createOrganisationsRepository } from '#repositories/organisations/mongo
 import { createOverseasSitesRepository } from '#overseas-sites/repository/mongodb.js'
 import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/mongodb.js'
 import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
 import { computeRebuiltTotals } from '#waste-balances/application/compute-rebuilt-totals.js'
 import { computeRebuiltStream } from '#waste-balances/application/compute-rebuilt-stream.js'
@@ -18,7 +19,6 @@ const LOCK_NAME = 'balance-divergence-diagnostic'
  * @property {string} organisationId
  * @property {number} amount
  * @property {number} availableAmount
- * @property {Array<import('#waste-balances/domain/model.js').WasteBalanceTransaction>} [transactions]
  */
 
 /**
@@ -28,6 +28,7 @@ const LOCK_NAME = 'balance-divergence-diagnostic'
  * @property {import('#repositories/waste-records/port.js').WasteRecordsRepository} wasteRecordsRepository
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
  * @property {import('#repositories/summary-logs/port.js').SummaryLogsRepository} summaryLogsRepository
+ * @property {import('#repositories/system-logs/port.js').SystemLogsRepository} systemLogsRepository
  */
 
 /**
@@ -47,8 +48,7 @@ const findEmbeddedWasteBalances = async (db) => {
           accreditationId: 1,
           organisationId: 1,
           amount: 1,
-          availableAmount: 1,
-          transactions: 1
+          availableAmount: 1
         }
       }
     )
@@ -261,13 +261,17 @@ const buildDependencies = async (server) => {
   const summaryLogsRepository = (
     await createSummaryLogsRepository(server.db, /** @type {any} */ ({}))
   )(logger)
+  const systemLogsRepository = (
+    await createSystemLogsRepository(server.db)
+  )(logger)
 
   return /** @type {DiagnosticDependencies} */ ({
     organisationsRepository,
     wasteRecordsRepository,
     prnRepository,
     overseasSitesRepository,
-    summaryLogsRepository
+    summaryLogsRepository,
+    systemLogsRepository
   })
 }
 

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -261,9 +261,9 @@ const buildDependencies = async (server) => {
   const summaryLogsRepository = (
     await createSummaryLogsRepository(server.db, /** @type {any} */ ({}))
   )(logger)
-  const systemLogsRepository = (
-    await createSystemLogsRepository(server.db)
-  )(logger)
+  const systemLogsRepository = (await createSystemLogsRepository(server.db))(
+    logger
+  )
 
   return /** @type {DiagnosticDependencies} */ ({
     organisationsRepository,

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -10,6 +10,7 @@ import { computeRebuiltStream } from '#waste-balances/application/compute-rebuil
 import { buildStreamEvent } from '#waste-balances/repository/stream-test-data.js'
 import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
 import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
 
 import { runBalanceDivergenceDiagnostic } from './run-balance-divergence-diagnostic.js'
 
@@ -44,6 +45,9 @@ vi.mock('#application/waste-records/resolve-overseas-sites.js', () => ({
 vi.mock('#repositories/summary-logs/mongodb.js', () => ({
   createSummaryLogsRepository: vi.fn()
 }))
+vi.mock('#repositories/system-logs/mongodb.js', () => ({
+  createSystemLogsRepository: vi.fn()
+}))
 
 describe('runBalanceDivergenceDiagnostic', () => {
   let mockServer
@@ -53,6 +57,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
   let prnRepository
   let overseasSitesRepository
   let summaryLogsRepository
+  let systemLogsRepository
   let mockToArray
   let mockFind
   let collectionByName
@@ -127,6 +132,13 @@ describe('runBalanceDivergenceDiagnostic', () => {
     }
     vi.mocked(createSummaryLogsRepository).mockResolvedValue(
       () => summaryLogsRepository
+    )
+
+    systemLogsRepository = {
+      findSubmittersBySummaryLogIds: vi.fn().mockResolvedValue(new Map())
+    }
+    vi.mocked(createSystemLogsRepository).mockResolvedValue(
+      () => systemLogsRepository
     )
 
     vi.mocked(computeRebuiltTotals).mockReturnValue(
@@ -649,20 +661,14 @@ describe('runBalanceDivergenceDiagnostic', () => {
     })
   })
 
-  it('recovers the real submitter from the embedded transactions and threads it into computeRebuiltStream', async () => {
+  it('recovers the real submitter from system-logs and threads it into computeRebuiltStream', async () => {
     const accreditation = { id: 'acc-1', accreditationNumber: 'ACC-001' }
     setEmbeddedBalances([
       {
         accreditationId: 'acc-1',
         organisationId: 'org-1',
         amount: 0,
-        availableAmount: 0,
-        transactions: [
-          {
-            createdBy: { id: 'user-9', name: 'real@example.com' },
-            entities: [{ currentVersionId: 'ver-1' }]
-          }
-        ]
+        availableAmount: 0
       }
     ])
     registrations['org-1'] = [
@@ -685,18 +691,16 @@ describe('runBalanceDivergenceDiagnostic', () => {
         }
       }
     ])
-    const wasteRecords = [
-      {
-        rowId: 'r-1',
-        type: 'received',
-        versions: [{ id: 'ver-1', summaryLog: { id: 'file-id-1' } }]
-      }
-    ]
-    wasteRecordsRepository.findByRegistration.mockResolvedValue(wasteRecords)
+    systemLogsRepository.findSubmittersBySummaryLogIds.mockResolvedValue(
+      new Map([['doc-id-1', { id: 'user-9', name: 'real@example.com' }]])
+    )
     prnRepository.findByAccreditation.mockResolvedValue([])
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
+    expect(
+      systemLogsRepository.findSubmittersBySummaryLogIds
+    ).toHaveBeenCalledWith(['doc-id-1'])
     expect(computeRebuiltStream).toHaveBeenCalledWith(
       expect.objectContaining({
         summaryLogs: [

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -200,9 +200,9 @@ const buildDependencies = async (server) => {
   const summaryLogsRepository = (
     await createSummaryLogsRepository(server.db, /** @type {any} */ ({}))
   )(logger)
-  const systemLogsRepository = (
-    await createSystemLogsRepository(server.db)
-  )(logger)
+  const systemLogsRepository = (await createSystemLogsRepository(server.db))(
+    logger
+  )
 
   return {
     wasteBalancesRepository,

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -4,6 +4,7 @@ import { createOrganisationsRepository } from '#repositories/organisations/mongo
 import { createOverseasSitesRepository } from '#overseas-sites/repository/mongodb.js'
 import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/mongodb.js'
 import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
 import { createWasteBalancesRepository } from '#waste-balances/repository/mongodb.js'
 import { createMongoStreamRepository } from '#waste-balances/repository/stream-mongodb.js'
@@ -48,13 +49,12 @@ const findEmbeddedBalances = async (db) => {
           _id: 0,
           accreditationId: 1,
           organisationId: 1,
-          registrationId: 1,
-          transactions: 1
+          registrationId: 1
         }
       }
     )
     .toArray()
-  return /** @type {{ accreditationId: string, organisationId: string, registrationId: string, transactions?: Array<import('#waste-balances/domain/model.js').WasteBalanceTransaction> }[]} */ (
+  return /** @type {{ accreditationId: string, organisationId: string, registrationId: string }[]} */ (
     /** @type {unknown} */ (docs)
   )
 }
@@ -68,10 +68,11 @@ const findEmbeddedBalances = async (db) => {
  * @property {import('#repositories/waste-records/port.js').WasteRecordsRepository} wasteRecordsRepository
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
  * @property {import('#repositories/summary-logs/port.js').SummaryLogsRepository} summaryLogsRepository
+ * @property {import('#repositories/system-logs/port.js').SystemLogsRepository} systemLogsRepository
  */
 
 /**
- * @param {{ accreditationId: string, organisationId: string, transactions?: Array<import('#waste-balances/domain/model.js').WasteBalanceTransaction> }} row
+ * @param {{ accreditationId: string, organisationId: string }} row
  * @param {PromotionDependencies} deps
  * @returns {Promise<{ events: Array, registration: { id: string } }>}
  */
@@ -90,7 +91,7 @@ const rebuildEvents = async (row, deps) => {
 }
 
 /**
- * @param {{ accreditationId: string, organisationId: string, transactions?: Array<import('#waste-balances/domain/model.js').WasteBalanceTransaction> }} row
+ * @param {{ accreditationId: string, organisationId: string }} row
  * @param {PromotionDependencies} deps
  */
 export const promoteAccreditation = async (row, deps) => {
@@ -199,6 +200,9 @@ const buildDependencies = async (server) => {
   const summaryLogsRepository = (
     await createSummaryLogsRepository(server.db, /** @type {any} */ ({}))
   )(logger)
+  const systemLogsRepository = (
+    await createSystemLogsRepository(server.db)
+  )(logger)
 
   return {
     wasteBalancesRepository,
@@ -207,7 +211,8 @@ const buildDependencies = async (server) => {
     wasteRecordsRepository,
     prnRepository,
     overseasSitesRepository,
-    summaryLogsRepository
+    summaryLogsRepository,
+    systemLogsRepository
   }
 }
 

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -154,11 +154,9 @@ describe('runStreamPromotion', () => {
       () => summaryLogsRepository
     )
 
-    vi.mocked(createSystemLogsRepository).mockResolvedValue(
-      () => ({
-        findSubmittersBySummaryLogIds: vi.fn().mockResolvedValue(new Map())
-      })
-    )
+    vi.mocked(createSystemLogsRepository).mockResolvedValue(() => ({
+      findSubmittersBySummaryLogIds: vi.fn().mockResolvedValue(new Map())
+    }))
 
     vi.mocked(createOverseasSitesRepository).mockResolvedValue(
       () => /** @type {*} */ ({})

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -7,6 +7,7 @@ import { createOverseasSitesRepository } from '#overseas-sites/repository/mongod
 import { createPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/mongodb.js'
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
 import { createSummaryLogsRepository } from '#repositories/summary-logs/mongodb.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
 import { createWasteBalancesRepository } from '#waste-balances/repository/mongodb.js'
 import { createMongoStreamRepository } from '#waste-balances/repository/stream-mongodb.js'
 import { computeRebuiltStream } from '#waste-balances/application/compute-rebuilt-stream.js'
@@ -39,6 +40,9 @@ vi.mock('#overseas-sites/repository/mongodb.js', () => ({
 }))
 vi.mock('#repositories/summary-logs/mongodb.js', () => ({
   createSummaryLogsRepository: vi.fn()
+}))
+vi.mock('#repositories/system-logs/mongodb.js', () => ({
+  createSystemLogsRepository: vi.fn()
 }))
 vi.mock('#waste-balances/repository/mongodb.js', () => ({
   createWasteBalancesRepository: vi.fn()
@@ -148,6 +152,12 @@ describe('runStreamPromotion', () => {
     }
     vi.mocked(createSummaryLogsRepository).mockResolvedValue(
       () => summaryLogsRepository
+    )
+
+    vi.mocked(createSystemLogsRepository).mockResolvedValue(
+      () => ({
+        findSubmittersBySummaryLogIds: vi.fn().mockResolvedValue(new Map())
+      })
     )
 
     vi.mocked(createOverseasSitesRepository).mockResolvedValue(

--- a/src/waste-balances/application/summary-log-submitters.js
+++ b/src/waste-balances/application/summary-log-submitters.js
@@ -1,62 +1,33 @@
-import { BACKFILL_ACTOR } from '../repository/stream-schema.js'
-
 /**
- * @param {Array<{ versions: Array<{ id: string, summaryLog: { id: string } }> }>} wasteRecords
- * @returns {Map<string, string>}
- */
-const indexSummaryLogIdByVersion = (wasteRecords) => {
-  const summaryLogIdByVersion = new Map()
-  for (const record of wasteRecords) {
-    for (const version of record.versions ?? []) {
-      summaryLogIdByVersion.set(version.id, version.summaryLog.id)
-    }
-  }
-  return summaryLogIdByVersion
-}
-
-/**
- * Recover the real submitting actor for each historical summary log from the
- * embedded waste-balance transactions. The submitting session is not persisted
- * on the summary-log document or the waste-record version, but every embedded
- * waste-balance transaction stamps `createdBy` with the submitting user and
- * links the waste-record version it credited via `currentVersionId`. Each
- * version carries the `summaryLog.id` of the submission that produced it, so
- * the chain transaction.createdBy → currentVersionId → version → summaryLog.id
- * yields a summary-log-id → actor map straight from authoritative sources.
- *
- * The system placeholder actor is rejected: it is the rebuild's own marker for
- * "no real actor", so accepting it would falsely report a submission as
- * recovered and hide the gap from the divergence diagnostic. Submissions that
- * predate the SQS submit path may carry no recoverable actor at all; those are
- * left to fall back to the backfill actor rather than be credited to a
- * placeholder.
- *
- * Sourced from the embedded waste-balance document's `transactions` and the
- * registration's waste records; typed structurally to the fields consumed.
+ * Build a map from summary-log file ID to the submitting actor, sourced from
+ * the system-logs collection. Each summary-log submission audit event records
+ * the submitter's identity keyed by the summary-log document _id
+ * (`context.summaryLogId`). The summary-log documents carry both the document
+ * _id and the file identifier (`file.id`) that the stream uses as its natural
+ * key. This function joins the two namespaces so callers can look up submitters
+ * by the file-level ID that computeRebuiltStream expects.
  *
  * @param {Object} params
- * @param {Array<{ createdBy?: { id: string, name: string }, entities?: Array<{ currentVersionId: string }> }>} [params.transactions]
- * @param {Array<{ versions: Array<{ id: string, summaryLog: { id: string } }> }>} params.wasteRecords
+ * @param {Map<string, import('../repository/stream-schema.js').StreamUserSummary>} params.systemLogSubmitters
+ *   Map from summary-log document _id to the submitting actor, as returned by
+ *   systemLogsRepository.findSubmittersBySummaryLogIds.
+ * @param {Array<{ id: *, summaryLog: { file: { id: string } } }>} params.summaryLogDocs
+ *   Summary-log documents from findAllByOrgReg (id = document _id, summaryLog.file.id = file key).
  * @returns {Map<string, import('../repository/stream-schema.js').StreamUserSummary>}
+ *   Map from summary-log file ID to actor.
  */
-export const buildSummaryLogSubmitters = ({ transactions, wasteRecords }) => {
-  const summaryLogIdByVersion = indexSummaryLogIdByVersion(wasteRecords)
-
+export const buildSummaryLogSubmitters = ({
+  systemLogSubmitters,
+  summaryLogDocs
+}) => {
+  /** @type {Map<string, import('../repository/stream-schema.js').StreamUserSummary>} */
   const submitters = new Map()
-  for (const transaction of transactions ?? []) {
-    const { createdBy } = transaction
-    if (createdBy === undefined || createdBy.id === BACKFILL_ACTOR.id) {
-      continue
-    }
-    for (const entity of transaction.entities ?? []) {
-      const summaryLogId = summaryLogIdByVersion.get(entity.currentVersionId)
-      if (summaryLogId === undefined || submitters.has(summaryLogId)) {
-        continue
-      }
-      submitters.set(summaryLogId, {
-        id: createdBy.id,
-        name: createdBy.name
-      })
+
+  for (const doc of summaryLogDocs) {
+    const docId = String(doc.id)
+    const submitter = systemLogSubmitters.get(docId)
+    if (submitter) {
+      submitters.set(doc.summaryLog.file.id, submitter)
     }
   }
 

--- a/src/waste-balances/application/summary-log-submitters.test.js
+++ b/src/waste-balances/application/summary-log-submitters.test.js
@@ -1,169 +1,80 @@
 import { describe, expect, it } from 'vitest'
 
-import { BACKFILL_ACTOR } from '../repository/stream-schema.js'
 import { buildSummaryLogSubmitters } from './summary-log-submitters.js'
 
-const versionWithSummaryLog = (versionId, summaryLogId) => ({
-  id: versionId,
-  summaryLog: { id: summaryLogId, uri: `s3://bucket/${summaryLogId}` },
-  data: {}
-})
-
-const wasteRecordWithVersions = (versions) => ({
-  rowId: 'row-1',
-  versions
-})
-
-const creditTransaction = (createdBy, currentVersionId) => ({
-  id: `txn-${currentVersionId}`,
-  type: 'credit',
-  createdBy,
-  entities: [
-    {
-      id: 'row-1',
-      currentVersionId,
-      previousVersionIds: [],
-      type: 'waste-record-received'
-    }
-  ]
+const summaryLogDoc = (docId, fileId) => ({
+  id: docId,
+  summaryLog: { file: { id: fileId }, status: 'submitted' }
 })
 
 describe('buildSummaryLogSubmitters', () => {
-  it('credits a summary log to the actor of the transaction that referenced its version', () => {
-    const wasteRecords = [
-      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
-    ]
-    const transactions = [
-      creditTransaction({ id: 'user-1', name: 'alice@example.com' }, 'v1')
+  it('maps file IDs to submitters via the document _id join', () => {
+    const systemLogSubmitters = new Map([
+      ['doc-1', { id: 'user-a', name: 'alice@example.com' }],
+      ['doc-2', { id: 'user-b', name: 'bob@example.com' }]
+    ])
+    const summaryLogDocs = [
+      summaryLogDoc('doc-1', 'file-1'),
+      summaryLogDoc('doc-2', 'file-2')
     ]
 
-    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
+    const result = buildSummaryLogSubmitters({
+      systemLogSubmitters,
+      summaryLogDocs
+    })
 
-    expect(submitters.get('sl-1')).toEqual({
-      id: 'user-1',
+    expect(result.get('file-1')).toEqual({
+      id: 'user-a',
       name: 'alice@example.com'
     })
-  })
-
-  it('attributes each summary log to its own submitter across multiple submits', () => {
-    const wasteRecords = [
-      wasteRecordWithVersions([
-        versionWithSummaryLog('v1', 'sl-1'),
-        versionWithSummaryLog('v2', 'sl-2')
-      ])
-    ]
-    const transactions = [
-      creditTransaction({ id: 'user-1', name: 'alice@example.com' }, 'v1'),
-      creditTransaction({ id: 'user-2', name: 'bob@example.com' }, 'v2')
-    ]
-
-    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
-
-    expect(submitters.get('sl-1')).toEqual({
-      id: 'user-1',
-      name: 'alice@example.com'
-    })
-    expect(submitters.get('sl-2')).toEqual({
-      id: 'user-2',
+    expect(result.get('file-2')).toEqual({
+      id: 'user-b',
       name: 'bob@example.com'
     })
   })
 
-  it('skips system-generated transactions that name no actor', () => {
-    const wasteRecords = [
-      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
-    ]
-    const transactions = [creditTransaction(undefined, 'v1')]
+  it('omits summary logs with no matching system-log submitter', () => {
+    const systemLogSubmitters = new Map()
+    const summaryLogDocs = [summaryLogDoc('doc-1', 'file-1')]
 
-    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
+    const result = buildSummaryLogSubmitters({
+      systemLogSubmitters,
+      summaryLogDocs
+    })
 
-    expect(submitters.has('sl-1')).toBe(false)
+    expect(result.size).toBe(0)
   })
 
-  it('rejects the system placeholder actor so it never masquerades as a real submitter', () => {
-    const wasteRecords = [
-      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
-    ]
-    const transactions = [
-      creditTransaction({ ...BACKFILL_ACTOR }, 'v1'),
-      creditTransaction({ id: 'system', name: 'system' }, 'v1')
-    ]
+  it('returns an empty map when there are no summary log docs', () => {
+    const systemLogSubmitters = new Map([
+      ['doc-1', { id: 'user-a', name: 'alice@example.com' }]
+    ])
 
-    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
+    const result = buildSummaryLogSubmitters({
+      systemLogSubmitters,
+      summaryLogDocs: []
+    })
 
-    expect(submitters.has('sl-1')).toBe(false)
+    expect(result.size).toBe(0)
   })
 
-  it('ignores entities whose version matches no waste record', () => {
-    const wasteRecords = [
-      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
-    ]
-    const transactions = [
-      creditTransaction({ id: 'user-1', name: 'alice@example.com' }, 'prn-v-9')
-    ]
-
-    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
-
-    expect(submitters.size).toBe(0)
-  })
-
-  it('keeps the first actor when two transactions reference the same summary log', () => {
-    const wasteRecords = [
-      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')]),
-      {
-        rowId: 'row-2',
-        versions: [versionWithSummaryLog('v2', 'sl-1')]
-      }
-    ]
-    const transactions = [
-      creditTransaction({ id: 'user-1', name: 'alice@example.com' }, 'v1'),
-      creditTransaction({ id: 'user-2', name: 'bob@example.com' }, 'v2')
+  it('coerces ObjectId-like doc IDs to string for the join', () => {
+    const objectIdLike = { toString: () => 'abc123' }
+    const systemLogSubmitters = new Map([
+      ['abc123', { id: 'user-a', name: 'alice@example.com' }]
+    ])
+    const summaryLogDocs = [
+      { id: objectIdLike, summaryLog: { file: { id: 'file-1' } } }
     ]
 
-    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
+    const result = buildSummaryLogSubmitters({
+      systemLogSubmitters,
+      summaryLogDocs
+    })
 
-    expect(submitters.get('sl-1')).toEqual({
-      id: 'user-1',
+    expect(result.get('file-1')).toEqual({
+      id: 'user-a',
       name: 'alice@example.com'
     })
-  })
-
-  it('returns an empty map when there are no transactions', () => {
-    const wasteRecords = [
-      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
-    ]
-
-    const submitters = buildSummaryLogSubmitters({
-      transactions: [],
-      wasteRecords
-    })
-
-    expect(submitters.size).toBe(0)
-  })
-
-  it('tolerates a transaction that carries no entities', () => {
-    const wasteRecords = [
-      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
-    ]
-    const transactions = [
-      { createdBy: { id: 'user-1', name: 'alice@example.com' } }
-    ]
-
-    const submitters = buildSummaryLogSubmitters({ transactions, wasteRecords })
-
-    expect(submitters.size).toBe(0)
-  })
-
-  it('tolerates a balance document with no transactions array', () => {
-    const wasteRecords = [
-      wasteRecordWithVersions([versionWithSummaryLog('v1', 'sl-1')])
-    ]
-
-    const submitters = buildSummaryLogSubmitters({
-      transactions: undefined,
-      wasteRecords
-    })
-
-    expect(submitters.size).toBe(0)
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

The waste-balance divergence diagnostic and stream promotion both need to attribute each historical summary-log submission to the user who made it. PR #1250 attempted to recover this from the embedded waste-balance transactions, but those transactions have `createdBy: null` for all pre-May 2026 data (the original calculator set `createdBy: record.updatedBy`, and `updatedBy` was never a field on waste records, so MongoDB serialised `undefined` as `null`). This caused a `TypeError: Cannot read properties of null (reading 'id')` crash on 258 of 278 accreditations.

This PR replaces the embedded-transaction recovery with a system-logs lookup. The summary-log submit handler has always written an audit event to the `system-logs` MongoDB collection with the submitter's full identity (`createdBy.id`, `createdBy.email`), keyed by `context.summaryLogId` (the summary-log document `_id`). The new approach queries system-logs by summary-log document ID and joins to the file-level ID that the stream uses as its natural key.

## Changes

- **System-logs repository**: add `findSubmittersBySummaryLogIds` to port, inmemory, and mongodb implementations with contract tests. Single `$in` query on `context.summaryLogId` filtered to `action=submit, subCategory=summary-log`.
- **`buildSummaryLogSubmitters`**: rewritten to join system-log submitters (keyed by document `_id`) to summary-log file IDs via the summary-log documents, replacing the embedded-transaction walk.
- **`loadAccreditationSources`**: add `systemLogsRepository` to deps, query it for summary-log doc IDs, and use the new submitter builder. Drop `transactions` from the row parameter.
- **Diagnostic and promotion callers**: wire `systemLogsRepository` into `buildDependencies`, remove `transactions: 1` from the waste-balances projection.
- **Dev promote-to-ledger endpoint**: pass `systemLogsRepository` from request, drop `transactions` from the row.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ