### PR TITLE
PAE-1382: Sequence startup promotion before diagnostics

### DIFF
--- a/src/server/run-promotion-then-diagnostics.js
+++ b/src/server/run-promotion-then-diagnostics.js
@@ -1,0 +1,26 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import { runStreamPromotion } from '#server/run-stream-promotion.js'
+import { runRowIdCollisionDiagnostic } from '#server/run-row-id-collision-diagnostic.js'
+import { runBalanceDivergenceDiagnostic } from '#server/run-balance-divergence-diagnostic.js'
+import { runBalanceSizeDiagnostic } from '#server/run-balance-size-diagnostic.js'
+import { runCanonicalSourceCensus } from '#server/run-canonical-source-census.js'
+
+/**
+ * Sequences ledger promotion before diagnostics. Called as a floating
+ * promise from onPostStart so the main loop is never blocked.
+ */
+export async function runPromotionThenDiagnostics(server) {
+  try {
+    await runStreamPromotion(server)
+  } catch (error) {
+    logger.error({
+      message: 'Stream promotion failed, continuing with diagnostics',
+      error
+    })
+  }
+
+  runRowIdCollisionDiagnostic(server)
+  runBalanceDivergenceDiagnostic(server)
+  runBalanceSizeDiagnostic(server)
+  runCanonicalSourceCensus(server)
+}

--- a/src/server/run-promotion-then-diagnostics.test.js
+++ b/src/server/run-promotion-then-diagnostics.test.js
@@ -32,8 +32,9 @@ describe('runPromotionThenDiagnostics', () => {
   })
 
   it('should not start diagnostics until promotion completes', async () => {
-    let resolvePromotion
-    runStreamPromotion.mockReturnValue(
+    /** @type {Function} */
+    let resolvePromotion = () => {}
+    vi.mocked(runStreamPromotion).mockReturnValue(
       new Promise((resolve) => {
         resolvePromotion = resolve
       })
@@ -62,7 +63,9 @@ describe('runPromotionThenDiagnostics', () => {
   })
 
   it('should still run diagnostics if promotion rejects', async () => {
-    runStreamPromotion.mockRejectedValue(new Error('promotion failed'))
+    vi.mocked(runStreamPromotion).mockRejectedValue(
+      new Error('promotion failed')
+    )
 
     await runPromotionThenDiagnostics(server)
 

--- a/src/server/run-promotion-then-diagnostics.test.js
+++ b/src/server/run-promotion-then-diagnostics.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { runStreamPromotion } from './run-stream-promotion.js'
+import { runRowIdCollisionDiagnostic } from './run-row-id-collision-diagnostic.js'
+import { runBalanceDivergenceDiagnostic } from './run-balance-divergence-diagnostic.js'
+import { runBalanceSizeDiagnostic } from './run-balance-size-diagnostic.js'
+import { runCanonicalSourceCensus } from './run-canonical-source-census.js'
+
+import { runPromotionThenDiagnostics } from './run-promotion-then-diagnostics.js'
+
+vi.mock('./run-stream-promotion.js', () => ({
+  runStreamPromotion: vi.fn()
+}))
+vi.mock('./run-row-id-collision-diagnostic.js', () => ({
+  runRowIdCollisionDiagnostic: vi.fn()
+}))
+vi.mock('./run-balance-divergence-diagnostic.js', () => ({
+  runBalanceDivergenceDiagnostic: vi.fn()
+}))
+vi.mock('./run-balance-size-diagnostic.js', () => ({
+  runBalanceSizeDiagnostic: vi.fn()
+}))
+vi.mock('./run-canonical-source-census.js', () => ({
+  runCanonicalSourceCensus: vi.fn()
+}))
+
+describe('runPromotionThenDiagnostics', () => {
+  const server = { name: 'fake-server' }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should not start diagnostics until promotion completes', async () => {
+    let resolvePromotion
+    runStreamPromotion.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePromotion = resolve
+      })
+    )
+
+    const promise = runPromotionThenDiagnostics(server)
+
+    // Flush microtasks — diagnostics should NOT have been called yet
+    await vi.waitFor(() => {
+      expect(runStreamPromotion).toHaveBeenCalledWith(server)
+    })
+
+    expect(runRowIdCollisionDiagnostic).not.toHaveBeenCalled()
+    expect(runBalanceDivergenceDiagnostic).not.toHaveBeenCalled()
+    expect(runBalanceSizeDiagnostic).not.toHaveBeenCalled()
+    expect(runCanonicalSourceCensus).not.toHaveBeenCalled()
+
+    // Now let promotion finish
+    resolvePromotion()
+    await promise
+
+    expect(runRowIdCollisionDiagnostic).toHaveBeenCalledWith(server)
+    expect(runBalanceDivergenceDiagnostic).toHaveBeenCalledWith(server)
+    expect(runBalanceSizeDiagnostic).toHaveBeenCalledWith(server)
+    expect(runCanonicalSourceCensus).toHaveBeenCalledWith(server)
+  })
+
+  it('should still run diagnostics if promotion rejects', async () => {
+    runStreamPromotion.mockRejectedValue(new Error('promotion failed'))
+
+    await runPromotionThenDiagnostics(server)
+
+    expect(runRowIdCollisionDiagnostic).toHaveBeenCalledWith(server)
+    expect(runBalanceDivergenceDiagnostic).toHaveBeenCalledWith(server)
+    expect(runBalanceSizeDiagnostic).toHaveBeenCalledWith(server)
+    expect(runCanonicalSourceCensus).toHaveBeenCalledWith(server)
+  })
+})

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -42,11 +42,7 @@ import { getConfig } from '#root/config.js'
 import { commandQueueConsumerPlugin } from '#server/queue-consumer/queue-consumer.plugin.js'
 import { runFormsDataMigration } from '#server/run-forms-data-migration.js'
 import { copyFormFilesToS3 } from '#server/copy-form-files-to-s3.js'
-import { runBalanceDivergenceDiagnostic } from '#server/run-balance-divergence-diagnostic.js'
-import { runBalanceSizeDiagnostic } from '#server/run-balance-size-diagnostic.js'
-import { runCanonicalSourceCensus } from '#server/run-canonical-source-census.js'
-import { runRowIdCollisionDiagnostic } from '#server/run-row-id-collision-diagnostic.js'
-import { runStreamPromotion } from '#server/run-stream-promotion.js'
+import { runPromotionThenDiagnostics } from '#server/run-promotion-then-diagnostics.js'
 
 /** @import { Lifecycle } from '@hapi/hapi' */
 
@@ -225,11 +221,7 @@ async function createServer(options = {}) {
   server.ext('onPostStart', () => {
     runFormsDataMigration(server)
     copyFormFilesToS3(server)
-    runRowIdCollisionDiagnostic(server)
-    runBalanceDivergenceDiagnostic(server)
-    runBalanceSizeDiagnostic(server)
-    runCanonicalSourceCensus(server)
-    runStreamPromotion(server)
+    runPromotionThenDiagnostics(server)
   })
 
   return server


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

On startup, the `onPostStart` hook fires all background jobs (stream promotion, diagnostics) concurrently as floating promises. This means ledger discrepancy diagnostics run at the same time as stream promotion, producing wasted computation and incorrect results: the diagnostics observe records in the transient `migrating` state mid-promotion, falsely reporting them as discrepancies.

This PR extracts a `runPromotionThenDiagnostics` wrapper that `await`s stream promotion before firing the four diagnostic jobs. The wrapper itself is called as a floating promise from `onPostStart`, so the main event loop is never blocked. The independent startup jobs (`runFormsDataMigration`, `copyFormFilesToS3`) continue to fire concurrently as before.

If stream promotion throws, the error is caught and logged, and diagnostics still proceed.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ