### PR TITLE
PAE-1382: Carry reports changedBy email distinctly from name

### DIFF
--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -5,7 +5,8 @@
 /**
  * @typedef {Object} UserSummary
  * @property {string} id
- * @property {string} name
+ * @property {string} [name]
+ * @property {string} [email]
  * @property {string} position
  */
 

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -31,7 +31,8 @@ export const periodSchema = Joi.number()
 
 export const userSummarySchema = Joi.object({
   id: Joi.string().required(),
-  name: Joi.string().required(),
+  name: Joi.string().optional(),
+  email: Joi.string().optional(),
   position: Joi.string().optional()
 }).required()
 

--- a/src/reports/routes/shared.js
+++ b/src/reports/routes/shared.js
@@ -47,13 +47,16 @@ export function withRegistrationDetails(report, registration) {
 
 /**
  * Extracts a changedBy user summary from request credentials.
+ * Carries name and email distinctly: name is omitted when there is no real
+ * name, and the email is never coerced into the name slot.
  * @param {object} credentials
- * @returns {{ id: string, name: string, position: string }}
+ * @returns {{ id: string, name?: string, email?: string, position: string }}
  */
 export function extractChangedBy(credentials) {
   return {
     id: credentials.id,
-    name: credentials.name ?? credentials.email,
+    ...(credentials.name && { name: credentials.name }),
+    ...(credentials.email && { email: credentials.email }),
     position: credentials.position ?? 'User'
   }
 }

--- a/src/reports/routes/shared.test.js
+++ b/src/reports/routes/shared.test.js
@@ -42,12 +42,15 @@ describe('extractChangedBy', () => {
     expect(extractChangedBy(entraAdminUser).name).toBeUndefined()
   })
 
-  it('produces a value userSummarySchema accepts for both providers', () => {
-    expect(
-      userSummarySchema.validate(extractChangedBy(defraIdStandardUser)).error
-    ).toBeUndefined()
-    expect(
-      userSummarySchema.validate(extractChangedBy(entraAdminUser)).error
-    ).toBeUndefined()
+  it('produces a value userSummarySchema accepts and preserves email for both providers', () => {
+    const defraId = userSummarySchema.validate(
+      extractChangedBy(defraIdStandardUser)
+    )
+    expect(defraId.error).toBeUndefined()
+    expect(defraId.value.email).toBe('ada@example.com')
+
+    const entra = userSummarySchema.validate(extractChangedBy(entraAdminUser))
+    expect(entra.error).toBeUndefined()
+    expect(entra.value.email).toBe('maintainer@example.com')
   })
 })

--- a/src/reports/routes/shared.test.js
+++ b/src/reports/routes/shared.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { userSummarySchema } from '#reports/repository/schema.js'
+
+import { extractChangedBy } from './shared.js'
+
+const defraIdStandardUser = {
+  id: 'contact-1',
+  email: 'ada@example.com',
+  name: 'Ada Lovelace',
+  issuer: 'defra-id',
+  scope: ['standard_user'],
+  currentRelationshipId: 'rel-1'
+}
+
+const entraAdminUser = {
+  id: 'oid-1',
+  email: 'maintainer@example.com',
+  issuer: 'entra-id',
+  scope: ['admin.write']
+}
+
+describe('extractChangedBy', () => {
+  it('carries name and email distinctly for a Defra ID standard user', () => {
+    expect(extractChangedBy(defraIdStandardUser)).toEqual({
+      id: 'contact-1',
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      position: 'User'
+    })
+  })
+
+  it('carries email and omits name for an Entra ID admin (no name claim)', () => {
+    expect(extractChangedBy(entraAdminUser)).toEqual({
+      id: 'oid-1',
+      email: 'maintainer@example.com',
+      position: 'User'
+    })
+  })
+
+  it('never coerces the email into the name slot', () => {
+    expect(extractChangedBy(entraAdminUser).name).toBeUndefined()
+  })
+
+  it('produces a value userSummarySchema accepts for both providers', () => {
+    expect(
+      userSummarySchema.validate(extractChangedBy(defraIdStandardUser)).error
+    ).toBeUndefined()
+    expect(
+      userSummarySchema.validate(extractChangedBy(entraAdminUser)).error
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
Report state changes (submit, unsubmit, status, patch, delete) record their actor via `extractChangedBy`, which set `name` to `credentials.name ?? credentials.email`. That stored the actor's email in the name field whenever the credential carried no name. Defra ID credentials (the standard-user report routes) carry a real name, but Entra ID credentials (the admin unsubmit route) carry none — so every admin-initiated report change mislabelled the maintainer's email as their display name.

The actor now carries email in its own field and omits name when there is no real name, never coercing one into the other. The `UserSummary` type and the `userSummarySchema` Joi validator are updated to match: `name` is optional and `email` is a permitted field. The schema continues to accept previously-stored records, so no data migration is required.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ