### PR TITLE
PAE-1382: Confirm rebuild attributes historical PRN actors

### DIFF
--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -616,6 +616,96 @@ describe('computeRebuiltStream', () => {
       expect(issued?.createdBy).toEqual({ id: 'sig-7', name: 'Sam Signatory' })
     })
 
+    it('attributes a human-initiated PRN transition to its id and name, never an email', () => {
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 30,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.DRAFT,
+                  at: new Date('2025-01-20T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                },
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date('2025-01-21T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: [submittedLog()]
+      })
+
+      const created =
+        /** @type {import('../repository/stream-schema.js').StreamEventInsert} */ (
+          result.events.find((e) => e.kind === STREAM_EVENT_KIND.PRN_CREATED)
+        )
+      expect(created.createdBy).toEqual({
+        id: 'rep-1',
+        name: 'Rita Reprocessor'
+      })
+      expect('email' in created.createdBy).toBe(false)
+    })
+
+    it('attributes an RPD-initiated PRN transition to its id and the name RPD, never an email', () => {
+      const rpdActor = { id: 'rpd-client', name: 'RPD' }
+      const result = computeRebuiltStream({
+        accreditation,
+        registrationId,
+        organisationId,
+        wasteRecords: [submittedRecord(100)],
+        prns: [
+          {
+            id: 'prn-1',
+            tonnage: 30,
+            status: {
+              history: [
+                {
+                  status: PRN_STATUS.DRAFT,
+                  at: new Date('2025-01-20T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                },
+                {
+                  status: PRN_STATUS.AWAITING_AUTHORISATION,
+                  at: new Date('2025-01-21T00:00:00.000Z'),
+                  by: { id: 'rep-1', name: 'Rita Reprocessor' }
+                },
+                {
+                  status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                  at: new Date('2025-01-22T00:00:00.000Z'),
+                  by: { id: 'sig-7', name: 'Sam Signatory' }
+                },
+                {
+                  status: PRN_STATUS.ACCEPTED,
+                  at: new Date('2025-01-23T00:00:00.000Z'),
+                  by: rpdActor
+                }
+              ]
+            }
+          }
+        ],
+        overseasSites,
+        summaryLogs: [submittedLog()]
+      })
+
+      const accepted =
+        /** @type {import('../repository/stream-schema.js').StreamEventInsert} */ (
+          result.events.find((e) => e.kind === STREAM_EVENT_KIND.PRN_ACCEPTED)
+        )
+      expect(accepted.createdBy).toEqual({ id: 'rpd-client', name: 'RPD' })
+      expect('email' in accepted.createdBy).toBe(false)
+    })
+
     it('attributes summary-log events to the supplied submitter', () => {
       const submitter = { id: 'usr-9', name: 'submitter@example.com' }
       const result = computeRebuiltStream({


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
When the waste-balance stream is rebuilt from a PRN's status history, each transition's actor is recovered from `prn.status.history.by` and carried onto the stream event's `createdBy`. This adds regression cover locking in that attribution for both the human and the RPD case.

A human-initiated transition (e.g. a reprocessor moving a PRN to awaiting authorisation) is attributed to `{ id, name }` from the history entry, with no email — history entries never carry an email, so none is fabricated.

An RPD-initiated transition is attributed to `{ id, name: 'RPD' }` from the history entry, again with no email. RPD is the only actor that can reach the accepted and rejected transitions, and its historic actor carries the service name, which the rebuild preserves rather than reducing to an id alone.

The existing backfill boundary already covers the case where a history entry names no actor at all, falling back to the system backfill actor.

These are characterisation tests over behaviour already present on main; no production code changes.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ