### PR TITLE
PAE-1382: Attribute live RPD PRN transitions to the RPD service

### DIFF
--- a/src/packaging-recycling-notes/routes/external-transition-handler.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.js
@@ -16,7 +16,7 @@ import { getProjectedPrnByNumber } from '#packaging-recycling-notes/application/
 
 /**
  * @import { Request, Lifecycle } from '@hapi/hapi'
- * @import { HapiRequest } from '#common/hapi-types.js'
+ * @import { HapiRequest, MachineCredentials } from '#common/hapi-types.js'
  * @import { PrnStatus } from '#packaging-recycling-notes/domain/model.js'
  * @import { PackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/port.js'
  * @import { WasteBalancesRepository } from '#waste-balances/repository/port.js'
@@ -82,9 +82,14 @@ export function createExternalTransitionHandler({
           ? new Date(payload[timestampField])
           : new Date()
 
-        const user = /** @type {{ id: string; name: string }} */ (
+        // RPD reaches this route through the machine-credential strategy, which
+        // identifies the service in the name slot. Select id and name into the
+        // actor explicitly so the machine marker never travels downstream; no
+        // email exists for a service identity.
+        const { id, name } = /** @type {MachineCredentials} */ (
           request.auth.credentials
         )
+        const user = { id, name }
 
         const updatedPrn = await updatePrnStatus({
           prnRepository: packagingRecyclingNotesRepository,

--- a/src/packaging-recycling-notes/routes/external-transition-handler.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.js
@@ -82,10 +82,6 @@ export function createExternalTransitionHandler({
           ? new Date(payload[timestampField])
           : new Date()
 
-        // RPD reaches this route through the machine-credential strategy, which
-        // identifies the service in the name slot. Select id and name into the
-        // actor explicitly so the machine marker never travels downstream; no
-        // email exists for a service identity.
         const { id, name } = /** @type {MachineCredentials} */ (
           request.auth.credentials
         )

--- a/src/packaging-recycling-notes/routes/external-transition-handler.test.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.test.js
@@ -175,9 +175,6 @@ describe('external PRN transition read-side fold', () => {
   })
 
   it('attributes a live RPD accept to the RPD service with no email', async () => {
-    // RPD drives the accept through the machine-credential strategy. The stream
-    // event it writes must carry the RPD service identity in the name slot and
-    // no email — RPD is a genuine service name, not a fabricated human.
     await startServer({
       currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
       events: [],

--- a/src/packaging-recycling-notes/routes/external-transition-handler.test.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.test.js
@@ -110,6 +110,7 @@ const buildBalance = (canonicalSource) => ({
 })
 
 let server
+let streamRepository
 
 /**
  * Starts a test server wired with real in-memory adapters: the PRN store, the
@@ -122,7 +123,7 @@ let server
  * @param {string} params.canonicalSource
  */
 const startServer = async ({ currentStatus, events, canonicalSource }) => {
-  const streamRepository = createInMemoryStreamRepository(events)()
+  streamRepository = createInMemoryStreamRepository(events)()
   server = await createTestServer({
     config: {
       packagingRecyclingNotesExternalApi: {
@@ -171,6 +172,32 @@ describe('external PRN transition read-side fold', () => {
     })
 
     expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+  })
+
+  it('attributes a live RPD accept to the RPD service with no email', async () => {
+    // RPD drives the accept through the machine-credential strategy. The stream
+    // event it writes must carry the RPD service identity in the name slot and
+    // no email — RPD is a genuine service name, not a fabricated human.
+    await startServer({
+      currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+      events: [],
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+    })
+
+    const response = await server.inject({
+      method: 'POST',
+      url: acceptUrl,
+      headers: authHeaders
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
+
+    const latest = await streamRepository.findLatestByPartition(REG_ID, ACC_ID)
+    expect(latest.kind).toBe(STREAM_EVENT_KIND.PRN_ACCEPTED)
+    expect(latest.createdBy).toEqual({
+      id: externalApiClientId,
+      name: 'RPD'
+    })
   })
 
   it('accepts an embedded PRN even when the stream shows it cancelled', async () => {


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)

A live, RPD-initiated PRN status transition (accept or reject) now attributes its waste-balance stream event to the RPD service identity — `createdBy = { id, name: 'RPD' }` with no email. RPD is a genuine service name, so `'RPD'` sits in the `name` slot; a service has no email, so none is carried.

These transitions reach the backend through the machine-credential strategy, which already identifies the RPD service in the `name` slot. The external-transition route now selects `id` and `name` into the actor explicitly at the write boundary, so the machine marker the credentials carry never travels downstream to the stream write. Previously the route cast the credentials to a shape that omitted that marker and passed the whole object through, leaving the event clean only because the storage layer stripped the extra field.

A new end-to-end test drives a live RPD accept through the real machine-credential auth and the in-memory stream adapter, then asserts the appended `PRN_ACCEPTED` event carries `{ id, name: 'RPD' }` and no email.

Builds on [#1258](https://github.com/DEFRA/epr-backend/pull/1258), which threads the human actor's name and email through the same PRN ledger write chain; this PR is based on that branch.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ