### PR TITLE
PAE-1541: Classify loads by reporting period status

### DIFF
--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -161,8 +161,11 @@ export const classifyByPeriodStatus = ({
 
   const closedPeriods = buildClosedPeriods(submittedReports, cadence)
 
-  const wasteBalanceRowIds = new Set(
-    wasteBalanceRecords.map((wr) => wr.record.rowId)
+  /** @param {ValidatedWasteRecord['record']} record */
+  const recordKey = (record) => `${record.type}:${record.rowId}`
+
+  const wasteBalanceRowKeys = new Set(
+    wasteBalanceRecords.map((wr) => recordKey(wr.record))
   )
 
   for (const wasteRecord of wasteRecords) {
@@ -188,14 +191,15 @@ export const classifyByPeriodStatus = ({
     const periodKey = `${year}:${period}`
 
     const periodStatus = closedPeriods.has(periodKey) ? 'closed' : 'open'
+    const key = recordKey(record)
     const isIncluded =
-      outcome === ROW_OUTCOME.INCLUDED && wasteBalanceRowIds.has(record.rowId)
+      outcome === ROW_OUTCOME.INCLUDED && wasteBalanceRowKeys.has(key)
 
     const bucket = result[periodStatus][status]
 
     if (isIncluded) {
       bucket.included.count += 1
-      bucket.included.tonnes += transactionAmounts.get(record.rowId) ?? 0
+      bucket.included.tonnes += transactionAmounts.get(key) ?? 0
     } else {
       bucket.excluded.count += 1
     }

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -13,7 +13,7 @@ import { REPORT_STATUS } from '#reports/domain/report-status.js'
 /** @import {PeriodicReport, ReportsRepository} from '#reports/repository/port.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
-/** @import {WasteRecord} from '#domain/waste-records/model.js' */
+/** @import {WasteRecord, WasteRecordVersion} from '#domain/waste-records/model.js' */
 
 /**
  * @typedef {Object} PeriodStatusBucket
@@ -310,7 +310,9 @@ export const buildTransactionAmounts = (
     }
 
     const key = `${record.type}:${record.rowId}`
-    const lastVersion = record.versions[record.versions.length - 1]
+    const lastVersion = /** @type {WasteRecordVersion} */ (
+      record.versions.at(-1)
+    )
     const isAdjusted =
       lastVersion.summaryLog?.id === summaryLogId &&
       lastVersion.status === VERSION_STATUS.UPDATED

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -299,10 +299,10 @@ export const buildTransactionAmounts = (
   existingRecordsMap
 ) => {
   const amounts = new Map()
-  for (const { record, outcome } of wasteBalanceRecords) {
-    if (outcome !== ROW_OUTCOME.INCLUDED) {
-      continue
-    }
+  const included = wasteBalanceRecords.filter(
+    ({ outcome }) => outcome === ROW_OUTCOME.INCLUDED
+  )
+  for (const { record } of included) {
     const schema = findSchemaForProcessingType(processingType, record.type)
     const newAmount = getTransactionAmount(schema, record.data, registration)
     if (newAmount === 0) {
@@ -310,7 +310,7 @@ export const buildTransactionAmounts = (
     }
 
     const key = `${record.type}:${record.rowId}`
-    const lastVersion = record.versions[record.versions.length - 1]
+    const lastVersion = record.versions.at(-1)
     const isAdjusted =
       lastVersion.summaryLog?.id === summaryLogId &&
       lastVersion.status === VERSION_STATUS.UPDATED

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -50,12 +50,18 @@ const emptyResult = () => ({
  * @returns {'added' | 'adjusted' | 'unchanged'}
  */
 const determineRecordStatus = (record, summaryLogId) => {
-  const lastVersion = record.versions[record.versions.length - 1]
-  if (lastVersion.summaryLog?.id !== summaryLogId) {
+  const lastVersion = record.versions.at(-1)
+  if (lastVersion?.summaryLog?.id !== summaryLogId) {
     return 'unchanged'
   }
   return lastVersion.status === VERSION_STATUS.CREATED ? 'added' : 'adjusted'
 }
+
+/** Position of the year portion in an ISO date string (YYYY-MM-DD) */
+const YEAR_END = 4
+/** Position of the month portion in an ISO date string */
+const MONTH_START = 5
+const MONTH_END = 7
 
 /**
  * Normalises a date value to an ISO string (YYYY-MM-DD or YYYY-MM).
@@ -71,14 +77,13 @@ const toIsoDate = (dateValue) =>
 
 /**
  * Extracts the month number (1-12) from a date value.
- * Handles Date objects, YYYY-MM-DD and YYYY-MM formats.
  *
  * @param {string | Date} dateValue
  * @returns {number}
  */
 const extractMonth = (dateValue) => {
   const str = toIsoDate(dateValue)
-  return Number(str.slice(5, 7))
+  return Number(str.slice(MONTH_START, MONTH_END))
 }
 
 /**
@@ -87,7 +92,8 @@ const extractMonth = (dateValue) => {
  * @param {string | Date} dateValue
  * @returns {number}
  */
-const extractYear = (dateValue) => Number(toIsoDate(dateValue).slice(0, 4))
+const extractYear = (dateValue) =>
+  Number(toIsoDate(dateValue).slice(0, YEAR_END))
 
 /**
  * Builds a set of closed period keys from submitted reports.
@@ -106,7 +112,9 @@ const buildClosedPeriods = (submittedReports, cadence) => {
   const closed = new Set()
   for (const periodicReport of submittedReports) {
     const slots = periodicReport.reports[cadence]
-    if (!slots) continue
+    if (!slots) {
+      continue
+    }
     for (const [period, slot] of Object.entries(slots)) {
       const hasBeenSubmitted =
         slot.current?.status === REPORT_STATUS.SUBMITTED ||
@@ -131,6 +139,71 @@ const monthToPeriod = (month, cadence) => {
   return Math.ceil(month / monthsPerPeriod)
 }
 
+/** @param {ValidatedWasteRecord['record']} record */
+const recordKey = (record) => `${record.type}:${record.rowId}`
+
+/**
+ * Classifies a single waste record into the appropriate period status bucket.
+ *
+ * @param {Object} params
+ * @param {ValidatedWasteRecord} params.wasteRecord
+ * @param {string} params.summaryLogId
+ * @param {Set<string>} params.closedPeriods
+ * @param {Set<string>} params.wasteBalanceRowKeys
+ * @param {string} params.cadence
+ * @param {Object<string, { reportingDateField: string }>} params.tableSchemas
+ * @param {Map<string, number>} params.transactionAmounts
+ * @param {LoadsByPeriodStatus} params.result
+ */
+const classifyRecord = ({
+  wasteRecord,
+  summaryLogId,
+  closedPeriods,
+  wasteBalanceRowKeys,
+  cadence,
+  tableSchemas,
+  transactionAmounts,
+  result
+}) => {
+  const { record, outcome } = wasteRecord
+
+  if (outcome === ROW_OUTCOME.IGNORED) {
+    return
+  }
+
+  const status = determineRecordStatus(record, summaryLogId)
+  if (status === 'unchanged') {
+    return
+  }
+
+  const schema = tableSchemas[wasteRecord.tableName]
+  if (!schema) {
+    return
+  }
+
+  const dateValue = record.data[schema.reportingDateField]
+  if (!dateValue) {
+    return
+  }
+
+  const period = monthToPeriod(extractMonth(dateValue), cadence)
+  const periodKey = `${extractYear(dateValue)}:${period}`
+  const periodStatus = closedPeriods.has(periodKey) ? 'closed' : 'open'
+
+  const key = recordKey(record)
+  const isIncluded =
+    outcome === ROW_OUTCOME.INCLUDED && wasteBalanceRowKeys.has(key)
+
+  const bucket = result[periodStatus][status]
+
+  if (isIncluded) {
+    bucket.included.count += 1
+    bucket.included.tonnes += transactionAmounts.get(key) ?? 0
+  } else {
+    bucket.excluded.count += 1
+  }
+}
+
 /**
  * Classifies waste records by reporting period status (open/closed).
  *
@@ -141,7 +214,7 @@ const monthToPeriod = (month, cadence) => {
  * @param {Registration} params.registration
  * @param {PeriodicReport[]} params.submittedReports
  * @param {Object<string, { reportingDateField: string, wasteRecordType: string }>} params.tableSchemas
- * @param {Map<string, number>} params.transactionAmounts - rowId => tonnage for included waste-balance records
+ * @param {Map<string, number>} params.transactionAmounts - "type:rowId" => waste balance impact
  * @returns {LoadsByPeriodStatus}
  */
 export const classifyByPeriodStatus = ({
@@ -161,48 +234,21 @@ export const classifyByPeriodStatus = ({
 
   const closedPeriods = buildClosedPeriods(submittedReports, cadence)
 
-  /** @param {ValidatedWasteRecord['record']} record */
-  const recordKey = (record) => `${record.type}:${record.rowId}`
-
   const wasteBalanceRowKeys = new Set(
     wasteBalanceRecords.map((wr) => recordKey(wr.record))
   )
 
   for (const wasteRecord of wasteRecords) {
-    const { record, outcome } = wasteRecord
-
-    // Skip IGNORED records (outside accreditation date range)
-    if (outcome === ROW_OUTCOME.IGNORED) continue
-
-    // Skip unchanged records (not displayed on check page)
-    const status = determineRecordStatus(record, summaryLogId)
-    if (status === 'unchanged') continue
-
-    // Look up the table schema to find the reporting date field
-    const schema = tableSchemas[wasteRecord.tableName]
-    if (!schema) continue
-
-    const dateValue = record.data[schema.reportingDateField]
-    if (!dateValue) continue
-
-    const year = extractYear(dateValue)
-    const month = extractMonth(dateValue)
-    const period = monthToPeriod(month, cadence)
-    const periodKey = `${year}:${period}`
-
-    const periodStatus = closedPeriods.has(periodKey) ? 'closed' : 'open'
-    const key = recordKey(record)
-    const isIncluded =
-      outcome === ROW_OUTCOME.INCLUDED && wasteBalanceRowKeys.has(key)
-
-    const bucket = result[periodStatus][status]
-
-    if (isIncluded) {
-      bucket.included.count += 1
-      bucket.included.tonnes += transactionAmounts.get(key) ?? 0
-    } else {
-      bucket.excluded.count += 1
-    }
+    classifyRecord({
+      wasteRecord,
+      summaryLogId,
+      closedPeriods,
+      wasteBalanceRowKeys,
+      cadence,
+      tableSchemas,
+      transactionAmounts,
+      result
+    })
   }
 
   return result

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -1,0 +1,205 @@
+import { VERSION_STATUS } from '#domain/waste-records/model.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
+import { MONTHS_PER_PERIOD } from '#reports/domain/cadence.js'
+import { REPORT_STATUS } from '#reports/domain/report-status.js'
+
+/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {PeriodicReport} from '#reports/repository/port.js' */
+/** @import {Registration} from '#domain/organisations/registration.js' */
+
+/**
+ * @typedef {Object} PeriodStatusBucket
+ * @property {{ count: number, tonnes: number }} included
+ * @property {{ count: number }} excluded
+ */
+
+/**
+ * @typedef {Object} PeriodStatusByChange
+ * @property {PeriodStatusBucket} added
+ * @property {PeriodStatusBucket} adjusted
+ */
+
+/**
+ * @typedef {Object} LoadsByPeriodStatus
+ * @property {PeriodStatusByChange} open
+ * @property {PeriodStatusByChange} closed
+ */
+
+const emptyBucket = () => ({
+  included: { count: 0, tonnes: 0 },
+  excluded: { count: 0 }
+})
+
+const emptyStatus = () => ({
+  added: emptyBucket(),
+  adjusted: emptyBucket()
+})
+
+/** @returns {LoadsByPeriodStatus} */
+const emptyResult = () => ({
+  open: emptyStatus(),
+  closed: emptyStatus()
+})
+
+/**
+ * Determines record status from the waste record's version history.
+ *
+ * @param {ValidatedWasteRecord['record']} record
+ * @param {string} summaryLogId
+ * @returns {'added' | 'adjusted' | 'unchanged'}
+ */
+const determineRecordStatus = (record, summaryLogId) => {
+  const lastVersion = record.versions[record.versions.length - 1]
+  if (lastVersion.summaryLog?.id !== summaryLogId) {
+    return 'unchanged'
+  }
+  return lastVersion.status === VERSION_STATUS.CREATED ? 'added' : 'adjusted'
+}
+
+/**
+ * Normalises a date value to an ISO string (YYYY-MM-DD or YYYY-MM).
+ * Handles Date objects, ISO date strings, and YYYY-MM month strings.
+ *
+ * @param {string | Date} dateValue
+ * @returns {string}
+ */
+const toIsoDate = (dateValue) =>
+  dateValue instanceof Date
+    ? dateValue.toISOString().slice(0, 10)
+    : String(dateValue)
+
+/**
+ * Extracts the month number (1-12) from a date value.
+ * Handles Date objects, YYYY-MM-DD and YYYY-MM formats.
+ *
+ * @param {string | Date} dateValue
+ * @returns {number}
+ */
+const extractMonth = (dateValue) => {
+  const str = toIsoDate(dateValue)
+  return Number(str.slice(5, 7))
+}
+
+/**
+ * Extracts the year from a date value.
+ *
+ * @param {string | Date} dateValue
+ * @returns {number}
+ */
+const extractYear = (dateValue) => Number(toIsoDate(dateValue).slice(0, 4))
+
+/**
+ * Builds a set of closed period keys from submitted reports.
+ *
+ * A period is closed when a report has been submitted for it. That means
+ * either the current report is in submitted status, or there is at least
+ * one previous submission.
+ *
+ * Keys are formatted as "year:period" (e.g. "2026:1").
+ *
+ * @param {PeriodicReport[]} submittedReports
+ * @param {string} cadence
+ * @returns {Set<string>}
+ */
+const buildClosedPeriods = (submittedReports, cadence) => {
+  const closed = new Set()
+  for (const periodicReport of submittedReports) {
+    const slots = periodicReport.reports[cadence]
+    if (!slots) continue
+    for (const [period, slot] of Object.entries(slots)) {
+      const hasBeenSubmitted =
+        slot.current?.status === REPORT_STATUS.SUBMITTED ||
+        slot.previousSubmissions?.length > 0
+      if (hasBeenSubmitted) {
+        closed.add(`${periodicReport.year}:${period}`)
+      }
+    }
+  }
+  return closed
+}
+
+/**
+ * Maps a month to its reporting period number.
+ *
+ * @param {number} month - 1-12
+ * @param {string} cadence - 'monthly' or 'quarterly'
+ * @returns {number}
+ */
+const monthToPeriod = (month, cadence) => {
+  const monthsPerPeriod = MONTHS_PER_PERIOD[cadence]
+  return Math.ceil(month / monthsPerPeriod)
+}
+
+/**
+ * Classifies waste records by reporting period status (open/closed).
+ *
+ * @param {Object} params
+ * @param {ValidatedWasteRecord[]} params.wasteRecords
+ * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords
+ * @param {string} params.summaryLogId
+ * @param {Registration} params.registration
+ * @param {PeriodicReport[]} params.submittedReports
+ * @param {Object<string, { reportingDateField: string, wasteRecordType: string }>} params.tableSchemas
+ * @param {Map<string, number>} params.transactionAmounts - rowId => tonnage for included waste-balance records
+ * @returns {LoadsByPeriodStatus}
+ */
+export const classifyByPeriodStatus = ({
+  wasteRecords,
+  wasteBalanceRecords,
+  summaryLogId,
+  registration,
+  submittedReports,
+  tableSchemas,
+  transactionAmounts
+}) => {
+  const result = emptyResult()
+
+  const cadence = isRegistrationAccredited(registration)
+    ? 'monthly'
+    : 'quarterly'
+
+  const closedPeriods = buildClosedPeriods(submittedReports, cadence)
+
+  const wasteBalanceRowIds = new Set(
+    wasteBalanceRecords.map((wr) => wr.record.rowId)
+  )
+
+  for (const wasteRecord of wasteRecords) {
+    const { record, outcome } = wasteRecord
+
+    // Skip IGNORED records (outside accreditation date range)
+    if (outcome === ROW_OUTCOME.IGNORED) continue
+
+    // Skip unchanged records (not displayed on check page)
+    const status = determineRecordStatus(record, summaryLogId)
+    if (status === 'unchanged') continue
+
+    // Look up the table schema to find the reporting date field
+    const schema = tableSchemas[wasteRecord.tableName]
+    if (!schema) continue
+
+    const dateValue = record.data[schema.reportingDateField]
+    if (!dateValue) continue
+
+    const year = extractYear(dateValue)
+    const month = extractMonth(dateValue)
+    const period = monthToPeriod(month, cadence)
+    const periodKey = `${year}:${period}`
+
+    const periodStatus = closedPeriods.has(periodKey) ? 'closed' : 'open'
+    const isIncluded =
+      outcome === ROW_OUTCOME.INCLUDED && wasteBalanceRowIds.has(record.rowId)
+
+    const bucket = result[periodStatus][status]
+
+    if (isIncluded) {
+      bucket.included.count += 1
+      bucket.included.tonnes += transactionAmounts.get(record.rowId) ?? 0
+    } else {
+      bucket.excluded.count += 1
+    }
+  }
+
+  return result
+}

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -310,7 +310,7 @@ export const buildTransactionAmounts = (
     }
 
     const key = `${record.type}:${record.rowId}`
-    const lastVersion = record.versions.at(-1)
+    const lastVersion = record.versions[record.versions.length - 1]
     const isAdjusted =
       lastVersion.summaryLog?.id === summaryLogId &&
       lastVersion.status === VERSION_STATUS.UPDATED

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -1,12 +1,19 @@
 import { VERSION_STATUS } from '#domain/waste-records/model.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import {
+  PROCESSING_TYPE_TABLES,
+  findSchemaForProcessingType
+} from '#domain/summary-logs/table-schemas/index.js'
+import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
 import { MONTHS_PER_PERIOD } from '#reports/domain/cadence.js'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
-/** @import {PeriodicReport} from '#reports/repository/port.js' */
+/** @import {PeriodicReport, ReportsRepository} from '#reports/repository/port.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
+/** @import {WasteRecord} from '#domain/waste-records/model.js' */
 
 /**
  * @typedef {Object} PeriodStatusBucket
@@ -252,4 +259,138 @@ export const classifyByPeriodStatus = ({
   }
 
   return result
+}
+
+/**
+ * Computes the transaction amount for a record's data via classifyForWasteBalance.
+ * Returns 0 if the record is not INCLUDED.
+ *
+ * @param {import('#domain/summary-logs/table-schemas/index.js').TableSchema | null} schema
+ * @param {Record<string, any>} data
+ * @param {Registration} registration
+ * @returns {number}
+ */
+const getTransactionAmount = (schema, data, registration) => {
+  const result = schema?.classifyForWasteBalance?.(data, {
+    accreditation: registration.accreditation,
+    overseasSites: ORS_VALIDATION_DISABLED
+  })
+  return result?.outcome === ROW_OUTCOME.INCLUDED ? result.transactionAmount : 0
+}
+
+/**
+ * Builds a map of "type:rowId" => waste balance impact for included waste-balance records.
+ *
+ * For added records, the impact is the full transaction amount.
+ * For adjusted records, the impact is the delta: new amount minus old amount.
+ *
+ * @param {ValidatedWasteRecord[]} wasteBalanceRecords
+ * @param {Registration} registration
+ * @param {string} processingType
+ * @param {string} summaryLogId
+ * @param {Map<string, WasteRecord>} existingRecordsMap
+ * @returns {Map<string, number>}
+ */
+export const buildTransactionAmounts = (
+  wasteBalanceRecords,
+  registration,
+  processingType,
+  summaryLogId,
+  existingRecordsMap
+) => {
+  const amounts = new Map()
+  for (const { record, outcome } of wasteBalanceRecords) {
+    if (outcome !== ROW_OUTCOME.INCLUDED) {
+      continue
+    }
+    const schema = findSchemaForProcessingType(processingType, record.type)
+    const newAmount = getTransactionAmount(schema, record.data, registration)
+    if (newAmount === 0) {
+      continue
+    }
+
+    const key = `${record.type}:${record.rowId}`
+    const lastVersion = record.versions[record.versions.length - 1]
+    const isAdjusted =
+      lastVersion.summaryLog?.id === summaryLogId &&
+      lastVersion.status === VERSION_STATUS.UPDATED
+
+    if (isAdjusted) {
+      const existing = existingRecordsMap.get(key)
+      const oldAmount = existing
+        ? getTransactionAmount(schema, existing.data, registration)
+        : 0
+      amounts.set(key, newAmount - oldAmount)
+    } else {
+      amounts.set(key, newAmount)
+    }
+  }
+  return amounts
+}
+
+/**
+ * Computes loadsByPeriodStatus for a validated summary log.
+ * Returns null if the reports lookup fails.
+ *
+ * @param {Object} params
+ * @param {ValidatedWasteRecord[]} params.wasteRecords
+ * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords
+ * @param {string} params.summaryLogId
+ * @param {Registration} params.registration
+ * @param {string} params.processingType
+ * @param {Map<string, WasteRecord>} params.existingRecordsMap
+ * @param {ReportsRepository} params.reportsRepository
+ * @param {string} params.organisationId
+ * @param {string} params.registrationId
+ * @param {string} params.loggingContext
+ * @param {TypedLogger} params.logger
+ * @returns {Promise<LoadsByPeriodStatus | null>}
+ */
+export const computeLoadsByPeriodStatus = async ({
+  wasteRecords,
+  wasteBalanceRecords,
+  summaryLogId,
+  registration,
+  processingType,
+  existingRecordsMap,
+  reportsRepository,
+  organisationId,
+  registrationId,
+  loggingContext,
+  logger
+}) => {
+  try {
+    const submittedReports = await reportsRepository.findPeriodicReports({
+      organisationId,
+      registrationId
+    })
+
+    const transactionAmounts = buildTransactionAmounts(
+      wasteBalanceRecords,
+      registration,
+      processingType,
+      summaryLogId,
+      existingRecordsMap
+    )
+
+    return classifyByPeriodStatus({
+      wasteRecords,
+      wasteBalanceRecords,
+      summaryLogId,
+      registration,
+      submittedReports,
+      tableSchemas: PROCESSING_TYPE_TABLES[processingType],
+      transactionAmounts
+    })
+  } catch (err) {
+    logger.warn({
+      message: `Failed to classify loads by period status: ${loggingContext}`,
+      err,
+      event: {
+        category: 'server',
+        action: 'process_failure'
+      }
+    })
+    return null
+  }
 }

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -76,7 +76,7 @@ describe('classifyByPeriodStatus', () => {
         registration: { accreditation: { status: 'approved' } },
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
-        transactionAmounts: new Map([['1000', 10]])
+        transactionAmounts: new Map([['received:1000', 10]])
       })
 
       expect(result.open.added.included).toEqual({ count: 1, tonnes: 10 })
@@ -112,7 +112,7 @@ describe('classifyByPeriodStatus', () => {
         registration: { accreditation: { status: 'approved' } },
         submittedReports,
         tableSchemas: TABLE_SCHEMAS,
-        transactionAmounts: new Map([['1000', 10]])
+        transactionAmounts: new Map([['received:1000', 10]])
       })
 
       expect(result.closed.added.included).toEqual({ count: 1, tonnes: 10 })
@@ -148,7 +148,7 @@ describe('classifyByPeriodStatus', () => {
         registration: { accreditation: { status: 'approved' } },
         submittedReports,
         tableSchemas: TABLE_SCHEMAS,
-        transactionAmounts: new Map([['1000', 10]])
+        transactionAmounts: new Map([['received:1000', 10]])
       })
 
       expect(result.closed.added.included).toEqual({ count: 1, tonnes: 10 })
@@ -214,7 +214,7 @@ describe('classifyByPeriodStatus', () => {
         registration: { accreditation: { status: 'approved' } },
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
-        transactionAmounts: new Map([['1000', 5]])
+        transactionAmounts: new Map([['received:1000', 5]])
       })
 
       expect(result.open.adjusted.included).toEqual({ count: 1, tonnes: 5 })
@@ -312,8 +312,8 @@ describe('classifyByPeriodStatus', () => {
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map([
-          ['1000', 10],
-          ['1001', 20]
+          ['received:1000', 10],
+          ['received:1001', 20]
         ])
       })
 
@@ -335,8 +335,8 @@ describe('classifyByPeriodStatus', () => {
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map([
-          ['1000', 7.5],
-          ['1001', 2.5]
+          ['received:1000', 7.5],
+          ['received:1001', 2.5]
         ])
       })
 

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -1,0 +1,481 @@
+import { describe, expect, it } from 'vitest'
+import { classifyByPeriodStatus } from './period-status.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { VERSION_STATUS } from '#domain/waste-records/model.js'
+
+/**
+ * @param {object} overrides
+ * @returns {import('#application/waste-records/transform-from-summary-log.js').ValidatedWasteRecord}
+ */
+const buildWasteRecord = ({
+  rowId = '1000',
+  date = '2026-01-15',
+  dateField = 'DATE_RECEIVED_FOR_REPROCESSING',
+  outcome = ROW_OUTCOME.INCLUDED,
+  change = 'CREATED',
+  summaryLogId = 'sl-1',
+  tableName = 'RECEIVED_LOADS_FOR_REPROCESSING',
+  wasteRecordType = 'received'
+} = {}) => ({
+  record: {
+    organisationId: 'org-1',
+    registrationId: 'reg-1',
+    rowId,
+    type: wasteRecordType,
+    data: { [dateField]: date },
+    versions: [
+      {
+        summaryLog: { id: summaryLogId },
+        status:
+          change === 'CREATED' ? VERSION_STATUS.CREATED : VERSION_STATUS.UPDATED
+      }
+    ]
+  },
+  issues: [],
+  outcome,
+  change,
+  tableName,
+  wasteRecordType
+})
+
+const SUMMARY_LOG_ID = 'sl-1'
+
+const TABLE_SCHEMAS = {
+  RECEIVED_LOADS_FOR_REPROCESSING: {
+    reportingDateField: 'DATE_RECEIVED_FOR_REPROCESSING',
+    wasteRecordType: 'received'
+  }
+}
+
+const emptyBucket = () => ({
+  included: { count: 0, tonnes: 0 },
+  excluded: { count: 0 }
+})
+
+const emptyStatus = () => ({
+  added: emptyBucket(),
+  adjusted: emptyBucket()
+})
+
+const emptyResult = () => ({
+  open: emptyStatus(),
+  closed: emptyStatus()
+})
+
+describe('classifyByPeriodStatus', () => {
+  describe('period classification', () => {
+    it('classifies a load in an open period as open/added/included', () => {
+      const wasteRecords = [
+        buildWasteRecord({ date: '2026-01-15', tonnage: 10 })
+      ]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: wasteRecords,
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map([['1000', 10]])
+      })
+
+      expect(result.open.added.included).toEqual({ count: 1, tonnes: 10 })
+    })
+
+    it('classifies a load in a closed period as closed/added/included', () => {
+      const wasteRecords = [
+        buildWasteRecord({ date: '2026-01-15', tonnage: 10 })
+      ]
+
+      // Period 1 (Jan) for monthly cadence has a previous submission => closed
+      const submittedReports = [
+        {
+          year: 2026,
+          reports: {
+            monthly: {
+              1: {
+                startDate: '2026-01-01',
+                endDate: '2026-01-31',
+                dueDate: '2026-02-20',
+                current: null,
+                previousSubmissions: [{ id: 'report-1' }]
+              }
+            }
+          }
+        }
+      ]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: wasteRecords,
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports,
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map([['1000', 10]])
+      })
+
+      expect(result.closed.added.included).toEqual({ count: 1, tonnes: 10 })
+      expect(result.open.added.included).toEqual({ count: 0, tonnes: 0 })
+    })
+
+    it('treats a period as closed when current report is submitted (no previousSubmissions)', () => {
+      const wasteRecords = [
+        buildWasteRecord({ date: '2026-01-15', tonnage: 10 })
+      ]
+
+      const submittedReports = [
+        {
+          year: 2026,
+          reports: {
+            monthly: {
+              1: {
+                startDate: '2026-01-01',
+                endDate: '2026-01-31',
+                dueDate: '2026-02-20',
+                current: { id: 'report-1', status: 'submitted' },
+                previousSubmissions: []
+              }
+            }
+          }
+        }
+      ]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: wasteRecords,
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports,
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map([['1000', 10]])
+      })
+
+      expect(result.closed.added.included).toEqual({ count: 1, tonnes: 10 })
+      expect(result.open.added.included).toEqual({ count: 0, tonnes: 0 })
+    })
+
+    it('classifies quarterly periods for registered-only registrations', () => {
+      const tableSchemas = {
+        RECEIVED_LOADS_FOR_REPROCESSING: {
+          reportingDateField: 'MONTH_RECEIVED_FOR_REPROCESSING',
+          wasteRecordType: 'received'
+        }
+      }
+
+      const wasteRecords = [
+        buildWasteRecord({
+          date: '2026-02',
+          dateField: 'MONTH_RECEIVED_FOR_REPROCESSING',
+          tableName: 'RECEIVED_LOADS_FOR_REPROCESSING'
+        })
+      ]
+
+      // Q1 (period 1) is closed
+      const submittedReports = [
+        {
+          year: 2026,
+          reports: {
+            quarterly: {
+              1: {
+                startDate: '2026-01-01',
+                endDate: '2026-03-31',
+                dueDate: '2026-04-20',
+                current: null,
+                previousSubmissions: [{ id: 'report-q1' }]
+              }
+            }
+          }
+        }
+      ]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: [],
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: {},
+        submittedReports,
+        tableSchemas,
+        transactionAmounts: new Map()
+      })
+
+      expect(result.closed.added.excluded).toEqual({ count: 1 })
+    })
+  })
+
+  describe('record status classification', () => {
+    it('classifies adjusted records into adjusted bucket', () => {
+      const wasteRecords = [buildWasteRecord({ change: 'UPDATED' })]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: wasteRecords,
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map([['1000', 5]])
+      })
+
+      expect(result.open.adjusted.included).toEqual({ count: 1, tonnes: 5 })
+    })
+  })
+
+  describe('inclusion classification', () => {
+    it('classifies excluded records without tonnes', () => {
+      const wasteRecords = [buildWasteRecord({ outcome: ROW_OUTCOME.EXCLUDED })]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: [],
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map()
+      })
+
+      expect(result.open.added.excluded).toEqual({ count: 1 })
+      expect(result.open.added.included).toEqual({ count: 0, tonnes: 0 })
+    })
+  })
+
+  describe('skipped records', () => {
+    it('skips unchanged records', () => {
+      const wasteRecords = [
+        buildWasteRecord({
+          change: 'UNCHANGED',
+          summaryLogId: 'other-sl'
+        })
+      ]
+      // The record's last version doesn't match summaryLogId => unchanged
+      wasteRecords[0].record.versions = [
+        { summaryLog: { id: 'other-sl' }, status: VERSION_STATUS.CREATED }
+      ]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: [],
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map()
+      })
+
+      expect(result).toEqual(emptyResult())
+    })
+
+    it('skips IGNORED records', () => {
+      const wasteRecords = [buildWasteRecord({ outcome: ROW_OUTCOME.IGNORED })]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: [],
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map()
+      })
+
+      expect(result).toEqual(emptyResult())
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns empty result when no waste records', () => {
+      const result = classifyByPeriodStatus({
+        wasteRecords: [],
+        wasteBalanceRecords: [],
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map()
+      })
+
+      expect(result).toEqual(emptyResult())
+    })
+
+    it('all loads in open periods when no submitted reports', () => {
+      const wasteRecords = [
+        buildWasteRecord({ rowId: '1000', date: '2026-01-15' }),
+        buildWasteRecord({ rowId: '1001', date: '2026-03-15' })
+      ]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: wasteRecords,
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map([
+          ['1000', 10],
+          ['1001', 20]
+        ])
+      })
+
+      expect(result.open.added.included).toEqual({ count: 2, tonnes: 30 })
+      expect(result.closed).toEqual(emptyStatus())
+    })
+
+    it('accumulates tonnage across multiple included records', () => {
+      const wasteRecords = [
+        buildWasteRecord({ rowId: '1000', date: '2026-01-15' }),
+        buildWasteRecord({ rowId: '1001', date: '2026-01-20' })
+      ]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: wasteRecords,
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map([
+          ['1000', 7.5],
+          ['1001', 2.5]
+        ])
+      })
+
+      expect(result.open.added.included).toEqual({ count: 2, tonnes: 10 })
+    })
+
+    it('skips records with no date value', () => {
+      const wasteRecords = [buildWasteRecord({ date: null })]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: [],
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map()
+      })
+
+      expect(result).toEqual(emptyResult())
+    })
+
+    it('ignores submitted reports for a different cadence', () => {
+      const wasteRecords = [buildWasteRecord({ date: '2026-01-15' })]
+
+      const submittedReports = [
+        {
+          year: 2026,
+          reports: {
+            quarterly: {
+              1: {
+                startDate: '2026-01-01',
+                endDate: '2026-03-31',
+                dueDate: '2026-04-20',
+                current: { id: 'r-1', status: 'submitted' },
+                previousSubmissions: []
+              }
+            }
+          }
+        }
+      ]
+
+      // Registration is accredited => monthly cadence, but reports are quarterly
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: [],
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports,
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map()
+      })
+
+      // All open because monthly slots don't exist in the reports
+      expect(result.open.added.excluded.count).toBe(1)
+      expect(result.closed.added.excluded.count).toBe(0)
+    })
+
+    it('treats open periods with in_progress reports as open', () => {
+      const wasteRecords = [buildWasteRecord({ date: '2026-01-15' })]
+
+      const submittedReports = [
+        {
+          year: 2026,
+          reports: {
+            monthly: {
+              1: {
+                startDate: '2026-01-01',
+                endDate: '2026-01-31',
+                dueDate: '2026-02-20',
+                current: { id: 'r-1', status: 'in_progress' },
+                previousSubmissions: []
+              }
+            }
+          }
+        }
+      ]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: [],
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports,
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map()
+      })
+
+      expect(result.open.added.excluded.count).toBe(1)
+      expect(result.closed.added.excluded.count).toBe(0)
+    })
+
+    it('defaults to zero tonnes when transactionAmounts has no entry for rowId', () => {
+      const wasteRecords = [buildWasteRecord()]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: wasteRecords,
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map()
+      })
+
+      expect(result.open.added.included).toEqual({ count: 1, tonnes: 0 })
+    })
+
+    it('handles Date objects as date values', () => {
+      const wasteRecords = [buildWasteRecord({ date: new Date('2026-01-15') })]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: [],
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map()
+      })
+
+      expect(result.open.added.excluded.count).toBe(1)
+    })
+
+    it('handles records with no matching table schema gracefully', () => {
+      const wasteRecords = [buildWasteRecord({ tableName: 'UNKNOWN_TABLE' })]
+
+      const result = classifyByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords: [],
+        summaryLogId: SUMMARY_LOG_ID,
+        registration: { accreditation: { status: 'approved' } },
+        submittedReports: [],
+        tableSchemas: TABLE_SCHEMAS,
+        transactionAmounts: new Map()
+      })
+
+      // Record is skipped when table schema not found
+      expect(result).toEqual(emptyResult())
+    })
+  })
+})

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -3,9 +3,21 @@ import { classifyByPeriodStatus } from './period-status.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { VERSION_STATUS } from '#domain/waste-records/model.js'
 
+/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {PeriodicReport} from '#reports/repository/port.js' */
+/** @import {Registration} from '#domain/organisations/registration.js' */
+
+/** @type {Registration} */
+const accreditedRegistration = /** @type {any} */ ({
+  accreditation: { status: 'approved' }
+})
+
+/** @type {Registration} */
+const registeredOnlyRegistration = /** @type {any} */ ({})
+
 /**
- * @param {object} overrides
- * @returns {import('#application/waste-records/transform-from-summary-log.js').ValidatedWasteRecord}
+ * @param {object} [overrides]
+ * @returns {ValidatedWasteRecord}
  */
 const buildWasteRecord = ({
   rowId = '1000',
@@ -16,27 +28,32 @@ const buildWasteRecord = ({
   summaryLogId = 'sl-1',
   tableName = 'RECEIVED_LOADS_FOR_REPROCESSING',
   wasteRecordType = 'received'
-} = {}) => ({
-  record: {
-    organisationId: 'org-1',
-    registrationId: 'reg-1',
-    rowId,
-    type: wasteRecordType,
-    data: { [dateField]: date },
-    versions: [
-      {
-        summaryLog: { id: summaryLogId },
-        status:
-          change === 'CREATED' ? VERSION_STATUS.CREATED : VERSION_STATUS.UPDATED
-      }
-    ]
-  },
-  issues: [],
-  outcome,
-  change,
-  tableName,
-  wasteRecordType
-})
+} = {}) =>
+  /** @type {ValidatedWasteRecord} */ (
+    /** @type {unknown} */ ({
+      record: {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        rowId,
+        type: wasteRecordType,
+        data: { [dateField]: date },
+        versions: [
+          {
+            summaryLog: { id: summaryLogId, uri: 's3://bucket/key' },
+            status:
+              change === 'CREATED'
+                ? VERSION_STATUS.CREATED
+                : VERSION_STATUS.UPDATED
+          }
+        ]
+      },
+      issues: [],
+      outcome,
+      change,
+      tableName,
+      wasteRecordType
+    })
+  )
 
 const SUMMARY_LOG_ID = 'sl-1'
 
@@ -73,7 +90,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: wasteRecords,
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map([['received:1000', 10]])
@@ -88,8 +105,11 @@ describe('classifyByPeriodStatus', () => {
       ]
 
       // Period 1 (Jan) for monthly cadence has a previous submission => closed
+      /** @type {PeriodicReport[]} */
       const submittedReports = [
         {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
           year: 2026,
           reports: {
             monthly: {
@@ -98,7 +118,15 @@ describe('classifyByPeriodStatus', () => {
                 endDate: '2026-01-31',
                 dueDate: '2026-02-20',
                 current: null,
-                previousSubmissions: [{ id: 'report-1' }]
+                previousSubmissions: [
+                  {
+                    id: 'report-1',
+                    status: 'submitted',
+                    submissionNumber: 1,
+                    submittedAt: null,
+                    submittedBy: null
+                  }
+                ]
               }
             }
           }
@@ -109,7 +137,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: wasteRecords,
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports,
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map([['received:1000', 10]])
@@ -124,8 +152,11 @@ describe('classifyByPeriodStatus', () => {
         buildWasteRecord({ date: '2026-01-15', tonnage: 10 })
       ]
 
+      /** @type {PeriodicReport[]} */
       const submittedReports = [
         {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
           year: 2026,
           reports: {
             monthly: {
@@ -133,7 +164,13 @@ describe('classifyByPeriodStatus', () => {
                 startDate: '2026-01-01',
                 endDate: '2026-01-31',
                 dueDate: '2026-02-20',
-                current: { id: 'report-1', status: 'submitted' },
+                current: {
+                  id: 'report-1',
+                  status: 'submitted',
+                  submissionNumber: 1,
+                  submittedAt: null,
+                  submittedBy: null
+                },
                 previousSubmissions: []
               }
             }
@@ -145,7 +182,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: wasteRecords,
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports,
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map([['received:1000', 10]])
@@ -172,8 +209,11 @@ describe('classifyByPeriodStatus', () => {
       ]
 
       // Q1 (period 1) is closed
+      /** @type {PeriodicReport[]} */
       const submittedReports = [
         {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
           year: 2026,
           reports: {
             quarterly: {
@@ -182,7 +222,15 @@ describe('classifyByPeriodStatus', () => {
                 endDate: '2026-03-31',
                 dueDate: '2026-04-20',
                 current: null,
-                previousSubmissions: [{ id: 'report-q1' }]
+                previousSubmissions: [
+                  {
+                    id: 'report-q1',
+                    status: 'submitted',
+                    submissionNumber: 1,
+                    submittedAt: null,
+                    submittedBy: null
+                  }
+                ]
               }
             }
           }
@@ -193,7 +241,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: [],
         summaryLogId: SUMMARY_LOG_ID,
-        registration: {},
+        registration: registeredOnlyRegistration,
         submittedReports,
         tableSchemas,
         transactionAmounts: new Map()
@@ -211,7 +259,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: wasteRecords,
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map([['received:1000', 5]])
@@ -229,7 +277,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: [],
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map()
@@ -249,15 +297,19 @@ describe('classifyByPeriodStatus', () => {
         })
       ]
       // The record's last version doesn't match summaryLogId => unchanged
-      wasteRecords[0].record.versions = [
-        { summaryLog: { id: 'other-sl' }, status: VERSION_STATUS.CREATED }
-      ]
+      wasteRecords[0].record.versions =
+        /** @type {ValidatedWasteRecord['record']['versions']} */ ([
+          {
+            summaryLog: { id: 'other-sl', uri: 's3://bucket/old' },
+            status: VERSION_STATUS.CREATED
+          }
+        ])
 
       const result = classifyByPeriodStatus({
         wasteRecords,
         wasteBalanceRecords: [],
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map()
@@ -273,7 +325,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: [],
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map()
@@ -289,7 +341,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords: [],
         wasteBalanceRecords: [],
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map()
@@ -308,7 +360,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: wasteRecords,
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map([
@@ -331,7 +383,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: wasteRecords,
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map([
@@ -350,7 +402,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: [],
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map()
@@ -362,8 +414,11 @@ describe('classifyByPeriodStatus', () => {
     it('ignores submitted reports for a different cadence', () => {
       const wasteRecords = [buildWasteRecord({ date: '2026-01-15' })]
 
+      /** @type {PeriodicReport[]} */
       const submittedReports = [
         {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
           year: 2026,
           reports: {
             quarterly: {
@@ -371,7 +426,13 @@ describe('classifyByPeriodStatus', () => {
                 startDate: '2026-01-01',
                 endDate: '2026-03-31',
                 dueDate: '2026-04-20',
-                current: { id: 'r-1', status: 'submitted' },
+                current: {
+                  id: 'r-1',
+                  status: 'submitted',
+                  submissionNumber: 1,
+                  submittedAt: null,
+                  submittedBy: null
+                },
                 previousSubmissions: []
               }
             }
@@ -384,7 +445,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: [],
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports,
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map()
@@ -398,8 +459,11 @@ describe('classifyByPeriodStatus', () => {
     it('treats open periods with in_progress reports as open', () => {
       const wasteRecords = [buildWasteRecord({ date: '2026-01-15' })]
 
+      /** @type {PeriodicReport[]} */
       const submittedReports = [
         {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
           year: 2026,
           reports: {
             monthly: {
@@ -407,7 +471,13 @@ describe('classifyByPeriodStatus', () => {
                 startDate: '2026-01-01',
                 endDate: '2026-01-31',
                 dueDate: '2026-02-20',
-                current: { id: 'r-1', status: 'in_progress' },
+                current: {
+                  id: 'r-1',
+                  status: 'in_progress',
+                  submissionNumber: 1,
+                  submittedAt: null,
+                  submittedBy: null
+                },
                 previousSubmissions: []
               }
             }
@@ -419,7 +489,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: [],
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports,
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map()
@@ -436,7 +506,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: wasteRecords,
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map()
@@ -452,7 +522,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: [],
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map()
@@ -468,7 +538,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords,
         wasteBalanceRecords: [],
         summaryLogId: SUMMARY_LOG_ID,
-        registration: { accreditation: { status: 'approved' } },
+        registration: accreditedRegistration,
         submittedReports: [],
         tableSchemas: TABLE_SCHEMAS,
         transactionAmounts: new Map()

--- a/src/application/summary-logs/validate-issue-logging.js
+++ b/src/application/summary-logs/validate-issue-logging.js
@@ -1,6 +1,7 @@
 import {
   LOGGING_EVENT_ACTIONS,
-  LOGGING_EVENT_CATEGORIES
+  LOGGING_EVENT_CATEGORIES,
+  VALIDATION_SEVERITY
 } from '#common/enums/index.js'
 import { LOCATION_KEYS } from '#common/validation/validation-issues.js'
 
@@ -127,4 +128,58 @@ export const logValidationIssues = ({
       registrationId: summaryLog.registrationId
     })
   )
+}
+
+export const MAX_ACTUAL_LENGTH = 200
+
+/** @param {ValidationIssue[]} issues */
+const truncateActualValues = (issues) => {
+  for (const issue of issues) {
+    if (
+      typeof issue.context?.actual === 'string' &&
+      issue.context.actual.length > MAX_ACTUAL_LENGTH
+    ) {
+      issue.context.actual =
+        issue.context.actual.slice(0, MAX_ACTUAL_LENGTH) + '…'
+    }
+  }
+}
+
+/**
+ * Caps the issues array and truncates long actual values for MongoDB storage.
+ *
+ * Both the issue count and per-issue actual values are bounded to prevent
+ * the summary log document exceeding MongoDB's 16 MiB BSON limit.
+ * @see https://eaflood.atlassian.net/browse/PAE-1244
+ *
+ * Fatal issues are always preserved — they determine the summary log status
+ * and are required by the frontend to render specific error messages.
+ * Non-fatal issues fill the remaining capacity.
+ *
+ * @param {ValidationIssue[]} allIssues - All validation issues
+ * @returns {ValidationIssue[]} The capped, actual-value-truncated issues
+ */
+export const capIssuesForStorage = (allIssues) => {
+  let cappedIssues
+
+  if (allIssues.length <= MAX_VALIDATION_ISSUES) {
+    cappedIssues = allIssues
+  } else {
+    const fatal = allIssues.filter(
+      (issue) => issue.severity === VALIDATION_SEVERITY.FATAL
+    )
+    const nonFatal = allIssues.filter(
+      (issue) => issue.severity !== VALIDATION_SEVERITY.FATAL
+    )
+    const cappedFatal = fatal.slice(0, MAX_VALIDATION_ISSUES)
+    const nonFatalSlots = Math.max(
+      0,
+      MAX_VALIDATION_ISSUES - cappedFatal.length
+    )
+    cappedIssues = [...cappedFatal, ...nonFatal.slice(0, nonFatalSlots)]
+  }
+
+  truncateActualValues(cappedIssues)
+
+  return cappedIssues
 }

--- a/src/application/summary-logs/validate-metrics.js
+++ b/src/application/summary-logs/validate-metrics.js
@@ -1,0 +1,108 @@
+import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+
+/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
+/** @import {ProcessingType} from '#domain/summary-logs/meta-fields.js' */
+/** @import {SummaryLogStatus} from '#domain/summary-logs/status.js' */
+
+/**
+ * Records validation issue metrics grouped by severity x category
+ *
+ * @param {ValidationIssuesCollector} issues
+ * @param {string} processingType
+ */
+const recordValidationIssueMetrics = async (issues, processingType) => {
+  const allIssues = issues.getAllIssues()
+  if (allIssues.length === 0) {
+    return
+  }
+
+  const counts = new Map()
+  for (const issue of allIssues) {
+    const key = `${issue.severity}:${issue.category}`
+    counts.set(key, (counts.get(key) || 0) + 1)
+  }
+
+  for (const [key, count] of counts) {
+    const [severity, category] = key.split(':')
+    await summaryLogMetrics.recordValidationIssues(
+      {
+        severity:
+          /** @type {import('#common/helpers/metrics/summary-logs.js').ValidationSeverity} */ (
+            severity
+          ),
+        category:
+          /** @type {import('#common/helpers/metrics/summary-logs.js').ValidationCategory} */ (
+            category
+          ),
+        processingType: /** @type {ProcessingType} */ (processingType)
+      },
+      count
+    )
+  }
+}
+
+/**
+ * Records row outcome metrics grouped by outcome
+ *
+ * @param {ValidatedWasteRecord[] | null} wasteRecords
+ * @param {string} processingType
+ */
+const recordRowOutcomeMetrics = async (wasteRecords, processingType) => {
+  if (!wasteRecords || wasteRecords.length === 0) {
+    return
+  }
+
+  const counts = {
+    [ROW_OUTCOME.INCLUDED]: 0,
+    [ROW_OUTCOME.EXCLUDED]: 0,
+    [ROW_OUTCOME.REJECTED]: 0,
+    [ROW_OUTCOME.IGNORED]: 0
+  }
+
+  for (const { outcome } of wasteRecords) {
+    counts[outcome]++
+  }
+
+  for (const [outcome, count] of Object.entries(counts)) {
+    if (count > 0) {
+      await summaryLogMetrics.recordRowOutcome(
+        {
+          outcome:
+            /** @type {import('#common/helpers/metrics/summary-logs.js').RowOutcome} */ (
+              outcome
+            ),
+          processingType: /** @type {ProcessingType} */ (processingType)
+        },
+        count
+      )
+    }
+  }
+}
+
+/**
+ * Records all validation-related metrics.
+ *
+ * @param {Object} params
+ * @param {ValidationIssuesCollector} params.issues
+ * @param {ProcessingType} params.processingType
+ * @param {SummaryLogStatus} params.status
+ * @param {number} params.validationDurationMs
+ * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords
+ */
+export const recordValidationMetrics = async ({
+  issues,
+  processingType,
+  status,
+  validationDurationMs,
+  wasteBalanceRecords
+}) => {
+  await summaryLogMetrics.recordValidationDuration(
+    { processingType },
+    validationDurationMs
+  )
+  await summaryLogMetrics.recordStatusTransition({ status, processingType })
+  await recordValidationIssueMetrics(issues, processingType)
+  await recordRowOutcomeMetrics(wasteBalanceRecords, processingType)
+}

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto'
+import { ObjectId } from 'mongodb'
 
 import { createInMemorySummaryLogExtractor } from '#application/summary-logs/extractor-inmemory.js'
 import { createSummaryLogsValidator } from '#application/summary-logs/validate.js'
@@ -15,6 +16,7 @@ import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data
 import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
+import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 
 /** @import {DataSection, MetadataEntry, SummaryLogExtractor} from '#domain/summary-logs/extractor/port.js' */
 /** @import {WasteProcessingTypeValue} from '#domain/organisations/model.js' */
@@ -119,13 +121,15 @@ describe('SummaryLogsValidator integration', () => {
       summaryLogExtractor || createExtractor(summaryLog.file.id, metadata, data)
 
     const wasteRecordsRepository = createInMemoryWasteRecordsRepository()()
+    const reportsRepository = createInMemoryReportsRepository()()
 
     const validateSummaryLog = createSummaryLogsValidator({
       logger,
       summaryLogsRepository,
       organisationsRepository,
       wasteRecordsRepository,
-      summaryLogExtractor: extractor
+      summaryLogExtractor: extractor,
+      reportsRepository
     })
 
     await summaryLogsRepository.insert(summaryLogId, summaryLog)
@@ -1044,6 +1048,287 @@ describe('SummaryLogsValidator integration', () => {
       expect(erroringSheets).toEqual(
         expect.arrayContaining(['Exported', 'Sent on'])
       )
+    })
+  })
+
+  describe('loadsByPeriodStatus', () => {
+    const organisationId = new ObjectId().toString()
+    const registrationId = new ObjectId().toString()
+    const accreditationId = new ObjectId().toString()
+    const accreditationNumber = 'ACC-PS-001'
+
+    const createTestOrgWithObjectIds = () => {
+      const org = buildOrganisation()
+      org.id = organisationId
+      org.status = ORGANISATION_STATUS.ACTIVE
+
+      org.registrations = [
+        {
+          id: registrationId,
+          registrationNumber: 'REG-PS-001',
+          status: 'approved',
+          material: 'paper',
+          wasteProcessingType: 'reprocessor',
+          reprocessingType: 'input',
+          formSubmission: { id: registrationId, time: new Date() },
+          submittedToRegulator: 'ea',
+          accreditationId,
+          statusHistory: [
+            { status: 'approved', updatedAt: new Date().toISOString() }
+          ]
+        }
+      ]
+
+      org.accreditations = [
+        {
+          id: accreditationId,
+          accreditationNumber,
+          status: 'approved',
+          material: 'paper',
+          wasteProcessingType: 'reprocessor',
+          reprocessingType: 'input',
+          formSubmission: { id: accreditationId, time: new Date() },
+          submittedToRegulator: 'ea',
+          statusHistory: [
+            { status: 'approved', updatedAt: new Date().toISOString() }
+          ]
+        }
+      ]
+
+      return org
+    }
+
+    const metadata = {
+      REGISTRATION_NUMBER: {
+        value: 'REG-PS-001',
+        location: { sheet: 'Cover', row: 1, column: 'B' }
+      },
+      PROCESSING_TYPE: {
+        value: 'REPROCESSOR_INPUT',
+        location: { sheet: 'Cover', row: 2, column: 'B' }
+      },
+      MATERIAL: {
+        value: 'Paper_and_board',
+        location: { sheet: 'Cover', row: 3, column: 'B' }
+      },
+      TEMPLATE_VERSION: {
+        value: 5,
+        location: { sheet: 'Cover', row: 4, column: 'B' }
+      },
+      ACCREDITATION_NUMBER: {
+        value: accreditationNumber,
+        location: { sheet: 'Cover', row: 5, column: 'B' }
+      }
+    }
+
+    /**
+     * Builds a submitted report document for seeding the in-memory store.
+     */
+    const buildSubmittedReport = ({
+      year,
+      cadence,
+      period,
+      startDate,
+      endDate,
+      dueDate
+    }) => {
+      const id = new ObjectId().toString()
+      const now = new Date().toISOString()
+      return {
+        id,
+        version: 1,
+        schemaVersion: 1,
+        submissionNumber: 1,
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        startDate,
+        endDate,
+        dueDate,
+        status: {
+          currentStatus: 'submitted',
+          currentStatusAt: now,
+          created: {
+            at: now,
+            by: { id: 'user-1', name: 'Test', position: 'Tester' }
+          },
+          submitted: {
+            at: now,
+            by: { id: 'user-1', name: 'Test', position: 'Tester' }
+          },
+          history: [
+            {
+              status: 'submitted',
+              at: now,
+              by: { id: 'user-1', name: 'Test', position: 'Tester' }
+            }
+          ]
+        }
+      }
+    }
+
+    it('classifies loads into open and closed periods for accredited reprocessor', async () => {
+      const testOrg = createTestOrgWithObjectIds()
+      const organisationsRepository = createInMemoryOrganisationsRepository([
+        testOrg
+      ])()
+      const summaryLog = summaryLogFactory.validating({
+        organisationId,
+        registrationId
+      })
+      const summaryLogId = randomUUID()
+
+      // Seed a single submitted report for Jan 2026 (period 1) => closed
+      // Period 2 (Feb) has no report => open
+      const reportsMap = new Map()
+      const submittedReport = buildSubmittedReport({
+        year: 2026,
+        cadence: 'monthly',
+        period: 1,
+        startDate: '2026-01-01',
+        endDate: '2026-01-31',
+        dueDate: '2026-02-20'
+      })
+      reportsMap.set(submittedReport.id, submittedReport)
+
+      const reportsRepository = createInMemoryReportsRepository(reportsMap)()
+
+      const extractor = createInMemorySummaryLogExtractor({
+        [summaryLog.file.id]: {
+          meta: metadata,
+          data: {
+            RECEIVED_LOADS_FOR_REPROCESSING: {
+              location: { sheet: 'Received', row: 7, column: 'A' },
+              headers: [
+                'ROW_ID',
+                'DATE_RECEIVED_FOR_REPROCESSING',
+                'EWC_CODE',
+                'DESCRIPTION_WASTE',
+                'WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE',
+                'GROSS_WEIGHT',
+                'TARE_WEIGHT',
+                'PALLET_WEIGHT',
+                'NET_WEIGHT',
+                'BAILING_WIRE_PROTOCOL',
+                'HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION',
+                'WEIGHT_OF_NON_TARGET_MATERIALS',
+                'RECYCLABLE_PROPORTION_PERCENTAGE',
+                'TONNAGE_RECEIVED_FOR_RECYCLING',
+                'SUPPLIER_NAME',
+                'SUPPLIER_ADDRESS',
+                'SUPPLIER_POSTCODE',
+                'SUPPLIER_EMAIL',
+                'SUPPLIER_PHONE_NUMBER',
+                'ACTIVITIES_CARRIED_OUT_BY_SUPPLIER',
+                'YOUR_REFERENCE',
+                'WEIGHBRIDGE_TICKET',
+                'CARRIER_NAME',
+                'CBD_REG_NUMBER',
+                'CARRIER_VEHICLE_REGISTRATION_NUMBER'
+              ],
+              rows: [
+                {
+                  rowNumber: 8,
+                  values: [
+                    1000,
+                    new Date('2026-01-15'), // Jan => period 1 (closed)
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                  ]
+                },
+                {
+                  rowNumber: 9,
+                  values: [
+                    1001,
+                    new Date('2026-02-10'), // Feb => period 2 (open)
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      })
+
+      const wasteRecordsRepository = createInMemoryWasteRecordsRepository()()
+
+      const validateSummaryLog = createSummaryLogsValidator({
+        logger,
+        summaryLogsRepository,
+        organisationsRepository,
+        wasteRecordsRepository,
+        summaryLogExtractor: extractor,
+        reportsRepository
+      })
+
+      await summaryLogsRepository.insert(summaryLogId, summaryLog)
+      await validateSummaryLog(summaryLogId).catch((err) => err)
+
+      const updated = await waitForVersion(
+        summaryLogsRepository,
+        summaryLogId,
+        2
+      )
+
+      expect(updated.summaryLog.status).toBe(SUMMARY_LOG_STATUS.VALIDATED)
+      expect(updated.summaryLog.loadsByPeriodStatus).toBeDefined()
+
+      const { open, closed } = updated.summaryLog.loadsByPeriodStatus
+
+      // Jan load => closed period, added, excluded (missing required waste balance fields)
+      expect(closed.added.excluded.count).toBe(1)
+
+      // Feb load => open period, added, excluded
+      expect(open.added.excluded.count).toBe(1)
+
+      // No included loads (waste balance fields are null)
+      expect(closed.added.included.count).toBe(0)
+      expect(open.added.included.count).toBe(0)
     })
   })
 })

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -1058,43 +1058,42 @@ describe('SummaryLogsValidator integration', () => {
     const accreditationNumber = 'ACC-PS-001'
 
     const createTestOrgWithObjectIds = () => {
-      const org = buildOrganisation()
-      org.id = organisationId
-      org.status = ORGANISATION_STATUS.ACTIVE
+      const registration = {
+        id: registrationId,
+        registrationNumber: 'REG-PS-001',
+        material: 'paper',
+        wasteProcessingType: 'reprocessor',
+        reprocessingType: 'input',
+        formSubmission: { id: registrationId, time: new Date() },
+        submittedToRegulator: 'ea',
+        accreditationId
+      }
 
-      org.registrations = [
-        {
-          id: registrationId,
-          registrationNumber: 'REG-PS-001',
-          status: 'approved',
-          material: 'paper',
-          wasteProcessingType: 'reprocessor',
-          reprocessingType: 'input',
-          formSubmission: { id: registrationId, time: new Date() },
-          submittedToRegulator: 'ea',
-          accreditationId,
-          statusHistory: [
-            { status: 'approved', updatedAt: new Date().toISOString() }
-          ]
-        }
-      ]
+      const accreditation = {
+        id: accreditationId,
+        accreditationNumber,
+        status: 'approved',
+        material: 'paper',
+        wasteProcessingType: 'reprocessor',
+        formSubmission: { id: accreditationId, time: new Date() },
+        submittedToRegulator: 'ea'
+      }
 
-      org.accreditations = [
-        {
-          id: accreditationId,
-          accreditationNumber,
-          status: 'approved',
-          material: 'paper',
-          wasteProcessingType: 'reprocessor',
-          reprocessingType: 'input',
-          formSubmission: { id: accreditationId, time: new Date() },
-          submittedToRegulator: 'ea',
-          statusHistory: [
-            { status: 'approved', updatedAt: new Date().toISOString() }
-          ]
-        }
-      ]
+      const org = {
+        ...buildOrganisation({
+          registrations: [registration],
+          accreditations: [accreditation]
+        }),
+        id: organisationId,
+        status: ORGANISATION_STATUS.ACTIVE
+      }
 
+      // status is derived from statusHistory; append 'approved' so
+      // isRegistrationAccredited returns true
+      org.accreditations[0].statusHistory.push({
+        status: 'approved',
+        updatedAt: new Date()
+      })
       return org
     }
 

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -1092,7 +1092,7 @@ describe('SummaryLogsValidator integration', () => {
       // isRegistrationAccredited returns true
       org.accreditations[0].statusHistory.push({
         status: 'approved',
-        updatedAt: new Date()
+        updatedAt: new Date().toISOString()
       })
       return org
     }

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -16,7 +16,6 @@ import {
 import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 
 import { transformFromSummaryLog } from '#application/waste-records/transform-from-summary-log.js'
-import { VERSION_STATUS } from '#domain/waste-records/model.js'
 import { SUMMARY_LOG_META_FIELDS } from '#domain/summary-logs/meta-fields.js'
 import {
   PROCESSING_TYPE_TABLES,
@@ -30,7 +29,7 @@ import {
   countByWasteRecordType,
   mergeLoads
 } from './load-counts.js'
-import { classifyByPeriodStatus } from './period-status.js'
+import { computeLoadsByPeriodStatus } from './period-status.js'
 import {
   logValidationIssues,
   MAX_VALIDATION_ISSUES
@@ -603,141 +602,6 @@ const classifyLoads = ({
   })
 
   return { loads, loadsByWasteRecordType }
-}
-
-/**
- * Computes the transaction amount for a record's data via classifyForWasteBalance.
- * Returns 0 if the record is not INCLUDED.
- *
- * @param {import('#domain/summary-logs/table-schemas/index.js').TableSchema | null} schema
- * @param {Record<string, any>} data
- * @param {Registration} registration
- * @returns {number}
- */
-const getTransactionAmount = (schema, data, registration) => {
-  const result = schema?.classifyForWasteBalance?.(data, {
-    accreditation: registration.accreditation,
-    overseasSites: ORS_VALIDATION_DISABLED
-  })
-  return result?.outcome === ROW_OUTCOME.INCLUDED ? result.transactionAmount : 0
-}
-
-/**
- * Builds a map of rowId => waste balance impact for included waste-balance records.
- *
- * For added records, the impact is the full transaction amount.
- * For adjusted records, the impact is the delta: new amount minus old amount.
- * This reflects the actual change each record makes to the waste balance.
- *
- * @param {ValidatedWasteRecord[]} wasteBalanceRecords
- * @param {Registration} registration
- * @param {string} processingType
- * @param {string} summaryLogId
- * @param {Map<string, import('#domain/waste-records/model.js').WasteRecord>} existingRecordsMap - keyed by "type:rowId"
- * @returns {Map<string, number>}
- */
-export const buildTransactionAmounts = (
-  wasteBalanceRecords,
-  registration,
-  processingType,
-  summaryLogId,
-  existingRecordsMap
-) => {
-  const amounts = new Map()
-  for (const { record, outcome } of wasteBalanceRecords) {
-    if (outcome !== ROW_OUTCOME.INCLUDED) {
-      continue
-    }
-    const schema = findSchemaForProcessingType(processingType, record.type)
-    const newAmount = getTransactionAmount(schema, record.data, registration)
-    if (newAmount === 0) {
-      continue
-    }
-
-    const key = `${record.type}:${record.rowId}`
-    const lastVersion = record.versions[record.versions.length - 1]
-    const isAdjusted =
-      lastVersion.summaryLog?.id === summaryLogId &&
-      lastVersion.status === VERSION_STATUS.UPDATED
-
-    if (isAdjusted) {
-      const existing = existingRecordsMap.get(key)
-      const oldAmount = existing
-        ? getTransactionAmount(schema, existing.data, registration)
-        : 0
-      amounts.set(key, newAmount - oldAmount)
-    } else {
-      amounts.set(key, newAmount)
-    }
-  }
-  return amounts
-}
-
-/**
- * Computes loadsByPeriodStatus for a validated summary log.
- * Returns null if the summary log is not validated or if the reports lookup fails.
- *
- * @param {Object} params
- * @param {ValidatedWasteRecord[]} params.wasteRecords
- * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords
- * @param {string} params.summaryLogId
- * @param {Registration} params.registration
- * @param {string} params.processingType
- * @param {Map<string, import('#domain/waste-records/model.js').WasteRecord>} params.existingRecordsMap
- * @param {import('#reports/repository/port.js').ReportsRepository} params.reportsRepository
- * @param {string} params.organisationId
- * @param {string} params.registrationId
- * @param {string} params.loggingContext
- * @param {TypedLogger} params.logger
- * @returns {Promise<import('./period-status.js').LoadsByPeriodStatus | null>}
- */
-const computeLoadsByPeriodStatus = async ({
-  wasteRecords,
-  wasteBalanceRecords,
-  summaryLogId,
-  registration,
-  processingType,
-  existingRecordsMap,
-  reportsRepository,
-  organisationId,
-  registrationId,
-  loggingContext,
-  logger
-}) => {
-  try {
-    const submittedReports = await reportsRepository.findPeriodicReports({
-      organisationId,
-      registrationId
-    })
-
-    const transactionAmounts = buildTransactionAmounts(
-      wasteBalanceRecords,
-      registration,
-      processingType,
-      summaryLogId,
-      existingRecordsMap
-    )
-
-    return classifyByPeriodStatus({
-      wasteRecords,
-      wasteBalanceRecords,
-      summaryLogId,
-      registration,
-      submittedReports,
-      tableSchemas: PROCESSING_TYPE_TABLES[processingType],
-      transactionAmounts
-    })
-  } catch (err) {
-    logger.warn({
-      message: `Failed to classify loads by period status: ${loggingContext}`,
-      err,
-      event: {
-        category: LOGGING_EVENT_CATEGORIES.SERVER,
-        action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
-      }
-    })
-    return null
-  }
 }
 
 /**

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -29,6 +29,7 @@ import {
   countByWasteRecordType,
   mergeLoads
 } from './load-counts.js'
+import { classifyByPeriodStatus } from './period-status.js'
 import {
   logValidationIssues,
   MAX_VALIDATION_ISSUES
@@ -56,6 +57,7 @@ export const MAX_ACTUAL_LENGTH = 200
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 /** @import {SummaryLogExtractor} from './extractor.js' */
 /** @import {Loads} from './load-counts.js' */
+/** @import {ReportsRepository} from '#reports/repository/port.js' */
 
 /**
  * @param {{
@@ -183,6 +185,7 @@ const fetchRegistration = async ({
  * @property {ValidationIssuesCollector} issues - Validation issues object with methods like getAllIssues(), isFatal()
  * @property {ValidatedWasteRecord[]|null} wasteRecords - Waste records with validation issues (null if transformation not reached)
  * @property {ExtractedMeta} [meta] - Extracted metadata values (only present after successful extraction)
+ * @property {Registration} [registration] - The fetched registration (only present after successful meta validation)
  */
 
 /**
@@ -305,6 +308,7 @@ const performValidationChecks = async ({
   const issues = createValidationIssues()
   let wasteRecords = null
   let meta
+  let registration
 
   try {
     const parsed = await extractSummaryLog({
@@ -322,7 +326,7 @@ const performValidationChecks = async ({
       return { issues, wasteRecords, meta }
     }
 
-    const registration = await fetchRegistration({
+    registration = await fetchRegistration({
       organisationsRepository,
       organisationId: summaryLog.organisationId,
       registrationId: summaryLog.registrationId,
@@ -372,7 +376,7 @@ const performValidationChecks = async ({
     )
   }
 
-  return { issues, wasteRecords, meta }
+  return { issues, wasteRecords, meta, registration }
 }
 
 /**
@@ -505,6 +509,7 @@ const recordValidationMetrics = async ({
  * @param {ValidationIssuesCollector} params.issues
  * @param {Loads | null} params.loads
  * @param {import('./load-counts.js').LoadsByWasteRecordType | null} params.loadsByWasteRecordType
+ * @param {import('./period-status.js').LoadsByPeriodStatus | null} params.loadsByPeriodStatus
  * @param {ExtractedMeta | undefined} params.meta
  * @param {SummaryLogStatus} params.status
  * @param {SummaryLog} params.summaryLog
@@ -516,6 +521,7 @@ const persistValidationResult = async ({
   issues,
   loads,
   loadsByWasteRecordType,
+  loadsByPeriodStatus,
   meta,
   status,
   summaryLog,
@@ -534,6 +540,7 @@ const persistValidationResult = async ({
     },
     ...(loads && { loads }),
     ...(loadsByWasteRecordType && { loadsByWasteRecordType }),
+    ...(loadsByPeriodStatus && { loadsByPeriodStatus }),
     ...(meta && { meta })
   })
 }
@@ -594,6 +601,38 @@ const classifyLoads = ({
 }
 
 /**
+ * Builds a map of rowId => transactionAmount for included waste-balance records.
+ *
+ * Re-invokes classifyForWasteBalance to extract the tonnage. This mirrors
+ * the call in markIgnoredByDateRange but collects the transaction amounts
+ * rather than modifying outcomes.
+ *
+ * @param {ValidatedWasteRecord[]} wasteBalanceRecords
+ * @param {Registration} registration
+ * @param {string} processingType
+ * @returns {Map<string, number>}
+ */
+const buildTransactionAmounts = (
+  wasteBalanceRecords,
+  registration,
+  processingType
+) => {
+  const amounts = new Map()
+  for (const { record, outcome } of wasteBalanceRecords) {
+    if (outcome !== ROW_OUTCOME.INCLUDED) continue
+    const schema = findSchemaForProcessingType(processingType, record.type)
+    const result = schema?.classifyForWasteBalance?.(record.data, {
+      accreditation: registration.accreditation,
+      overseasSites: ORS_VALIDATION_DISABLED
+    })
+    if (result?.outcome === ROW_OUTCOME.INCLUDED) {
+      amounts.set(record.rowId, result.transactionAmount)
+    }
+  }
+  return amounts
+}
+
+/**
  * Creates a summary logs validator function.
  *
  * @param {{
@@ -601,7 +640,8 @@ const classifyLoads = ({
  *   summaryLogsRepository: SummaryLogsRepository,
  *   organisationsRepository: OrganisationsRepository,
  *   wasteRecordsRepository: WasteRecordsRepository,
- *   summaryLogExtractor: SummaryLogExtractor
+ *   summaryLogExtractor: SummaryLogExtractor,
+ *   reportsRepository: ReportsRepository
  * }} params
  * @returns {(summaryLogId: string) => Promise<void>}
  */
@@ -610,7 +650,8 @@ export const createSummaryLogsValidator = ({
   summaryLogsRepository,
   organisationsRepository,
   wasteRecordsRepository,
-  summaryLogExtractor
+  summaryLogExtractor,
+  reportsRepository
 }) => {
   const validateDataSyntax = createDataSyntaxValidator(PROCESSING_TYPE_TABLES)
 
@@ -636,16 +677,17 @@ export const createSummaryLogsValidator = ({
     })
 
     const validationStart = Date.now()
-    const { issues, wasteRecords, meta } = await performValidationChecks({
-      summaryLogId,
-      summaryLog,
-      loggingContext,
-      logger,
-      summaryLogExtractor,
-      organisationsRepository,
-      wasteRecordsRepository,
-      validateDataSyntax
-    })
+    const { issues, wasteRecords, meta, registration } =
+      await performValidationChecks({
+        summaryLogId,
+        summaryLog,
+        loggingContext,
+        logger,
+        summaryLogExtractor,
+        organisationsRepository,
+        wasteRecordsRepository,
+        validateDataSyntax
+      })
     const validationDurationMs = Date.now() - validationStart
 
     logValidationIssues({ summaryLogId, summaryLog, issues, logger })
@@ -677,10 +719,52 @@ export const createSummaryLogsValidator = ({
       wasteRecords
     })
 
+    let loadsByPeriodStatus = null
+    if (
+      status === SUMMARY_LOG_STATUS.VALIDATED &&
+      wasteRecords &&
+      registration
+    ) {
+      try {
+        const submittedReports = await reportsRepository.findPeriodicReports({
+          organisationId: summaryLog.organisationId,
+          registrationId: summaryLog.registrationId
+        })
+
+        const transactionAmounts = buildTransactionAmounts(
+          wasteBalanceRecords,
+          registration,
+          processingType
+        )
+
+        const tableSchemas = PROCESSING_TYPE_TABLES[processingType]
+
+        loadsByPeriodStatus = classifyByPeriodStatus({
+          wasteRecords,
+          wasteBalanceRecords,
+          summaryLogId,
+          registration,
+          submittedReports,
+          tableSchemas,
+          transactionAmounts
+        })
+      } catch (err) {
+        logger.warn({
+          message: `Failed to classify loads by period status: ${loggingContext}`,
+          err,
+          event: {
+            category: LOGGING_EVENT_CATEGORIES.SERVER,
+            action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
+          }
+        })
+      }
+    }
+
     await persistValidationResult({
       issues,
       loads,
       loadsByWasteRecordType,
+      loadsByPeriodStatus,
       meta,
       status,
       summaryLog,

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -655,7 +655,7 @@ export const buildTransactionAmounts = (
     }
 
     const key = `${record.type}:${record.rowId}`
-    const lastVersion = record.versions.at(-1)
+    const lastVersion = record.versions[record.versions.length - 1]
     const isAdjusted =
       lastVersion.summaryLog?.id === summaryLogId &&
       lastVersion.status === VERSION_STATUS.UPDATED

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -605,6 +605,102 @@ const classifyLoads = ({
 }
 
 /**
+ * Classifies loads, computes period status, records metrics, and persists the result.
+ *
+ * @param {Object} params
+ * @param {ValidationResult & { registration?: Registration, existingRecordsMap?: Map<string, import('#domain/waste-records/model.js').WasteRecord> }} params.validationResult
+ * @param {string} params.summaryLogId
+ * @param {SubmittedSummaryLog} params.summaryLog
+ * @param {number} params.validationDurationMs
+ * @param {string} params.loggingContext
+ * @param {SummaryLogsRepository} params.summaryLogsRepository
+ * @param {ReportsRepository} params.reportsRepository
+ * @param {TypedLogger} params.logger
+ * @param {number} params.version
+ */
+const classifyAndPersist = async ({
+  validationResult: {
+    issues,
+    wasteRecords,
+    meta,
+    registration,
+    existingRecordsMap
+  },
+  summaryLogId,
+  summaryLog,
+  validationDurationMs,
+  loggingContext,
+  summaryLogsRepository,
+  reportsRepository,
+  logger,
+  version
+}) => {
+  const processingType = meta?.[SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]
+
+  const status = issues.isFatal()
+    ? SUMMARY_LOG_STATUS.INVALID
+    : SUMMARY_LOG_STATUS.VALIDATED
+
+  const wasteBalanceRecords = filterWasteBalanceRecords(
+    wasteRecords,
+    processingType
+  )
+
+  await recordValidationMetrics({
+    issues,
+    processingType,
+    status,
+    validationDurationMs,
+    wasteBalanceRecords
+  })
+
+  const { loads, loadsByWasteRecordType } = classifyLoads({
+    processingType,
+    status,
+    summaryLogId,
+    wasteBalanceRecords,
+    wasteRecords
+  })
+
+  const canClassifyPeriodStatus =
+    status === SUMMARY_LOG_STATUS.VALIDATED &&
+    wasteRecords &&
+    registration &&
+    existingRecordsMap
+
+  const loadsByPeriodStatus = canClassifyPeriodStatus
+    ? await computeLoadsByPeriodStatus({
+        wasteRecords,
+        wasteBalanceRecords,
+        summaryLogId,
+        registration,
+        processingType,
+        existingRecordsMap,
+        reportsRepository,
+        organisationId: summaryLog.organisationId,
+        registrationId: summaryLog.registrationId,
+        loggingContext,
+        logger
+      })
+    : null
+
+  await persistValidationResult({
+    issues,
+    loads,
+    loadsByWasteRecordType,
+    loadsByPeriodStatus,
+    meta,
+    status,
+    summaryLog,
+    summaryLogId,
+    summaryLogsRepository,
+    version
+  })
+
+  return status
+}
+
+/**
  * Creates a summary logs validator function.
  *
  * @param {{
@@ -664,65 +760,21 @@ export const createSummaryLogsValidator = ({
 
     logValidationIssues({ summaryLogId, summaryLog, issues, logger })
 
-    const processingType = meta?.[SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]
-
-    const status = issues.isFatal()
-      ? SUMMARY_LOG_STATUS.INVALID
-      : SUMMARY_LOG_STATUS.VALIDATED
-
-    const wasteBalanceRecords = filterWasteBalanceRecords(
-      wasteRecords,
-      processingType
-    )
-
-    await recordValidationMetrics({
-      issues,
-      processingType,
-      status,
-      validationDurationMs,
-      wasteBalanceRecords
-    })
-
-    const { loads, loadsByWasteRecordType } = classifyLoads({
-      processingType,
-      status,
+    const status = await classifyAndPersist({
+      validationResult: {
+        issues,
+        wasteRecords,
+        meta,
+        registration,
+        existingRecordsMap
+      },
       summaryLogId,
-      wasteBalanceRecords,
-      wasteRecords
-    })
-
-    const canClassifyPeriodStatus =
-      status === SUMMARY_LOG_STATUS.VALIDATED &&
-      wasteRecords &&
-      registration &&
-      existingRecordsMap
-
-    const loadsByPeriodStatus = canClassifyPeriodStatus
-      ? await computeLoadsByPeriodStatus({
-          wasteRecords,
-          wasteBalanceRecords,
-          summaryLogId,
-          registration,
-          processingType,
-          existingRecordsMap,
-          reportsRepository,
-          organisationId: summaryLog.organisationId,
-          registrationId: summaryLog.registrationId,
-          loggingContext,
-          logger
-        })
-      : null
-
-    await persistValidationResult({
-      issues,
-      loads,
-      loadsByWasteRecordType,
-      loadsByPeriodStatus,
-      meta,
-      status,
       summaryLog,
-      summaryLogId,
+      validationDurationMs,
+      loggingContext,
       summaryLogsRepository,
+      reportsRepository,
+      logger,
       version
     })
 

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -645,13 +645,17 @@ export const buildTransactionAmounts = (
 ) => {
   const amounts = new Map()
   for (const { record, outcome } of wasteBalanceRecords) {
-    if (outcome !== ROW_OUTCOME.INCLUDED) continue
+    if (outcome !== ROW_OUTCOME.INCLUDED) {
+      continue
+    }
     const schema = findSchemaForProcessingType(processingType, record.type)
     const newAmount = getTransactionAmount(schema, record.data, registration)
-    if (newAmount === 0) continue
+    if (newAmount === 0) {
+      continue
+    }
 
     const key = `${record.type}:${record.rowId}`
-    const lastVersion = record.versions[record.versions.length - 1]
+    const lastVersion = record.versions.at(-1)
     const isAdjusted =
       lastVersion.summaryLog?.id === summaryLogId &&
       lastVersion.status === VERSION_STATUS.UPDATED
@@ -667,6 +671,73 @@ export const buildTransactionAmounts = (
     }
   }
   return amounts
+}
+
+/**
+ * Computes loadsByPeriodStatus for a validated summary log.
+ * Returns null if the summary log is not validated or if the reports lookup fails.
+ *
+ * @param {Object} params
+ * @param {ValidatedWasteRecord[]} params.wasteRecords
+ * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords
+ * @param {string} params.summaryLogId
+ * @param {Registration} params.registration
+ * @param {string} params.processingType
+ * @param {Map<string, import('#domain/waste-records/model.js').WasteRecord>} params.existingRecordsMap
+ * @param {import('#reports/repository/port.js').ReportsRepository} params.reportsRepository
+ * @param {string} params.organisationId
+ * @param {string} params.registrationId
+ * @param {string} params.loggingContext
+ * @param {TypedLogger} params.logger
+ * @returns {Promise<import('./period-status.js').LoadsByPeriodStatus | null>}
+ */
+const computeLoadsByPeriodStatus = async ({
+  wasteRecords,
+  wasteBalanceRecords,
+  summaryLogId,
+  registration,
+  processingType,
+  existingRecordsMap,
+  reportsRepository,
+  organisationId,
+  registrationId,
+  loggingContext,
+  logger
+}) => {
+  try {
+    const submittedReports = await reportsRepository.findPeriodicReports({
+      organisationId,
+      registrationId
+    })
+
+    const transactionAmounts = buildTransactionAmounts(
+      wasteBalanceRecords,
+      registration,
+      processingType,
+      summaryLogId,
+      existingRecordsMap
+    )
+
+    return classifyByPeriodStatus({
+      wasteRecords,
+      wasteBalanceRecords,
+      summaryLogId,
+      registration,
+      submittedReports,
+      tableSchemas: PROCESSING_TYPE_TABLES[processingType],
+      transactionAmounts
+    })
+  } catch (err) {
+    logger.warn({
+      message: `Failed to classify loads by period status: ${loggingContext}`,
+      err,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
+      }
+    })
+    return null
+  }
 }
 
 /**
@@ -756,49 +827,27 @@ export const createSummaryLogsValidator = ({
       wasteRecords
     })
 
-    let loadsByPeriodStatus = null
-    if (
+    const canClassifyPeriodStatus =
       status === SUMMARY_LOG_STATUS.VALIDATED &&
       wasteRecords &&
       registration &&
       existingRecordsMap
-    ) {
-      try {
-        const submittedReports = await reportsRepository.findPeriodicReports({
-          organisationId: summaryLog.organisationId,
-          registrationId: summaryLog.registrationId
-        })
 
-        const transactionAmounts = buildTransactionAmounts(
-          wasteBalanceRecords,
-          registration,
-          processingType,
-          summaryLogId,
-          existingRecordsMap
-        )
-
-        const tableSchemas = PROCESSING_TYPE_TABLES[processingType]
-
-        loadsByPeriodStatus = classifyByPeriodStatus({
+    const loadsByPeriodStatus = canClassifyPeriodStatus
+      ? await computeLoadsByPeriodStatus({
           wasteRecords,
           wasteBalanceRecords,
           summaryLogId,
           registration,
-          submittedReports,
-          tableSchemas,
-          transactionAmounts
+          processingType,
+          existingRecordsMap,
+          reportsRepository,
+          organisationId: summaryLog.organisationId,
+          registrationId: summaryLog.registrationId,
+          loggingContext,
+          logger
         })
-      } catch (err) {
-        logger.warn({
-          message: `Failed to classify loads by period status: ${loggingContext}`,
-          err,
-          event: {
-            category: LOGGING_EVENT_CATEGORIES.SERVER,
-            action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
-          }
-        })
-      }
-    }
+      : null
 
     await persistValidationResult({
       issues,

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -3,8 +3,7 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES,
   VALIDATION_CATEGORY,
-  VALIDATION_CODE,
-  VALIDATION_SEVERITY
+  VALIDATION_CODE
 } from '#common/enums/index.js'
 import { isNil } from '#common/helpers/is-nil.js'
 import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
@@ -31,6 +30,7 @@ import {
 } from './load-counts.js'
 import { computeLoadsByPeriodStatus } from './period-status.js'
 import {
+  capIssuesForStorage,
   logValidationIssues,
   MAX_VALIDATION_ISSUES
 } from './validate-issue-logging.js'
@@ -40,8 +40,7 @@ import { validateMetaBusiness } from './validations/meta-business.js'
 import { validateMetaSyntax } from './validations/meta-syntax.js'
 
 export { MAX_VALIDATION_ISSUES }
-
-export const MAX_ACTUAL_LENGTH = 200
+export { MAX_ACTUAL_LENGTH } from './validate-issue-logging.js'
 
 /** @import {ValidatedSummaryLog, ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
@@ -786,56 +785,4 @@ export const createSummaryLogsValidator = ({
       }
     })
   }
-}
-
-/** @param {ValidationIssue[]} issues */
-const truncateActualValues = (issues) => {
-  for (const issue of issues) {
-    if (
-      typeof issue.context?.actual === 'string' &&
-      issue.context.actual.length > MAX_ACTUAL_LENGTH
-    ) {
-      issue.context.actual =
-        issue.context.actual.slice(0, MAX_ACTUAL_LENGTH) + '…'
-    }
-  }
-}
-
-/**
- * Caps the issues array and truncates long actual values for MongoDB storage.
- *
- * Both the issue count and per-issue actual values are bounded to prevent
- * the summary log document exceeding MongoDB's 16 MiB BSON limit.
- * @see https://eaflood.atlassian.net/browse/PAE-1244
- *
- * Fatal issues are always preserved — they determine the summary log status
- * and are required by the frontend to render specific error messages.
- * Non-fatal issues fill the remaining capacity.
- *
- * @param {ValidationIssue[]} allIssues - All validation issues
- * @returns {ValidationIssue[]} The capped, actual-value-truncated issues
- */
-const capIssuesForStorage = (allIssues) => {
-  let cappedIssues
-
-  if (allIssues.length <= MAX_VALIDATION_ISSUES) {
-    cappedIssues = allIssues
-  } else {
-    const fatal = allIssues.filter(
-      (issue) => issue.severity === VALIDATION_SEVERITY.FATAL
-    )
-    const nonFatal = allIssues.filter(
-      (issue) => issue.severity !== VALIDATION_SEVERITY.FATAL
-    )
-    const cappedFatal = fatal.slice(0, MAX_VALIDATION_ISSUES)
-    const nonFatalSlots = Math.max(
-      0,
-      MAX_VALIDATION_ISSUES - cappedFatal.length
-    )
-    cappedIssues = [...cappedFatal, ...nonFatal.slice(0, nonFatalSlots)]
-  }
-
-  truncateActualValues(cappedIssues)
-
-  return cappedIssues
 }

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -6,7 +6,6 @@ import {
   VALIDATION_CODE
 } from '#common/enums/index.js'
 import { isNil } from '#common/helpers/is-nil.js'
-import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
 import { createValidationIssues } from '#common/validation/validation-issues.js'
 import {
   SUMMARY_LOG_STATUS,
@@ -31,16 +30,18 @@ import {
 import { computeLoadsByPeriodStatus } from './period-status.js'
 import {
   capIssuesForStorage,
-  logValidationIssues,
-  MAX_VALIDATION_ISSUES
+  logValidationIssues
 } from './validate-issue-logging.js'
 import { validateDataBusiness } from './validations/data-business.js'
 import { createDataSyntaxValidator } from './validations/data-syntax.js'
 import { validateMetaBusiness } from './validations/meta-business.js'
+import { recordValidationMetrics } from './validate-metrics.js'
 import { validateMetaSyntax } from './validations/meta-syntax.js'
 
-export { MAX_VALIDATION_ISSUES }
-export { MAX_ACTUAL_LENGTH } from './validate-issue-logging.js'
+export {
+  MAX_VALIDATION_ISSUES,
+  MAX_ACTUAL_LENGTH
+} from './validate-issue-logging.js'
 
 /** @import {ValidatedSummaryLog, ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
@@ -383,85 +384,6 @@ const performValidationChecks = async ({
 }
 
 /**
- * Records validation issue metrics grouped by severity × category
- *
- * @param {ValidationIssuesCollector} issues - Validation issues object
- * @param {string} processingType - The processing type for the metric dimension
- */
-const recordValidationIssueMetrics = async (issues, processingType) => {
-  const allIssues = issues.getAllIssues()
-  if (allIssues.length === 0) {
-    return
-  }
-
-  // Count issues by severity × category
-  const counts = new Map()
-  for (const issue of allIssues) {
-    const key = `${issue.severity}:${issue.category}`
-    counts.set(key, (counts.get(key) || 0) + 1)
-  }
-
-  // Record metrics for each combination
-  for (const [key, count] of counts) {
-    const [severity, category] = key.split(':')
-    await summaryLogMetrics.recordValidationIssues(
-      {
-        severity:
-          /** @type {import('#common/helpers/metrics/summary-logs.js').ValidationSeverity} */ (
-            severity
-          ),
-        category:
-          /** @type {import('#common/helpers/metrics/summary-logs.js').ValidationCategory} */ (
-            category
-          ),
-        processingType: /** @type {ProcessingType} */ (processingType)
-      },
-      count
-    )
-  }
-}
-
-/**
- * Records row outcome metrics grouped by outcome
- *
- * @param {ValidatedWasteRecord[] | null} wasteRecords - Waste records with outcomes
- * @param {string} processingType - The processing type for the metric dimension
- */
-const recordRowOutcomeMetrics = async (wasteRecords, processingType) => {
-  if (!wasteRecords || wasteRecords.length === 0) {
-    return
-  }
-
-  // Count by outcome
-  const counts = {
-    [ROW_OUTCOME.INCLUDED]: 0,
-    [ROW_OUTCOME.EXCLUDED]: 0,
-    [ROW_OUTCOME.REJECTED]: 0,
-    [ROW_OUTCOME.IGNORED]: 0
-  }
-
-  for (const { outcome } of wasteRecords) {
-    counts[outcome]++
-  }
-
-  // Record metrics for each outcome with non-zero count
-  for (const [outcome, count] of Object.entries(counts)) {
-    if (count > 0) {
-      await summaryLogMetrics.recordRowOutcome(
-        {
-          outcome:
-            /** @type {import('#common/helpers/metrics/summary-logs.js').RowOutcome} */ (
-              outcome
-            ),
-          processingType: /** @type {ProcessingType} */ (processingType)
-        },
-        count
-      )
-    }
-  }
-}
-
-/**
  * @param {{ summaryLog: SummaryLog, version: number } | null | undefined} result
  * @param {string} summaryLogId
  */
@@ -477,32 +399,6 @@ const assertValidatingStatus = (result, summaryLogId) => {
       `Summary log must be in validating status. Current status: ${result.summaryLog.status}`
     )
   }
-}
-
-/**
- * Records all validation-related metrics.
- *
- * @param {Object} params
- * @param {ValidationIssuesCollector} params.issues
- * @param {ProcessingType} params.processingType
- * @param {SummaryLogStatus} params.status
- * @param {number} params.validationDurationMs
- * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords
- */
-const recordValidationMetrics = async ({
-  issues,
-  processingType,
-  status,
-  validationDurationMs,
-  wasteBalanceRecords
-}) => {
-  await summaryLogMetrics.recordValidationDuration(
-    { processingType },
-    validationDurationMs
-  )
-  await summaryLogMetrics.recordStatusTransition({ status, processingType })
-  await recordValidationIssueMetrics(issues, processingType)
-  await recordRowOutcomeMetrics(wasteBalanceRecords, processingType)
 }
 
 /**

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -97,7 +97,8 @@ const extractSummaryLog = async ({
  * }} params
  * @returns {Promise<{
  *   wasteRecords: ValidatedWasteRecord[],
- *   issues: ValidationIssuesCollector
+ *   issues: ValidationIssuesCollector,
+ *   existingRecordsMap: Map<string, import('#domain/waste-records/model.js').WasteRecord>
  * }>}
  */
 const transformAndValidateData = async ({
@@ -759,7 +760,8 @@ export const createSummaryLogsValidator = ({
     if (
       status === SUMMARY_LOG_STATUS.VALIDATED &&
       wasteRecords &&
-      registration
+      registration &&
+      existingRecordsMap
     ) {
       try {
         const submittedReports = await reportsRepository.findPeriodicReports({

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -44,7 +44,7 @@ export { MAX_ACTUAL_LENGTH } from './validate-issue-logging.js'
 
 /** @import {ValidatedSummaryLog, ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
-/** @import {ValidationIssue, ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
+/** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {ParsedSummaryLog} from '#domain/summary-logs/extractor/port.js' */
 /** @import {ProcessingType} from '#domain/summary-logs/meta-fields.js' */

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -16,6 +16,7 @@ import {
 import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 
 import { transformFromSummaryLog } from '#application/waste-records/transform-from-summary-log.js'
+import { VERSION_STATUS } from '#domain/waste-records/model.js'
 import { SUMMARY_LOG_META_FIELDS } from '#domain/summary-logs/meta-fields.js'
 import {
   PROCESSING_TYPE_TABLES,
@@ -139,7 +140,7 @@ const transformAndValidateData = async ({
   // Data business validation using waste records
   const issues = validateDataBusiness({ wasteRecords, existingWasteRecords })
 
-  return { wasteRecords, issues }
+  return { wasteRecords, issues, existingRecordsMap }
 }
 
 /**
@@ -186,6 +187,7 @@ const fetchRegistration = async ({
  * @property {ValidatedWasteRecord[]|null} wasteRecords - Waste records with validation issues (null if transformation not reached)
  * @property {ExtractedMeta} [meta] - Extracted metadata values (only present after successful extraction)
  * @property {Registration} [registration] - The fetched registration (only present after successful meta validation)
+ * @property {Map<string, import('#domain/waste-records/model.js').WasteRecord>} [existingRecordsMap] - Existing waste records keyed by "type:rowId"
  */
 
 /**
@@ -309,6 +311,7 @@ const performValidationChecks = async ({
   let wasteRecords = null
   let meta
   let registration
+  let existingRecordsMap
 
   try {
     const parsed = await extractSummaryLog({
@@ -363,6 +366,7 @@ const performValidationChecks = async ({
     })
 
     wasteRecords = dataResult.wasteRecords
+    existingRecordsMap = dataResult.existingRecordsMap
 
     markIgnoredByDateRange(wasteRecords, registration, meta.PROCESSING_TYPE)
 
@@ -376,7 +380,7 @@ const performValidationChecks = async ({
     )
   }
 
-  return { issues, wasteRecords, meta, registration }
+  return { issues, wasteRecords, meta, registration, existingRecordsMap }
 }
 
 /**
@@ -601,32 +605,64 @@ const classifyLoads = ({
 }
 
 /**
- * Builds a map of rowId => transactionAmount for included waste-balance records.
+ * Computes the transaction amount for a record's data via classifyForWasteBalance.
+ * Returns 0 if the record is not INCLUDED.
  *
- * Re-invokes classifyForWasteBalance to extract the tonnage. This mirrors
- * the call in markIgnoredByDateRange but collects the transaction amounts
- * rather than modifying outcomes.
+ * @param {import('#domain/summary-logs/table-schemas/index.js').TableSchema | null} schema
+ * @param {Record<string, any>} data
+ * @param {Registration} registration
+ * @returns {number}
+ */
+const getTransactionAmount = (schema, data, registration) => {
+  const result = schema?.classifyForWasteBalance?.(data, {
+    accreditation: registration.accreditation,
+    overseasSites: ORS_VALIDATION_DISABLED
+  })
+  return result?.outcome === ROW_OUTCOME.INCLUDED ? result.transactionAmount : 0
+}
+
+/**
+ * Builds a map of rowId => waste balance impact for included waste-balance records.
+ *
+ * For added records, the impact is the full transaction amount.
+ * For adjusted records, the impact is the delta: new amount minus old amount.
+ * This reflects the actual change each record makes to the waste balance.
  *
  * @param {ValidatedWasteRecord[]} wasteBalanceRecords
  * @param {Registration} registration
  * @param {string} processingType
+ * @param {string} summaryLogId
+ * @param {Map<string, import('#domain/waste-records/model.js').WasteRecord>} existingRecordsMap - keyed by "type:rowId"
  * @returns {Map<string, number>}
  */
-const buildTransactionAmounts = (
+export const buildTransactionAmounts = (
   wasteBalanceRecords,
   registration,
-  processingType
+  processingType,
+  summaryLogId,
+  existingRecordsMap
 ) => {
   const amounts = new Map()
   for (const { record, outcome } of wasteBalanceRecords) {
     if (outcome !== ROW_OUTCOME.INCLUDED) continue
     const schema = findSchemaForProcessingType(processingType, record.type)
-    const result = schema?.classifyForWasteBalance?.(record.data, {
-      accreditation: registration.accreditation,
-      overseasSites: ORS_VALIDATION_DISABLED
-    })
-    if (result?.outcome === ROW_OUTCOME.INCLUDED) {
-      amounts.set(record.rowId, result.transactionAmount)
+    const newAmount = getTransactionAmount(schema, record.data, registration)
+    if (newAmount === 0) continue
+
+    const key = `${record.type}:${record.rowId}`
+    const lastVersion = record.versions[record.versions.length - 1]
+    const isAdjusted =
+      lastVersion.summaryLog?.id === summaryLogId &&
+      lastVersion.status === VERSION_STATUS.UPDATED
+
+    if (isAdjusted) {
+      const existing = existingRecordsMap.get(key)
+      const oldAmount = existing
+        ? getTransactionAmount(schema, existing.data, registration)
+        : 0
+      amounts.set(key, newAmount - oldAmount)
+    } else {
+      amounts.set(key, newAmount)
     }
   }
   return amounts
@@ -677,7 +713,7 @@ export const createSummaryLogsValidator = ({
     })
 
     const validationStart = Date.now()
-    const { issues, wasteRecords, meta, registration } =
+    const { issues, wasteRecords, meta, registration, existingRecordsMap } =
       await performValidationChecks({
         summaryLogId,
         summaryLog,
@@ -734,7 +770,9 @@ export const createSummaryLogsValidator = ({
         const transactionAmounts = buildTransactionAmounts(
           wasteBalanceRecords,
           registration,
-          processingType
+          processingType,
+          summaryLogId,
+          existingRecordsMap
         )
 
         const tableSchemas = PROCESSING_TYPE_TABLES[processingType]

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -7,6 +7,7 @@ import Boom from '@hapi/boom'
 
 import {
   createSummaryLogsValidator,
+  buildTransactionAmounts,
   MAX_VALIDATION_ISSUES,
   MAX_ACTUAL_LENGTH
 } from './validate.js'
@@ -2055,5 +2056,106 @@ describe('SummaryLogsValidator', () => {
       // Status should be invalid (the fatal was detected pre-cap)
       expect(updateCall.status).toBe(SUMMARY_LOG_STATUS.INVALID)
     })
+  })
+})
+
+describe('buildTransactionAmounts', () => {
+  const summaryLogId = 'sl-1'
+  const registration = {
+    accreditation: {
+      validFrom: '2025-01-01',
+      validTo: '2025-12-31',
+      statusHistory: [
+        { status: 'created', updatedAt: '2024-12-01T00:00:00.000Z' },
+        { status: 'approved', updatedAt: '2024-12-15T00:00:00.000Z' }
+      ]
+    }
+  }
+
+  const buildRecord = ({ rowId, tonnage, status, slId = summaryLogId }) => ({
+    record: {
+      type: 'received',
+      rowId: String(rowId),
+      data: {
+        ROW_ID: rowId,
+        DATE_RECEIVED_FOR_REPROCESSING: '2025-06-15',
+        EWC_CODE: '20 01 01',
+        DESCRIPTION_WASTE: 'Paper - other',
+        WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+        GROSS_WEIGHT: tonnage + 10,
+        TARE_WEIGHT: 5,
+        PALLET_WEIGHT: 2,
+        NET_WEIGHT: tonnage + 3,
+        BAILING_WIRE_PROTOCOL: 'No',
+        HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Actual weight (100%)',
+        WEIGHT_OF_NON_TARGET_MATERIALS: 3,
+        RECYCLABLE_PROPORTION_PERCENTAGE: 1,
+        TONNAGE_RECEIVED_FOR_RECYCLING: tonnage
+      },
+      versions: [
+        {
+          summaryLog: { id: slId },
+          status
+        }
+      ]
+    },
+    outcome: 'INCLUDED'
+  })
+
+  it('returns full amount for added records', () => {
+    const records = [
+      buildRecord({ rowId: 1000, tonnage: 50, status: 'created' })
+    ]
+    const result = buildTransactionAmounts(
+      records,
+      registration,
+      'REPROCESSOR_INPUT',
+      summaryLogId,
+      new Map()
+    )
+    expect(result.get('received:1000')).toBe(50)
+  })
+
+  it('returns delta for adjusted records', () => {
+    const records = [
+      buildRecord({ rowId: 1000, tonnage: 80, status: 'updated' })
+    ]
+    const existingRecordsMap = new Map([
+      [
+        'received:1000',
+        {
+          type: 'received',
+          rowId: '1000',
+          data: {
+            ...records[0].record.data,
+            TONNAGE_RECEIVED_FOR_RECYCLING: 50,
+            GROSS_WEIGHT: 60,
+            NET_WEIGHT: 53
+          }
+        }
+      ]
+    ])
+    const result = buildTransactionAmounts(
+      records,
+      registration,
+      'REPROCESSOR_INPUT',
+      summaryLogId,
+      existingRecordsMap
+    )
+    expect(result.get('received:1000')).toBe(30) // 80 - 50
+  })
+
+  it('returns full amount when adjusted record has no existing record', () => {
+    const records = [
+      buildRecord({ rowId: 1000, tonnage: 80, status: 'updated' })
+    ]
+    const result = buildTransactionAmounts(
+      records,
+      registration,
+      'REPROCESSOR_INPUT',
+      summaryLogId,
+      new Map()
+    )
+    expect(result.get('received:1000')).toBe(80) // 80 - 0
   })
 })

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -2059,9 +2059,12 @@ describe('SummaryLogsValidator', () => {
   })
 })
 
+/** @import {Registration} from '#domain/organisations/registration.js' */
+
 describe('buildTransactionAmounts', () => {
   const summaryLogId = 'sl-1'
-  const registration = {
+  /** @type {Registration} */
+  const registration = /** @type {any} */ ({
     accreditation: {
       validFrom: '2025-01-01',
       validTo: '2025-12-31',
@@ -2070,37 +2073,41 @@ describe('buildTransactionAmounts', () => {
         { status: 'approved', updatedAt: '2024-12-15T00:00:00.000Z' }
       ]
     }
-  }
-
-  const buildRecord = ({ rowId, tonnage, status, slId = summaryLogId }) => ({
-    record: {
-      type: 'received',
-      rowId: String(rowId),
-      data: {
-        ROW_ID: rowId,
-        DATE_RECEIVED_FOR_REPROCESSING: '2025-06-15',
-        EWC_CODE: '20 01 01',
-        DESCRIPTION_WASTE: 'Paper - other',
-        WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
-        GROSS_WEIGHT: tonnage + 10,
-        TARE_WEIGHT: 5,
-        PALLET_WEIGHT: 2,
-        NET_WEIGHT: tonnage + 3,
-        BAILING_WIRE_PROTOCOL: 'No',
-        HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Actual weight (100%)',
-        WEIGHT_OF_NON_TARGET_MATERIALS: 3,
-        RECYCLABLE_PROPORTION_PERCENTAGE: 1,
-        TONNAGE_RECEIVED_FOR_RECYCLING: tonnage
-      },
-      versions: [
-        {
-          summaryLog: { id: slId },
-          status
-        }
-      ]
-    },
-    outcome: 'INCLUDED'
   })
+
+  /** @param {{ rowId: number, tonnage: number, status: string, slId?: string }} params */
+  const buildRecord = ({ rowId, tonnage, status, slId = summaryLogId }) =>
+    /** @type {import('#application/waste-records/transform-from-summary-log.js').ValidatedWasteRecord} */ ({
+      record: {
+        type: 'received',
+        rowId: String(rowId),
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        data: {
+          ROW_ID: rowId,
+          DATE_RECEIVED_FOR_REPROCESSING: '2025-06-15',
+          EWC_CODE: '20 01 01',
+          DESCRIPTION_WASTE: 'Paper - other',
+          WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+          GROSS_WEIGHT: tonnage + 10,
+          TARE_WEIGHT: 5,
+          PALLET_WEIGHT: 2,
+          NET_WEIGHT: tonnage + 3,
+          BAILING_WIRE_PROTOCOL: 'No',
+          HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Actual weight (100%)',
+          WEIGHT_OF_NON_TARGET_MATERIALS: 3,
+          RECYCLABLE_PROPORTION_PERCENTAGE: 1,
+          TONNAGE_RECEIVED_FOR_RECYCLING: tonnage
+        },
+        versions: [
+          {
+            summaryLog: { id: slId, uri: 's3://bucket/key' },
+            status
+          }
+        ]
+      },
+      outcome: 'INCLUDED'
+    })
 
   it('returns full amount for added records', () => {
     const records = [
@@ -2120,21 +2127,24 @@ describe('buildTransactionAmounts', () => {
     const records = [
       buildRecord({ rowId: 1000, tonnage: 80, status: 'updated' })
     ]
-    const existingRecordsMap = new Map([
-      [
-        'received:1000',
-        {
-          type: 'received',
-          rowId: '1000',
-          data: {
-            ...records[0].record.data,
-            TONNAGE_RECEIVED_FOR_RECYCLING: 50,
-            GROSS_WEIGHT: 60,
-            NET_WEIGHT: 53
+    /** @type {Map<string, import('#domain/waste-records/model.js').WasteRecord>} */
+    const existingRecordsMap = /** @type {any} */ (
+      new Map([
+        [
+          'received:1000',
+          {
+            type: 'received',
+            rowId: '1000',
+            data: {
+              ...records[0].record.data,
+              TONNAGE_RECEIVED_FOR_RECYCLING: 50,
+              GROSS_WEIGHT: 60,
+              NET_WEIGHT: 53
+            }
           }
-        }
-      ]
-    ])
+        ]
+      ])
+    )
     const result = buildTransactionAmounts(
       records,
       registration,

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -7,10 +7,10 @@ import Boom from '@hapi/boom'
 
 import {
   createSummaryLogsValidator,
-  buildTransactionAmounts,
   MAX_VALIDATION_ISSUES,
   MAX_ACTUAL_LENGTH
 } from './validate.js'
+import { buildTransactionAmounts } from './period-status.js'
 import {
   createEmptyLoadCategory,
   createEmptyLoadValidity

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -249,7 +249,10 @@ describe('SummaryLogsValidator', () => {
       summaryLogsRepository: /** @type {any} */ (summaryLogsRepository),
       organisationsRepository: /** @type {any} */ (organisationsRepository),
       wasteRecordsRepository: /** @type {any} */ (wasteRecordsRepository),
-      summaryLogExtractor
+      summaryLogExtractor,
+      reportsRepository: /** @type {any} */ ({
+        findPeriodicReports: vi.fn().mockResolvedValue([])
+      })
     })
   })
 
@@ -672,7 +675,10 @@ describe('SummaryLogsValidator', () => {
       summaryLogsRepository: brokenRepository,
       organisationsRepository: /** @type {any} */ (organisationsRepository),
       wasteRecordsRepository: /** @type {any} */ (wasteRecordsRepository),
-      summaryLogExtractor
+      summaryLogExtractor,
+      reportsRepository: /** @type {any} */ ({
+        findPeriodicReports: vi.fn().mockResolvedValue([])
+      })
     })
 
     const result = await brokenValidate(summaryLogId).catch((err) => err)

--- a/src/domain/summary-logs/loads-schema.js
+++ b/src/domain/summary-logs/loads-schema.js
@@ -28,6 +28,26 @@ export const loadsSchema = Joi.object({
   adjusted: loadValiditySchema.required()
 })
 
+const periodStatusBucketSchema = Joi.object({
+  included: Joi.object({
+    count: Joi.number().integer().min(0).required(),
+    tonnes: Joi.number().required()
+  }).required(),
+  excluded: Joi.object({
+    count: Joi.number().integer().min(0).required()
+  }).required()
+})
+
+const periodStatusByChangeSchema = Joi.object({
+  added: periodStatusBucketSchema.required(),
+  adjusted: periodStatusBucketSchema.required()
+})
+
+export const loadsByPeriodStatusSchema = Joi.object({
+  open: periodStatusByChangeSchema.required(),
+  closed: periodStatusByChangeSchema.required()
+})
+
 export const loadsByWasteRecordTypeSchema = Joi.array()
   .items(
     Joi.object({

--- a/src/domain/summary-logs/model.js
+++ b/src/domain/summary-logs/model.js
@@ -34,6 +34,7 @@
  */
 
 /** @import {Loads, LoadsByWasteRecordType} from '#application/summary-logs/load-counts.js' */
+/** @import {LoadsByPeriodStatus} from '#application/summary-logs/period-status.js' */
 /** @import {ValidationIssueCounts} from '#common/validation/validation-issues.js' */
 /** @import {ProcessingType} from './meta-fields.js' */
 /** @import {SummaryLogStatus} from './status.js' */
@@ -58,6 +59,7 @@
  *   expiresAt?: Date | null,
  *   file: SummaryLogFile,
  *   loads?: Loads,
+ *   loadsByPeriodStatus?: LoadsByPeriodStatus,
  *   loadsByWasteRecordType?: LoadsByWasteRecordType,
  *   meta?: SummaryLogMeta,
  *   organisationId?: string,

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/loads-exported.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/loads-exported.js
@@ -26,6 +26,7 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const LOADS_EXPORTED = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_OF_EXPORT,
   wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
   sheetName: 'Exported (sections 2 and 3)',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/received-loads-for-export.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/received-loads-for-export.js
@@ -46,6 +46,7 @@ const transformWithMonthSlice = (rowData, rowIndex) => {
  */
 export const RECEIVED_LOADS_FOR_EXPORT = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.MONTH_RECEIVED_FOR_EXPORT,
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received (section 1)',
   rowTransformer: transformWithMonthSlice,

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/sent-on-loads.js
@@ -19,6 +19,7 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on (section 4)',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter/received-loads-for-export.js
+++ b/src/domain/summary-logs/table-schemas/exporter/received-loads-for-export.js
@@ -103,6 +103,7 @@ const SUPPLEMENTARY_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_EXPORT = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_RECEIVED_FOR_EXPORT,
   wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
   sheetName: 'Exported',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/exporter/sent-on-loads.js
@@ -10,11 +10,14 @@ import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
  * Tracks waste sent on from exporters to other facilities.
  * Does not contribute to waste balance.
  */
-export const SENT_ON_LOADS = createSentOnLoadsSchema(
-  ROW_ID_MINIMUMS.SENT_ON_LOADS,
-  createRowTransformer({
-    wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
-    processingType: PROCESSING_TYPES.EXPORTER,
-    rowIdField: FIELDS.ROW_ID
-  })
-)
+export const SENT_ON_LOADS = {
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
+  ...createSentOnLoadsSchema(
+    ROW_ID_MINIMUMS.SENT_ON_LOADS,
+    createRowTransformer({
+      wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
+      processingType: PROCESSING_TYPES.EXPORTER,
+      rowIdField: FIELDS.ROW_ID
+    })
+  )
+}

--- a/src/domain/summary-logs/table-schemas/index.js
+++ b/src/domain/summary-logs/table-schemas/index.js
@@ -57,6 +57,7 @@ export const MIN_TEMPLATE_VERSIONS = {
 /**
  * @typedef {Object} TableSchema
  * @property {string} rowIdField - Field name containing the row identifier
+ * @property {string} reportingDateField - Field name containing the date used for reporting period classification
  * @property {string} wasteRecordType - The waste record type this table maps to (e.g. 'received', 'exported')
  * @property {string} sheetName - The spreadsheet sheet name for this table (e.g. 'Received', 'Exported')
  * @property {(rowData: Record<string, any>, rowIndex: number) => {wasteRecordType: string, rowId: string, data: Record<string, any>}} rowTransformer - Function to transform a parsed row into waste record metadata

--- a/src/domain/summary-logs/table-schemas/index.test.js
+++ b/src/domain/summary-logs/table-schemas/index.test.js
@@ -254,6 +254,26 @@ describe('table-schemas', () => {
     })
   })
 
+  describe('reportingDateField', () => {
+    it.each(
+      Object.entries(PROCESSING_TYPE_TABLES).flatMap(
+        ([processingType, tables]) =>
+          Object.entries(tables).map(([tableName, schema]) => ({
+            processingType,
+            tableName,
+            schema
+          }))
+      )
+    )(
+      '$processingType/$tableName has a reportingDateField in requiredHeaders',
+      ({ schema }) => {
+        expect(schema.reportingDateField).toBeDefined()
+        expect(typeof schema.reportingDateField).toBe('string')
+        expect(schema.requiredHeaders).toContain(schema.reportingDateField)
+      }
+    )
+  })
+
   describe('aggregateUnfilledValues', () => {
     it('returns empty object for registry with no unfilledValues', () => {
       const registry = {

--- a/src/domain/summary-logs/table-schemas/index.test.js
+++ b/src/domain/summary-logs/table-schemas/index.test.js
@@ -140,9 +140,12 @@ describe('table-schemas', () => {
       )
 
       expect(result).not.toBeNull()
-      expect(result.tableName).toBe('RECEIVED_LOADS_FOR_REPROCESSING')
-      expect(result.schema.wasteRecordType).toBe(WASTE_RECORD_TYPE.RECEIVED)
-      expect(result.schema.sheetName).toBe('Received')
+      const { tableName, schema } = /** @type {NonNullable<typeof result>} */ (
+        result
+      )
+      expect(tableName).toBe('RECEIVED_LOADS_FOR_REPROCESSING')
+      expect(schema.wasteRecordType).toBe(WASTE_RECORD_TYPE.RECEIVED)
+      expect(schema.sheetName).toBe('Received')
     })
 
     it('returns the correct table for exported waste record type', () => {
@@ -152,8 +155,11 @@ describe('table-schemas', () => {
       )
 
       expect(result).not.toBeNull()
-      expect(result.tableName).toBe('RECEIVED_LOADS_FOR_EXPORT')
-      expect(result.schema.sheetName).toBe('Exported')
+      const { tableName, schema } = /** @type {NonNullable<typeof result>} */ (
+        result
+      )
+      expect(tableName).toBe('RECEIVED_LOADS_FOR_EXPORT')
+      expect(schema.sheetName).toBe('Exported')
     })
 
     it('returns the correct table for processed waste record type', () => {
@@ -163,8 +169,11 @@ describe('table-schemas', () => {
       )
 
       expect(result).not.toBeNull()
-      expect(result.tableName).toBe('REPROCESSED_LOADS')
-      expect(result.schema.sheetName).toBe('Processed')
+      const { tableName, schema } = /** @type {NonNullable<typeof result>} */ (
+        result
+      )
+      expect(tableName).toBe('REPROCESSED_LOADS')
+      expect(schema.sheetName).toBe('Processed')
     })
 
     it('returns the correct table for sent on waste record type', () => {
@@ -174,8 +183,11 @@ describe('table-schemas', () => {
       )
 
       expect(result).not.toBeNull()
-      expect(result.tableName).toBe('SENT_ON_LOADS')
-      expect(result.schema.sheetName).toBe('Sent on')
+      const { tableName, schema } = /** @type {NonNullable<typeof result>} */ (
+        result
+      )
+      expect(tableName).toBe('SENT_ON_LOADS')
+      expect(schema.sheetName).toBe('Sent on')
     })
 
     it('returns null for an unknown waste record type', () => {
@@ -205,23 +217,25 @@ describe('table-schemas', () => {
 
   describe('findSchemaForProcessingType', () => {
     it('finds REPROCESSOR_INPUT received loads schema by waste record type', () => {
-      const schema = findSchemaForProcessingType(
+      const result = findSchemaForProcessingType(
         PROCESSING_TYPES.REPROCESSOR_INPUT,
         WASTE_RECORD_TYPE.RECEIVED
       )
 
-      expect(schema).toBeDefined()
+      expect(result).not.toBeNull()
+      const schema = /** @type {NonNullable<typeof result>} */ (result)
       expect(schema.wasteRecordType).toBe(WASTE_RECORD_TYPE.RECEIVED)
       expect(schema.sheetName).toBe('Received')
     })
 
     it('finds EXPORTER exported loads schema by waste record type', () => {
-      const schema = findSchemaForProcessingType(
+      const result = findSchemaForProcessingType(
         PROCESSING_TYPES.EXPORTER,
         WASTE_RECORD_TYPE.EXPORTED
       )
 
-      expect(schema).toBeDefined()
+      expect(result).not.toBeNull()
+      const schema = /** @type {NonNullable<typeof result>} */ (result)
       expect(schema.wasteRecordType).toBe(WASTE_RECORD_TYPE.EXPORTED)
     })
 
@@ -231,8 +245,10 @@ describe('table-schemas', () => {
         WASTE_RECORD_TYPE.SENT_ON
       )
 
-      expect(schema).toBeDefined()
-      expect(schema.wasteRecordType).toBe(WASTE_RECORD_TYPE.SENT_ON)
+      expect(schema).not.toBeNull()
+      expect(
+        /** @type {NonNullable<typeof schema>} */ (schema).wasteRecordType
+      ).toBe(WASTE_RECORD_TYPE.SENT_ON)
     })
 
     it('returns null for unknown processing type', () => {

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/received-loads-for-reprocessing.js
@@ -82,6 +82,7 @@ const SUPPLEMENTARY_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_RECEIVED_FOR_REPROCESSING,
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.js
@@ -29,6 +29,7 @@ const ALL_FIELDS = [
  */
 export const REPROCESSED_LOADS = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   wasteRecordType: WASTE_RECORD_TYPE.PROCESSED,
   sheetName: 'Processed',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/sent-on-loads.js
@@ -25,6 +25,7 @@ const WASTE_BALANCE_FIELDS = [
  * Tracks waste sent on to other facilities.
  */
 export const SENT_ON_LOADS = {
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   ...createSentOnLoadsSchema(
     ROW_ID_MINIMUMS.SENT_ON_LOADS,
     createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.js
@@ -43,6 +43,7 @@ const ALL_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_RECEIVED_FOR_REPROCESSING,
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/reprocessed-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/reprocessed-loads.js
@@ -36,6 +36,7 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
  */
 export const REPROCESSED_LOADS = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   wasteRecordType: WASTE_RECORD_TYPE.PROCESSED,
   sheetName: 'Processed',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/sent-on-loads.js
@@ -30,6 +30,7 @@ const ALL_FIELDS = [
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-registered-only/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-registered-only/received-loads-for-reprocessing.js
@@ -46,6 +46,7 @@ const transformWithMonthSlice = (rowData, rowIndex) => {
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.MONTH_RECEIVED_FOR_REPROCESSING,
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: transformWithMonthSlice,

--- a/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.js
@@ -20,6 +20,7 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on',
   rowTransformer: createRowTransformer({

--- a/src/repositories/summary-logs/schema.js
+++ b/src/repositories/summary-logs/schema.js
@@ -3,6 +3,7 @@ import Joi from 'joi'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import {
   loadsSchema,
+  loadsByPeriodStatusSchema,
   loadsByWasteRecordTypeSchema
 } from '#domain/summary-logs/loads-schema.js'
 
@@ -89,6 +90,7 @@ export const summaryLogUpdateSchema = Joi.object({
   status: statusSchema.optional(),
   validation: validationSchema.optional(),
   loads: loadsSchema.optional(),
+  loadsByPeriodStatus: loadsByPeriodStatusSchema.optional(),
   loadsByWasteRecordType: loadsByWasteRecordTypeSchema.optional(),
   file: fileSchema.optional(),
   organisationId: Joi.string().optional(),

--- a/src/routes/v1/organisations/registrations/summary-logs/get.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.js
@@ -46,6 +46,9 @@ export const summaryLogsGet = {
       status: summaryLog.status,
       ...transformValidationResponse(summaryLog.validation),
       ...(summaryLog.loads && { loads: summaryLog.loads }),
+      ...(summaryLog.loadsByPeriodStatus && {
+        loadsByPeriodStatus: summaryLog.loadsByPeriodStatus
+      }),
       ...(summaryLog.loadsByWasteRecordType && {
         loadsByWasteRecordType: summaryLog.loadsByWasteRecordType
       }),

--- a/src/routes/v1/organisations/registrations/summary-logs/get.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.test.js
@@ -22,12 +22,14 @@ describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/
 
   const createServer = async () => {
     const summaryLogsRepositoryFactory = createInMemorySummaryLogsRepository()
-    const summaryLogsRepository = summaryLogsRepositoryFactory({
+    /** @type {import('#common/helpers/logging/logger.js').TypedLogger} */
+    const mockLogger = /** @type {any} */ ({
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
       debug: vi.fn()
     })
+    const summaryLogsRepository = summaryLogsRepositoryFactory(mockLogger)
 
     const server = await createTestServer({
       repositories: {
@@ -271,13 +273,14 @@ describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/
         summaryLogId,
         summaryLogFactory.invalid({ organisationId, registrationId })
       )
-      await summaryLogsRepository.update(summaryLogId, 1, {
-        meta: {
-          PROCESSING_TYPE: null,
-          MATERIAL: null,
-          ACCREDITATION_NUMBER: null
-        }
+      // Null values can exist in MongoDB; verify they're omitted from the response
+      /** @type {import('#domain/summary-logs/model.js').SummaryLogMeta} */
+      const nullMeta = /** @type {any} */ ({
+        PROCESSING_TYPE: null,
+        MATERIAL: null,
+        ACCREDITATION_NUMBER: null
       })
+      await summaryLogsRepository.update(summaryLogId, 1, { meta: nullMeta })
       await waitForVersion(summaryLogsRepository, summaryLogId, 2)
 
       const response = await makeRequest(server)

--- a/src/routes/v1/organisations/registrations/summary-logs/get.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.test.js
@@ -151,6 +151,38 @@ describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/
     })
   })
 
+  describe('loadsByPeriodStatus in response', () => {
+    const createLoadsByPeriodStatus = () => ({
+      open: {
+        added: { included: { count: 3, tonnes: 15 }, excluded: { count: 1 } },
+        adjusted: { included: { count: 0, tonnes: 0 }, excluded: { count: 0 } }
+      },
+      closed: {
+        added: { included: { count: 2, tonnes: 10 }, excluded: { count: 0 } },
+        adjusted: { included: { count: 1, tonnes: 5 }, excluded: { count: 0 } }
+      }
+    })
+
+    it('includes loadsByPeriodStatus when present', async () => {
+      const { server, summaryLogsRepository } = await createServer()
+      const loadsByPeriodStatus = createLoadsByPeriodStatus()
+      await summaryLogsRepository.insert(
+        summaryLogId,
+        summaryLogFactory.validated({ organisationId, registrationId })
+      )
+      await summaryLogsRepository.update(summaryLogId, 1, {
+        loadsByPeriodStatus
+      })
+      await waitForVersion(summaryLogsRepository, summaryLogId, 2)
+
+      const response = await makeRequest(server)
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const payload = JSON.parse(response.payload)
+      expect(payload.loadsByPeriodStatus).toEqual(loadsByPeriodStatus)
+    })
+  })
+
   describe('meta fields in response', () => {
     it('includes processingType and material when meta exists', async () => {
       const { server, summaryLogsRepository } = await createServer()

--- a/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
@@ -3,6 +3,7 @@ import Joi from 'joi'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import {
   loadsSchema,
+  loadsByPeriodStatusSchema,
   loadsByWasteRecordTypeSchema
 } from '#domain/summary-logs/loads-schema.js'
 
@@ -69,6 +70,7 @@ export const summaryLogResponseSchema = Joi.object({
     }).required()
   }).optional(),
   loads: loadsSchema.optional(),
+  loadsByPeriodStatus: loadsByPeriodStatusSchema.optional(),
   loadsByWasteRecordType: loadsByWasteRecordTypeSchema.optional(),
   processingType: Joi.string().optional(),
   material: Joi.string().optional(),

--- a/src/server/queue-consumer/queue-consumer.plugin.js
+++ b/src/server/queue-consumer/queue-consumer.plugin.js
@@ -19,7 +19,8 @@ import { orsImportCommandHandlers } from './ors-import-commands.js'
  *   summaryLogsRepository: import('#repositories/summary-logs/port.js').SummaryLogsRepository,
  *   organisationsRepository: import('#repositories/organisations/port.js').OrganisationsRepository,
  *   wasteRecordsRepository: import('#repositories/waste-records/port.js').WasteRecordsRepository,
- *   wasteBalancesRepository: import('#waste-balances/repository/port.js').WasteBalancesRepository
+ *   wasteBalancesRepository: import('#waste-balances/repository/port.js').WasteBalancesRepository,
+ *   reportsRepository: import('#reports/repository/port.js').ReportsRepository
  * }} QueueConsumerRepositories
  */
 
@@ -31,7 +32,8 @@ export const commandQueueConsumerPlugin = {
     'organisationsRepository',
     'wasteRecordsRepository',
     'wasteBalancesRepository',
-    'uploadsRepository'
+    'uploadsRepository',
+    'reportsRepository'
   ],
 
   register: async (
@@ -55,7 +57,8 @@ export const commandQueueConsumerPlugin = {
       summaryLogsRepository,
       organisationsRepository,
       wasteRecordsRepository,
-      wasteBalancesRepository
+      wasteBalancesRepository,
+      reportsRepository
     } = /** @type {QueueConsumerRepositories} */ (server.app)
 
     const summaryLogExtractor = createSummaryLogExtractor({
@@ -83,6 +86,7 @@ export const commandQueueConsumerPlugin = {
         organisationsRepository,
         wasteRecordsRepository,
         wasteBalancesRepository,
+        reportsRepository,
         summaryLogExtractor
       }
 

--- a/src/server/queue-consumer/summary-log-commands.js
+++ b/src/server/queue-consumer/summary-log-commands.js
@@ -15,6 +15,8 @@ import { submitSummaryLog } from '#application/summary-logs/submit.js'
 /** @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository */
 /** @typedef {import('#domain/summary-logs/extractor/port.js').SummaryLogExtractor} SummaryLogExtractor */
 
+/** @typedef {import('#reports/repository/port.js').ReportsRepository} ReportsRepository */
+
 /**
  * @typedef {object} SummaryLogHandlerDeps
  * @property {TypedLogger} logger
@@ -23,6 +25,7 @@ import { submitSummaryLog } from '#application/summary-logs/submit.js'
  * @property {WasteRecordsRepository} wasteRecordsRepository
  * @property {WasteBalancesRepository} wasteBalancesRepository
  * @property {SummaryLogExtractor} summaryLogExtractor
+ * @property {ReportsRepository} reportsRepository
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
  */
 
@@ -59,7 +62,8 @@ export const summaryLogCommandHandlers = [
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
-        summaryLogExtractor
+        summaryLogExtractor,
+        reportsRepository
       } = deps
 
       const validateSummaryLog = createSummaryLogsValidator({
@@ -67,7 +71,8 @@ export const summaryLogCommandHandlers = [
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
-        summaryLogExtractor
+        summaryLogExtractor,
+        reportsRepository
       })
 
       await validateSummaryLog(payload.summaryLogId)


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)
## Summary

- During summary log validation, classifies each waste record into its reporting period and determines whether that period is open or closed (i.e. whether a report has already been submitted for it)
- Computes `loadsByPeriodStatus` aggregates: counts and tonnages bucketed by open/closed, added/adjusted, and included/excluded
- Persists `loadsByPeriodStatus` alongside existing `loads` on the summary log document and returns it via the GET endpoint

## Approach

Each table schema now declares a `reportingDateField` property identifying which field holds the date used for period assignment. A cross-schema drift-guard test ensures every schema has this property and that it appears in `requiredHeaders`.

Period status is determined by looking up submitted reports for the organisation/registration via the reports repository. A period is closed if any report has been submitted for it (either the current report is in submitted status, or there are previous submissions).

For tonnage, added records contribute their full `transactionAmount`. Adjusted records contribute the delta (new amount minus old amount), reflecting the actual change to the waste balance rather than the absolute tonnage.

The classification runs only for successfully validated summary logs. If the reports lookup fails, it degrades gracefully with a warning log and omits `loadsByPeriodStatus` from the document.

## Changes

- **New**: `period-status.js` with `classifyByPeriodStatus` function and unit tests
- **New**: `reportingDateField` on all 13 table schemas, plus drift-guard test
- **New**: `loadsByPeriodStatusSchema` Joi schema for storage and response validation
- **Modified**: `validate.js` to accept `reportsRepository`, fetch submitted reports, build transaction amounts (with delta for adjusted records), and compute period status
- **Modified**: Queue consumer plugin and command handler to wire `reportsRepository` through
- **Modified**: Summary log update schema, GET handler, and response schema to persist and return `loadsByPeriodStatus`

[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ