### PR TITLE
PAE-1382: Cover PRN transition actor reaching the waste-balance stream end to end

### DIFF
--- a/src/routes/v1/organisations/registrations/summary-logs/integration.prn-transition-actor.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.prn-transition-actor.test.js
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict'
+
+import { ObjectId } from 'mongodb'
+import { http, HttpResponse } from 'msw'
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import {
+  SUMMARY_LOG_STATUS,
+  UPLOAD_STATUS
+} from '#domain/summary-logs/status.js'
+import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+
+import {
+  asStandardUser,
+  buildGetUrl,
+  buildPostUrl,
+  buildSubmitUrl,
+  createUploadPayload,
+  pollForValidation,
+  setupWasteBalanceIntegrationEnvironment,
+  createWasteBalanceMeta,
+  createExporterRowValues,
+  EXPORTER_HEADERS
+} from './integration-test-helpers.js'
+
+const LEDGER_ACCREDITATION_ID = 'ACC-123'
+const POLL_INTERVAL_MS = 50
+const MAX_POLL_ATTEMPTS = 20
+
+/**
+ * The human whose authenticated session drives the PRN transition. The route
+ * reads id, name and email from the request credentials; the test asserts all
+ * three reach the appended waste-balance stream event.
+ */
+const SIGNATORY = Object.freeze({
+  id: 'signatory-user-7',
+  name: 'Ada Lovelace',
+  email: 'ada.lovelace@example.com'
+})
+
+const sharedMeta = createWasteBalanceMeta('EXPORTER')
+
+const setupLedgerEnv = () => {
+  const organisationId = new ObjectId().toString()
+  const registrationId = new ObjectId().toString()
+  /** @type {import('#waste-balances/domain/model.js').WasteBalance[]} */
+  const existingWasteBalances = [
+    {
+      id: 'seeded-ledger-balance',
+      accreditationId: LEDGER_ACCREDITATION_ID,
+      registrationId,
+      organisationId,
+      schemaVersion: 1,
+      version: 0,
+      amount: 0,
+      availableAmount: 0,
+      transactions: [],
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+    }
+  ]
+  return setupWasteBalanceIntegrationEnvironment({
+    processingType: 'exporter',
+    organisationId,
+    registrationId,
+    featureFlagOverrides: { wasteBalanceLedger: true },
+    // @ts-expect-error -- existingWasteBalances defaults to never[]; WasteBalance[] is correct at runtime
+    existingWasteBalances
+  })
+}
+
+const submitCredit = async (env, tonnage) => {
+  const { server, fileDataMap, organisationId, registrationId } = env
+  const summaryLogId = 'log-actor'
+  const fileId = 'file-actor'
+
+  fileDataMap[fileId] = {
+    meta: sharedMeta,
+    data: {
+      RECEIVED_LOADS_FOR_EXPORT: {
+        location: { sheet: 'Received', row: 7, column: 'A' },
+        headers: EXPORTER_HEADERS,
+        rows: [
+          {
+            rowNumber: 8,
+            values: createExporterRowValues({
+              rowId: 1001,
+              exportTonnage: tonnage
+            })
+          }
+        ]
+      }
+    }
+  }
+
+  await server.inject({
+    method: 'POST',
+    url: buildPostUrl(organisationId, registrationId, summaryLogId),
+    payload: createUploadPayload(
+      organisationId,
+      registrationId,
+      UPLOAD_STATUS.COMPLETE,
+      fileId,
+      'waste-actor.xlsx'
+    )
+  })
+
+  await pollForValidation(server, organisationId, registrationId, summaryLogId)
+
+  await server.inject({
+    method: 'POST',
+    url: buildSubmitUrl(organisationId, registrationId, summaryLogId),
+    ...asStandardUser({ linkedOrgId: organisationId })
+  })
+
+  let attempts = 0
+  let status = SUMMARY_LOG_STATUS.SUBMITTING
+  while (
+    status === SUMMARY_LOG_STATUS.SUBMITTING &&
+    attempts < MAX_POLL_ATTEMPTS
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+
+    const checkResponse = await server.inject({
+      method: 'GET',
+      url: buildGetUrl(organisationId, registrationId, summaryLogId),
+      ...asStandardUser({ linkedOrgId: organisationId })
+    })
+
+    status = JSON.parse(checkResponse.payload).status
+    attempts++
+  }
+
+  assert.equal(status, SUMMARY_LOG_STATUS.SUBMITTED)
+}
+
+const createPrn = async (env, tonnage) => {
+  const { server, organisationId, registrationId, accreditationId } = env
+
+  const response = await server.inject({
+    method: 'POST',
+    url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes`,
+    ...asStandardUser({ linkedOrgId: organisationId }),
+    payload: {
+      issuedToOrganisation: {
+        id: 'producer-org-123',
+        name: 'Producer Org',
+        tradingName: 'Producer Trading'
+      },
+      tonnage
+    }
+  })
+
+  return JSON.parse(response.payload)
+}
+
+/**
+ * Raises a PRN through the status route as a named human, threading the
+ * signatory's full credentials so the route can carry id, name and email onto
+ * the stream event.
+ */
+const raiseAs = async (env, prnId, credentials) => {
+  const { server, organisationId, registrationId, accreditationId } = env
+
+  return server.inject({
+    method: 'POST',
+    url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${prnId}/status`,
+    ...asStandardUser({ linkedOrgId: organisationId, ...credentials }),
+    payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
+  })
+}
+
+describe('PRN transition actor on the waste-balance stream', () => {
+  const { getServer } = setupAuthContext()
+
+  beforeEach(() => {
+    getServer().use(
+      http.post(
+        'http://localhost:3001/v1/organisations/:orgId/registrations/:regId/summary-logs/:summaryLogId/upload-completed',
+        () => HttpResponse.json({ success: true }, { status: 200 })
+      )
+    )
+  })
+
+  it('carries the requesting human id, name and email onto the appended stream event', async () => {
+    const env = await setupLedgerEnv()
+    const { streamRepository, registrationId } = env
+
+    await submitCredit(env, 300)
+
+    const prn = await createPrn(env, 50)
+    const response = await raiseAs(env, prn.id, {
+      id: SIGNATORY.id,
+      name: SIGNATORY.name,
+      email: SIGNATORY.email
+    })
+    expect(response.statusCode).toBe(200)
+
+    const latest = await streamRepository.findLatestByPartition(
+      registrationId,
+      LEDGER_ACCREDITATION_ID
+    )
+    assert(latest)
+    expect(latest.kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+    expect(latest.payload).toEqual({ prnId: prn.id, amount: 50 })
+    expect(latest.createdBy).toEqual({
+      id: SIGNATORY.id,
+      name: SIGNATORY.name,
+      email: SIGNATORY.email
+    })
+  })
+})


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)

Adds a route-to-stream integration test for the actor recorded on a balance-carrying human PRN status transition. Raising a PRN through the status route as a named, authenticated human now has end-to-end cover asserting the appended waste-balance stream event carries `createdBy = { id, name, email }` sourced from the request credentials.

The `id`, `name` and `email` threading onto the stream event was previously verified only at unit, application and contract level — no test drove the full route to application to repository to stream-append path for a live transition. A `userId` to `createdBy` contract change had already broken a direct-repo call that only surfaced in CI, evidence this seam was under-covered. The test closes it: it runs on the event-sourced ledger path with real in-memory adapters (no mocks), submits a credit, creates a PRN, raises it as a signatory with a distinctive name and email, then reads the latest stream event by partition and asserts its kind, payload and full `createdBy`.

It is failing-first: reducing the route actor to `{ id }` alone (the pre-fix behaviour where name was fabricated from the id and email dropped) makes the assertion fail with name and email absent from the stream event.

This stacks on the actor-threading change in [PR #1258](https://github.com/DEFRA/epr-backend/pull/1258) and is based off that branch, not main.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ