### PR TITLE
PAE-1382: Capture name and email on live human PRN status transition events

### DIFF
--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
@@ -42,13 +42,16 @@ const applyEvent = (prn, event) => {
     throw new Error(`Unmappable stream event kind: ${event.kind}`)
   }
   const slot = STREAM_EVENT_KIND_TO_STATUS_SLOT[event.kind]
-  const slotValue = { at: event.createdAt, by: event.createdBy }
+  // PRN actors record id and name only; the event's createdBy may also carry an
+  // email (best-view enrichment on the stream), which the PRN document omits.
+  const by = { id: event.createdBy.id, name: event.createdBy.name }
+  const slotValue = { at: event.createdAt, by }
 
   return {
     ...prn,
     version: (prn.version ?? 0) + 1,
     updatedAt: event.createdAt,
-    updatedBy: event.createdBy,
+    updatedBy: by,
     lastAppliedEventNumber: event.number,
     status: {
       ...prn.status,
@@ -57,7 +60,7 @@ const applyEvent = (prn, event) => {
       [slot]: slotValue,
       history: [
         ...prn.status.history,
-        { status: newStatus, at: event.createdAt, by: event.createdBy }
+        { status: newStatus, at: event.createdAt, by }
       ]
     }
   }

--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
@@ -104,8 +104,15 @@ describe('foldPrnFromTailEvents', () => {
 
       const expectedActor = { id: 'user-1', name: 'Test User' }
       expect(result.updatedBy).toEqual(expectedActor)
-      expect(result.status.created.by).toEqual(expectedActor)
-      expect(result.status.history.at(-1).by).toEqual(expectedActor)
+      expect(result.status.created).toEqual({
+        at: event.createdAt,
+        by: expectedActor
+      })
+      expect(result.status.history.at(-1)).toEqual({
+        status: PRN_STATUS.AWAITING_AUTHORISATION,
+        at: event.createdAt,
+        by: expectedActor
+      })
     })
 
     it('prn-issued sets currentStatus awaiting_acceptance and issued slot', () => {

--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
@@ -91,6 +91,23 @@ describe('foldPrnFromTailEvents', () => {
       expect(result.lastAppliedEventNumber).toBe(1)
     })
 
+    it('narrows the event actor to id and name, dropping the stream-only email', () => {
+      const prn = basePrn()
+      const event = buildEvent(
+        STREAM_EVENT_KIND.PRN_CREATED,
+        1,
+        '2026-02-01T12:00:00.000Z',
+        { id: 'user-1', name: 'Test User', email: 'test@example.com' }
+      )
+
+      const result = foldPrnFromTailEvents(prn, [event])
+
+      const expectedActor = { id: 'user-1', name: 'Test User' }
+      expect(result.updatedBy).toEqual(expectedActor)
+      expect(result.status.created.by).toEqual(expectedActor)
+      expect(result.status.history.at(-1).by).toEqual(expectedActor)
+    })
+
     it('prn-issued sets currentStatus awaiting_acceptance and issued slot', () => {
       const prn = basePrn()
       const event = buildEvent(

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -27,7 +27,7 @@ import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
  * @property {string} organisationId
  * @property {string} prnId
  * @property {number} tonnage
- * @property {string} userId
+ * @property {import('#waste-balances/repository/stream-schema.js').StreamUserSummary} createdBy
  */
 
 /**
@@ -52,7 +52,7 @@ export async function deductWasteBalanceIfNeeded(
     organisationId,
     prnId,
     tonnage,
-    userId
+    createdBy
   } = params
   const balance =
     await wasteBalancesRepository.findByAccreditationId(accreditationId)
@@ -68,7 +68,7 @@ export async function deductWasteBalanceIfNeeded(
       organisationId,
       prnId,
       tonnage,
-      userId
+      createdBy
     })
   } else {
     throw Boom.badRequest(
@@ -93,7 +93,7 @@ export async function deductTotalBalanceIfNeeded(
     organisationId,
     prnId,
     tonnage,
-    userId
+    createdBy
   } = params
   const balance =
     await wasteBalancesRepository.findByAccreditationId(accreditationId)
@@ -109,7 +109,7 @@ export async function deductTotalBalanceIfNeeded(
       organisationId,
       prnId,
       tonnage,
-      userId
+      createdBy
     })
   } else {
     throw Boom.badRequest(
@@ -135,7 +135,7 @@ export async function creditWasteBalanceIfNeeded(
     organisationId,
     prnId,
     tonnage,
-    userId
+    createdBy
   } = params
   const balance =
     await wasteBalancesRepository.findByAccreditationId(accreditationId)
@@ -147,7 +147,7 @@ export async function creditWasteBalanceIfNeeded(
       organisationId,
       prnId,
       tonnage,
-      userId
+      createdBy
     })
   } else {
     throw Boom.badRequest(
@@ -173,7 +173,7 @@ export async function creditFullBalanceIfNeeded(
     organisationId,
     prnId,
     tonnage,
-    userId
+    createdBy
   } = params
   const balance =
     await wasteBalancesRepository.findByAccreditationId(accreditationId)
@@ -185,7 +185,7 @@ export async function creditFullBalanceIfNeeded(
       organisationId,
       prnId,
       tonnage,
-      userId
+      createdBy
     })
   } else {
     throw Boom.badRequest(

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
@@ -70,7 +70,7 @@ const balanceParamsFor = (overrides) => ({
   accreditationId: ACCREDITATION_ID,
   registrationId: REGISTRATION_ID,
   organisationId: ORGANISATION_ID,
-  userId: 'user-1',
+  createdBy: { id: 'user-1' },
   ...overrides
 })
 

--- a/src/packaging-recycling-notes/application/update-status-embedded-write.js
+++ b/src/packaging-recycling-notes/application/update-status-embedded-write.js
@@ -109,7 +109,7 @@ export const EMBEDDED_BALANCE_EFFECTS = Object.freeze({
  * @property {import('#common/hapi-types.js').TypedLogger} logger
  * @property {PrnStatus} currentStatus
  * @property {PrnStatus} newStatus
- * @property {{accreditationId: string, registrationId: string, organisationId: string, prnId: string, tonnage: number, userId: string}} params
+ * @property {{accreditationId: string, registrationId: string, organisationId: string, prnId: string, tonnage: number, createdBy: import('#waste-balances/repository/stream-schema.js').StreamUserSummary}} params
  */
 
 /**
@@ -221,7 +221,11 @@ export async function applyStatusUpdate({
 
   const operationSlot = STATUS_OPERATION_SLOT[newStatus]
   if (operationSlot) {
-    updateParams.operation = { slot: operationSlot, at: now, by: user }
+    updateParams.operation = {
+      slot: operationSlot,
+      at: now,
+      by: { id: user.id, name: user.name }
+    }
   }
 
   const updatedPrn = await prnRepository.updateStatus(updateParams)
@@ -356,7 +360,7 @@ export async function performCreation({
       organisationId,
       prnId: id,
       tonnage: prn.tonnage,
-      userId: user.id
+      createdBy: user
     }
   })
 
@@ -381,7 +385,7 @@ export async function performCreation({
           organisationId,
           prnId: id,
           tonnage: prn.tonnage,
-          userId: user.id
+          createdBy: user
         }),
       {
         forwardError,
@@ -441,7 +445,7 @@ export async function performTransition({
         organisationId,
         prnId: id,
         tonnage: prn.tonnage,
-        userId: user.id
+        createdBy: user
       }
     })
   } catch (forwardError) {
@@ -454,7 +458,7 @@ export async function performTransition({
         prnRepository[rollbackMethod]({
           id,
           expectedVersion: updatedPrn.version,
-          updatedBy: user,
+          updatedBy: { id: user.id, name: user.name },
           updatedAt: now,
           lastAppliedEventNumber: updatedPrn.lastAppliedEventNumber
         }),

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -45,7 +45,7 @@ import { foldPrnFromTailEvents } from './fold-prn-from-tail-events.js'
  * @property {string} organisationId
  * @property {string} registrationId
  * @property {string} accreditationId
- * @property {{ id: string; name: string }} user
+ * @property {{ id: string; name: string; email?: string }} user
  * @property {PrnStatus} currentStatus
  * @property {Date} now
  * @property {string} id
@@ -190,7 +190,7 @@ async function performLedgerWrite({
     organisationId,
     prnId: id,
     tonnage: prn.tonnage,
-    userId: user.id
+    createdBy: user
   })
 
   /* c8 ignore next 5 - defensive: the only legal transition with no balance events (DRAFT→DISCARDED) is handled before this branch */
@@ -268,7 +268,7 @@ const dispatchStatusWrite = async (ctx) =>
  * @param {string} params.accreditationId
  * @param {import('#packaging-recycling-notes/domain/model.js').PrnStatus} params.newStatus
  * @param {import('#packaging-recycling-notes/domain/model.js').PrnActor} params.actor
- * @param {{ id: string; name: string }} params.user
+ * @param {{ id: string; name: string; email?: string }} params.user
  * @param {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} [params.providedPrn] - Optional pre-fetched PRN to avoid duplicate fetch
  * @param {Date} [params.updatedAt] - Optional timestamp override (defaults to now)
  * @returns {Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote>}
@@ -306,7 +306,7 @@ export async function updatePrnStatus({
     id,
     version: prn.version,
     status: newStatus,
-    updatedBy: user,
+    updatedBy: { id: user.id, name: user.name },
     updatedAt: now,
     lastAppliedEventNumber: prn.lastAppliedEventNumber
   }

--- a/src/packaging-recycling-notes/application/update-status.test.js
+++ b/src/packaging-recycling-notes/application/update-status.test.js
@@ -9,6 +9,12 @@ import {
 } from '#packaging-recycling-notes/domain/model.js'
 import { REGULATOR } from '#domain/organisations/model.js'
 import { PrnNumberConflictError } from '#packaging-recycling-notes/repository/port.js'
+import {
+  createMockOrganisationsRepository,
+  createMockPackagingRecyclingNotesRepository,
+  createMockWasteBalancesRepository
+} from '#test/mock-repositories.js'
+import { createMockLogger } from '#test/mock-logger.js'
 
 const mockRecordStatusTransition = vi.fn()
 
@@ -20,28 +26,15 @@ vi.mock('./metrics.js', () => ({
 
 const { updatePrnStatus } = await import('./update-status.js')
 
-const defaultOrganisationsRepository = {
+const defaultOrganisationsRepository = createMockOrganisationsRepository({
   findAccreditationById: vi.fn().mockResolvedValue({
     submittedToRegulator: REGULATOR.EA
   })
-}
-
-const mockLogger = {
-  info: vi.fn(),
-  error: vi.fn(),
-  warn: vi.fn(),
-  debug: vi.fn(),
-  trace: vi.fn(),
-  fatal: vi.fn()
-}
-
-const createMockPrnRepository = (overrides = {}) => ({
-  create: vi.fn(),
-  findById: vi.fn(),
-  findByAccreditation: vi.fn(),
-  updateStatus: vi.fn(),
-  ...overrides
 })
+
+const mockLogger = createMockLogger()
+
+const createMockPrnRepository = createMockPackagingRecyclingNotesRepository
 
 describe('updatePrnStatus', () => {
   beforeEach(() => {
@@ -55,7 +48,7 @@ describe('updatePrnStatus', () => {
     const prnRepository = createMockPrnRepository({
       findById: vi.fn().mockResolvedValue(null)
     })
-    const wasteBalancesRepository = {}
+    const wasteBalancesRepository = createMockWasteBalancesRepository()
 
     await expect(
       updatePrnStatus({
@@ -65,6 +58,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -82,7 +76,7 @@ describe('updatePrnStatus', () => {
         status: { currentStatus: PRN_STATUS.DRAFT }
       })
     })
-    const wasteBalancesRepository = {}
+    const wasteBalancesRepository = createMockWasteBalancesRepository()
 
     await expect(
       updatePrnStatus({
@@ -92,6 +86,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -109,7 +104,7 @@ describe('updatePrnStatus', () => {
         status: { currentStatus: PRN_STATUS.DRAFT }
       })
     })
-    const wasteBalancesRepository = {}
+    const wasteBalancesRepository = createMockWasteBalancesRepository()
 
     await expect(
       updatePrnStatus({
@@ -119,6 +114,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -136,7 +132,7 @@ describe('updatePrnStatus', () => {
         status: { currentStatus: PRN_STATUS.DRAFT }
       })
     })
-    const wasteBalancesRepository = {}
+    const wasteBalancesRepository = createMockWasteBalancesRepository()
 
     // DRAFT cannot transition directly to AWAITING_ACCEPTANCE (must go via AWAITING_AUTHORISATION)
     await expect(
@@ -147,6 +143,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -164,7 +161,7 @@ describe('updatePrnStatus', () => {
         status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
       })
     })
-    const wasteBalancesRepository = {}
+    const wasteBalancesRepository = createMockWasteBalancesRepository()
 
     // Only PRODUCER can transition from awaiting_acceptance to accepted
     await expect(
@@ -175,6 +172,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.ACCEPTED,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -192,7 +190,7 @@ describe('updatePrnStatus', () => {
         status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
       })
     })
-    const wasteBalancesRepository = {}
+    const wasteBalancesRepository = createMockWasteBalancesRepository()
 
     await expect(
       updatePrnStatus({
@@ -202,6 +200,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.ACCEPTED,
         actor: PRN_ACTOR.SIGNATORY,
@@ -224,14 +223,14 @@ describe('updatePrnStatus', () => {
         status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
       })
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductAvailableBalanceForPrnCreation: vi.fn().mockResolvedValue({})
-    }
+    })
 
     await updatePrnStatus({
       prnRepository,
@@ -240,6 +239,7 @@ describe('updatePrnStatus', () => {
       logger: mockLogger,
       id: '507f1f77bcf86cd799439011',
       organisationId: 'org-123',
+      registrationId: 'reg-123',
       accreditationId: 'acc-456',
       newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
       actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -253,6 +253,7 @@ describe('updatePrnStatus', () => {
       organisationId: 'org-123',
       prnId: '507f1f77bcf86cd799439011',
       tonnage: 100,
+      registrationId: 'reg-123',
       createdBy: { id: 'user-789', name: 'Test User' }
     })
   })
@@ -267,9 +268,9 @@ describe('updatePrnStatus', () => {
         status: { currentStatus: PRN_STATUS.DRAFT }
       })
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue(null)
-    }
+    })
 
     await expect(
       updatePrnStatus({
@@ -279,6 +280,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -306,14 +308,14 @@ describe('updatePrnStatus', () => {
       }),
       updateStatus: vi.fn().mockResolvedValue(updatedPrn)
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductAvailableBalanceForPrnCreation: vi.fn().mockResolvedValue({})
-    }
+    })
 
     await updatePrnStatus({
       prnRepository,
@@ -322,6 +324,7 @@ describe('updatePrnStatus', () => {
       logger: mockLogger,
       id: '507f1f77bcf86cd799439011',
       organisationId: 'org-123',
+      registrationId: 'reg-123',
       accreditationId: 'acc-456',
       newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
       actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -353,14 +356,14 @@ describe('updatePrnStatus', () => {
       }),
       updateStatus: vi.fn().mockResolvedValue(updatedPrn)
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductAvailableBalanceForPrnCreation: vi.fn().mockResolvedValue({})
-    }
+    })
 
     const result = await updatePrnStatus({
       prnRepository,
@@ -369,6 +372,7 @@ describe('updatePrnStatus', () => {
       logger: mockLogger,
       id: '507f1f77bcf86cd799439011',
       organisationId: 'org-123',
+      registrationId: 'reg-123',
       accreditationId: 'acc-456',
       newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
       actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -406,14 +410,14 @@ describe('updatePrnStatus', () => {
       }),
       updateStatus: vi.fn().mockResolvedValue(updatedPrn)
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductTotalBalanceForPrnIssue: vi.fn().mockResolvedValue({})
-    }
+    })
 
     const result = await updatePrnStatus({
       prnRepository,
@@ -422,6 +426,7 @@ describe('updatePrnStatus', () => {
       logger: mockLogger,
       id: '507f1f77bcf86cd799439011',
       organisationId: 'org-123',
+      registrationId: 'reg-123',
       accreditationId: 'acc-456',
       newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
       actor: PRN_ACTOR.SIGNATORY,
@@ -459,14 +464,14 @@ describe('updatePrnStatus', () => {
         status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
       })
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductTotalBalanceForPrnIssue: vi.fn().mockResolvedValue({})
-    }
+    })
 
     await updatePrnStatus({
       prnRepository,
@@ -475,14 +480,15 @@ describe('updatePrnStatus', () => {
       logger: mockLogger,
       id: '507f1f77bcf86cd799439011',
       organisationId: 'org-123',
+      registrationId: 'reg-123',
       accreditationId: 'acc-456',
       newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
       actor: PRN_ACTOR.SIGNATORY,
       user: { id: 'user-789', name: 'Test User' }
     })
 
-    const updateCall = prnRepository.updateStatus.mock.calls[0][0]
-    expect(updateCall.operation.at).toStrictEqual(updateCall.updatedAt)
+    const updateCall = vi.mocked(prnRepository.updateStatus).mock.calls[0][0]
+    expect(updateCall.operation?.at).toStrictEqual(updateCall.updatedAt)
   })
 
   it('deducts total waste balance when issuing PRN (transitioning to awaiting_acceptance)', async () => {
@@ -502,14 +508,14 @@ describe('updatePrnStatus', () => {
       }),
       updateStatus: vi.fn().mockResolvedValue(updatedPrn)
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductTotalBalanceForPrnIssue: vi.fn().mockResolvedValue({})
-    }
+    })
 
     await updatePrnStatus({
       prnRepository,
@@ -518,6 +524,7 @@ describe('updatePrnStatus', () => {
       logger: mockLogger,
       id: '507f1f77bcf86cd799439011',
       organisationId: 'org-123',
+      registrationId: 'reg-123',
       accreditationId: 'acc-456',
       newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
       actor: PRN_ACTOR.SIGNATORY,
@@ -531,6 +538,7 @@ describe('updatePrnStatus', () => {
       organisationId: 'org-123',
       prnId: '507f1f77bcf86cd799439011',
       tonnage: 75,
+      registrationId: 'reg-123',
       createdBy: { id: 'user-789', name: 'Test User' }
     })
   })
@@ -551,9 +559,9 @@ describe('updatePrnStatus', () => {
         status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
       })
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue(null)
-    }
+    })
 
     await expect(
       updatePrnStatus({
@@ -563,6 +571,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
         actor: PRN_ACTOR.SIGNATORY,
@@ -591,14 +600,14 @@ describe('updatePrnStatus', () => {
         .mockRejectedValueOnce(new PrnNumberConflictError('WE26000001'))
         .mockResolvedValueOnce(updatedPrn)
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductTotalBalanceForPrnIssue: vi.fn().mockResolvedValue({})
-    }
+    })
 
     const result = await updatePrnStatus({
       prnRepository,
@@ -607,6 +616,7 @@ describe('updatePrnStatus', () => {
       logger: mockLogger,
       id: '507f1f77bcf86cd799439011',
       organisationId: 'org-123',
+      registrationId: 'reg-123',
       accreditationId: 'acc-456',
       newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
       actor: PRN_ACTOR.SIGNATORY,
@@ -645,14 +655,14 @@ describe('updatePrnStatus', () => {
         .fn()
         .mockRejectedValue(new PrnNumberConflictError('collision'))
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductTotalBalanceForPrnIssue: vi.fn().mockResolvedValue({})
-    }
+    })
 
     await expect(
       updatePrnStatus({
@@ -662,6 +672,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
         actor: PRN_ACTOR.SIGNATORY,
@@ -684,17 +695,17 @@ describe('updatePrnStatus', () => {
       }),
       updateStatus: vi.fn()
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductTotalBalanceForPrnIssue: vi.fn().mockResolvedValue({})
-    }
-    const organisationsRepository = {
+    })
+    const organisationsRepository = createMockOrganisationsRepository({
       findAccreditationById: vi.fn().mockResolvedValue(null)
-    }
+    })
 
     await expect(
       updatePrnStatus({
@@ -704,6 +715,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
         actor: PRN_ACTOR.SIGNATORY,
@@ -726,20 +738,20 @@ describe('updatePrnStatus', () => {
       }),
       updateStatus: vi.fn()
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductTotalBalanceForPrnIssue: vi.fn().mockResolvedValue({})
-    }
-    const organisationsRepository = {
+    })
+    const organisationsRepository = createMockOrganisationsRepository({
       findAccreditationById: vi.fn().mockResolvedValue({
         submittedToRegulator: REGULATOR.EA,
         status: 'suspended'
       })
-    }
+    })
 
     await expect(
       updatePrnStatus({
@@ -749,6 +761,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
         actor: PRN_ACTOR.SIGNATORY,
@@ -772,14 +785,14 @@ describe('updatePrnStatus', () => {
       }),
       updateStatus: vi.fn().mockRejectedValue(dbError)
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductTotalBalanceForPrnIssue: vi.fn().mockResolvedValue({})
-    }
+    })
 
     await expect(
       updatePrnStatus({
@@ -789,6 +802,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
         actor: PRN_ACTOR.SIGNATORY,
@@ -810,14 +824,14 @@ describe('updatePrnStatus', () => {
       }),
       updateStatus: vi.fn().mockResolvedValue(null)
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductAvailableBalanceForPrnCreation: vi.fn().mockResolvedValue({})
-    }
+    })
 
     await expect(
       updatePrnStatus({
@@ -827,6 +841,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -847,14 +862,14 @@ describe('updatePrnStatus', () => {
       }),
       updateStatus: vi.fn().mockResolvedValue(null)
     })
-    const wasteBalancesRepository = {
+    const wasteBalancesRepository = createMockWasteBalancesRepository({
       findByAccreditationId: vi.fn().mockResolvedValue({
         accreditationId: 'acc-456',
         amount: 1000,
         availableAmount: 1000
       }),
       deductTotalBalanceForPrnIssue: vi.fn().mockResolvedValue({})
-    }
+    })
 
     await expect(
       updatePrnStatus({
@@ -864,6 +879,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
         actor: PRN_ACTOR.SIGNATORY,
@@ -884,14 +900,14 @@ describe('updatePrnStatus', () => {
         }),
         updateStatus: vi.fn()
       })
-      const wasteBalancesRepository = {
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi.fn().mockResolvedValue({
           accreditationId: 'acc-456',
           amount: 500,
           availableAmount: 50
         }),
         deductAvailableBalanceForPrnCreation: vi.fn()
-      }
+      })
 
       await expect(
         updatePrnStatus({
@@ -901,6 +917,7 @@ describe('updatePrnStatus', () => {
           logger: mockLogger,
           id: '507f1f77bcf86cd799439011',
           organisationId: 'org-123',
+          registrationId: 'reg-123',
           accreditationId: 'acc-456',
           newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
           actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -930,14 +947,14 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
         })
       })
-      const wasteBalancesRepository = {
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi.fn().mockResolvedValue({
           accreditationId: 'acc-456',
           amount: 50,
           availableAmount: 200
         }),
         deductTotalBalanceForPrnIssue: vi.fn()
-      }
+      })
 
       await expect(
         updatePrnStatus({
@@ -947,6 +964,7 @@ describe('updatePrnStatus', () => {
           logger: mockLogger,
           id: '507f1f77bcf86cd799439011',
           organisationId: 'org-123',
+          registrationId: 'reg-123',
           accreditationId: 'acc-456',
           newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
           actor: PRN_ACTOR.SIGNATORY,
@@ -974,14 +992,14 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
         })
       })
-      const wasteBalancesRepository = {
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi.fn().mockResolvedValue({
           accreditationId: 'acc-456',
           amount: 500,
           availableAmount: 100
         }),
         deductAvailableBalanceForPrnCreation: vi.fn().mockResolvedValue({})
-      }
+      })
 
       await updatePrnStatus({
         prnRepository,
@@ -990,6 +1008,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -1012,12 +1031,12 @@ describe('updatePrnStatus', () => {
         }),
         updateStatus: vi.fn()
       })
-      const wasteBalancesRepository = {
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi.fn().mockResolvedValue({
           accreditationId: 'acc-456',
           amount: 500
         })
-      }
+      })
 
       await expect(
         updatePrnStatus({
@@ -1027,6 +1046,7 @@ describe('updatePrnStatus', () => {
           logger: mockLogger,
           id: '507f1f77bcf86cd799439011',
           organisationId: 'org-123',
+          registrationId: 'reg-123',
           accreditationId: 'acc-456',
           newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
           actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -1051,12 +1071,12 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
         })
       })
-      const wasteBalancesRepository = {
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi.fn().mockResolvedValue({
           accreditationId: 'acc-456',
           availableAmount: 200
         })
-      }
+      })
 
       await expect(
         updatePrnStatus({
@@ -1066,6 +1086,7 @@ describe('updatePrnStatus', () => {
           logger: mockLogger,
           id: '507f1f77bcf86cd799439011',
           organisationId: 'org-123',
+          registrationId: 'reg-123',
           accreditationId: 'acc-456',
           newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
           actor: PRN_ACTOR.SIGNATORY,
@@ -1090,14 +1111,14 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
         })
       })
-      const wasteBalancesRepository = {
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi.fn().mockResolvedValue({
           accreditationId: 'acc-456',
           amount: 50,
           availableAmount: 200
         }),
         deductTotalBalanceForPrnIssue: vi.fn().mockResolvedValue({})
-      }
+      })
 
       await updatePrnStatus({
         prnRepository,
@@ -1106,6 +1127,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
         actor: PRN_ACTOR.SIGNATORY,
@@ -1134,14 +1156,14 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
         })
       })
-      const wasteBalancesRepository = {
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi.fn().mockResolvedValue({
           accreditationId: 'acc-456',
           amount: 1000,
           availableAmount: 1000
         }),
         deductAvailableBalanceForPrnCreation: vi.fn().mockResolvedValue({})
-      }
+      })
 
       await updatePrnStatus({
         prnRepository,
@@ -1150,6 +1172,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -1184,14 +1207,14 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE }
         })
       })
-      const wasteBalancesRepository = {
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi.fn().mockResolvedValue({
           accreditationId: 'acc-456',
           amount: 1000,
           availableAmount: 1000
         }),
         deductTotalBalanceForPrnIssue: vi.fn().mockResolvedValue({})
-      }
+      })
 
       await updatePrnStatus({
         prnRepository,
@@ -1200,6 +1223,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
         actor: PRN_ACTOR.SIGNATORY,
@@ -1218,7 +1242,7 @@ describe('updatePrnStatus', () => {
       const prnRepository = createMockPrnRepository({
         findById: vi.fn().mockResolvedValue(null)
       })
-      const wasteBalancesRepository = {}
+      const wasteBalancesRepository = createMockWasteBalancesRepository()
 
       await expect(
         updatePrnStatus({
@@ -1228,6 +1252,7 @@ describe('updatePrnStatus', () => {
           logger: mockLogger,
           id: '507f1f77bcf86cd799439011',
           organisationId: 'org-123',
+          registrationId: 'reg-123',
           accreditationId: 'acc-456',
           newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
           actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -1247,7 +1272,7 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.DRAFT }
         })
       })
-      const wasteBalancesRepository = {}
+      const wasteBalancesRepository = createMockWasteBalancesRepository()
 
       await expect(
         updatePrnStatus({
@@ -1257,6 +1282,7 @@ describe('updatePrnStatus', () => {
           logger: mockLogger,
           id: '507f1f77bcf86cd799439011',
           organisationId: 'org-123',
+          registrationId: 'reg-123',
           accreditationId: 'acc-456',
           newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
           actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -1285,7 +1311,7 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.DISCARDED }
         })
       })
-      const wasteBalancesRepository = {}
+      const wasteBalancesRepository = createMockWasteBalancesRepository()
 
       const result = await updatePrnStatus({
         prnRepository,
@@ -1294,6 +1320,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.DISCARDED,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -1325,9 +1352,9 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.DISCARDED }
         })
       })
-      const wasteBalancesRepository = {
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         creditAvailableBalanceForPrnCancellation: vi.fn()
-      }
+      })
 
       await updatePrnStatus({
         prnRepository,
@@ -1336,6 +1363,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.DISCARDED,
         actor: PRN_ACTOR.REPROCESSOR_EXPORTER,
@@ -1357,7 +1385,7 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.AWAITING_AUTHORISATION }
         })
       })
-      const wasteBalancesRepository = {}
+      const wasteBalancesRepository = createMockWasteBalancesRepository()
 
       await expect(
         updatePrnStatus({
@@ -1367,6 +1395,7 @@ describe('updatePrnStatus', () => {
           logger: mockLogger,
           id: '507f1f77bcf86cd799439011',
           organisationId: 'org-123',
+          registrationId: 'reg-123',
           accreditationId: 'acc-456',
           newStatus: PRN_STATUS.DISCARDED,
           actor: PRN_ACTOR.SIGNATORY,
@@ -1391,12 +1420,12 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.CANCELLED }
         })
       })
-      const wasteBalancesRepository = {
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi
           .fn()
           .mockResolvedValue({ accreditationId: 'acc-456' }),
         creditFullBalanceForIssuedPrnCancellation: vi.fn().mockResolvedValue({})
-      }
+      })
 
       await updatePrnStatus({
         prnRepository,
@@ -1405,6 +1434,7 @@ describe('updatePrnStatus', () => {
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.CANCELLED,
         actor: PRN_ACTOR.SIGNATORY,
@@ -1418,6 +1448,7 @@ describe('updatePrnStatus', () => {
         organisationId: 'org-123',
         prnId: '507f1f77bcf86cd799439011',
         tonnage: 60,
+        registrationId: 'reg-123',
         createdBy: { id: 'user-789', name: 'Test User' }
       })
     })
@@ -1436,9 +1467,9 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.CANCELLED }
         })
       })
-      const wasteBalancesRepository = {
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi.fn().mockResolvedValue(null)
-      }
+      })
 
       await expect(
         updatePrnStatus({
@@ -1448,6 +1479,7 @@ describe('updatePrnStatus', () => {
           logger: mockLogger,
           id: '507f1f77bcf86cd799439011',
           organisationId: 'org-123',
+          registrationId: 'reg-123',
           accreditationId: 'acc-456',
           newStatus: PRN_STATUS.CANCELLED,
           actor: PRN_ACTOR.SIGNATORY,
@@ -1459,7 +1491,7 @@ describe('updatePrnStatus', () => {
 
   describe('deletion waste balance credit', () => {
     it('credits available waste balance when deleting from awaiting_authorisation', async () => {
-      const prnRepository = {
+      const prnRepository = createMockPrnRepository({
         findById: vi.fn().mockResolvedValue({
           id: '507f1f77bcf86cd799439011',
           organisation: { id: 'org-123' },
@@ -1473,20 +1505,22 @@ describe('updatePrnStatus', () => {
           id: '507f1f77bcf86cd799439011',
           status: { currentStatus: PRN_STATUS.DELETED }
         })
-      }
-      const wasteBalancesRepository = {
+      })
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi
           .fn()
           .mockResolvedValue({ accreditationId: 'acc-456' }),
         creditAvailableBalanceForPrnCancellation: vi.fn().mockResolvedValue({})
-      }
+      })
 
       await updatePrnStatus({
         prnRepository,
         wasteBalancesRepository,
+        organisationsRepository: defaultOrganisationsRepository,
         logger: mockLogger,
         id: '507f1f77bcf86cd799439011',
         organisationId: 'org-123',
+        registrationId: 'reg-123',
         accreditationId: 'acc-456',
         newStatus: PRN_STATUS.DELETED,
         actor: PRN_ACTOR.SIGNATORY,
@@ -1500,12 +1534,13 @@ describe('updatePrnStatus', () => {
         organisationId: 'org-123',
         prnId: '507f1f77bcf86cd799439011',
         tonnage: 75,
+        registrationId: 'reg-123',
         createdBy: { id: 'user-789', name: 'Test User' }
       })
     })
 
     it('throws error when deleting awaiting_authorisation PRN without waste balance', async () => {
-      const prnRepository = {
+      const prnRepository = createMockPrnRepository({
         findById: vi.fn().mockResolvedValue({
           id: '507f1f77bcf86cd799439011',
           organisation: { id: 'org-123' },
@@ -1521,18 +1556,20 @@ describe('updatePrnStatus', () => {
           status: { currentStatus: PRN_STATUS.DELETED }
         }),
         rollbackPendingCancellation: vi.fn().mockResolvedValue({})
-      }
-      const wasteBalancesRepository = {
+      })
+      const wasteBalancesRepository = createMockWasteBalancesRepository({
         findByAccreditationId: vi.fn().mockResolvedValue(null)
-      }
+      })
 
       await expect(
         updatePrnStatus({
           prnRepository,
           wasteBalancesRepository,
+          organisationsRepository: defaultOrganisationsRepository,
           logger: mockLogger,
           id: '507f1f77bcf86cd799439011',
           organisationId: 'org-123',
+          registrationId: 'reg-123',
           accreditationId: 'acc-456',
           newStatus: PRN_STATUS.DELETED,
           actor: PRN_ACTOR.SIGNATORY,

--- a/src/packaging-recycling-notes/application/update-status.test.js
+++ b/src/packaging-recycling-notes/application/update-status.test.js
@@ -253,7 +253,7 @@ describe('updatePrnStatus', () => {
       organisationId: 'org-123',
       prnId: '507f1f77bcf86cd799439011',
       tonnage: 100,
-      userId: 'user-789'
+      createdBy: { id: 'user-789', name: 'Test User' }
     })
   })
 
@@ -531,7 +531,7 @@ describe('updatePrnStatus', () => {
       organisationId: 'org-123',
       prnId: '507f1f77bcf86cd799439011',
       tonnage: 75,
-      userId: 'user-789'
+      createdBy: { id: 'user-789', name: 'Test User' }
     })
   })
 
@@ -1418,7 +1418,7 @@ describe('updatePrnStatus', () => {
         organisationId: 'org-123',
         prnId: '507f1f77bcf86cd799439011',
         tonnage: 60,
-        userId: 'user-789'
+        createdBy: { id: 'user-789', name: 'Test User' }
       })
     })
 
@@ -1500,7 +1500,7 @@ describe('updatePrnStatus', () => {
         organisationId: 'org-123',
         prnId: '507f1f77bcf86cd799439011',
         tonnage: 75,
-        userId: 'user-789'
+        createdBy: { id: 'user-789', name: 'Test User' }
       })
     })
 

--- a/src/packaging-recycling-notes/routes/external-transition-handler.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.js
@@ -16,7 +16,7 @@ import { getProjectedPrnByNumber } from '#packaging-recycling-notes/application/
 
 /**
  * @import { Request, Lifecycle } from '@hapi/hapi'
- * @import { HapiRequest } from '#common/hapi-types.js'
+ * @import { HapiRequest, MachineCredentials } from '#common/hapi-types.js'
  * @import { PrnStatus } from '#packaging-recycling-notes/domain/model.js'
  * @import { PackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/port.js'
  * @import { WasteBalancesRepository } from '#waste-balances/repository/port.js'
@@ -82,9 +82,10 @@ export function createExternalTransitionHandler({
           ? new Date(payload[timestampField])
           : new Date()
 
-        const user = /** @type {{ id: string; name: string }} */ (
+        const { id, name } = /** @type {MachineCredentials} */ (
           request.auth.credentials
         )
+        const user = { id, name }
 
         const updatedPrn = await updatePrnStatus({
           prnRepository: packagingRecyclingNotesRepository,

--- a/src/packaging-recycling-notes/routes/external-transition-handler.test.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.test.js
@@ -110,6 +110,7 @@ const buildBalance = (canonicalSource) => ({
 })
 
 let server
+let streamRepository
 
 /**
  * Starts a test server wired with real in-memory adapters: the PRN store, the
@@ -122,7 +123,7 @@ let server
  * @param {string} params.canonicalSource
  */
 const startServer = async ({ currentStatus, events, canonicalSource }) => {
-  const streamRepository = createInMemoryStreamRepository(events)()
+  streamRepository = createInMemoryStreamRepository(events)()
   server = await createTestServer({
     config: {
       packagingRecyclingNotesExternalApi: {
@@ -171,6 +172,29 @@ describe('external PRN transition read-side fold', () => {
     })
 
     expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+  })
+
+  it('attributes a live RPD accept to the RPD service with no email', async () => {
+    await startServer({
+      currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+      events: [],
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+    })
+
+    const response = await server.inject({
+      method: 'POST',
+      url: acceptUrl,
+      headers: authHeaders
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
+
+    const latest = await streamRepository.findLatestByPartition(REG_ID, ACC_ID)
+    expect(latest.kind).toBe(STREAM_EVENT_KIND.PRN_ACCEPTED)
+    expect(latest.createdBy).toEqual({
+      id: externalApiClientId,
+      name: 'RPD'
+    })
   })
 
   it('accepts an embedded PRN even when the stream shows it cancelled', async () => {

--- a/src/packaging-recycling-notes/routes/status.js
+++ b/src/packaging-recycling-notes/routes/status.js
@@ -105,9 +105,11 @@ export const packagingRecyclingNotesUpdateStatus = {
     } = request
     const { organisationId, registrationId, accreditationId, id } = params
     const { status: newStatus } = payload
+    const credentialEmail = auth.credentials?.email
     const user = {
       id: auth.credentials?.id ?? 'unknown',
-      name: auth.credentials?.name ?? 'unknown'
+      name: auth.credentials?.name ?? 'unknown',
+      ...(typeof credentialEmail === 'string' ? { email: credentialEmail } : {})
     }
 
     try {

--- a/src/packaging-recycling-notes/routes/status.test.js
+++ b/src/packaging-recycling-notes/routes/status.test.js
@@ -936,10 +936,16 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
       const response = await server.inject({
         method: 'POST',
         url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${prnId}/status`,
-        ...asStandardUser({
-          linkedOrgId: organisationId,
-          name: 'Ada Lovelace'
-        }),
+        auth: {
+          strategy: 'access-token',
+          credentials: {
+            scope: ['standard_user'],
+            id: 'test-user-id',
+            name: 'Ada Lovelace',
+            email: 'ada@example.com',
+            linkedOrgId: organisationId
+          }
+        },
         payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
       })
 
@@ -955,7 +961,7 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
         createdBy: {
           id: 'test-user-id',
           name: 'Ada Lovelace',
-          email: 'test@example.com'
+          email: 'ada@example.com'
         }
       })
     })

--- a/src/packaging-recycling-notes/routes/status.test.js
+++ b/src/packaging-recycling-notes/routes/status.test.js
@@ -936,7 +936,10 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
       const response = await server.inject({
         method: 'POST',
         url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${prnId}/status`,
-        ...asStandardUser({ linkedOrgId: organisationId }),
+        ...asStandardUser({
+          linkedOrgId: organisationId,
+          name: 'Ada Lovelace'
+        }),
         payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
       })
 
@@ -949,7 +952,11 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
         organisationId,
         prnId,
         tonnage: 50.5,
-        userId: expect.any(String)
+        createdBy: {
+          id: 'test-user-id',
+          name: 'Ada Lovelace',
+          email: 'test@example.com'
+        }
       })
     })
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.prn-transition-actor.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.prn-transition-actor.test.js
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict'
+
+import { ObjectId } from 'mongodb'
+import { http, HttpResponse } from 'msw'
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import {
+  SUMMARY_LOG_STATUS,
+  UPLOAD_STATUS
+} from '#domain/summary-logs/status.js'
+import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+
+import {
+  asStandardUser,
+  buildGetUrl,
+  buildPostUrl,
+  buildSubmitUrl,
+  createUploadPayload,
+  pollForValidation,
+  setupWasteBalanceIntegrationEnvironment,
+  createWasteBalanceMeta,
+  createExporterRowValues,
+  EXPORTER_HEADERS
+} from './integration-test-helpers.js'
+
+const LEDGER_ACCREDITATION_ID = 'ACC-123'
+const POLL_INTERVAL_MS = 50
+const MAX_POLL_ATTEMPTS = 20
+
+/**
+ * The human whose authenticated session drives the PRN transition. The route
+ * reads id, name and email from the request credentials; the test asserts all
+ * three reach the appended waste-balance stream event.
+ */
+const SIGNATORY = Object.freeze({
+  id: 'signatory-user-7',
+  name: 'Ada Lovelace',
+  email: 'ada.lovelace@example.com'
+})
+
+const sharedMeta = createWasteBalanceMeta('EXPORTER')
+
+const setupLedgerEnv = () => {
+  const organisationId = new ObjectId().toString()
+  const registrationId = new ObjectId().toString()
+  /** @type {import('#waste-balances/domain/model.js').WasteBalance[]} */
+  const existingWasteBalances = [
+    {
+      id: 'seeded-ledger-balance',
+      accreditationId: LEDGER_ACCREDITATION_ID,
+      registrationId,
+      organisationId,
+      schemaVersion: 1,
+      version: 0,
+      amount: 0,
+      availableAmount: 0,
+      transactions: [],
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+    }
+  ]
+  return setupWasteBalanceIntegrationEnvironment({
+    processingType: 'exporter',
+    organisationId,
+    registrationId,
+    featureFlagOverrides: { wasteBalanceLedger: true },
+    // @ts-expect-error -- existingWasteBalances defaults to never[]; WasteBalance[] is correct at runtime
+    existingWasteBalances
+  })
+}
+
+const submitCredit = async (env, tonnage) => {
+  const { server, fileDataMap, organisationId, registrationId } = env
+  const summaryLogId = 'log-actor'
+  const fileId = 'file-actor'
+
+  fileDataMap[fileId] = {
+    meta: sharedMeta,
+    data: {
+      RECEIVED_LOADS_FOR_EXPORT: {
+        location: { sheet: 'Received', row: 7, column: 'A' },
+        headers: EXPORTER_HEADERS,
+        rows: [
+          {
+            rowNumber: 8,
+            values: createExporterRowValues({
+              rowId: 1001,
+              exportTonnage: tonnage
+            })
+          }
+        ]
+      }
+    }
+  }
+
+  await server.inject({
+    method: 'POST',
+    url: buildPostUrl(organisationId, registrationId, summaryLogId),
+    payload: createUploadPayload(
+      organisationId,
+      registrationId,
+      UPLOAD_STATUS.COMPLETE,
+      fileId,
+      'waste-actor.xlsx'
+    )
+  })
+
+  await pollForValidation(server, organisationId, registrationId, summaryLogId)
+
+  await server.inject({
+    method: 'POST',
+    url: buildSubmitUrl(organisationId, registrationId, summaryLogId),
+    ...asStandardUser({ linkedOrgId: organisationId })
+  })
+
+  let attempts = 0
+  let status = SUMMARY_LOG_STATUS.SUBMITTING
+  while (
+    status === SUMMARY_LOG_STATUS.SUBMITTING &&
+    attempts < MAX_POLL_ATTEMPTS
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+
+    const checkResponse = await server.inject({
+      method: 'GET',
+      url: buildGetUrl(organisationId, registrationId, summaryLogId),
+      ...asStandardUser({ linkedOrgId: organisationId })
+    })
+
+    status = JSON.parse(checkResponse.payload).status
+    attempts++
+  }
+
+  assert.equal(status, SUMMARY_LOG_STATUS.SUBMITTED)
+}
+
+const createPrn = async (env, tonnage) => {
+  const { server, organisationId, registrationId, accreditationId } = env
+
+  const response = await server.inject({
+    method: 'POST',
+    url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes`,
+    ...asStandardUser({ linkedOrgId: organisationId }),
+    payload: {
+      issuedToOrganisation: {
+        id: 'producer-org-123',
+        name: 'Producer Org',
+        tradingName: 'Producer Trading'
+      },
+      tonnage
+    }
+  })
+
+  return JSON.parse(response.payload)
+}
+
+/**
+ * Raises a PRN through the status route as a named human, threading the
+ * signatory's full credentials so the route can carry id, name and email onto
+ * the stream event.
+ */
+const raiseAs = async (env, prnId, credentials) => {
+  const { server, organisationId, registrationId, accreditationId } = env
+
+  return server.inject({
+    method: 'POST',
+    url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${prnId}/status`,
+    ...asStandardUser({ linkedOrgId: organisationId, ...credentials }),
+    payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
+  })
+}
+
+describe('PRN transition actor on the waste-balance stream', () => {
+  const { getServer } = setupAuthContext()
+
+  beforeEach(() => {
+    getServer().use(
+      http.post(
+        'http://localhost:3001/v1/organisations/:orgId/registrations/:regId/summary-logs/:summaryLogId/upload-completed',
+        () => HttpResponse.json({ success: true }, { status: 200 })
+      )
+    )
+  })
+
+  it('carries the requesting human id, name and email onto the appended stream event', async () => {
+    const env = await setupLedgerEnv()
+    const { streamRepository, registrationId } = env
+
+    await submitCredit(env, 300)
+
+    const prn = await createPrn(env, 50)
+    const response = await raiseAs(env, prn.id, {
+      id: SIGNATORY.id,
+      name: SIGNATORY.name,
+      email: SIGNATORY.email
+    })
+    expect(response.statusCode).toBe(200)
+
+    const latest = await streamRepository.findLatestByPartition(
+      registrationId,
+      LEDGER_ACCREDITATION_ID
+    )
+    assert(latest)
+    expect(latest.kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+    expect(latest.payload).toEqual({ prnId: prn.id, amount: 50 })
+    expect(latest.createdBy).toEqual({
+      id: SIGNATORY.id,
+      name: SIGNATORY.name,
+      email: SIGNATORY.email
+    })
+  })
+})

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
@@ -520,7 +520,7 @@ describe('Waste balance arithmetic integration tests', () => {
         organisationId: env.organisationId,
         prnId: 'other-prn',
         tonnage: 80,
-        userId: 'test-user'
+        createdBy: { id: 'test-user' }
       })
 
       balance = await getWasteBalance(wasteBalancesRepository, accreditationId)
@@ -1059,7 +1059,7 @@ describe('Waste balance arithmetic integration tests', () => {
         organisationId,
         prnId: 'other-prn',
         tonnage: 80,
-        userId: 'test-user'
+        createdBy: { id: 'test-user' }
       })
 
       const result = await transitionPrnStatus(
@@ -1110,7 +1110,7 @@ describe('Waste balance arithmetic integration tests', () => {
         organisationId,
         prnId: 'other-prn',
         tonnage: 20,
-        userId: 'test-user'
+        createdBy: { id: 'test-user' }
       })
 
       await Promise.allSettled([

--- a/src/test/mock-logger.js
+++ b/src/test/mock-logger.js
@@ -1,0 +1,26 @@
+import { vi } from 'vitest'
+
+/** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
+
+/**
+ * Builds a fully-typed TypedLogger mock with every method as a vi.fn(). `child`
+ * returns the same mock so chained logging (and assertions on it) work. Use this
+ * instead of hand-rolling inline logger mocks so new TypedLogger methods only
+ * need adding in one place.
+ *
+ * @returns {TypedLogger}
+ */
+export const createMockLogger = () => {
+  /** @type {TypedLogger} */
+  const logger = {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(() => logger)
+  }
+
+  return logger
+}

--- a/src/test/mock-logger.test.js
+++ b/src/test/mock-logger.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { createMockLogger } from './mock-logger.js'
+
+describe('createMockLogger', () => {
+  it('provides every TypedLogger method as a mock function', () => {
+    const logger = createMockLogger()
+
+    const methods = [
+      'info',
+      'error',
+      'warn',
+      'debug',
+      'trace',
+      'fatal',
+      'child'
+    ]
+
+    expect(methods.every((m) => vi.isMockFunction(logger[m]))).toBe(true)
+  })
+
+  it('returns a usable logger from child so chained logging works', () => {
+    const logger = createMockLogger()
+
+    const child = logger.child({ requestId: 'abc' })
+
+    expect(vi.isMockFunction(child.info)).toBe(true)
+  })
+
+  it('returns a fresh set of mocks on each call', () => {
+    const first = createMockLogger()
+    const second = createMockLogger()
+
+    expect(first.info).not.toBe(second.info)
+  })
+})

--- a/src/test/mock-repositories.js
+++ b/src/test/mock-repositories.js
@@ -1,0 +1,174 @@
+import { vi } from 'vitest'
+
+/** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
+/** @import {SummaryLogsRepository} from '#repositories/summary-logs/port.js' */
+/** @import {WasteRecordsRepository} from '#repositories/waste-records/port.js' */
+/** @import {SystemLogsRepository} from '#repositories/system-logs/port.js' */
+/** @import {FormSubmissionsRepository} from '#repositories/form-submissions/port.js' */
+/** @import {PackagingRecyclingNotesRepository} from '#packaging-recycling-notes/repository/port.js' */
+/** @import {WasteBalancesRepository} from '#waste-balances/repository/port.js' */
+/** @import {OverseasSitesRepository} from '#overseas-sites/repository/port.js' */
+
+/**
+ * Builds a fully-typed OrganisationsRepository mock with every method as a
+ * vi.fn(). Pass `overrides` to stub specific methods for a test. Use this
+ * instead of hand-rolling partial inline mocks so new port methods only need
+ * adding in one place.
+ *
+ * @param {Partial<OrganisationsRepository>} [overrides]
+ * @returns {OrganisationsRepository}
+ */
+export const createMockOrganisationsRepository = (overrides = {}) => ({
+  insert: vi.fn(),
+  replace: vi.fn(),
+  replaceRaw: vi.fn(),
+  findAll: vi.fn(),
+  findAllBySchemaVersion: vi.fn(),
+  findPage: vi.fn(),
+  findAllForOverseasSitesAdminList: vi.fn(),
+  findPageForOverseasSitesAdminList: vi.fn(),
+  findByIds: vi.fn(),
+  findById: vi.fn(),
+  findByLinkedDefraOrgId: vi.fn(),
+  findAllLinked: vi.fn(),
+  findAllLinkableForUser: vi.fn(),
+  findRegistrationById: vi.fn(),
+  findAccreditationById: vi.fn(),
+  findAllIds: vi.fn(),
+  findByOrgId: vi.fn(),
+  replaceRegistrationOverseasSites: vi.fn(),
+  ...overrides
+})
+
+/**
+ * Builds a fully-typed SummaryLogsRepository mock with every method as a
+ * vi.fn(). Pass `overrides` to stub specific methods for a test.
+ *
+ * @param {Partial<SummaryLogsRepository>} [overrides]
+ * @returns {SummaryLogsRepository}
+ */
+export const createMockSummaryLogsRepository = (overrides = {}) => ({
+  insert: vi.fn(),
+  update: vi.fn(),
+  findById: vi.fn(),
+  findLatestSubmittedForOrgReg: vi.fn(),
+  findAllByOrgReg: vi.fn(),
+  findAllSummaryLogStatsByRegistrationId: vi.fn(),
+  transitionToSubmittingExclusive: vi.fn(),
+  getDownloadUrl: vi.fn(),
+  ...overrides
+})
+
+/**
+ * Builds a fully-typed WasteRecordsRepository mock with every method as a
+ * vi.fn(). Pass `overrides` to stub specific methods for a test.
+ *
+ * @param {Partial<WasteRecordsRepository>} [overrides]
+ * @returns {WasteRecordsRepository}
+ */
+export const createMockWasteRecordsRepository = (overrides = {}) => ({
+  findByRegistration: vi.fn(),
+  appendVersions: vi.fn(),
+  findDistinctDataKeys: vi.fn(),
+  ...overrides
+})
+
+/**
+ * Builds a fully-typed SystemLogsRepository mock with every method as a
+ * vi.fn(). Pass `overrides` to stub specific methods for a test.
+ *
+ * @param {Partial<SystemLogsRepository>} [overrides]
+ * @returns {SystemLogsRepository}
+ */
+export const createMockSystemLogsRepository = (overrides = {}) => ({
+  insert: vi.fn(),
+  find: vi.fn(),
+  findSummaryLogSubmitActors: vi.fn(),
+  ...overrides
+})
+
+/**
+ * Builds a fully-typed FormSubmissionsRepository mock with every method as a
+ * vi.fn(). Pass `overrides` to stub specific methods for a test.
+ *
+ * @param {Partial<FormSubmissionsRepository>} [overrides]
+ * @returns {FormSubmissionsRepository}
+ */
+export const createMockFormSubmissionsRepository = (overrides = {}) => ({
+  findAllAccreditations: vi.fn(),
+  findAccreditationById: vi.fn(),
+  findAccreditationsBySystemReference: vi.fn(),
+  findAccreditationsCreatedAfter: vi.fn(),
+  findAllRegistrations: vi.fn(),
+  findRegistrationById: vi.fn(),
+  findRegistrationsBySystemReference: vi.fn(),
+  findRegistrationsCreatedAfter: vi.fn(),
+  findAllOrganisations: vi.fn(),
+  findOrganisationById: vi.fn(),
+  findAllFormSubmissionIds: vi.fn(),
+  ...overrides
+})
+
+/**
+ * Builds a fully-typed PackagingRecyclingNotesRepository mock with every
+ * method as a vi.fn(). Pass `overrides` to stub specific methods for a test.
+ *
+ * @param {Partial<PackagingRecyclingNotesRepository>} [overrides]
+ * @returns {PackagingRecyclingNotesRepository}
+ */
+export const createMockPackagingRecyclingNotesRepository = (
+  overrides = {}
+) => ({
+  findById: vi.fn(),
+  findByPrnNumber: vi.fn(),
+  create: vi.fn(),
+  findByAccreditation: vi.fn(),
+  findByStatus: vi.fn(),
+  updateStatus: vi.fn(),
+  persistProjection: vi.fn(),
+  rollbackIssuance: vi.fn(),
+  rollbackPendingCancellation: vi.fn(),
+  rollbackIssuedCancellation: vi.fn(),
+  ...overrides
+})
+
+/**
+ * Builds a fully-typed WasteBalancesRepository mock with every method as a
+ * vi.fn(). Pass `overrides` to stub specific methods for a test.
+ *
+ * @param {Partial<WasteBalancesRepository>} [overrides]
+ * @returns {WasteBalancesRepository}
+ */
+export const createMockWasteBalancesRepository = (overrides = {}) => ({
+  findByAccreditationId: vi.fn(),
+  findByAccreditationIds: vi.fn(),
+  updateWasteBalanceTransactions: vi.fn(),
+  deductAvailableBalanceForPrnCreation: vi.fn(),
+  deductTotalBalanceForPrnIssue: vi.fn(),
+  creditAvailableBalanceForPrnCancellation: vi.fn(),
+  creditFullBalanceForIssuedPrnCancellation: vi.fn(),
+  appendStreamEvent: vi.fn(),
+  flipCanonicalSourceToMigrating: vi.fn(),
+  flipCanonicalSourceToLedger: vi.fn(),
+  resetCanonicalSourceToEmbedded: vi.fn(),
+  getPrnCatchupEvents: vi.fn(),
+  ...overrides
+})
+
+/**
+ * Builds a fully-typed OverseasSitesRepository mock with every method as a
+ * vi.fn(). Pass `overrides` to stub specific methods for a test.
+ *
+ * @param {Partial<OverseasSitesRepository>} [overrides]
+ * @returns {OverseasSitesRepository}
+ */
+export const createMockOverseasSitesRepository = (overrides = {}) => ({
+  findById: vi.fn(),
+  findByProperties: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
+  findAll: vi.fn(),
+  findByIds: vi.fn(),
+  ...overrides
+})

--- a/src/test/mock-repositories.test.js
+++ b/src/test/mock-repositories.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  createMockOrganisationsRepository,
+  createMockSummaryLogsRepository,
+  createMockWasteRecordsRepository,
+  createMockSystemLogsRepository,
+  createMockFormSubmissionsRepository,
+  createMockPackagingRecyclingNotesRepository,
+  createMockWasteBalancesRepository,
+  createMockOverseasSitesRepository
+} from '#test/mock-repositories.js'
+
+describe('mock-repositories', () => {
+  const builders = {
+    createMockOrganisationsRepository: {
+      build: createMockOrganisationsRepository,
+      methods: [
+        'insert',
+        'replace',
+        'replaceRaw',
+        'findAll',
+        'findAllBySchemaVersion',
+        'findPage',
+        'findAllForOverseasSitesAdminList',
+        'findPageForOverseasSitesAdminList',
+        'findByIds',
+        'findById',
+        'findByLinkedDefraOrgId',
+        'findAllLinked',
+        'findAllLinkableForUser',
+        'findRegistrationById',
+        'findAccreditationById',
+        'findAllIds',
+        'findByOrgId',
+        'replaceRegistrationOverseasSites'
+      ]
+    },
+    createMockSummaryLogsRepository: {
+      build: createMockSummaryLogsRepository,
+      methods: [
+        'insert',
+        'update',
+        'findById',
+        'findLatestSubmittedForOrgReg',
+        'findAllByOrgReg',
+        'findAllSummaryLogStatsByRegistrationId',
+        'transitionToSubmittingExclusive',
+        'getDownloadUrl'
+      ]
+    },
+    createMockWasteRecordsRepository: {
+      build: createMockWasteRecordsRepository,
+      methods: ['findByRegistration', 'appendVersions', 'findDistinctDataKeys']
+    },
+    createMockSystemLogsRepository: {
+      build: createMockSystemLogsRepository,
+      methods: ['insert', 'find', 'findSummaryLogSubmitActors']
+    },
+    createMockFormSubmissionsRepository: {
+      build: createMockFormSubmissionsRepository,
+      methods: [
+        'findAllAccreditations',
+        'findAccreditationById',
+        'findAccreditationsBySystemReference',
+        'findAccreditationsCreatedAfter',
+        'findAllRegistrations',
+        'findRegistrationById',
+        'findRegistrationsBySystemReference',
+        'findRegistrationsCreatedAfter',
+        'findAllOrganisations',
+        'findOrganisationById',
+        'findAllFormSubmissionIds'
+      ]
+    },
+    createMockPackagingRecyclingNotesRepository: {
+      build: createMockPackagingRecyclingNotesRepository,
+      methods: [
+        'findById',
+        'findByPrnNumber',
+        'create',
+        'findByAccreditation',
+        'findByStatus',
+        'updateStatus',
+        'persistProjection',
+        'rollbackIssuance',
+        'rollbackPendingCancellation',
+        'rollbackIssuedCancellation'
+      ]
+    },
+    createMockWasteBalancesRepository: {
+      build: createMockWasteBalancesRepository,
+      methods: [
+        'findByAccreditationId',
+        'findByAccreditationIds',
+        'updateWasteBalanceTransactions',
+        'deductAvailableBalanceForPrnCreation',
+        'deductTotalBalanceForPrnIssue',
+        'creditAvailableBalanceForPrnCancellation',
+        'creditFullBalanceForIssuedPrnCancellation',
+        'appendStreamEvent',
+        'flipCanonicalSourceToMigrating',
+        'flipCanonicalSourceToLedger',
+        'resetCanonicalSourceToEmbedded',
+        'getPrnCatchupEvents'
+      ]
+    },
+    createMockOverseasSitesRepository: {
+      build: createMockOverseasSitesRepository,
+      methods: [
+        'findById',
+        'findByProperties',
+        'create',
+        'update',
+        'remove',
+        'findAll',
+        'findByIds'
+      ]
+    }
+  }
+
+  describe.each(Object.entries(builders))('%s', (_name, { build, methods }) => {
+    it('should expose every port method as a vi mock', () => {
+      const repository = build()
+
+      expect(Object.keys(repository).sort()).toEqual([...methods].sort())
+      for (const method of methods) {
+        expect(vi.isMockFunction(repository[method])).toBe(true)
+      }
+    })
+
+    it('should apply overrides over the default mocks', () => {
+      const stub = vi.fn()
+      const [firstMethod] = methods
+
+      const repository = build({ [firstMethod]: stub })
+
+      expect(repository[firstMethod]).toBe(stub)
+    })
+  })
+})

--- a/src/waste-balances/repository/contract/appendStreamEvent.contract.js
+++ b/src/waste-balances/repository/contract/appendStreamEvent.contract.js
@@ -24,13 +24,19 @@ export const testAppendStreamEventBehaviour = (it) => {
 
       await insertWasteBalance(wasteBalance)
 
+      const createdBy = {
+        id: 'user-abc',
+        name: 'Ada Lovelace',
+        email: 'ada@example.com'
+      }
+
       const appended = await repository.appendStreamEvent({
         accreditationId: 'acc-append-1',
         registrationId: 'reg-1',
         organisationId: 'org-1',
         prnId: 'prn-1',
         tonnage: 10,
-        createdBy: { id: 'user-abc' },
+        createdBy,
         streamKind: STREAM_EVENT_KIND.PRN_ACCEPTED
       })
 
@@ -41,6 +47,8 @@ export const testAppendStreamEventBehaviour = (it) => {
       expect(appended.number).toBe(latest.number)
       expect(appended.kind).toBe(STREAM_EVENT_KIND.PRN_ACCEPTED)
       expect(appended.payload).toEqual({ prnId: 'prn-1', amount: 10 })
+      expect(appended.createdBy).toEqual(createdBy)
+      expect(latest.createdBy).toEqual(createdBy)
     })
 
     it('throws on the embedded path', async ({ insertWasteBalance }) => {

--- a/src/waste-balances/repository/contract/appendStreamEvent.contract.js
+++ b/src/waste-balances/repository/contract/appendStreamEvent.contract.js
@@ -30,7 +30,7 @@ export const testAppendStreamEventBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-1',
         tonnage: 10,
-        userId: 'user-abc',
+        createdBy: { id: 'user-abc' },
         streamKind: STREAM_EVENT_KIND.PRN_ACCEPTED
       })
 
@@ -58,7 +58,7 @@ export const testAppendStreamEventBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-2',
           tonnage: 10,
-          userId: 'user-abc',
+          createdBy: { id: 'user-abc' },
           streamKind: STREAM_EVENT_KIND.PRN_REJECTED
         })
       ).rejects.toThrow(/ledger-only/)
@@ -72,7 +72,7 @@ export const testAppendStreamEventBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-3',
           tonnage: 10,
-          userId: 'user-abc',
+          createdBy: { id: 'user-abc' },
           streamKind: STREAM_EVENT_KIND.PRN_ACCEPTED
         })
       ).rejects.toThrow(/ledger-only/)

--- a/src/waste-balances/repository/contract/appendStreamEvent.contract.js
+++ b/src/waste-balances/repository/contract/appendStreamEvent.contract.js
@@ -3,13 +3,22 @@ import { buildWasteBalance } from './test-data.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { STREAM_EVENT_KIND } from '../stream-schema.js'
 
+/**
+ * @typedef {object} WasteBalanceContractContext
+ * @property {import('../port.js').WasteBalancesRepositoryFactory} wasteBalancesRepository
+ */
+
 export const testAppendStreamEventBehaviour = (it) => {
   describe('appendStreamEvent', () => {
     let repository
 
-    beforeEach(async ({ wasteBalancesRepository }) => {
-      repository = await wasteBalancesRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {WasteBalanceContractContext} */ { wasteBalancesRepository }
+      ) => {
+        repository = await wasteBalancesRepository()
+      }
+    )
 
     it('appends a status-only stream event on the ledger path', async ({
       insertWasteBalance,

--- a/src/waste-balances/repository/contract/creditAvailableBalanceForPrnCancellation.contract.js
+++ b/src/waste-balances/repository/contract/creditAvailableBalanceForPrnCancellation.contract.js
@@ -31,7 +31,7 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-123',
         tonnage: 50,
-        userId: 'user-abc'
+        createdBy: { id: 'user-abc' }
       })
 
       const result = await repository.findByAccreditationId('acc-cancel-1')
@@ -58,7 +58,7 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-456',
         tonnage: 25.5,
-        userId: 'user-xyz'
+        createdBy: { id: 'user-xyz' }
       })
 
       const result = await repository.findByAccreditationId('acc-cancel-2')
@@ -78,7 +78,7 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-789',
           tonnage: 10,
-          userId: 'user-123'
+          createdBy: { id: 'user-123' }
         })
       ).rejects.toThrow(Boom.Boom)
     })
@@ -103,7 +103,7 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-ledger',
           tonnage: 10,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         })
 
       const latest = await streamRepository.findLatestByPartition(
@@ -130,7 +130,7 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-embedded',
           tonnage: 10,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         })
 
       expect(watermark).toBeNull()
@@ -150,7 +150,7 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-999',
         tonnage: 10,
-        userId: 'user-456'
+        createdBy: { id: 'user-456' }
       })
 
       const result = await repository.findByAccreditationId('acc-cancel-3')

--- a/src/waste-balances/repository/contract/creditAvailableBalanceForPrnCancellation.contract.js
+++ b/src/waste-balances/repository/contract/creditAvailableBalanceForPrnCancellation.contract.js
@@ -6,13 +6,22 @@ import {
   WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
 } from '../../domain/model.js'
 
+/**
+ * @typedef {object} WasteBalanceContractContext
+ * @property {import('../port.js').WasteBalancesRepositoryFactory} wasteBalancesRepository
+ */
+
 export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
   describe('creditAvailableBalanceForPrnCancellation', () => {
     let repository
 
-    beforeEach(async ({ wasteBalancesRepository }) => {
-      repository = await wasteBalancesRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {WasteBalanceContractContext} */ { wasteBalancesRepository }
+      ) => {
+        repository = await wasteBalancesRepository()
+      }
+    )
 
     it('credits tonnage back to available balance only', async ({
       insertWasteBalance

--- a/src/waste-balances/repository/contract/creditFullBalanceForIssuedPrnCancellation.contract.js
+++ b/src/waste-balances/repository/contract/creditFullBalanceForIssuedPrnCancellation.contract.js
@@ -31,7 +31,7 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-123',
         tonnage: 60,
-        userId: 'user-abc'
+        createdBy: { id: 'user-abc' }
       })
 
       const result = await repository.findByAccreditationId('acc-full-cancel-1')
@@ -58,7 +58,7 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-456',
         tonnage: 25.5,
-        userId: 'user-xyz'
+        createdBy: { id: 'user-xyz' }
       })
 
       const result = await repository.findByAccreditationId('acc-full-cancel-2')
@@ -78,7 +78,7 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-789',
           tonnage: 10,
-          userId: 'user-123'
+          createdBy: { id: 'user-123' }
         })
       ).rejects.toThrow(Boom.Boom)
     })
@@ -103,7 +103,7 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-ledger',
           tonnage: 10,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         })
 
       const latest = await streamRepository.findLatestByPartition(
@@ -130,7 +130,7 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-embedded',
           tonnage: 10,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         })
 
       expect(watermark).toBeNull()
@@ -150,7 +150,7 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-999',
         tonnage: 10,
-        userId: 'user-456'
+        createdBy: { id: 'user-456' }
       })
 
       const result = await repository.findByAccreditationId('acc-full-cancel-3')

--- a/src/waste-balances/repository/contract/creditFullBalanceForIssuedPrnCancellation.contract.js
+++ b/src/waste-balances/repository/contract/creditFullBalanceForIssuedPrnCancellation.contract.js
@@ -6,13 +6,22 @@ import {
   WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
 } from '../../domain/model.js'
 
+/**
+ * @typedef {object} WasteBalanceContractContext
+ * @property {import('../port.js').WasteBalancesRepositoryFactory} wasteBalancesRepository
+ */
+
 export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
   describe('creditFullBalanceForIssuedPrnCancellation', () => {
     let repository
 
-    beforeEach(async ({ wasteBalancesRepository }) => {
-      repository = await wasteBalancesRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {WasteBalanceContractContext} */ { wasteBalancesRepository }
+      ) => {
+        repository = await wasteBalancesRepository()
+      }
+    )
 
     it('credits tonnage back to both amount and available balance', async ({
       insertWasteBalance

--- a/src/waste-balances/repository/contract/deductAvailableBalanceForPrnCreation.contract.js
+++ b/src/waste-balances/repository/contract/deductAvailableBalanceForPrnCreation.contract.js
@@ -30,7 +30,7 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-123',
         tonnage: 50,
-        userId: 'user-abc'
+        createdBy: { id: 'user-abc' }
       })
 
       const result = await repository.findByAccreditationId('acc-prn-1')
@@ -57,7 +57,7 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-456',
         tonnage: 25.5,
-        userId: 'user-xyz'
+        createdBy: { id: 'user-xyz' }
       })
 
       const result = await repository.findByAccreditationId('acc-prn-2')
@@ -76,7 +76,7 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-789',
         tonnage: 10,
-        userId: 'user-123'
+        createdBy: { id: 'user-123' }
       })
 
       const result = await repository.findByAccreditationId('acc-nonexistent')
@@ -103,7 +103,7 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-ledger',
         tonnage: 10,
-        userId: 'user-abc'
+        createdBy: { id: 'user-abc' }
       })
 
       const latest = await streamRepository.findLatestByPartition(
@@ -129,7 +129,7 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-embedded',
         tonnage: 10,
-        userId: 'user-abc'
+        createdBy: { id: 'user-abc' }
       })
 
       expect(watermark).toBeNull()
@@ -149,7 +149,7 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-999',
         tonnage: 10,
-        userId: 'user-456'
+        createdBy: { id: 'user-456' }
       })
 
       const result = await repository.findByAccreditationId('acc-prn-3')

--- a/src/waste-balances/repository/contract/deductAvailableBalanceForPrnCreation.contract.js
+++ b/src/waste-balances/repository/contract/deductAvailableBalanceForPrnCreation.contract.js
@@ -5,13 +5,22 @@ import {
   WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
 } from '../../domain/model.js'
 
+/**
+ * @typedef {object} WasteBalanceContractContext
+ * @property {import('../port.js').WasteBalancesRepositoryFactory} wasteBalancesRepository
+ */
+
 export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
   describe('deductAvailableBalanceForPrnCreation', () => {
     let repository
 
-    beforeEach(async ({ wasteBalancesRepository }) => {
-      repository = await wasteBalancesRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {WasteBalanceContractContext} */ { wasteBalancesRepository }
+      ) => {
+        repository = await wasteBalancesRepository()
+      }
+    )
 
     it('deducts tonnage from available balance only', async ({
       insertWasteBalance

--- a/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
+++ b/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
@@ -6,13 +6,22 @@ import {
   WASTE_BALANCE_TRANSACTION_ENTITY_TYPE
 } from '../../domain/model.js'
 
+/**
+ * @typedef {object} WasteBalanceContractContext
+ * @property {import('../port.js').WasteBalancesRepositoryFactory} wasteBalancesRepository
+ */
+
 export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
   describe('deductTotalBalanceForPrnIssue', () => {
     let repository
 
-    beforeEach(async ({ wasteBalancesRepository }) => {
-      repository = await wasteBalancesRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {WasteBalanceContractContext} */ { wasteBalancesRepository }
+      ) => {
+        repository = await wasteBalancesRepository()
+      }
+    )
 
     it('deducts tonnage from total balance only', async ({
       insertWasteBalance

--- a/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
+++ b/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
@@ -33,7 +33,7 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-123',
         tonnage: 50,
-        userId: 'user-abc'
+        createdBy: { id: 'user-abc' }
       })
 
       const result = await repository.findByAccreditationId('acc-issue-1')
@@ -60,7 +60,7 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-456',
         tonnage: 25.5,
-        userId: 'user-xyz'
+        createdBy: { id: 'user-xyz' }
       })
 
       const result = await repository.findByAccreditationId('acc-issue-2')
@@ -91,7 +91,7 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-789',
         tonnage: 30,
-        userId: 'user-123'
+        createdBy: { id: 'user-123' }
       })
 
       const result = await repository.findByAccreditationId('acc-issue-3')
@@ -109,7 +109,7 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-999',
         tonnage: 10,
-        userId: 'user-456'
+        createdBy: { id: 'user-456' }
       })
 
       const result = await repository.findByAccreditationId('acc-nonexistent')
@@ -136,7 +136,7 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-ledger',
         tonnage: 10,
-        userId: 'user-abc'
+        createdBy: { id: 'user-abc' }
       })
 
       const latest = await streamRepository.findLatestByPartition(
@@ -162,7 +162,7 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-embedded',
         tonnage: 10,
-        userId: 'user-abc'
+        createdBy: { id: 'user-abc' }
       })
 
       expect(watermark).toBeNull()
@@ -195,7 +195,7 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-marker',
         tonnage: 1,
-        userId: 'user-1'
+        createdBy: { id: 'user-1' }
       })
 
       const result = await repository.findByAccreditationId('acc-issue-marker')
@@ -216,7 +216,7 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-111',
         tonnage: 10,
-        userId: 'user-789'
+        createdBy: { id: 'user-789' }
       })
 
       const result = await repository.findByAccreditationId('acc-issue-4')

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
@@ -200,7 +200,7 @@ export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-during-rebuild',
         tonnage: 5,
-        userId: 'user-1'
+        createdBy: { id: 'user-1' }
       })
 
       const result = await repository.flipCanonicalSourceToLedger({

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToLedger.contract.js
@@ -4,13 +4,22 @@ import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { buildWasteBalance } from './test-data.js'
 import { buildStreamEvent } from '../stream-test-data.js'
 
+/**
+ * @typedef {object} WasteBalanceContractContext
+ * @property {import('../port.js').WasteBalancesRepositoryFactory} wasteBalancesRepository
+ */
+
 export const testFlipCanonicalSourceToLedgerBehaviour = (it) => {
   describe('flipCanonicalSourceToLedger', () => {
     let repository
 
-    beforeEach(async ({ wasteBalancesRepository }) => {
-      repository = await wasteBalancesRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {WasteBalanceContractContext} */ { wasteBalancesRepository }
+      ) => {
+        repository = await wasteBalancesRepository()
+      }
+    )
 
     it('flips the marker from migrating to ledger when the captured version matches and clears migratingSince', async ({
       insertWasteBalance,

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToMigrating.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToMigrating.contract.js
@@ -170,7 +170,7 @@ export const testFlipCanonicalSourceToMigratingBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-during-rebuild',
         tonnage: 5,
-        userId: 'user-1'
+        createdBy: { id: 'user-1' }
       })
 
       const result = await repository.flipCanonicalSourceToMigrating({

--- a/src/waste-balances/repository/contract/flipCanonicalSourceToMigrating.contract.js
+++ b/src/waste-balances/repository/contract/flipCanonicalSourceToMigrating.contract.js
@@ -4,13 +4,22 @@ import { WASTE_BALANCE_CANONICAL_SOURCE } from '../../domain/model.js'
 import { buildWasteBalance } from './test-data.js'
 import { buildStreamEvent } from '../stream-test-data.js'
 
+/**
+ * @typedef {object} WasteBalanceContractContext
+ * @property {import('../port.js').WasteBalancesRepositoryFactory} wasteBalancesRepository
+ */
+
 export const testFlipCanonicalSourceToMigratingBehaviour = (it) => {
   describe('flipCanonicalSourceToMigrating', () => {
     let repository
 
-    beforeEach(async ({ wasteBalancesRepository }) => {
-      repository = await wasteBalancesRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {WasteBalanceContractContext} */ { wasteBalancesRepository }
+      ) => {
+        repository = await wasteBalancesRepository()
+      }
+    )
 
     it('flips the marker from embedded to migrating when the captured version matches and stamps migratingSince', async ({
       insertWasteBalance

--- a/src/waste-balances/repository/helpers-prn.js
+++ b/src/waste-balances/repository/helpers-prn.js
@@ -59,7 +59,7 @@ export const buildPrnCreationTransaction = ({
  * @param {string} params.organisationId
  * @param {string} params.prnId
  * @param {number} params.tonnage
- * @param {string} params.userId
+ * @param {import('./stream-schema.js').StreamUserSummary} params.createdBy
  * @param {import('./stream-schema.js').StreamEventKind} params.streamKind
  * @returns {Promise<import('./stream-port.js').StreamEvent>} The appended event.
  */
@@ -70,7 +70,7 @@ const appendPrnStreamEvent = async ({
   organisationId,
   prnId,
   tonnage,
-  userId,
+  createdBy,
   streamKind
 }) =>
   appendToStream(
@@ -83,7 +83,7 @@ const appendPrnStreamEvent = async ({
     {
       kind: streamKind,
       payload: { prnId, amount: tonnage },
-      createdBy: { id: userId, name: userId }
+      createdBy
     }
   )
 
@@ -101,7 +101,7 @@ const appendPrnStreamEvent = async ({
  * @param {string} params.appendParams.organisationId
  * @param {string} params.appendParams.prnId
  * @param {number} params.appendParams.tonnage
- * @param {string} params.appendParams.userId
+ * @param {import('./stream-schema.js').StreamUserSummary} params.appendParams.createdBy
  * @param {import('./stream-schema.js').StreamEventKind} params.appendParams.streamKind
  * @param {(accreditationId: string) => Promise<import('../domain/model.js').WasteBalance | null>} params.findBalance
  * @param {Object} [params.dependencies]
@@ -119,7 +119,7 @@ export const performAppendPrnStreamEvent = async ({
     organisationId,
     prnId,
     tonnage,
-    userId,
+    createdBy,
     streamKind
   } = appendParams
   const validatedAccreditationId = validateAccreditationId(accreditationId)
@@ -142,7 +142,7 @@ export const performAppendPrnStreamEvent = async ({
     organisationId,
     prnId,
     tonnage,
-    userId,
+    createdBy,
     streamKind
   })
 }
@@ -172,7 +172,7 @@ export const performDeductAvailableBalanceForPrnCreation = async ({
     organisationId,
     prnId,
     tonnage,
-    userId
+    createdBy
   } = deductParams
   const validatedAccreditationId = validateAccreditationId(accreditationId)
 
@@ -193,7 +193,7 @@ export const performDeductAvailableBalanceForPrnCreation = async ({
       organisationId,
       prnId,
       tonnage,
-      userId,
+      createdBy,
       streamKind: STREAM_EVENT_KIND.PRN_CREATED
     })
   }
@@ -201,7 +201,7 @@ export const performDeductAvailableBalanceForPrnCreation = async ({
   const transaction = buildPrnCreationTransaction({
     prnId,
     tonnage,
-    userId,
+    userId: createdBy.id,
     currentBalance: wasteBalance
   })
 
@@ -278,7 +278,7 @@ export const performDeductTotalBalanceForPrnIssue = async ({
     organisationId,
     prnId,
     tonnage,
-    userId
+    createdBy
   } = deductParams
   const validatedAccreditationId = validateAccreditationId(accreditationId)
 
@@ -299,7 +299,7 @@ export const performDeductTotalBalanceForPrnIssue = async ({
       organisationId,
       prnId,
       tonnage,
-      userId,
+      createdBy,
       streamKind: STREAM_EVENT_KIND.PRN_ISSUED
     })
   }
@@ -307,7 +307,7 @@ export const performDeductTotalBalanceForPrnIssue = async ({
   const transaction = buildPrnIssuedTransaction({
     prnId,
     tonnage,
-    userId,
+    userId: createdBy.id,
     currentBalance: wasteBalance
   })
 
@@ -426,7 +426,7 @@ export const performCreditFullBalanceForIssuedPrnCancellation = async ({
     organisationId,
     prnId,
     tonnage,
-    userId
+    createdBy
   } = creditParams
   const validatedAccreditationId = validateAccreditationId(accreditationId)
 
@@ -449,7 +449,7 @@ export const performCreditFullBalanceForIssuedPrnCancellation = async ({
       organisationId,
       prnId,
       tonnage,
-      userId,
+      createdBy,
       streamKind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE
     })
   }
@@ -457,7 +457,7 @@ export const performCreditFullBalanceForIssuedPrnCancellation = async ({
   const transaction = buildIssuedPrnCancellationTransaction({
     prnId,
     tonnage,
-    userId,
+    userId: createdBy.id,
     currentBalance: wasteBalance
   })
 
@@ -499,7 +499,7 @@ export const performCreditAvailableBalanceForPrnCancellation = async ({
     organisationId,
     prnId,
     tonnage,
-    userId
+    createdBy
   } = creditParams
   const validatedAccreditationId = validateAccreditationId(accreditationId)
 
@@ -522,7 +522,7 @@ export const performCreditAvailableBalanceForPrnCancellation = async ({
       organisationId,
       prnId,
       tonnage,
-      userId,
+      createdBy,
       streamKind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED
     })
   }
@@ -530,7 +530,7 @@ export const performCreditAvailableBalanceForPrnCancellation = async ({
   const transaction = buildPrnCancellationTransaction({
     prnId,
     tonnage,
-    userId,
+    userId: createdBy.id,
     currentBalance: wasteBalance
   })
 

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -1296,6 +1296,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           findLatestByPartition: vi.fn(),
           findLatestByPartitionAndKind: vi.fn(),
           findEventsByPrnIdAfter: vi.fn(),
+          findAllByPartition: vi.fn(),
           deleteByPartition: vi.fn(),
           bulkAppendEvents: vi.fn()
         })
@@ -1543,6 +1544,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           findLatestByPartition: vi.fn(),
           findLatestByPartitionAndKind: vi.fn(),
           findEventsByPrnIdAfter: vi.fn(),
+          findAllByPartition: vi.fn(),
           deleteByPartition: vi.fn(),
           bulkAppendEvents: vi.fn()
         })
@@ -1779,6 +1781,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           findLatestByPartition: vi.fn(),
           findLatestByPartitionAndKind: vi.fn(),
           findEventsByPrnIdAfter: vi.fn(),
+          findAllByPartition: vi.fn(),
           deleteByPartition: vi.fn(),
           bulkAppendEvents: vi.fn()
         })
@@ -1972,6 +1975,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           findLatestByPartition: vi.fn(),
           findLatestByPartitionAndKind: vi.fn(),
           findEventsByPrnIdAfter: vi.fn(),
+          findAllByPartition: vi.fn(),
           deleteByPartition: vi.fn(),
           bulkAppendEvents: vi.fn()
         })

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -1154,7 +1154,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-123',
           tonnage: 50.5,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         },
         findBalance,
         saveBalance
@@ -1187,7 +1187,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-123',
           tonnage: 50.5,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         },
         findBalance,
         saveBalance
@@ -1224,7 +1224,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-456',
           tonnage: 25,
-          userId: 'user-xyz'
+          createdBy: { id: 'user-xyz' }
         },
         findBalance,
         saveBalance
@@ -1262,7 +1262,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-789',
           tonnage: 10,
-          userId: 'user-123'
+          createdBy: { id: 'user-123' }
         },
         findBalance,
         saveBalance
@@ -1310,7 +1310,11 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-123',
           tonnage: 50,
-          userId: 'user-abc'
+          createdBy: {
+            id: 'user-abc',
+            name: 'Ada Lovelace',
+            email: 'ada@example.com'
+          }
         },
         findBalance,
         saveBalance,
@@ -1318,6 +1322,16 @@ describe('src/waste-balances/repository/helpers.js', () => {
       })
 
       expect(appendToStream).toHaveBeenCalledTimes(1)
+      expect(appendToStream).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          createdBy: {
+            id: 'user-abc',
+            name: 'Ada Lovelace',
+            email: 'ada@example.com'
+          }
+        })
+      )
       expect(saveBalance).not.toHaveBeenCalled()
     })
   })
@@ -1386,7 +1400,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-123',
           tonnage: 50,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         },
         findBalance,
         saveBalance
@@ -1419,7 +1433,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-123',
           tonnage: 50,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         },
         findBalance,
         saveBalance
@@ -1456,7 +1470,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-456',
           tonnage: 25,
-          userId: 'user-xyz'
+          createdBy: { id: 'user-xyz' }
         },
         findBalance,
         saveBalance
@@ -1494,7 +1508,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-789',
           tonnage: 10,
-          userId: 'user-123'
+          createdBy: { id: 'user-123' }
         },
         findBalance,
         saveBalance
@@ -1543,7 +1557,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-123',
           tonnage: 50,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         },
         findBalance,
         saveBalance,
@@ -1619,7 +1633,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-123',
           tonnage: 50,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         },
         findBalance,
         saveBalance
@@ -1653,7 +1667,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
             organisationId: 'org-1',
             prnId: 'prn-123',
             tonnage: 50,
-            userId: 'user-abc'
+            createdBy: { id: 'user-abc' }
           },
           findBalance,
           saveBalance
@@ -1691,7 +1705,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-456',
           tonnage: 25,
-          userId: 'user-xyz'
+          createdBy: { id: 'user-xyz' }
         },
         findBalance,
         saveBalance
@@ -1729,7 +1743,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-789',
           tonnage: 10,
-          userId: 'user-123'
+          createdBy: { id: 'user-123' }
         },
         findBalance,
         saveBalance
@@ -1779,7 +1793,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-123',
           tonnage: 50,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         },
         findBalance,
         saveBalance,
@@ -1855,7 +1869,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-123',
           tonnage: 60,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         },
         findBalance,
         saveBalance
@@ -1889,7 +1903,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
             organisationId: 'org-1',
             prnId: 'prn-123',
             tonnage: 60,
-            userId: 'user-abc'
+            createdBy: { id: 'user-abc' }
           },
           findBalance,
           saveBalance
@@ -1922,7 +1936,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-123',
           tonnage: 60,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         },
         findBalance,
         saveBalance
@@ -1972,7 +1986,7 @@ describe('src/waste-balances/repository/helpers.js', () => {
           organisationId: 'org-1',
           prnId: 'prn-123',
           tonnage: 60,
-          userId: 'user-abc'
+          createdBy: { id: 'user-abc' }
         },
         findBalance,
         saveBalance,

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -5,7 +5,7 @@
  * @property {string} organisationId
  * @property {string} prnId
  * @property {number} tonnage
- * @property {string} userId
+ * @property {import('./stream-schema.js').StreamUserSummary} createdBy
  */
 
 /**
@@ -15,7 +15,7 @@
  * @property {string} organisationId
  * @property {string} prnId
  * @property {number} tonnage
- * @property {string} userId
+ * @property {import('./stream-schema.js').StreamUserSummary} createdBy
  */
 
 /**
@@ -25,7 +25,7 @@
  * @property {string} organisationId
  * @property {string} prnId
  * @property {number} tonnage
- * @property {string} userId
+ * @property {import('./stream-schema.js').StreamUserSummary} createdBy
  */
 
 /**
@@ -35,7 +35,7 @@
  * @property {string} organisationId
  * @property {string} prnId
  * @property {number} tonnage
- * @property {string} userId
+ * @property {import('./stream-schema.js').StreamUserSummary} createdBy
  */
 
 /**
@@ -45,7 +45,7 @@
  * @property {string} organisationId
  * @property {string} prnId
  * @property {number} tonnage
- * @property {string} userId
+ * @property {import('./stream-schema.js').StreamUserSummary} createdBy
  * @property {import('./stream-schema.js').StreamEventKind} streamKind
  */
 


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## What

A live, human-initiated PRN status transition now writes its waste-balance stream event with `createdBy = { id, name, email }`, carrying the authenticated user's real name and email instead of fabricating the actor from their id.

Previously the status route built `{ id, name }` correctly, but the application layer narrowed the actor to a `userId` string before the stream write, and the stream-append helper expanded that back to `createdBy: { id: userId, name: userId }` — fabricating the name from the id and dropping the email entirely.

## How it changed

- The waste-balance ledger write chain carries a best-view actor `{ id, name?, email? }` (the `StreamUserSummary` shape) instead of a bare `userId` string: the repository port parameters, the PRN balance-effect repository methods, the balance-event params, and the narrowing point in `update-status`.
- The PRN status route now reads `email` from the authenticated credentials and threads it onto the actor.
- The legacy embedded waste-balance transaction twin is unchanged: the transaction builders still take an id and the helpers pass `createdBy.id` through to them, so their output is preserved. Carrying the actor on the embedded transaction is tracked separately.
- The PRN document records actors by id and name only; email is enrichment that belongs on the waste-balance stream event. The actor is narrowed back to `{ id, name }` where it folds into the PRN projection and the embedded-write document, so email never reaches the PRN document.

## Scope

This covers the live human transition path. The RPD/system-initiated transition (which must record a system identity with no name or email) and the historical-rebuild paths are tracked separately.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ