### PR TITLE
PAE-1382: Widen waste-balance event actor to best-view record

### DIFF
--- a/src/packaging-recycling-notes/application/external-prn-mapper.js
+++ b/src/packaging-recycling-notes/application/external-prn-mapper.js
@@ -5,15 +5,12 @@
 
 /**
  * @param {Actor} actor
- * @returns {{ fullName: string; jobTitle?: string }}
+ * @returns {{ fullName?: string; jobTitle?: string }}
  */
-const mapUserSummary = (actor) => {
-  const summary = { fullName: actor.name }
-  if (actor.position) {
-    summary.jobTitle = actor.position
-  }
-  return summary
-}
+const mapUserSummary = (actor) => ({
+  ...(actor.name && { fullName: actor.name }),
+  ...(actor.position && { jobTitle: actor.position })
+})
 
 /**
  * @param {PackagingRecyclingNote['status']} status

--- a/src/packaging-recycling-notes/domain/model.js
+++ b/src/packaging-recycling-notes/domain/model.js
@@ -168,7 +168,7 @@ export function validateTransition(currentStatus, newStatus, actor) {
 /**
  * @typedef {{
  *   id: string;
- *   name: string;
+ *   name?: string;
  *   position?: string;
  * }} Actor
  */

--- a/src/packaging-recycling-notes/repository/schema.js
+++ b/src/packaging-recycling-notes/repository/schema.js
@@ -49,12 +49,12 @@ const accreditationSchema = Joi.object({
 
 const userSummarySchema = Joi.object({
   id: Joi.string().required(),
-  name: Joi.string().required()
+  name: Joi.string()
 })
 
 const actorSchema = Joi.object({
   id: Joi.string().required(),
-  name: Joi.string().required(),
+  name: Joi.string(),
   position: Joi.string().optional()
 })
 

--- a/src/packaging-recycling-notes/repository/validation.test.js
+++ b/src/packaging-recycling-notes/repository/validation.test.js
@@ -87,6 +87,28 @@ describe('validatePrnRead', () => {
     expect(result.schemaVersion).toBe(2)
   })
 
+  it('accepts ledger actors that carry only an id (no name)', () => {
+    const idOnlyActor = { id: 'user-1' }
+    const at = new Date('2025-06-15T12:00:00.000Z')
+    const data = buildReadDocument({
+      createdBy: idOnlyActor,
+      updatedBy: idOnlyActor,
+      status: {
+        currentStatus: 'draft',
+        currentStatusAt: at,
+        created: { at, by: idOnlyActor },
+        history: [{ status: 'draft', at, by: idOnlyActor }]
+      }
+    })
+
+    const result = validatePrnRead(data)
+
+    expect(result.createdBy).toEqual(idOnlyActor)
+    expect(result.updatedBy).toEqual(idOnlyActor)
+    expect(result.status.created.by).toEqual(idOnlyActor)
+    expect(result.status.history[0].by).toEqual(idOnlyActor)
+  })
+
   it('strips MongoDB _id from read documents', () => {
     const objectId = new ObjectId()
     const data = { ...buildReadDocument(), _id: objectId }

--- a/src/server/run-balance-divergence-diagnostic.integration.test.js
+++ b/src/server/run-balance-divergence-diagnostic.integration.test.js
@@ -291,7 +291,8 @@ describe('balance divergence diagnostic (integration)', () => {
     })
     expect(submitters.get(fileId)).toEqual({
       id: 'user-1',
-      name: 'alice@example.com'
+      email: 'alice@example.com',
+      scope: ['standardUser']
     })
 
     // 4. Migrate: replay the stream with the recovered submitter attached and
@@ -316,7 +317,8 @@ describe('balance divergence diagnostic (integration)', () => {
     expect(result.backfilledActorCount).toBe(0)
     expect(result.events[0].createdBy).toEqual({
       id: 'user-1',
-      name: 'alice@example.com'
+      email: 'alice@example.com',
+      scope: ['standardUser']
     })
   })
 })

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -712,7 +712,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
             id: 'file-id-1',
             status: 'submitted',
             submittedAt: '2025-01-01T00:00:00Z',
-            submittedBy: { id: 'user-9', name: 'real@example.com' }
+            submittedBy: { id: 'user-9', email: 'real@example.com', scope: [] }
           }
         ]
       })
@@ -767,7 +767,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
             id: 'file-id-1',
             status: 'submitted',
             submittedAt: '2025-01-01T00:00:00Z',
-            submittedBy: { id: 'sys-user', name: 'sys@example.com' }
+            submittedBy: { id: 'sys-user', email: 'sys@example.com', scope: [] }
           }
         ]
       })

--- a/src/waste-balances/application/calculator.js
+++ b/src/waste-balances/application/calculator.js
@@ -56,7 +56,7 @@ export const buildTransaction = (
     id: randomUUID(),
     type,
     createdAt: new Date().toISOString(),
-    createdBy: { id: user.id, name: user.email },
+    createdBy: { id: user.id, email: user.email, scope: user.scope },
     amount,
     openingAmount,
     closingAmount,

--- a/src/waste-balances/application/calculator.test.js
+++ b/src/waste-balances/application/calculator.test.js
@@ -11,7 +11,8 @@ import {
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import {
   WASTE_BALANCE_TRANSACTION_TYPE,
-  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
+  WASTE_BALANCE_TRANSACTION_ENTITY_TYPE,
+  WASTE_BALANCE_CANONICAL_SOURCE
 } from '../domain/model.js'
 import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 
@@ -94,7 +95,8 @@ describe('Waste Balance Calculator', () => {
     version: 1,
     amount: 0,
     availableAmount: 0,
-    transactions: []
+    transactions: [],
+    canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
   }
 
   it('AC01a: Should create transactions for valid PRN records (Export Tonnage)', () => {

--- a/src/waste-balances/application/calculator.test.js
+++ b/src/waste-balances/application/calculator.test.js
@@ -80,7 +80,11 @@ describe('Waste Balance Calculator', () => {
     email: 'user-1@example.test',
     scope: ['standard_user']
   }
-  const expectedCreatedBy = { id: testUser.id, name: testUser.email }
+  const expectedCreatedBy = {
+    id: testUser.id,
+    email: testUser.email,
+    scope: testUser.scope
+  }
 
   const emptyBalance = {
     id: 'bal-1',

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -109,13 +109,27 @@ const isStructurallyValidPrnTransition = (fromStatus, toStatus) =>
   (PRN_STATUS_TRANSITIONS[fromStatus] ?? []).some((t) => t.status === toStatus)
 
 /**
- * Reduce a PRN status-history actor to the stream's user-summary shape.
+ * Reduce a source actor to the stream's user-summary shape, carrying each piece
+ * of identity in its own slot and dropping any field the summary has no slot for
+ * (a PRN history actor may carry e.g. a `position`). Falls back to the backfill
+ * actor when no real actor was recoverable. A value is never moved into a slot it
+ * does not belong in.
  *
- * @param {{ id: string, name: string } | undefined} actor
+ * @param {{ id: string, name?: string, email?: string, scope?: string[] } | undefined} actor
  * @returns {import('../repository/stream-schema.js').StreamUserSummary}
  */
-const actorOf = (actor) =>
-  actor ? { id: actor.id, name: actor.name } : { ...BACKFILL_ACTOR }
+const actorOf = (actor) => {
+  if (!actor) {
+    return { ...BACKFILL_ACTOR }
+  }
+  const { id, name, email, scope } = actor
+  return {
+    id,
+    ...(name !== undefined && { name }),
+    ...(email !== undefined && { email }),
+    ...(scope !== undefined && { scope })
+  }
+}
 
 /**
  * Sparse count of backfilled-actor events keyed by the stream event kind that

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -570,7 +570,7 @@ describe('computeRebuiltStream', () => {
       ...(submittedBy ? { submittedBy } : {})
     })
 
-    it('attributes PRN events to the actor on the status history entry, reduced to id and name', () => {
+    it('attributes PRN events to the actor on the status history entry, carrying its identity slots', () => {
       const signatory = {
         id: 'sig-7',
         name: 'Sam Signatory',
@@ -617,7 +617,11 @@ describe('computeRebuiltStream', () => {
     })
 
     it('attributes summary-log events to the supplied submitter', () => {
-      const submitter = { id: 'usr-9', name: 'submitter@example.com' }
+      const submitter = {
+        id: 'usr-9',
+        email: 'submitter@example.com',
+        scope: ['standard_user']
+      }
       const result = computeRebuiltStream({
         accreditation,
         registrationId,
@@ -1111,7 +1115,7 @@ describe('computeRebuiltStream', () => {
         prns: [createdPrn('prn-1', { id: 'rep-1', name: 'Rita Reprocessor' })],
         overseasSites,
         summaryLogs: [
-          submittedLog('sl-1', { id: 'usr-9', name: 'submitter@example.com' })
+          submittedLog('sl-1', { id: 'usr-9', email: 'submitter@example.com' })
         ]
       })
 

--- a/src/waste-balances/application/summary-log-submitters.js
+++ b/src/waste-balances/application/summary-log-submitters.js
@@ -3,23 +3,35 @@
  */
 
 /**
- * Reduce a submit-audit actor to the stream's `{ id, name }` summary, or `null`
- * when it carries no usable identity. A human actor's email is its only captured
- * label, so it stands in for the name; an actor with no id, or with neither a
- * name nor an email, has nothing real to attribute and is rejected rather than
- * relabelled with its id — so missing data stays visible downstream (the
- * submission falls back to backfill) instead of being masked by a fabricated
- * name. Shared with the unusable-actor count so both read identity the same way.
+ * Reduce a submit-audit actor to the stream's user summary, carrying each piece
+ * of identity in its own slot — name, email and scope present only when the
+ * source recorded them. A recorded-but-empty scope (`[]`, "this actor has no
+ * roles") is kept and distinguished from an unrecorded one (absent, "we never
+ * captured roles"). An actor with no id, or with neither a name nor an email,
+ * has nothing real to attribute and is rejected (returns `null`) rather than
+ * relabelled — so missing data stays visible downstream (the submission falls
+ * back to backfill) instead of being masked by a fabricated label. A value is
+ * never moved into a slot it does not belong in: an email stays in `email`,
+ * never becomes a `name`. Shared with the unusable-actor count so both read
+ * identity the same way.
  *
  * @param {SubmitAuditActor} [createdBy]
  * @returns {import('../repository/stream-schema.js').StreamUserSummary | null}
  */
 export const toStreamActor = (createdBy) => {
-  const name = createdBy?.name ?? createdBy?.email
-  if (createdBy?.id === undefined || name === undefined) {
+  if (createdBy?.id === undefined) {
     return null
   }
-  return { id: createdBy.id, name }
+  const { id, name, email, scope } = createdBy
+  if (name === undefined && email === undefined) {
+    return null
+  }
+  return {
+    id,
+    ...(name !== undefined && { name }),
+    ...(email !== undefined && { email }),
+    ...(scope !== undefined && { scope })
+  }
 }
 
 /**
@@ -28,8 +40,8 @@ export const toStreamActor = (createdBy) => {
  * keys on the summary-log document id (`context.summaryLogId`); the stream keys
  * on `summaryLog.file.id`, a different namespace, so the summary-log documents
  * bridge document id → file id. Each actor is reduced to the stream's
- * `{ id, name }` summary by `toStreamActor`, which rejects actors with no usable
- * identity so missing data is never masked by a fabricated name.
+ * user summary by `toStreamActor`, which rejects actors with no usable identity
+ * so missing data is never masked by a fabricated label.
  *
  * A document submitted more than once keeps the most recent audit: callers
  * supply `submitActors` newest-first, so the first one seen for a file id wins.

--- a/src/waste-balances/application/summary-log-submitters.test.js
+++ b/src/waste-balances/application/summary-log-submitters.test.js
@@ -13,6 +13,28 @@ describe('buildSystemLogSubmitters', () => {
       submitActors: [
         {
           summaryLogId: 'doc-1',
+          createdBy: {
+            id: 'user-1',
+            email: 'alice@example.com',
+            scope: ['standard_user']
+          }
+        }
+      ],
+      summaryLogDocs: [summaryLogDoc('doc-1', 'file-1')]
+    })
+
+    expect(submitters.get('file-1')).toEqual({
+      id: 'user-1',
+      email: 'alice@example.com',
+      scope: ['standard_user']
+    })
+  })
+
+  it('records an empty role list as no scopes rather than dropping it', () => {
+    const submitters = buildSystemLogSubmitters({
+      submitActors: [
+        {
+          summaryLogId: 'doc-1',
           createdBy: { id: 'user-1', email: 'alice@example.com', scope: [] }
         }
       ],
@@ -21,7 +43,25 @@ describe('buildSystemLogSubmitters', () => {
 
     expect(submitters.get('file-1')).toEqual({
       id: 'user-1',
-      name: 'alice@example.com'
+      email: 'alice@example.com',
+      scope: []
+    })
+  })
+
+  it('leaves scope absent when the audit never recorded roles', () => {
+    const submitters = buildSystemLogSubmitters({
+      submitActors: [
+        {
+          summaryLogId: 'doc-1',
+          createdBy: { id: 'user-1', email: 'alice@example.com' }
+        }
+      ],
+      summaryLogDocs: [summaryLogDoc('doc-1', 'file-1')]
+    })
+
+    expect(submitters.get('file-1')).toEqual({
+      id: 'user-1',
+      email: 'alice@example.com'
     })
   })
 
@@ -96,7 +136,8 @@ describe('buildSystemLogSubmitters', () => {
 
     expect(submitters.get('file-1')).toEqual({
       id: 'user-1',
-      name: 'alice@example.com'
+      email: 'alice@example.com',
+      scope: []
     })
   })
 

--- a/src/waste-balances/application/update-via-stream.js
+++ b/src/waste-balances/application/update-via-stream.js
@@ -58,7 +58,7 @@ export const performUpdateViaStream = async ({
     {
       kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
       payload: { summaryLogId, creditTotal },
-      createdBy: { id: user.id, name: user.email }
+      createdBy: { id: user.id, email: user.email, scope: user.scope }
     }
   )
 

--- a/src/waste-balances/application/update-via-stream.test.js
+++ b/src/waste-balances/application/update-via-stream.test.js
@@ -294,7 +294,11 @@ describe('performUpdateViaStream', () => {
         'reg-1',
         accreditationId
       )
-      expect(latest.createdBy).toEqual({ id: user.id, name: user.email })
+      expect(latest.createdBy).toEqual({
+        id: user.id,
+        email: user.email,
+        scope: user.scope
+      })
     })
   })
 })

--- a/src/waste-balances/domain/model.js
+++ b/src/waste-balances/domain/model.js
@@ -33,9 +33,16 @@ export const WASTE_BALANCE_TRANSACTION_ENTITY_TYPE = Object.freeze({
  */
 
 /**
+ * Best view of the actor behind a transaction. `id` is always known; the
+ * remaining slots are present only when the source supplies a real value for
+ * them, absent otherwise. A value is never written to a slot it does not belong
+ * in — an email goes only in `email`, an id only in `id`.
+ *
  * @typedef {Object} UserSummary
  * @property {string} id - User ID
- * @property {string} name - Name
+ * @property {string} [name] - Name
+ * @property {string} [email] - Email
+ * @property {string[]} [scope] - Roles
  */
 
 /**

--- a/src/waste-balances/repository/contract/updateWasteBalanceTransactions.contract.js
+++ b/src/waste-balances/repository/contract/updateWasteBalanceTransactions.contract.js
@@ -55,7 +55,8 @@ export const testUpdateWasteBalanceTransactionsBehaviour = (it) => {
       expect(balance.transactions[0].amount).toBe(10.5)
       expect(balance.transactions[0].createdBy).toEqual({
         id: user.id,
-        name: user.email
+        email: user.email,
+        scope: user.scope
       })
       expect(balance.amount).toBe(10.5)
     })

--- a/src/waste-balances/repository/helpers-prn.js
+++ b/src/waste-balances/repository/helpers-prn.js
@@ -31,7 +31,7 @@ export const buildPrnCreationTransaction = ({
   id: randomUUID(),
   type: WASTE_BALANCE_TRANSACTION_TYPE.DEBIT,
   createdAt: new Date().toISOString(),
-  createdBy: { id: userId, name: userId },
+  createdBy: { id: userId },
   amount: tonnage,
   openingAmount: currentBalance.amount,
   closingAmount: currentBalance.amount, // Total unchanged
@@ -83,7 +83,7 @@ const appendPrnStreamEvent = async ({
     {
       kind: streamKind,
       payload: { prnId, amount: tonnage },
-      createdBy: { id: userId, name: userId }
+      createdBy: { id: userId }
     }
   )
 
@@ -237,7 +237,7 @@ export const buildPrnIssuedTransaction = ({
   id: randomUUID(),
   type: WASTE_BALANCE_TRANSACTION_TYPE.DEBIT,
   createdAt: new Date().toISOString(),
-  createdBy: { id: userId, name: userId },
+  createdBy: { id: userId },
   amount: tonnage,
   openingAmount: currentBalance.amount,
   closingAmount: toNumber(subtract(currentBalance.amount, tonnage)), // Total deducted
@@ -343,7 +343,7 @@ export const buildPrnCancellationTransaction = ({
   id: randomUUID(),
   type: WASTE_BALANCE_TRANSACTION_TYPE.CREDIT,
   createdAt: new Date().toISOString(),
-  createdBy: { id: userId, name: userId },
+  createdBy: { id: userId },
   amount: tonnage,
   openingAmount: currentBalance.amount,
   closingAmount: currentBalance.amount, // Total unchanged
@@ -382,7 +382,7 @@ export const buildIssuedPrnCancellationTransaction = ({
   id: randomUUID(),
   type: WASTE_BALANCE_TRANSACTION_TYPE.CREDIT,
   createdAt: new Date().toISOString(),
-  createdBy: { id: userId, name: userId },
+  createdBy: { id: userId },
   amount: tonnage,
   openingAmount: currentBalance.amount,
   closingAmount: toNumber(add(currentBalance.amount, tonnage)),

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -1123,8 +1123,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_CREATED
       )
       expect(transaction.createdBy).toEqual({
-        id: 'user-abc',
-        name: 'user-abc'
+        id: 'user-abc'
       })
       expect(transaction.id).toBeDefined()
       expect(transaction.createdAt).toBeDefined()
@@ -1355,8 +1354,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_ISSUED
       )
       expect(transaction.createdBy).toEqual({
-        id: 'user-abc',
-        name: 'user-abc'
+        id: 'user-abc'
       })
       expect(transaction.id).toBeDefined()
       expect(transaction.createdAt).toBeDefined()
@@ -1588,8 +1586,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_CANCELLED
       )
       expect(transaction.createdBy).toEqual({
-        id: 'user-abc',
-        name: 'user-abc'
+        id: 'user-abc'
       })
       expect(transaction.id).toBeDefined()
       expect(transaction.createdAt).toBeDefined()
@@ -1824,8 +1821,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
         WASTE_BALANCE_TRANSACTION_ENTITY_TYPE.PRN_CANCELLED_POST_ISSUE
       )
       expect(transaction.createdBy).toEqual({
-        id: 'user-abc',
-        name: 'user-abc'
+        id: 'user-abc'
       })
       expect(transaction.id).toBeDefined()
       expect(transaction.createdAt).toBeDefined()

--- a/src/waste-balances/repository/stream-schema.js
+++ b/src/waste-balances/repository/stream-schema.js
@@ -35,9 +35,17 @@ const PRN_KINDS = new Set([
 export const ZERO_BALANCE = Object.freeze({ amount: 0, availableAmount: 0 })
 
 /**
+ * Best view of the actor behind an event. `id` is always known; the remaining
+ * slots are present only when the source supplies a real value for them, absent
+ * otherwise. A value is never written to a slot it does not belong in — an email
+ * goes only in `email`, an id only in `id` — so an actor never asserts that a
+ * person's name is their email or their id.
+ *
  * @typedef {Object} StreamUserSummary
  * @property {string} id
- * @property {string} name
+ * @property {string} [name]
+ * @property {string} [email]
+ * @property {string[]} [scope]
  */
 
 /**
@@ -87,7 +95,9 @@ export const BACKFILL_ACTOR = Object.freeze({ id: 'system', name: 'backfill' })
 
 const userSummarySchema = Joi.object({
   id: Joi.string().required(),
-  name: Joi.string().required()
+  name: Joi.string(),
+  email: Joi.string(),
+  scope: Joi.array().items(Joi.string())
 })
 
 const balanceSnapshotSchema = Joi.object({

--- a/src/waste-balances/repository/stream-schema.test.js
+++ b/src/waste-balances/repository/stream-schema.test.js
@@ -82,6 +82,27 @@ describe('stream event insert schema', () => {
     expect(error).toBeUndefined()
   })
 
+  it('accepts an actor carrying only an id', () => {
+    const { error } = validate(buildStreamEvent({ createdBy: { id: 'usr-1' } }))
+    expect(error).toBeUndefined()
+  })
+
+  it('accepts an actor carrying email and scope but no name', () => {
+    const { error } = validate(
+      buildStreamEvent({
+        createdBy: { id: 'usr-1', email: 'a@example.com', scope: ['admin'] }
+      })
+    )
+    expect(error).toBeUndefined()
+  })
+
+  it('rejects an actor with no id', () => {
+    const { error } = validate(
+      buildStreamEvent({ createdBy: { email: 'a@example.com' } })
+    )
+    expect(error).toBeDefined()
+  })
+
   it('rejects unknown kind values', () => {
     const { error } = validate(buildStreamEvent({ kind: 'unknown-kind' }))
     expect(error).toBeDefined()


### PR DESCRIPTION
The waste-balance event actor previously carried `{ id, name }` with both fields required, forcing lossy writes: when a source had only an email or only an id, that value was coerced into `name`, so an id-only actor became `{ id, name: id }` and an email landed in a name slot. This widens the actor to a best-view record — `id` required, with `name`, `email` and `scope` each present only when the source genuinely recorded them, and absent otherwise. A value is never written to a slot it does not belong in (an email stays in `email`, never becomes a `name`), and an actor with no usable identity is left unattributed rather than relabelled with a fabricated name.

What changed:

- `StreamUserSummary` and its Joi `userSummarySchema` are widened so `name`, `email` and `scope` are optional while `id` stays required; the embedded `UserSummary` typedef is widened to match.
- The live write paths (`calculator`, `update-via-stream`) carry `email` and `scope` from the authenticated submit user instead of squeezing identity into `name`.
- `helpers-prn` no longer fabricates `{ id, name: id }` for PRN transactions — it writes `{ id }` alone when only the id is known.
- The summary-log submit recovery (`toStreamActor`) and the rebuild projection (`actorOf`) reduce an actor to its real slots, distinguishing a recorded-but-empty scope (`[]`, meaning "no roles") from an unrecorded one (absent). The backfill sentinel remains valid.
- The PRN read-model `Actor` typedef, its persistence validation schema (`prnReadSchema`/`prnInsertSchema` actor shapes) and its external mapper accept id-only actors (name optional) and build the mapped summary immutably, so a name-less ledger actor projects and persists without being rejected.
- Waste-balance calculator test fixtures are completed with the required `canonicalSource` field.

This lands the open actor shape before the waste-balance ledger cutover so historical and live events attribute identity consistently, without lossy coercion. Admin-side rendering of the widened actor is out of scope and tracked separately.