### PR TITLE
PAE-1382: Attribute rebuilt RPD PRN events to the system id

### DIFF
--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -140,8 +140,10 @@ const RPD_INITIATED_PRN_KINDS = new Set([
  * Reduce a PRN history actor for the transition it performed. An RPD-initiated
  * accept or reject is the external system acting, identified by its id alone:
  * any name the source recorded is a system label, not a person, so it is
- * dropped rather than attributed. Every other transition keeps the recoverable
- * human actor.
+ * dropped rather than attributed. An RPD-initiated transition whose history
+ * entry names no actor has no id to keep, so it falls through to the backfill
+ * actor like any other unattributed event. Every other transition keeps the
+ * recoverable human actor.
  *
  * @param {import('../repository/stream-schema.js').StreamEventKind} kind
  * @param {{ id: string, name?: string } | undefined} actor

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -122,6 +122,35 @@ const actorOf = (actor) =>
     : { ...BACKFILL_ACTOR }
 
 /**
+ * Stream event kinds whose PRN transitions only the producer can perform, and
+ * the producer reaches the service solely through the external RPD API on
+ * machine credentials. The PRN state machine grants `AWAITING_ACCEPTANCE →
+ * ACCEPTED` and `→ AWAITING_CANCELLATION` to `PRODUCER` alone, and no internal
+ * route lets a human leave `AWAITING_ACCEPTANCE`, so an accept or reject is
+ * always the RPD system acting — never a person.
+ *
+ * @type {Set<import('../repository/stream-schema.js').StreamEventKind>}
+ */
+const RPD_INITIATED_PRN_KINDS = new Set([
+  STREAM_EVENT_KIND.PRN_ACCEPTED,
+  STREAM_EVENT_KIND.PRN_REJECTED
+])
+
+/**
+ * Reduce a PRN history actor for the transition it performed. An RPD-initiated
+ * accept or reject is the external system acting, identified by its id alone:
+ * any name the source recorded is a system label, not a person, so it is
+ * dropped rather than attributed. Every other transition keeps the recoverable
+ * human actor.
+ *
+ * @param {import('../repository/stream-schema.js').StreamEventKind} kind
+ * @param {{ id: string, name?: string } | undefined} actor
+ * @returns {import('../repository/stream-schema.js').StreamUserSummary}
+ */
+const prnActorOf = (kind, actor) =>
+  RPD_INITIATED_PRN_KINDS.has(kind) && actor ? { id: actor.id } : actorOf(actor)
+
+/**
  * Sparse count of backfilled-actor events keyed by the stream event kind that
  * fell back. Only kinds with at least one fallback appear.
  *
@@ -298,7 +327,7 @@ const prnTransitionEvent = ({
     registrationId,
     accreditationId: accreditation.id,
     organisationId,
-    createdBy: actorOf(history[index].by)
+    createdBy: prnActorOf(kind, history[index].by)
   }
 }
 

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -616,6 +616,100 @@ describe('computeRebuiltStream', () => {
       expect(issued?.createdBy).toEqual({ id: 'sig-7', name: 'Sam Signatory' })
     })
 
+    it('attributes a producer accept to the RPD system identity, id only', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 30,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.DRAFT,
+                  at: new Date('2025-01-20T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                },
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date('2025-01-21T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                },
+                {
+                  status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                  at: new Date('2025-01-22T00:00:00.000Z'),
+                  by: { id: 'sig-1', name: 'Sam Signatory' }
+                },
+                {
+                  status: PRN_STATUS.ACCEPTED,
+                  at: new Date('2025-01-23T00:00:00.000Z'),
+                  by: { id: 'rpd-client', name: 'RPD' }
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: [submittedLog()]
+      })
+
+      const accepted = result.events.find(
+        (e) => e.kind === STREAM_EVENT_KIND.PRN_ACCEPTED
+      )
+      expect(accepted?.createdBy).toEqual({ id: 'rpd-client' })
+      expect('name' in /** @type {object} */ (accepted?.createdBy)).toBe(false)
+    })
+
+    it('attributes a producer reject to the RPD system identity, id only', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 30,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.DRAFT,
+                  at: new Date('2025-01-20T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                },
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date('2025-01-21T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                },
+                {
+                  status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                  at: new Date('2025-01-22T00:00:00.000Z'),
+                  by: { id: 'sig-1', name: 'Sam Signatory' }
+                },
+                {
+                  status: PRN_STATUS.AWAITING_CANCELLATION,
+                  at: new Date('2025-01-23T00:00:00.000Z'),
+                  by: { id: 'rpd-client', name: 'RPD' }
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: [submittedLog()]
+      })
+
+      const rejected = result.events.find(
+        (e) => e.kind === STREAM_EVENT_KIND.PRN_REJECTED
+      )
+      expect(rejected?.createdBy).toEqual({ id: 'rpd-client' })
+      expect('name' in /** @type {object} */ (rejected?.createdBy)).toBe(false)
+    })
+
     it('attributes summary-log events to the supplied submitter', () => {
       const submitter = { id: 'usr-9', name: 'submitter@example.com' }
       const result = computeRebuiltStream({

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -660,7 +660,7 @@ describe('computeRebuiltStream', () => {
         (e) => e.kind === STREAM_EVENT_KIND.PRN_ACCEPTED
       )
       expect(accepted?.createdBy).toEqual({ id: 'rpd-client' })
-      expect('name' in /** @type {object} */ (accepted?.createdBy)).toBe(false)
+      expect(accepted?.createdBy).not.toHaveProperty('name')
     })
 
     it('attributes a producer reject to the RPD system identity, id only', () => {
@@ -707,7 +707,7 @@ describe('computeRebuiltStream', () => {
         (e) => e.kind === STREAM_EVENT_KIND.PRN_REJECTED
       )
       expect(rejected?.createdBy).toEqual({ id: 'rpd-client' })
-      expect('name' in /** @type {object} */ (rejected?.createdBy)).toBe(false)
+      expect(rejected?.createdBy).not.toHaveProperty('name')
     })
 
     it('attributes summary-log events to the supplied submitter', () => {


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
The waste-balance rebuild replays a PRN's status history into stream events, attributing each event to the actor recorded on its history entry. Producer accept and reject transitions reach the service only through the external RPD API, which authenticates with machine credentials, so those events should carry the RPD system identity — its id alone — rather than a person's details.

This change reduces the actor on rebuilt `PRN_ACCEPTED` and `PRN_REJECTED` events to `{ id }` only, dropping any name the source history recorded (the machine credential's display label, not a person). The transition kind is the signal: the PRN state machine grants `AWAITING_ACCEPTANCE → ACCEPTED` and `AWAITING_ACCEPTANCE → AWAITING_CANCELLATION` to the producer alone, and no internal route lets a human leave `AWAITING_ACCEPTANCE`, so an accept or reject is always the RPD system acting. Classifying by kind avoids matching on the machine credential's name, which the persistence schema does not retain.

Human-initiated transitions (`PRN_CREATED`, `PRN_ISSUED`, `PRN_CREATION_CANCELLED`, `PRN_CANCELLED_AFTER_ISSUE`) keep their recoverable actor unchanged. An RPD-initiated transition whose history entry names no actor has no id to keep and falls through to the existing system backfill actor.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ