### PR TITLE
PAE-1382: Capture the submitter's real name and email on summary-log events

### DIFF
--- a/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
@@ -99,7 +99,6 @@ describe('SQS command executor integration', () => {
       auth: {
         credentials: {
           id: 'user-123',
-          name: 'Test User',
           email: 'test@example.com',
           scope: ['admin']
         }
@@ -138,55 +137,9 @@ describe('SQS command executor integration', () => {
           summaryLogId,
           user: {
             id: 'user-123',
-            name: 'Test User',
             email: 'test@example.com',
             scope: ['admin']
           }
-        })
-      }
-    )
-
-    it(
-      'omits the name when the human credentials carry none',
-      { timeout: TEST_TIMEOUT },
-      async ({ sqsClient }) => {
-        const executor = await createSqsCommandExecutor({
-          sqsClient,
-          queueName: sqsClient.queueName,
-          logger
-        })
-
-        const namelessRequest = {
-          auth: {
-            credentials: {
-              id: 'user-456',
-              email: 'noname@example.com',
-              scope: ['admin']
-            }
-          }
-        }
-
-        const summaryLogId = `submit-noname-test-${Date.now()}`
-        await executor.summaryLogsWorker.submit(summaryLogId, namelessRequest)
-
-        const { QueueUrl: queueUrl } = await sqsClient.send(
-          new GetQueueUrlCommand({ QueueName: sqsClient.queueName })
-        )
-
-        const response = await sqsClient.send(
-          new ReceiveMessageCommand({
-            QueueUrl: queueUrl,
-            WaitTimeSeconds: 5
-          })
-        )
-
-        expect(response.Messages).toHaveLength(1)
-
-        const message = JSON.parse(response.Messages[0].Body)
-        expect(message.user).toEqual({
-          id: 'user-456',
-          email: 'noname@example.com',
-          scope: ['admin']
         })
       }
     )

--- a/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
@@ -99,6 +99,7 @@ describe('SQS command executor integration', () => {
       auth: {
         credentials: {
           id: 'user-123',
+          name: 'Test User',
           email: 'test@example.com',
           scope: ['admin']
         }
@@ -137,9 +138,55 @@ describe('SQS command executor integration', () => {
           summaryLogId,
           user: {
             id: 'user-123',
+            name: 'Test User',
             email: 'test@example.com',
             scope: ['admin']
           }
+        })
+      }
+    )
+
+    it(
+      'omits the name when the human credentials carry none',
+      { timeout: TEST_TIMEOUT },
+      async ({ sqsClient }) => {
+        const executor = await createSqsCommandExecutor({
+          sqsClient,
+          queueName: sqsClient.queueName,
+          logger
+        })
+
+        const namelessRequest = {
+          auth: {
+            credentials: {
+              id: 'user-456',
+              email: 'noname@example.com',
+              scope: ['admin']
+            }
+          }
+        }
+
+        const summaryLogId = `submit-noname-test-${Date.now()}`
+        await executor.summaryLogsWorker.submit(summaryLogId, namelessRequest)
+
+        const { QueueUrl: queueUrl } = await sqsClient.send(
+          new GetQueueUrlCommand({ QueueName: sqsClient.queueName })
+        )
+
+        const response = await sqsClient.send(
+          new ReceiveMessageCommand({
+            QueueUrl: queueUrl,
+            WaitTimeSeconds: 5
+          })
+        )
+
+        expect(response.Messages).toHaveLength(1)
+
+        const message = JSON.parse(response.Messages[0].Body)
+        expect(message.user).toEqual({
+          id: 'user-456',
+          email: 'noname@example.com',
+          scope: ['admin']
         })
       }
     )

--- a/src/adapters/sqs-command-executor/sqs-command-executor.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.js
@@ -28,10 +28,10 @@ import { ORS_IMPORT_COMMAND } from '#overseas-sites/domain/import-status.js'
  * message carries. The submit route is gated to standard_user scope, so the
  * union is narrowed to human credentials at the boundary.
  *
- * @param {import('#common/hapi-types.js').HapiRequest} request
+ * @param {import('#common/hapi-types.js').AuthenticatedRequest} request
  * @returns {import('#domain/summary-logs/worker/port.js').SubmitUser}
  */
-const extractUser = (request) => {
+export const extractUser = (request) => {
   const { credentials } = request.auth
   if (!('email' in credentials)) {
     throw new Error(
@@ -41,9 +41,7 @@ const extractUser = (request) => {
   return {
     id: credentials.id,
     ...(credentials.name && { name: credentials.name }),
-    // @ts-expect-error narrowed to HumanCredentials by `email in credentials` above; tsc loses the discriminant through Hapi's base Request intersection
     email: credentials.email,
-    // @ts-expect-error narrowed to HumanCredentials by `email in credentials` above; tsc loses the discriminant through Hapi's base Request intersection
     scope: credentials.scope
   }
 }

--- a/src/adapters/sqs-command-executor/sqs-command-executor.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.js
@@ -40,6 +40,7 @@ const extractUser = (request) => {
   }
   return {
     id: credentials.id,
+    ...(credentials.name && { name: credentials.name }),
     // @ts-expect-error narrowed to HumanCredentials by `email in credentials` above; tsc loses the discriminant through Hapi's base Request intersection
     email: credentials.email,
     // @ts-expect-error narrowed to HumanCredentials by `email in credentials` above; tsc loses the discriminant through Hapi's base Request intersection

--- a/src/adapters/sqs-command-executor/sqs-command-executor.test.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { extractUser } from './sqs-command-executor.js'
+
+describe('extractUser', () => {
+  it('projects a human submitter, carrying their name when present', () => {
+    /** @type {import('#common/hapi-types.js').AuthenticatedRequest} */
+    const request = {
+      auth: {
+        credentials: {
+          id: 'user-123',
+          name: 'Ada Lovelace',
+          email: 'ada@example.com',
+          scope: ['admin'],
+          issuer: 'defra-id'
+        }
+      }
+    }
+
+    expect(extractUser(request)).toEqual({
+      id: 'user-123',
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      scope: ['admin']
+    })
+  })
+
+  it('omits the name when the submitter has none', () => {
+    /** @type {import('#common/hapi-types.js').AuthenticatedRequest} */
+    const request = {
+      auth: {
+        credentials: {
+          id: 'user-456',
+          email: 'noname@example.com',
+          scope: ['admin'],
+          issuer: 'defra-id'
+        }
+      }
+    }
+
+    const user = extractUser(request)
+
+    expect(user).toEqual({
+      id: 'user-456',
+      email: 'noname@example.com',
+      scope: ['admin']
+    })
+    expect('name' in user).toBe(false)
+  })
+
+  it('rejects machine credentials at the boundary', () => {
+    /** @type {import('#common/hapi-types.js').AuthenticatedRequest} */
+    const request = {
+      auth: {
+        credentials: {
+          id: 'machine-1',
+          isMachine: true,
+          name: 'RPD'
+        }
+      }
+    }
+
+    expect(() => extractUser(request)).toThrow(
+      /Machine credentials cannot drive a summary-log submit/
+    )
+  })
+})

--- a/src/common/hapi-types.js
+++ b/src/common/hapi-types.js
@@ -38,6 +38,15 @@
  */
 
 /**
+ * The slice of a request a command executor consumes: the authenticated
+ * credentials. A full HapiRequest satisfies this, so route handlers pass their
+ * request unchanged while callers that only need to project credentials are
+ * spared constructing an entire request.
+ *
+ * @typedef {{ auth: { credentials: MachineCredentials | HumanCredentials } }} AuthenticatedRequest
+ */
+
+/**
  * Omit the base `logger` so our TypedLogger overrides hapi-pino's augmented
  * pino.Logger instead of intersecting with it. Without the Omit, calls like
  * `request.logger.warn({ ...non-allowlisted fields })` resolve to pino's

--- a/src/domain/summary-logs/worker/port.js
+++ b/src/domain/summary-logs/worker/port.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {Object} SubmitUser
  * @property {string} id
+ * @property {string} [name]
  * @property {string} email
  * @property {string[]} scope
  */

--- a/src/packaging-recycling-notes/application/external-prn-mapper.js
+++ b/src/packaging-recycling-notes/application/external-prn-mapper.js
@@ -5,15 +5,12 @@
 
 /**
  * @param {Actor} actor
- * @returns {{ fullName: string; jobTitle?: string }}
+ * @returns {{ fullName?: string; jobTitle?: string }}
  */
-const mapUserSummary = (actor) => {
-  const summary = { fullName: actor.name }
-  if (actor.position) {
-    summary.jobTitle = actor.position
-  }
-  return summary
-}
+const mapUserSummary = (actor) => ({
+  ...(actor.name && { fullName: actor.name }),
+  ...(actor.position && { jobTitle: actor.position })
+})
 
 /**
  * @param {PackagingRecyclingNote['status']} status

--- a/src/packaging-recycling-notes/application/external-prn-mapper.test.js
+++ b/src/packaging-recycling-notes/application/external-prn-mapper.test.js
@@ -197,6 +197,24 @@ describe('mapToExternalPrn', () => {
     })
   })
 
+  it('omits fullName when the actor has no name, leaving the id as the proof', () => {
+    const issuerWithoutName = { id: 'user-issuer' }
+    const prn = buildAwaitingAcceptancePrn({
+      status: {
+        currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+        currentStatusAt: issuedDate,
+        created: { at: authorisedDate, by: creator },
+        issued: { at: issuedDate, by: issuerWithoutName },
+        history: []
+      }
+    })
+
+    const result = mapToExternalPrn(prn)
+
+    expect(result.status.authorisedBy).toEqual({})
+    expect('fullName' in result.status.authorisedBy).toBe(false)
+  })
+
   it('includes registrationType when present on issuedToOrganisation', () => {
     const prn = buildAwaitingAcceptancePrn({
       issuedToOrganisation: {

--- a/src/packaging-recycling-notes/domain/model.js
+++ b/src/packaging-recycling-notes/domain/model.js
@@ -166,9 +166,13 @@ export function validateTransition(currentStatus, newStatus, actor) {
  */
 
 /**
+ * Records who performed a PRN operation. `id` is the proof of the actor;
+ * `name` and `position` are best-view enrichment, present only when the source
+ * carries them.
+ *
  * @typedef {{
  *   id: string;
- *   name: string;
+ *   name?: string;
  *   position?: string;
  * }} Actor
  */

--- a/src/server/queue-consumer/summary-log-commands.js
+++ b/src/server/queue-consumer/summary-log-commands.js
@@ -28,6 +28,7 @@ import { submitSummaryLog } from '#application/summary-logs/submit.js'
 
 const userSchema = Joi.object({
   id: Joi.string().required(),
+  name: Joi.string(),
   email: Joi.string().required(),
   scope: Joi.array().items(Joi.string()).required()
 })

--- a/src/server/queue-consumer/summary-log-commands.test.js
+++ b/src/server/queue-consumer/summary-log-commands.test.js
@@ -138,6 +138,20 @@ describe('summaryLogCommandHandlers', () => {
         expect(error).toBeUndefined()
       })
 
+      it('accepts a user carrying a name', () => {
+        const { error } = handler.payloadSchema.validate({
+          summaryLogId: 'log-123',
+          user: {
+            id: 'user-1',
+            name: 'Test User',
+            email: 'test@example.com',
+            scope: ['operator']
+          }
+        })
+
+        expect(error).toBeUndefined()
+      })
+
       it('requires summaryLogId', () => {
         const { error } = handler.payloadSchema.validate({})
 

--- a/src/server/queue-consumer/summary-log-commands.test.js
+++ b/src/server/queue-consumer/summary-log-commands.test.js
@@ -12,6 +12,28 @@ const { submitSummaryLog } = await import('#application/summary-logs/submit.js')
 const { markAsValidationFailed, markAsSubmissionFailed } =
   await import('#domain/summary-logs/mark-as-failed.js')
 
+/**
+ * @param {string} command
+ */
+const handlerFor = (command) => {
+  const handler = summaryLogCommandHandlers.find((h) => h.command === command)
+  if (!handler) {
+    throw new Error(`No handler registered for command: ${command}`)
+  }
+  return handler
+}
+
+/**
+ * @param {{ error?: import('joi').ValidationError }} result
+ * @returns {import('joi').ValidationError}
+ */
+const validationErrorFrom = ({ error }) => {
+  if (!error) {
+    throw new Error('Expected a validation error but validation passed')
+  }
+  return error
+}
+
 describe('summaryLogCommandHandlers', () => {
   let deps
 
@@ -35,9 +57,7 @@ describe('summaryLogCommandHandlers', () => {
   })
 
   describe('validate handler', () => {
-    const handler = summaryLogCommandHandlers.find(
-      (h) => h.command === 'validate'
-    )
+    const handler = handlerFor('validate')
 
     it('has command "validate"', () => {
       expect(handler.command).toBe('validate')
@@ -53,16 +73,18 @@ describe('summaryLogCommandHandlers', () => {
       })
 
       it('requires summaryLogId', () => {
-        const { error } = handler.payloadSchema.validate({})
+        const error = validationErrorFrom(handler.payloadSchema.validate({}))
 
         expect(error.message).toBe('"summaryLogId" is required')
       })
 
       it('rejects unknown fields', () => {
-        const { error } = handler.payloadSchema.validate({
-          summaryLogId: 'log-123',
-          extra: true
-        })
+        const error = validationErrorFrom(
+          handler.payloadSchema.validate({
+            summaryLogId: 'log-123',
+            extra: true
+          })
+        )
 
         expect(error.message).toContain('"extra" is not allowed')
       })
@@ -108,9 +130,7 @@ describe('summaryLogCommandHandlers', () => {
   })
 
   describe('submit handler', () => {
-    const handler = summaryLogCommandHandlers.find(
-      (h) => h.command === 'submit'
-    )
+    const handler = handlerFor('submit')
 
     it('has command "submit"', () => {
       expect(handler.command).toBe('submit')
@@ -118,9 +138,11 @@ describe('summaryLogCommandHandlers', () => {
 
     describe('payloadSchema', () => {
       it('rejects payload without user', () => {
-        const { error } = handler.payloadSchema.validate({
-          summaryLogId: 'log-123'
-        })
+        const error = validationErrorFrom(
+          handler.payloadSchema.validate({
+            summaryLogId: 'log-123'
+          })
+        )
 
         expect(error.message).toBe('"user" is required')
       })
@@ -153,30 +175,34 @@ describe('summaryLogCommandHandlers', () => {
       })
 
       it('requires summaryLogId', () => {
-        const { error } = handler.payloadSchema.validate({})
+        const error = validationErrorFrom(handler.payloadSchema.validate({}))
 
         expect(error.message).toBe('"summaryLogId" is required')
       })
 
       it('validates user schema when present', () => {
-        const { error } = handler.payloadSchema.validate({
-          summaryLogId: 'log-123',
-          user: { id: 'user-1' }
-        })
+        const error = validationErrorFrom(
+          handler.payloadSchema.validate({
+            summaryLogId: 'log-123',
+            user: { id: 'user-1' }
+          })
+        )
 
         expect(error.message).toContain('"user.email" is required')
       })
 
       it('rejects unknown fields', () => {
-        const { error } = handler.payloadSchema.validate({
-          summaryLogId: 'log-123',
-          user: {
-            id: 'user-1',
-            email: 'test@example.com',
-            scope: ['operator']
-          },
-          extra: true
-        })
+        const error = validationErrorFrom(
+          handler.payloadSchema.validate({
+            summaryLogId: 'log-123',
+            user: {
+              id: 'user-1',
+              email: 'test@example.com',
+              scope: ['operator']
+            },
+            extra: true
+          })
+        )
 
         expect(error.message).toContain('"extra" is not allowed')
       })

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -109,13 +109,17 @@ const isStructurallyValidPrnTransition = (fromStatus, toStatus) =>
   (PRN_STATUS_TRANSITIONS[fromStatus] ?? []).some((t) => t.status === toStatus)
 
 /**
- * Reduce a PRN status-history actor to the stream's user-summary shape.
+ * Reduce a PRN status-history actor to the stream's user-summary shape. The
+ * `id` is the proof of the actor; `name` rides along only when the source
+ * carries one, never fabricated.
  *
- * @param {{ id: string, name: string } | undefined} actor
+ * @param {{ id: string, name?: string } | undefined} actor
  * @returns {import('../repository/stream-schema.js').StreamUserSummary}
  */
 const actorOf = (actor) =>
-  actor ? { id: actor.id, name: actor.name } : { ...BACKFILL_ACTOR }
+  actor
+    ? { id: actor.id, ...(actor.name && { name: actor.name }) }
+    : { ...BACKFILL_ACTOR }
 
 /**
  * Sparse count of backfilled-actor events keyed by the stream event kind that

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -634,6 +634,21 @@ describe('computeRebuiltStream', () => {
       expect(result.events[0].createdBy).toEqual(submitter)
     })
 
+    it('keeps an id-only submitter id-only, without fabricating a name', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [],
+        overseasSites,
+        summaryLogs: [submittedLog({ id: 'usr-9' })]
+      })
+
+      expect(result.events[0].createdBy).toEqual({ id: 'usr-9' })
+      expect('name' in result.events[0].createdBy).toBe(false)
+    })
+
     it('falls back to a system backfill actor when no submitter is supplied', () => {
       const result = computeRebuiltStream({
         accreditation,

--- a/src/waste-balances/application/update-via-stream.js
+++ b/src/waste-balances/application/update-via-stream.js
@@ -58,7 +58,11 @@ export const performUpdateViaStream = async ({
     {
       kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
       payload: { summaryLogId, creditTotal },
-      createdBy: { id: user.id, name: user.email }
+      createdBy: {
+        id: user.id,
+        ...(user.name && { name: user.name }),
+        email: user.email
+      }
     }
   )
 

--- a/src/waste-balances/application/update-via-stream.test.js
+++ b/src/waste-balances/application/update-via-stream.test.js
@@ -52,6 +52,7 @@ const accreditation = {
 const overseasSites = /** @type {*} */ (new Map())
 const user = {
   id: 'user-1',
+  name: 'Test User',
   email: 'user@example.test',
   scope: ['standard_user']
 }
@@ -279,7 +280,7 @@ describe('performUpdateViaStream', () => {
   })
 
   describe('actor attribution', () => {
-    it('stamps createdBy from the SubmitUser', async () => {
+    it('stamps createdBy with the submitter id, name and email', async () => {
       await performUpdateViaStream({
         wasteRecords: [buildExporterRecord({ rowId: '1', tonnage: 50 })],
         accreditation,
@@ -294,7 +295,32 @@ describe('performUpdateViaStream', () => {
         'reg-1',
         accreditationId
       )
-      expect(latest.createdBy).toEqual({ id: user.id, name: user.email })
+      expect(latest.createdBy).toEqual({
+        id: user.id,
+        name: user.name,
+        email: user.email
+      })
+    })
+
+    it('omits name when the submitter has none, keeping the email distinct', async () => {
+      await performUpdateViaStream({
+        wasteRecords: [buildExporterRecord({ rowId: '1', tonnage: 50 })],
+        accreditation,
+        streamRepository,
+        dependencies: { systemLogsRepository },
+        user: { id: 'user-2', email: 'noname@example.test', scope: [] },
+        overseasSites,
+        summaryLogId: 'log-A'
+      })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        accreditationId
+      )
+      expect(latest.createdBy).toEqual({
+        id: 'user-2',
+        email: 'noname@example.test'
+      })
     })
   })
 })

--- a/src/waste-balances/repository/stream-schema.js
+++ b/src/waste-balances/repository/stream-schema.js
@@ -35,9 +35,14 @@ const PRN_KINDS = new Set([
 export const ZERO_BALANCE = Object.freeze({ amount: 0, availableAmount: 0 })
 
 /**
+ * Best-view actor for a stream event. `id` always identifies the actor; `name`
+ * and `email` are present only when the source carries a real value, and are
+ * left absent otherwise.
+ *
  * @typedef {Object} StreamUserSummary
  * @property {string} id
- * @property {string} name
+ * @property {string} [name]
+ * @property {string} [email]
  */
 
 /**
@@ -87,7 +92,8 @@ export const BACKFILL_ACTOR = Object.freeze({ id: 'system', name: 'backfill' })
 
 const userSummarySchema = Joi.object({
   id: Joi.string().required(),
-  name: Joi.string().required()
+  name: Joi.string(),
+  email: Joi.string()
 })
 
 const balanceSnapshotSchema = Joi.object({

--- a/src/waste-balances/repository/stream-schema.test.js
+++ b/src/waste-balances/repository/stream-schema.test.js
@@ -123,7 +123,11 @@ describe('stream event insert schema', () => {
   it('preserves email on createdBy', () => {
     const { value } = validate(
       buildStreamEvent({
-        createdBy: { id: 'user-1', name: 'Test User', email: 'user@example.test' }
+        createdBy: {
+          id: 'user-1',
+          name: 'Test User',
+          email: 'user@example.test'
+        }
       })
     )
     expect(value.createdBy.email).toBe('user@example.test')

--- a/src/waste-balances/repository/stream-schema.test.js
+++ b/src/waste-balances/repository/stream-schema.test.js
@@ -120,6 +120,24 @@ describe('stream event insert schema', () => {
     expect(error).toBeDefined()
   })
 
+  it('preserves email on createdBy', () => {
+    const { value } = validate(
+      buildStreamEvent({
+        createdBy: { id: 'user-1', name: 'Test User', email: 'user@example.test' }
+      })
+    )
+    expect(value.createdBy.email).toBe('user@example.test')
+  })
+
+  it('accepts createdBy without name', () => {
+    const { error } = validate(
+      buildStreamEvent({
+        createdBy: { id: 'user-1', email: 'user@example.test' }
+      })
+    )
+    expect(error).toBeUndefined()
+  })
+
   it('accepts accreditationId: null for registered-only streams', () => {
     const { error } = validate(buildStreamEvent({ accreditationId: null }))
     expect(error).toBeUndefined()


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
The live summary-log submission path stamped the waste-balance stream event's actor as `{ id, name: user.email }`, coercing the submitter's email into the `name` field. This carries the submitter's real name and email in their own fields, and aligns the actor model across the write and rebuild paths.

**Capture name and email on the summary-log write path**
Thread the authenticated user's name from their credentials through `extractUser`, the SQS submit message, and the queue-consumer payload schema, and write `createdBy` as `{ id, name?, email }` — the real name when present, the email in its own field, never email-as-name.

**Treat the actor id as the proof, name and email as enrichment**
Widen the stream user summary and the PRN domain actor to `{ id, name?, email? }`: the id identifies who acted, while name and email are best-view enrichment present only when the source carries a real value and left absent otherwise. A value is never written to the wrong slot.

**Make the existing consumers honest about an absent name**
The stream rebuild keeps an id-only actor id-only rather than fabricating a name, and the external PRN mapper omits `fullName` when there is no name.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ