### PR TITLE
PAE-1382: Carry submitter email distinctly when rebuilding summary-log events

### DIFF
--- a/src/server/run-balance-divergence-diagnostic.integration.test.js
+++ b/src/server/run-balance-divergence-diagnostic.integration.test.js
@@ -291,7 +291,7 @@ describe('balance divergence diagnostic (integration)', () => {
     })
     expect(submitters.get(fileId)).toEqual({
       id: 'user-1',
-      name: 'alice@example.com'
+      email: 'alice@example.com'
     })
 
     // 4. Migrate: replay the stream with the recovered submitter attached and
@@ -316,7 +316,7 @@ describe('balance divergence diagnostic (integration)', () => {
     expect(result.backfilledActorCount).toBe(0)
     expect(result.events[0].createdBy).toEqual({
       id: 'user-1',
-      name: 'alice@example.com'
+      email: 'alice@example.com'
     })
   })
 })

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -712,7 +712,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
             id: 'file-id-1',
             status: 'submitted',
             submittedAt: '2025-01-01T00:00:00Z',
-            submittedBy: { id: 'user-9', name: 'real@example.com' }
+            submittedBy: { id: 'user-9', email: 'real@example.com' }
           }
         ]
       })
@@ -767,7 +767,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
             id: 'file-id-1',
             status: 'submitted',
             submittedAt: '2025-01-01T00:00:00Z',
-            submittedBy: { id: 'sys-user', name: 'sys@example.com' }
+            submittedBy: { id: 'sys-user', email: 'sys@example.com' }
           }
         ]
       })

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -109,16 +109,20 @@ const isStructurallyValidPrnTransition = (fromStatus, toStatus) =>
   (PRN_STATUS_TRANSITIONS[fromStatus] ?? []).some((t) => t.status === toStatus)
 
 /**
- * Reduce a PRN status-history actor to the stream's user-summary shape. The
- * `id` is the proof of the actor; `name` rides along only when the source
- * carries one, never fabricated.
+ * Reduce a source actor to the stream's user-summary shape. The `id` is the
+ * proof of the actor; `name` and `email` each ride along only when the source
+ * carries them, and are never fabricated.
  *
- * @param {{ id: string, name?: string } | undefined} actor
+ * @param {{ id: string, name?: string, email?: string } | undefined} actor
  * @returns {import('../repository/stream-schema.js').StreamUserSummary}
  */
 const actorOf = (actor) =>
   actor
-    ? { id: actor.id, ...(actor.name && { name: actor.name }) }
+    ? {
+        id: actor.id,
+        ...(actor.name && { name: actor.name }),
+        ...(actor.email && { email: actor.email })
+      }
     : { ...BACKFILL_ACTOR }
 
 /**

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -649,6 +649,43 @@ describe('computeRebuiltStream', () => {
       expect('name' in result.events[0].createdBy).toBe(false)
     })
 
+    it('carries a submitter name and email distinctly to the rebuilt event', () => {
+      const submitter = {
+        id: 'usr-9',
+        name: 'Nora Submitter',
+        email: 'nora@example.com'
+      }
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [],
+        overseasSites,
+        summaryLogs: [submittedLog(submitter)]
+      })
+
+      expect(result.events[0].createdBy).toEqual(submitter)
+    })
+
+    it('carries an email-only submitter without inventing a name', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [],
+        overseasSites,
+        summaryLogs: [submittedLog({ id: 'usr-9', email: 'nora@example.com' })]
+      })
+
+      expect(result.events[0].createdBy).toEqual({
+        id: 'usr-9',
+        email: 'nora@example.com'
+      })
+      expect('name' in result.events[0].createdBy).toBe(false)
+    })
+
     it('falls back to a system backfill actor when no submitter is supplied', () => {
       const result = computeRebuiltStream({
         accreditation,

--- a/src/waste-balances/application/summary-log-submitters.js
+++ b/src/waste-balances/application/summary-log-submitters.js
@@ -3,23 +3,26 @@
  */
 
 /**
- * Reduce a submit-audit actor to the stream's `{ id, name }` summary, or `null`
- * when it carries no usable identity. A human actor's email is its only captured
- * label, so it stands in for the name; an actor with no id, or with neither a
- * name nor an email, has nothing real to attribute and is rejected rather than
- * relabelled with its id — so missing data stays visible downstream (the
- * submission falls back to backfill) instead of being masked by a fabricated
- * name. Shared with the unusable-actor count so both read identity the same way.
+ * Reduce a submit-audit actor to the stream's `{ id, name?, email? }` summary,
+ * or `null` when it carries no usable identity. The `id` is the proof of the
+ * actor; `name` and `email` are distinct labels, each carried only when the
+ * audit holds it. An actor with no id, or with neither a name nor an email, has
+ * nothing real to attribute, so it is rejected and the submission falls back to
+ * backfill — keeping missing data visible downstream. Shared with the
+ * unusable-actor count so both read identity the same way.
  *
  * @param {SubmitAuditActor} [createdBy]
  * @returns {import('../repository/stream-schema.js').StreamUserSummary | null}
  */
 export const toStreamActor = (createdBy) => {
-  const name = createdBy?.name ?? createdBy?.email
-  if (createdBy?.id === undefined || name === undefined) {
+  if (createdBy?.id === undefined || (!createdBy.name && !createdBy.email)) {
     return null
   }
-  return { id: createdBy.id, name }
+  return {
+    id: createdBy.id,
+    ...(createdBy.name && { name: createdBy.name }),
+    ...(createdBy.email && { email: createdBy.email })
+  }
 }
 
 /**
@@ -28,8 +31,8 @@ export const toStreamActor = (createdBy) => {
  * keys on the summary-log document id (`context.summaryLogId`); the stream keys
  * on `summaryLog.file.id`, a different namespace, so the summary-log documents
  * bridge document id → file id. Each actor is reduced to the stream's
- * `{ id, name }` summary by `toStreamActor`, which rejects actors with no usable
- * identity so missing data is never masked by a fabricated name.
+ * `{ id, name?, email? }` summary by `toStreamActor`, which rejects actors with
+ * no usable identity, keeping missing data visible downstream.
  *
  * A document submitted more than once keeps the most recent audit: callers
  * supply `submitActors` newest-first, so the first one seen for a file id wins.

--- a/src/waste-balances/application/summary-log-submitters.test.js
+++ b/src/waste-balances/application/summary-log-submitters.test.js
@@ -8,7 +8,7 @@ const summaryLogDoc = (docId, fileId) => ({
 })
 
 describe('buildSystemLogSubmitters', () => {
-  it('bridges the audit document id to the file id and credits the submitter', () => {
+  it('bridges the audit document id to the file id and credits the submitter by email', () => {
     const submitters = buildSystemLogSubmitters({
       submitActors: [
         {
@@ -21,7 +21,30 @@ describe('buildSystemLogSubmitters', () => {
 
     expect(submitters.get('file-1')).toEqual({
       id: 'user-1',
-      name: 'alice@example.com'
+      email: 'alice@example.com'
+    })
+  })
+
+  it('carries a name and an email distinctly when the audit holds both', () => {
+    const submitters = buildSystemLogSubmitters({
+      submitActors: [
+        {
+          summaryLogId: 'doc-1',
+          createdBy: {
+            id: 'user-1',
+            name: 'Alice Submitter',
+            email: 'alice@example.com',
+            scope: []
+          }
+        }
+      ],
+      summaryLogDocs: [summaryLogDoc('doc-1', 'file-1')]
+    })
+
+    expect(submitters.get('file-1')).toEqual({
+      id: 'user-1',
+      name: 'Alice Submitter',
+      email: 'alice@example.com'
     })
   })
 
@@ -96,7 +119,7 @@ describe('buildSystemLogSubmitters', () => {
 
     expect(submitters.get('file-1')).toEqual({
       id: 'user-1',
-      name: 'alice@example.com'
+      email: 'alice@example.com'
     })
   })
 


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
When the historical waste-balance event stream is rebuilt from source records, a summary-log submission event must attribute the real human submitter. The submitter is recovered from the dedicated submit system-log audit, which carries both the submitter's name and email — but the rebuild collapsed the two into a single `name` slot: `toStreamActor` fell back to the email when no name was present (using the email *as* the name) and then dropped the distinct email entirely, and `actorOf` carried only `id` and `name` onward. A rebuilt summary-log event therefore lost the submitter's email and could surface an email address where a name belongs.

This change reduces a submit-audit actor to `{ id, name?, email? }`, carrying name and email as distinct best-effort labels and rejecting an actor that has neither (so the submission falls back to the backfill actor and missing data stays visible rather than being masked). Email is threaded through `actorOf` so the rebuilt event keeps whatever the source holds. The actor shape and its Joi gate were already widened to accept an optional email, so no schema change is needed here.

`actorOf` is shared with the PRN status-history replay, which currently carries only `{ id, name }`, so the widening is inert on that path; distinct name/email handling for PRN transitions is tracked separately.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ