### PR TITLE
PAE-1382: Attribute id-only actors and report per-event-kind actor breakdown

### DIFF
--- a/src/server/load-accreditation-sources.js
+++ b/src/server/load-accreditation-sources.js
@@ -2,9 +2,10 @@ import { resolveOverseasSites } from '#application/waste-records/resolve-oversea
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import {
-  buildSystemLogSubmitters,
-  toStreamActor
+  addAttribution,
+  buildSystemLogSubmitters
 } from '#waste-balances/application/summary-log-submitters.js'
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
 
 /** @type {Set<import('#domain/organisations/registration.js').Registration['status']>} */
 const ACTIVE_REGISTRATION_STATUSES = new Set([
@@ -38,16 +39,31 @@ export const toStreamSummaryLog = ({ summaryLog }) => ({
  */
 
 /**
- * @typedef {{ systemLog: number, backfill: number }} SubmitterProvenance
+ * Map each summary-log document id to the audit actor that attributes its
+ * submission. Callers supply `submitActors` newest-first, so the first audit row
+ * seen for a document wins, matching how the submitter map resolves a
+ * resubmitted document.
+ *
+ * @param {Array<{ summaryLogId: string, createdBy?: import('#waste-balances/application/summary-log-submitters.js').SubmitAuditActor }>} submitActors
+ * @returns {Map<string, import('#waste-balances/application/summary-log-submitters.js').SubmitAuditActor | undefined>}
  */
+const auditActorByDocId = (submitActors) => {
+  const byDocId = new Map()
+  for (const { summaryLogId, createdBy } of submitActors) {
+    if (!byDocId.has(summaryLogId)) {
+      byDocId.set(summaryLogId, createdBy)
+    }
+  }
+  return byDocId
+}
 
 /**
  * Recover each submitted summary log's real submitter from the submit system-log
- * audit, falling back to the backfill actor when the audit names no usable
- * submitter. Counts how many submitters were recovered from the audit versus
- * left to backfill (`submitterProvenance`) and counts submit-audit rows that
- * carry no usable actor (`unusableSubmitAudit`) so dirty audit data surfaces as
- * its own number rather than hiding inside the backfill count.
+ * audit, falling back to the backfill actor only when no actor is attributable.
+ * Alongside, build the SUMMARY_LOG_SUBMITTED row of the per-event-kind
+ * attribution matrix: each submitted log is classified by the labels its audit
+ * actor carries (name, email, id-only, or no actor at all), with scope presence
+ * tallied too, so attribution quality is visible per kind before cutover.
  *
  * @param {Object} params
  * @param {Array<{ summaryLogId: string, createdBy?: import('#waste-balances/application/summary-log-submitters.js').SubmitAuditActor }>} params.submitActors
@@ -60,30 +76,28 @@ const recoverSubmitters = ({ submitActors, summaryLogDocs }) => {
     ({ summaryLog }) => summaryLog.status === SUMMARY_LOG_STATUS.SUBMITTED
   )
 
-  const submittedDocIds = new Set(submittedDocs.map((doc) => doc.id))
-  const unusableSubmitAudit = submitActors.filter(
-    ({ summaryLogId, createdBy }) =>
-      submittedDocIds.has(summaryLogId) && toStreamActor(createdBy) === null
-  ).length
+  const auditActors = auditActorByDocId(submitActors)
 
-  /** @type {SubmitterProvenance} */
-  const submitterProvenance = { systemLog: 0, backfill: 0 }
+  /** @type {import('#waste-balances/application/summary-log-submitters.js').AttributionMatrix} */
+  const attributionMatrix = {}
+  for (const doc of submittedDocs) {
+    addAttribution(
+      attributionMatrix,
+      STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+      auditActors.get(doc.id)
+    )
+  }
+
   const summaryLogs = submittedDocs
     .map(toStreamSummaryLog)
     .map((summaryLog) => {
       const submitter = submitters.get(summaryLog.id)
-      if (!submitter) {
-        submitterProvenance.backfill += 1
-        return summaryLog
-      }
-      submitterProvenance.systemLog += 1
-      return { ...summaryLog, submittedBy: submitter }
+      return submitter ? { ...summaryLog, submittedBy: submitter } : summaryLog
     })
 
   return {
     summaryLogs,
-    submitterProvenance,
-    unusableSubmitAudit
+    attributionMatrix
   }
 }
 
@@ -92,12 +106,12 @@ const recoverSubmitters = ({ submitActors, summaryLogDocs }) => {
  * then fetch all authoritative sources needed to rebuild the event stream
  * or recompute totals. Each historical summary log's real submitting actor is
  * recovered from the dedicated submit system-log audit, falling back to the
- * backfill actor, so the rebuilt stream attributes submissions to the person who
- * made them. How many submitters were recovered versus backfilled is counted
- * (`submitterProvenance`) so coverage is measurable before cutover, and
- * submit-audit rows for these submissions that carry no usable actor are counted
- * too (`unusableSubmitAudit`) so dirty audit data surfaces as its own number
- * rather than hiding inside the backfill count.
+ * backfill actor only when no actor is attributable, so the rebuilt stream
+ * attributes submissions to the person who made them. The SUMMARY_LOG_SUBMITTED
+ * row of the per-event-kind attribution matrix (`attributionMatrix`) records the
+ * label quality of each submission's actor — name, email, id-only, or no actor
+ * at all, plus scope presence — so coverage is measurable per kind before
+ * cutover.
  *
  * @param {{ accreditationId: string, organisationId: string }} row
  * @param {AccreditationSourceDeps} deps
@@ -153,11 +167,10 @@ export const loadAccreditationSources = async (row, deps) => {
   const submitActors =
     await systemLogsRepository.findSummaryLogSubmitActors(summaryLogDocIds)
 
-  const { summaryLogs, submitterProvenance, unusableSubmitAudit } =
-    recoverSubmitters({
-      submitActors,
-      summaryLogDocs
-    })
+  const { summaryLogs, attributionMatrix } = recoverSubmitters({
+    submitActors,
+    summaryLogDocs
+  })
 
   return {
     accreditation,
@@ -166,7 +179,6 @@ export const loadAccreditationSources = async (row, deps) => {
     prns,
     overseasSites,
     summaryLogs,
-    submitterProvenance,
-    unusableSubmitAudit
+    attributionMatrix
   }
 }

--- a/src/server/run-balance-divergence-diagnostic.integration.test.js
+++ b/src/server/run-balance-divergence-diagnostic.integration.test.js
@@ -313,7 +313,7 @@ describe('balance divergence diagnostic (integration)', () => {
     })
 
     expect(result.amount).toBe(202.47)
-    expect(result.backfilledActorCount).toBe(0)
+    expect(result.attributionMatrix).toEqual({})
     expect(result.events[0].createdBy).toEqual({
       id: 'user-1',
       email: 'alice@example.com'

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -7,6 +7,10 @@ import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js
 import { createWasteRecordsRepository } from '#repositories/waste-records/mongodb.js'
 import { computeRebuiltTotals } from '#waste-balances/application/compute-rebuilt-totals.js'
 import { computeRebuiltStream } from '#waste-balances/application/compute-rebuilt-stream.js'
+import {
+  formatAttributionMatrix,
+  mergeAttributionMatrices
+} from '#waste-balances/application/summary-log-submitters.js'
 import { loadAccreditationSources } from '#server/load-accreditation-sources.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 
@@ -102,8 +106,10 @@ export const compareForEmbedded = async (embedded, deps) => {
     stream,
     wasteRecords,
     prns,
-    submitterProvenance: sources.submitterProvenance,
-    unusableSubmitAudit: sources.unusableSubmitAudit
+    attributionMatrix: mergeAttributionMatrices([
+      sources.attributionMatrix,
+      stream.attributionMatrix
+    ])
   })
 }
 
@@ -115,8 +121,7 @@ const buildComparison = ({
   stream,
   wasteRecords,
   prns,
-  submitterProvenance,
-  unusableSubmitAudit
+  attributionMatrix
 }) => ({
   organisationId: embedded.organisationId,
   registrationNumber: registration.registrationNumber,
@@ -145,10 +150,7 @@ const buildComparison = ({
     stream.availableAmount
   ),
   streamEventCount: stream.events.length,
-  backfilledActorCount: stream.backfilledActorCount,
-  backfilledActorCountByKind: stream.backfilledActorCountByKind,
-  submitterProvenance,
-  unusableSubmitAudit
+  attributionMatrix
 })
 
 const isDivergent = (comparison) =>
@@ -191,43 +193,28 @@ const formatErrorLine = (embedded, error) =>
     `error="${error.message}"`
   ].join(' ')
 
-const formatBackfillByKind = (byKind) =>
-  Object.keys(byKind)
-    .sort((a, b) => a.localeCompare(b))
-    .map((kind) => `${kind}:${byKind[kind]}`)
-    .join(',')
+/**
+ * Whether any event in the matrix lacks full name+email attribution — either an
+ * id-only actor (real but unlabelled) or no actor at all. These are the gaps an
+ * operator wants flagged per accreditation before cutover.
+ *
+ * @param {import('#waste-balances/application/summary-log-submitters.js').AttributionMatrix} matrix
+ * @returns {boolean}
+ */
+const hasAttributionGap = (matrix) =>
+  Object.values(matrix).some(
+    (counts) => counts.idOnly > 0 || counts.noActor > 0
+  )
 
-const formatProvenance = (provenance) =>
-  `systemLog:${provenance.systemLog},backfill:${provenance.backfill}`
-
-const formatBackfillLine = (comparison) =>
+const formatAttributionLine = (comparison) =>
   [
-    'Waste-balance rebuild used backfill actor:',
+    'Waste-balance rebuild actor attribution gap:',
     `organisationId=${comparison.organisationId}`,
     `registrationNumber=${comparison.registrationNumber}`,
     `accreditationNumber=${comparison.accreditationNumber}`,
-    `backfilledActorCount=${comparison.backfilledActorCount}`,
-    `backfilledActorCountByKind=${formatBackfillByKind(comparison.backfilledActorCountByKind)}`,
-    `submitterProvenance=${formatProvenance(comparison.submitterProvenance)}`,
+    `attributionMatrix=${formatAttributionMatrix(comparison.attributionMatrix)}`,
     `streamEventCount=${comparison.streamEventCount}`
   ].join(' ')
-
-const formatUnusableSubmitAuditLine = (comparison) =>
-  [
-    'Waste-balance submit audit carries an unusable actor:',
-    `organisationId=${comparison.organisationId}`,
-    `registrationNumber=${comparison.registrationNumber}`,
-    `accreditationNumber=${comparison.accreditationNumber}`,
-    `unusableSubmitAudit=${comparison.unusableSubmitAudit}`
-  ].join(' ')
-
-const submittedSummaryLogCount = (provenance) =>
-  provenance.systemLog + provenance.backfill
-
-const accumulateProvenance = (totals, provenance) => {
-  totals.systemLog += provenance.systemLog
-  totals.backfill += provenance.backfill
-}
 
 /**
  * @param {import('mongodb').Db} db
@@ -243,20 +230,19 @@ const runDiagnostic = async (db, deps) => {
   let scanned = 0
   let changed = 0
   let failed = 0
-  const provenanceTotals = { systemLog: 0, backfill: 0 }
-  let unusableSubmitAuditTotal = 0
+  /** @type {import('#waste-balances/application/summary-log-submitters.js').AttributionMatrix} */
+  let attributionTotals = {}
 
   for (const row of embedded) {
     scanned += 1
     try {
       const comparison = await compareForEmbedded(row, deps)
-      accumulateProvenance(provenanceTotals, comparison.submitterProvenance)
-      unusableSubmitAuditTotal += comparison.unusableSubmitAudit
-      if (comparison.unusableSubmitAudit > 0) {
-        logger.warn({ message: formatUnusableSubmitAuditLine(comparison) })
-      }
-      if (comparison.backfilledActorCount > 0) {
-        logger.warn({ message: formatBackfillLine(comparison) })
+      attributionTotals = mergeAttributionMatrices([
+        attributionTotals,
+        comparison.attributionMatrix
+      ])
+      if (hasAttributionGap(comparison.attributionMatrix)) {
+        logger.warn({ message: formatAttributionLine(comparison) })
       }
       if (isDivergent(comparison)) {
         changed += 1
@@ -269,7 +255,7 @@ const runDiagnostic = async (db, deps) => {
   }
 
   logger.info({
-    message: `Waste-balance divergence diagnostic: scanned=${scanned} changed=${changed} failed=${failed} submittedSummaryLogs=${submittedSummaryLogCount(provenanceTotals)} submitterProvenance=${formatProvenance(provenanceTotals)} unusableSubmitAudit=${unusableSubmitAuditTotal}`
+    message: `Waste-balance divergence diagnostic: scanned=${scanned} changed=${changed} failed=${failed} attributionMatrix=${formatAttributionMatrix(attributionTotals)}`
   })
 }
 

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -194,21 +194,21 @@ const formatErrorLine = (embedded, error) =>
   ].join(' ')
 
 /**
- * Whether any event in the matrix lacks full name+email attribution — either an
- * id-only actor (real but unlabelled) or no actor at all. These are the gaps an
- * operator wants flagged per accreditation before cutover.
+ * Whether any event could not be attributed to an actor at all (no id — a true
+ * backfill). This is the unexpected case worth flagging per accreditation. An
+ * id-only or name-only actor is real and merely lacks some display labels, which
+ * is expected for historical data — PRN history never carries an email — so it
+ * is captured in the aggregate matrix rather than warned on per accreditation.
  *
  * @param {import('#waste-balances/application/summary-log-submitters.js').AttributionMatrix} matrix
  * @returns {boolean}
  */
-const hasAttributionGap = (matrix) =>
-  Object.values(matrix).some(
-    (counts) => counts.idOnly > 0 || counts.noActor > 0
-  )
+const hasUnattributedEvent = (matrix) =>
+  Object.values(matrix).some((counts) => counts.noActor > 0)
 
-const formatAttributionLine = (comparison) =>
+const formatUnattributedLine = (comparison) =>
   [
-    'Waste-balance rebuild actor attribution gap:',
+    'Waste-balance rebuild has unattributed events:',
     `organisationId=${comparison.organisationId}`,
     `registrationNumber=${comparison.registrationNumber}`,
     `accreditationNumber=${comparison.accreditationNumber}`,
@@ -241,8 +241,8 @@ const runDiagnostic = async (db, deps) => {
         attributionTotals,
         comparison.attributionMatrix
       ])
-      if (hasAttributionGap(comparison.attributionMatrix)) {
-        logger.warn({ message: formatAttributionLine(comparison) })
+      if (hasUnattributedEvent(comparison.attributionMatrix)) {
+        logger.warn({ message: formatUnattributedLine(comparison) })
       }
       if (isDivergent(comparison)) {
         changed += 1

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -148,8 +148,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 0,
       availableAmount: 0,
-      backfilledActorCount: 0,
-      backfilledActorCountByKind: {}
+      attributionMatrix: {}
     })
     vi.mocked(resolveOverseasSites).mockResolvedValue({})
   })
@@ -199,7 +198,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=0 changed=0 failed=0 submittedSummaryLogs=0 submitterProvenance=systemLog:0,backfill:0 unusableSubmitAudit=0'
+        'Waste-balance divergence diagnostic: scanned=0 changed=0 failed=0 attributionMatrix='
     })
   })
 
@@ -230,8 +229,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 7,
       availableAmount: 5,
-      backfilledActorCount: 0,
-      backfilledActorCountByKind: {}
+      attributionMatrix: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -246,7 +244,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     expect(perAccreditationLines).toHaveLength(0)
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 submittedSummaryLogs=0 submitterProvenance=systemLog:0,backfill:0 unusableSubmitAudit=0'
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix='
     })
   })
 
@@ -281,8 +279,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 95,
       availableAmount: 80,
-      backfilledActorCount: 0,
-      backfilledActorCountByKind: {}
+      attributionMatrix: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -293,7 +290,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     })
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=1 failed=0 submittedSummaryLogs=0 submitterProvenance=systemLog:0,backfill:0 unusableSubmitAudit=0'
+        'Waste-balance divergence diagnostic: scanned=1 changed=1 failed=0 attributionMatrix='
     })
   })
 
@@ -407,8 +404,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 7,
       availableAmount: 7,
-      backfilledActorCount: 0,
-      backfilledActorCountByKind: {}
+      attributionMatrix: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -487,7 +483,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     )
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=1 submittedSummaryLogs=0 submitterProvenance=systemLog:0,backfill:0 unusableSubmitAudit=0'
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=1 attributionMatrix='
     })
   })
 
@@ -557,8 +553,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 5,
       availableAmount: 5,
-      backfilledActorCount: 0,
-      backfilledActorCountByKind: {}
+      attributionMatrix: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -572,7 +567,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     )
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=2 changed=0 failed=1 submittedSummaryLogs=0 submitterProvenance=systemLog:0,backfill:0 unusableSubmitAudit=0'
+        'Waste-balance divergence diagnostic: scanned=2 changed=0 failed=1 attributionMatrix='
     })
   })
 
@@ -775,11 +770,84 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 submittedSummaryLogs=1 submitterProvenance=systemLog:1,backfill:0 unusableSubmitAudit=0'
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{nameAndEmail:0,nameOnly:0,emailOnly:1,idOnly:0,noActor:0,scope:0}'
     })
   })
 
-  it('counts and warns when a submitted log has a submit audit whose actor has no usable identity', async () => {
+  it('classifies a resubmitted document by its newest audit actor only', async () => {
+    const accreditation = { id: 'acc-1', accreditationNumber: 'ACC-001' }
+    setEmbeddedBalances([
+      {
+        accreditationId: 'acc-1',
+        organisationId: 'org-1',
+        amount: 0,
+        availableAmount: 0
+      }
+    ])
+    registrations['org-1'] = [
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-1',
+        registrationNumber: 'REG-1',
+        status: 'approved'
+      }
+    ]
+    accreditations['org-1'] = [accreditation]
+    summaryLogsRepository.findAllByOrgReg.mockResolvedValue([
+      {
+        id: 'doc-id-1',
+        version: 1,
+        summaryLog: {
+          status: 'submitted',
+          submittedAt: '2025-01-01T00:00:00Z',
+          file: { id: 'file-id-1', name: 'test.xlsx', uri: 's3://bucket/key' }
+        }
+      }
+    ])
+    systemLogsRepository.findSummaryLogSubmitActors.mockResolvedValue([
+      {
+        summaryLogId: 'doc-id-1',
+        createdBy: {
+          id: 'newest-user',
+          name: 'Newest Submitter',
+          email: 'newest@example.com',
+          scope: ['standard_user']
+        }
+      },
+      {
+        summaryLogId: 'doc-id-1',
+        createdBy: { id: 'older-user', email: 'older@example.com', scope: [] }
+      }
+    ])
+    wasteRecordsRepository.findByRegistration.mockResolvedValue([])
+    prnRepository.findByAccreditation.mockResolvedValue([])
+
+    await runBalanceDivergenceDiagnostic(mockServer)
+
+    expect(computeRebuiltStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summaryLogs: [
+          {
+            id: 'file-id-1',
+            status: 'submitted',
+            submittedAt: '2025-01-01T00:00:00Z',
+            submittedBy: {
+              id: 'newest-user',
+              name: 'Newest Submitter',
+              email: 'newest@example.com'
+            }
+          }
+        ]
+      })
+    )
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{nameAndEmail:1,nameOnly:0,emailOnly:0,idOnly:0,noActor:0,scope:1}'
+    })
+  })
+
+  it('attributes an id-only submit-audit actor as a real, id-only actor', async () => {
     const accreditation = { id: 'acc-1', accreditationNumber: 'ACC-1' }
     setEmbeddedBalances([
       {
@@ -818,19 +886,32 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
-    const unusableLine = vi
+    expect(computeRebuiltStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summaryLogs: [
+          {
+            id: 'file-id-1',
+            status: 'submitted',
+            submittedAt: '2025-01-01T00:00:00Z',
+            submittedBy: { id: 'sys-user' }
+          }
+        ]
+      })
+    )
+
+    const attributionLine = vi
       .mocked(logger.warn)
       .mock.calls.map(([arg]) => arg?.message ?? '')
       .find((message) =>
-        message.startsWith(
-          'Waste-balance submit audit carries an unusable actor:'
-        )
+        message.startsWith('Waste-balance rebuild actor attribution gap:')
       )
-    expect(unusableLine).toContain('unusableSubmitAudit=1')
+    expect(attributionLine).toContain(
+      'attributionMatrix=summary-log-submitted{nameAndEmail:0,nameOnly:0,emailOnly:0,idOnly:1,noActor:0,scope:0}'
+    )
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 submittedSummaryLogs=1 submitterProvenance=systemLog:0,backfill:1 unusableSubmitAudit=1'
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{nameAndEmail:0,nameOnly:0,emailOnly:0,idOnly:1,noActor:0,scope:0}'
     })
   })
 
@@ -918,8 +999,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [],
       amount: 95,
       availableAmount: 75,
-      backfilledActorCount: 0,
-      backfilledActorCountByKind: {}
+      attributionMatrix: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)
@@ -937,7 +1017,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     expect(divergenceLines[0][0].message).toContain('streamEventCount=0')
   })
 
-  it('warns with a tagged key=value line when the rebuild used the backfill actor', async () => {
+  it('warns with a tagged key=value line when an event lacks full attribution', async () => {
     setEmbeddedBalances([
       {
         accreditationId: 'acc-1',
@@ -961,10 +1041,15 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [buildStreamEvent(), buildStreamEvent(), buildStreamEvent()],
       amount: 0,
       availableAmount: 0,
-      backfilledActorCount: 2,
-      backfilledActorCountByKind: {
-        'summary-log-submitted': 1,
-        'prn-created': 1
+      attributionMatrix: {
+        'prn-created': {
+          nameAndEmail: 0,
+          nameOnly: 0,
+          emailOnly: 0,
+          idOnly: 1,
+          noActor: 1,
+          scope: 0
+        }
       }
     })
 
@@ -972,7 +1057,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.warn).toHaveBeenCalledWith({
       message:
-        'Waste-balance rebuild used backfill actor: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-1 backfilledActorCount=2 backfilledActorCountByKind=prn-created:1,summary-log-submitted:1 submitterProvenance=systemLog:0,backfill:0 streamEventCount=3'
+        'Waste-balance rebuild actor attribution gap: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-1 attributionMatrix=prn-created{nameAndEmail:0,nameOnly:0,emailOnly:0,idOnly:1,noActor:1,scope:0} streamEventCount=3'
     })
   })
 
@@ -1000,8 +1085,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
       events: [buildStreamEvent()],
       amount: 0,
       availableAmount: 0,
-      backfilledActorCount: 0,
-      backfilledActorCountByKind: {}
+      attributionMatrix: {}
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -899,15 +899,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
       })
     )
 
-    const attributionLine = vi
-      .mocked(logger.warn)
-      .mock.calls.map(([arg]) => arg?.message ?? '')
-      .find((message) =>
-        message.startsWith('Waste-balance rebuild actor attribution gap:')
-      )
-    expect(attributionLine).toContain(
-      'attributionMatrix=summary-log-submitted{nameAndEmail:0,nameOnly:0,emailOnly:0,idOnly:1,noActor:0,scope:0}'
-    )
+    expect(logger.warn).not.toHaveBeenCalled()
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
@@ -1017,7 +1009,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     expect(divergenceLines[0][0].message).toContain('streamEventCount=0')
   })
 
-  it('warns with a tagged key=value line when an event lacks full attribution', async () => {
+  it('warns with a tagged key=value line when an event has no attributable actor', async () => {
     setEmbeddedBalances([
       {
         accreditationId: 'acc-1',
@@ -1044,7 +1036,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
       attributionMatrix: {
         'prn-created': {
           nameAndEmail: 0,
-          nameOnly: 0,
+          nameOnly: 1,
           emailOnly: 0,
           idOnly: 1,
           noActor: 1,
@@ -1057,11 +1049,11 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.warn).toHaveBeenCalledWith({
       message:
-        'Waste-balance rebuild actor attribution gap: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-1 attributionMatrix=prn-created{nameAndEmail:0,nameOnly:0,emailOnly:0,idOnly:1,noActor:1,scope:0} streamEventCount=3'
+        'Waste-balance rebuild has unattributed events: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-1 attributionMatrix=prn-created{nameAndEmail:0,nameOnly:1,emailOnly:0,idOnly:1,noActor:1,scope:0} streamEventCount=3'
     })
   })
 
-  it('does not warn when every rebuilt event carried a real actor', async () => {
+  it('does not warn when every event is attributed, even if only by id', async () => {
     setEmbeddedBalances([
       {
         accreditationId: 'acc-1',
@@ -1082,10 +1074,19 @@ describe('runBalanceDivergenceDiagnostic', () => {
       { id: 'acc-1', accreditationNumber: 'ACC-1', status: 'approved' }
     ]
     vi.mocked(computeRebuiltStream).mockReturnValue({
-      events: [buildStreamEvent()],
+      events: [buildStreamEvent(), buildStreamEvent()],
       amount: 0,
       availableAmount: 0,
-      attributionMatrix: {}
+      attributionMatrix: {
+        'prn-created': {
+          nameAndEmail: 0,
+          nameOnly: 1,
+          emailOnly: 0,
+          idOnly: 1,
+          noActor: 0,
+          scope: 0
+        }
+      }
     })
 
     await runBalanceDivergenceDiagnostic(mockServer)

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -170,8 +170,7 @@ describe('runStreamPromotion', () => {
       events: [],
       amount: 0,
       availableAmount: 0,
-      backfilledActorCount: 0,
-      backfilledActorCountByKind: {}
+      attributionMatrix: {}
     })
   })
 
@@ -299,8 +298,7 @@ describe('runStreamPromotion', () => {
       events: builtEvents,
       amount: 100,
       availableAmount: 100,
-      backfilledActorCount: 0,
-      backfilledActorCountByKind: {}
+      attributionMatrix: {}
     })
 
     await runStreamPromotion(mockServer)

--- a/src/waste-balances/application/compute-rebuilt-stream.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.js
@@ -11,6 +11,10 @@ import {
   ZERO_BALANCE
 } from '../repository/stream-schema.js'
 import {
+  addAttribution,
+  mergeAttributionMatrices
+} from './summary-log-submitters.js'
+import {
   closingForSummaryLogSubmitted,
   closingForPrn
 } from './stream-closing-balance.js'
@@ -126,52 +130,6 @@ const actorOf = (actor) =>
     : { ...BACKFILL_ACTOR }
 
 /**
- * Sparse count of backfilled-actor events keyed by the stream event kind that
- * fell back. Only kinds with at least one fallback appear.
- *
- * @typedef {Partial<Record<import('../repository/stream-schema.js').StreamEventKind, number>>} BackfillTally
- */
-
-/**
- * Record one event-kind's fallback to the backfill actor in a per-kind tally.
- *
- * @param {BackfillTally} byKind
- * @param {import('../repository/stream-schema.js').StreamEventKind} kind
- */
-const tallyBackfill = (byKind, kind) => {
-  byKind[kind] = (byKind[kind] ?? 0) + 1
-}
-
-/**
- * Combine per-kind backfill tallies, summing counts for shared kinds.
- *
- * @param {BackfillTally[]} tallies
- * @returns {BackfillTally}
- */
-const mergeBackfillTallies = (tallies) => {
-  const merged = /** @type {BackfillTally} */ ({})
-  for (const tally of tallies) {
-    for (const [rawKind, count] of Object.entries(tally)) {
-      const kind =
-        /** @type {import('../repository/stream-schema.js').StreamEventKind} */ (
-          rawKind
-        )
-      merged[kind] = (merged[kind] ?? 0) + count
-    }
-  }
-  return merged
-}
-
-/**
- * Total backfilled-actor events across every kind in a tally.
- *
- * @param {BackfillTally} byKind
- * @returns {number}
- */
-const totalBackfilled = (byKind) =>
-  Object.values(byKind).reduce((sum, count) => sum + count, 0)
-
-/**
  * Build summary-log-submitted events, threading the running set of seen
  * summary-log ids so each submission credits the waste-record data as it
  * stood at that point.
@@ -204,7 +162,6 @@ const buildSummaryLogEvents = ({
 
   const seenSummaryLogIds = new Set()
   const events = []
-  const backfilledActorCountByKind = /** @type {BackfillTally} */ ({})
 
   for (const summaryLog of submitted) {
     seenSummaryLogIds.add(summaryLog.id)
@@ -226,16 +183,6 @@ const buildSummaryLogEvents = ({
       creditTotal = toNumber(add(creditTotal, amount))
     }
 
-    // One event is emitted per submitted log, so a missing submitter is
-    // exactly one backfilled event — no need to gate on emission as the PRN
-    // builder does.
-    if (!summaryLog.submittedBy) {
-      tallyBackfill(
-        backfilledActorCountByKind,
-        STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED
-      )
-    }
-
     events.push({
       timestamp: new Date(summaryLog.submittedAt),
       kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
@@ -247,7 +194,7 @@ const buildSummaryLogEvents = ({
     })
   }
 
-  return { events, backfilledActorCountByKind }
+  return events
 }
 
 /**
@@ -307,8 +254,9 @@ const prnTransitionEvent = ({
 }
 
 /**
- * Build the events from a single PRN's status history, counting those that
- * fall back to the system backfill actor because the history entry names none.
+ * Build the events from a single PRN's status history, classifying each event's
+ * acting actor into the per-event-kind attribution matrix by the labels the
+ * history entry carries (name, id-only, or no actor at all).
  *
  * @param {Object} params
  * @param {Object} params.prn
@@ -324,7 +272,8 @@ const buildPrnHistoryEvents = ({
 }) => {
   const history = prn.status.history
   const events = []
-  const backfilledActorCountByKind = /** @type {BackfillTally} */ ({})
+  /** @type {import('./summary-log-submitters.js').AttributionMatrix} */
+  const attributionMatrix = {}
 
   for (let i = 0; i < history.length; i++) {
     const event = prnTransitionEvent({
@@ -338,12 +287,10 @@ const buildPrnHistoryEvents = ({
       continue
     }
     events.push(event)
-    if (!history[i].by) {
-      tallyBackfill(backfilledActorCountByKind, event.kind)
-    }
+    addAttribution(attributionMatrix, event.kind, history[i].by)
   }
 
-  return { events, backfilledActorCountByKind }
+  return { events, attributionMatrix }
 }
 
 /**
@@ -372,15 +319,18 @@ const buildPrnEvents = ({
 
   return {
     events: perPrn.flatMap(({ events }) => events),
-    backfilledActorCountByKind: mergeBackfillTallies(
-      perPrn.map(({ backfilledActorCountByKind }) => backfilledActorCountByKind)
+    attributionMatrix: mergeAttributionMatrices(
+      perPrn.map(({ attributionMatrix }) => attributionMatrix)
     )
   }
 }
 
 /**
- * Build an unsorted list of chronologically timestamped event tuples
- * from summary log submissions and PRN status transitions.
+ * Build an unsorted list of chronologically timestamped event tuples from
+ * summary log submissions and PRN status transitions. The PRN events carry the
+ * PRN rows of the per-event-kind attribution matrix; the SUMMARY_LOG_SUBMITTED
+ * row is owned by the submitter-recovery path, which sees the raw submit-audit
+ * actor (with its scope), so it is not re-counted here.
  *
  * @param {Object} params
  * @param {{ id: string }} params.accreditation
@@ -392,15 +342,12 @@ const buildPrnEvents = ({
  * @param {Array<{ id: string, status: string, submittedAt?: string, submittedBy?: import('../repository/stream-schema.js').StreamUserSummary }>} params.summaryLogs
  */
 const buildChronologicalEvents = (params) => {
-  const summaryLog = buildSummaryLogEvents(params)
+  const summaryLogEvents = buildSummaryLogEvents(params)
   const prn = buildPrnEvents(params)
 
   return {
-    events: [...summaryLog.events, ...prn.events],
-    backfilledActorCountByKind: mergeBackfillTallies([
-      summaryLog.backfilledActorCountByKind,
-      prn.backfilledActorCountByKind
-    ])
+    events: [...summaryLogEvents, ...prn.events],
+    attributionMatrix: prn.attributionMatrix
   }
 }
 
@@ -491,10 +438,12 @@ const byStreamOrder = (a, b) =>
  * registration / organisation context and actor attribution, and throw on
  * source history that violates the PRN state machine — so the sequence is
  * seedable into the stream store, not only a totals cross-check. Also reports
- * `backfilledActorCount`: how many events fell back to the backfill actor
- * because no real actor was recoverable, and `backfilledActorCountByKind`: the
- * same total broken down by stream event kind, so callers can surface
- * attribution gaps and see which event kinds drive them.
+ * the PRN rows of the per-event-kind attribution matrix (`attributionMatrix`):
+ * for each PRN event kind, how many events carried which actor-label
+ * combination (name, id-only, or no actor at all), so callers can surface
+ * attribution quality and see which kinds carry it. The SUMMARY_LOG_SUBMITTED
+ * row is contributed by the submitter-recovery path, which sees the raw audit
+ * actor and its scope.
  *
  * @param {Object} params
  * @param {{ id: string }} params.accreditation
@@ -514,18 +463,15 @@ export const computeRebuiltStream = ({
   overseasSites,
   summaryLogs
 }) => {
-  const { events: unsorted, backfilledActorCountByKind } =
-    buildChronologicalEvents({
-      accreditation,
-      registrationId,
-      organisationId,
-      wasteRecords,
-      prns,
-      overseasSites,
-      summaryLogs
-    })
-
-  const backfilledActorCount = totalBackfilled(backfilledActorCountByKind)
+  const { events: unsorted, attributionMatrix } = buildChronologicalEvents({
+    accreditation,
+    registrationId,
+    organisationId,
+    wasteRecords,
+    prns,
+    overseasSites,
+    summaryLogs
+  })
 
   unsorted.sort(byStreamOrder)
 
@@ -535,8 +481,7 @@ export const computeRebuiltStream = ({
     return {
       events,
       ...ZERO_BALANCE,
-      backfilledActorCount,
-      backfilledActorCountByKind
+      attributionMatrix
     }
   }
 
@@ -549,7 +494,6 @@ export const computeRebuiltStream = ({
     events,
     amount: finalBalance.amount,
     availableAmount: finalBalance.availableAmount,
-    backfilledActorCount,
-    backfilledActorCountByKind
+    attributionMatrix
   }
 }

--- a/src/waste-balances/application/compute-rebuilt-stream.test.js
+++ b/src/waste-balances/application/compute-rebuilt-stream.test.js
@@ -56,8 +56,7 @@ describe('computeRebuiltStream', () => {
       events: [],
       amount: 0,
       availableAmount: 0,
-      backfilledActorCount: 0,
-      backfilledActorCountByKind: {}
+      attributionMatrix: {}
     })
   })
 
@@ -1129,9 +1128,19 @@ describe('computeRebuiltStream', () => {
     })
   })
 
-  describe('backfilled actor count', () => {
+  describe('per-event-kind PRN actor attribution', () => {
     const registrationId = 'reg-1'
     const organisationId = 'org-1'
+
+    const counts = (overrides) => ({
+      nameAndEmail: 0,
+      nameOnly: 0,
+      emailOnly: 0,
+      idOnly: 0,
+      noActor: 0,
+      scope: 0,
+      ...overrides
+    })
 
     const submittedLog = (id, submittedBy) => ({
       id,
@@ -1154,7 +1163,7 @@ describe('computeRebuiltStream', () => {
       }
     })
 
-    it('reports zero when every event carries a real actor', () => {
+    it('classifies a PRN history actor that carries a name', () => {
       const result = computeRebuiltStream({
         accreditation,
         registrationId,
@@ -1162,33 +1171,31 @@ describe('computeRebuiltStream', () => {
         wasteRecords: [],
         prns: [createdPrn('prn-1', { id: 'rep-1', name: 'Rita Reprocessor' })],
         overseasSites,
-        summaryLogs: [
-          submittedLog('sl-1', { id: 'usr-9', name: 'submitter@example.com' })
-        ]
+        summaryLogs: []
       })
 
-      expect(result.backfilledActorCount).toBe(0)
-      expect(result.backfilledActorCountByKind).toEqual({})
+      expect(result.attributionMatrix).toEqual({
+        [STREAM_EVENT_KIND.PRN_CREATED]: counts({ nameOnly: 1 })
+      })
     })
 
-    it('counts a summary-log event with no submitter', () => {
+    it('classifies a PRN history actor identified only by its id', () => {
       const result = computeRebuiltStream({
         accreditation,
         registrationId,
         organisationId,
         wasteRecords: [],
-        prns: [],
+        prns: [createdPrn('prn-1', { id: 'rep-1' })],
         overseasSites,
-        summaryLogs: [submittedLog('sl-1')]
+        summaryLogs: []
       })
 
-      expect(result.backfilledActorCount).toBe(1)
-      expect(result.backfilledActorCountByKind).toEqual({
-        [STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED]: 1
+      expect(result.attributionMatrix).toEqual({
+        [STREAM_EVENT_KIND.PRN_CREATED]: counts({ idOnly: 1 })
       })
     })
 
-    it('counts a PRN event whose history entry has no actor', () => {
+    it('classifies a PRN event whose history entry has no actor', () => {
       const result = computeRebuiltStream({
         accreditation,
         registrationId,
@@ -1199,13 +1206,12 @@ describe('computeRebuiltStream', () => {
         summaryLogs: []
       })
 
-      expect(result.backfilledActorCount).toBe(1)
-      expect(result.backfilledActorCountByKind).toEqual({
-        [STREAM_EVENT_KIND.PRN_CREATED]: 1
+      expect(result.attributionMatrix).toEqual({
+        [STREAM_EVENT_KIND.PRN_CREATED]: counts({ noActor: 1 })
       })
     })
 
-    it('breaks the backfilled count down by event type', () => {
+    it('does not count summary-log submissions, which the recovery path owns', () => {
       const result = computeRebuiltStream({
         accreditation,
         registrationId,
@@ -1216,10 +1222,8 @@ describe('computeRebuiltStream', () => {
         summaryLogs: [submittedLog('sl-1')]
       })
 
-      expect(result.backfilledActorCount).toBe(2)
-      expect(result.backfilledActorCountByKind).toEqual({
-        [STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED]: 1,
-        [STREAM_EVENT_KIND.PRN_CREATED]: 1
+      expect(result.attributionMatrix).toEqual({
+        [STREAM_EVENT_KIND.PRN_CREATED]: counts({ noActor: 1 })
       })
     })
 
@@ -1251,14 +1255,13 @@ describe('computeRebuiltStream', () => {
         summaryLogs: []
       })
 
-      expect(result.backfilledActorCount).toBe(2)
-      expect(result.backfilledActorCountByKind).toEqual({
-        [STREAM_EVENT_KIND.PRN_CREATED]: 1,
-        [STREAM_EVENT_KIND.PRN_ISSUED]: 1
+      expect(result.attributionMatrix).toEqual({
+        [STREAM_EVENT_KIND.PRN_CREATED]: counts({ noActor: 1 }),
+        [STREAM_EVENT_KIND.PRN_ISSUED]: counts({ noActor: 1 })
       })
     })
 
-    it('tallies repeated backfills of the same event type', () => {
+    it('tallies repeated events of the same kind', () => {
       const result = computeRebuiltStream({
         accreditation,
         registrationId,
@@ -1269,13 +1272,12 @@ describe('computeRebuiltStream', () => {
         summaryLogs: []
       })
 
-      expect(result.backfilledActorCount).toBe(2)
-      expect(result.backfilledActorCountByKind).toEqual({
-        [STREAM_EVENT_KIND.PRN_CREATED]: 2
+      expect(result.attributionMatrix).toEqual({
+        [STREAM_EVENT_KIND.PRN_CREATED]: counts({ noActor: 2 })
       })
     })
 
-    it('reports zero for an empty stream', () => {
+    it('reports an empty matrix for an empty stream', () => {
       const result = computeRebuiltStream({
         accreditation,
         registrationId,
@@ -1286,8 +1288,7 @@ describe('computeRebuiltStream', () => {
         summaryLogs: []
       })
 
-      expect(result.backfilledActorCount).toBe(0)
-      expect(result.backfilledActorCountByKind).toEqual({})
+      expect(result.attributionMatrix).toEqual({})
     })
   })
 })

--- a/src/waste-balances/application/summary-log-submitters.js
+++ b/src/waste-balances/application/summary-log-submitters.js
@@ -4,18 +4,18 @@
 
 /**
  * Reduce a submit-audit actor to the stream's `{ id, name?, email? }` summary,
- * or `null` when it carries no usable identity. The `id` is the proof of the
- * actor; `name` and `email` are distinct labels, each carried only when the
- * audit holds it. An actor with no id, or with neither a name nor an email, has
- * nothing real to attribute, so it is rejected and the submission falls back to
- * backfill — keeping missing data visible downstream. Shared with the
- * unusable-actor count so both read identity the same way.
+ * or `null` when no actor is present. The `id` is the proof of the actor; `name`
+ * and `email` are distinct labels, each carried only when the audit holds it. An
+ * actor identified solely by its id is still a real, attributable actor and is
+ * carried as `{ id }`; only an actor with no id has nothing to attribute and is
+ * rejected so the submission falls back to backfill. Shared with the attribution
+ * accounting so both read identity the same way.
  *
  * @param {SubmitAuditActor} [createdBy]
  * @returns {import('../repository/stream-schema.js').StreamUserSummary | null}
  */
 export const toStreamActor = (createdBy) => {
-  if (createdBy?.id === undefined || (!createdBy.name && !createdBy.email)) {
+  if (createdBy?.id === undefined) {
     return null
   }
   return {
@@ -26,13 +26,156 @@ export const toStreamActor = (createdBy) => {
 }
 
 /**
+ * Per-event-kind attribution quality for one actor-label combination. Each cell
+ * is mutually exclusive: an event lands in exactly one of `nameAndEmail`,
+ * `nameOnly`, `emailOnly`, `idOnly` (a real, attributed actor identified only by
+ * its id) or `noActor` (no id at all — a genuine backfill). `scope` is an
+ * orthogonal tally of how many of those actors also carried a non-empty role
+ * scope, so System Log render fidelity is visible before cutover.
+ *
+ * @typedef {Object} ActorAttributionCounts
+ * @property {number} nameAndEmail
+ * @property {number} nameOnly
+ * @property {number} emailOnly
+ * @property {number} idOnly
+ * @property {number} noActor
+ * @property {number} scope
+ */
+
+/**
+ * @returns {ActorAttributionCounts}
+ */
+export const emptyAttributionCounts = () => ({
+  nameAndEmail: 0,
+  nameOnly: 0,
+  emailOnly: 0,
+  idOnly: 0,
+  noActor: 0,
+  scope: 0
+})
+
+/**
+ * Classify one actor into its attribution cell, counting scope presence
+ * alongside. An actor with no id is a genuine backfill (`noActor`) regardless of
+ * any name or email it carries, because without an id there is nobody to
+ * attribute the event to.
+ *
+ * @param {SubmitAuditActor} [createdBy]
+ * @returns {ActorAttributionCounts}
+ */
+export const classifyActorAttribution = (createdBy) => {
+  const counts = emptyAttributionCounts()
+  if (createdBy?.id === undefined) {
+    counts.noActor = 1
+    return counts
+  }
+  const hasName = Boolean(createdBy.name)
+  const hasEmail = Boolean(createdBy.email)
+  if (hasName && hasEmail) {
+    counts.nameAndEmail = 1
+  } else if (hasName) {
+    counts.nameOnly = 1
+  } else if (hasEmail) {
+    counts.emailOnly = 1
+  } else {
+    counts.idOnly = 1
+  }
+  if (createdBy.scope?.length) {
+    counts.scope = 1
+  }
+  return counts
+}
+
+/**
+ * Per-event-kind attribution matrix. Sparse: only kinds that produced at least
+ * one event appear. Each kind maps to its accumulated `ActorAttributionCounts`,
+ * so the quality of actor attribution can be read per kind before cutover.
+ *
+ * @typedef {Partial<Record<import('../repository/stream-schema.js').StreamEventKind, ActorAttributionCounts>>} AttributionMatrix
+ */
+
+const ATTRIBUTION_CELLS = /** @type {const} */ ([
+  'nameAndEmail',
+  'nameOnly',
+  'emailOnly',
+  'idOnly',
+  'noActor',
+  'scope'
+])
+
+/**
+ * Classify one event's actor and add it into the matrix under its kind,
+ * creating the kind's row on first sight.
+ *
+ * @param {AttributionMatrix} matrix
+ * @param {import('../repository/stream-schema.js').StreamEventKind} kind
+ * @param {SubmitAuditActor} [createdBy]
+ */
+export const addAttribution = (matrix, kind, createdBy) => {
+  const row = (matrix[kind] ??= emptyAttributionCounts())
+  const counts = classifyActorAttribution(createdBy)
+  for (const cell of ATTRIBUTION_CELLS) {
+    row[cell] += counts[cell]
+  }
+}
+
+/**
+ * Combine per-kind attribution matrices, summing each cell for shared kinds.
+ *
+ * @param {AttributionMatrix[]} matrices
+ * @returns {AttributionMatrix}
+ */
+export const mergeAttributionMatrices = (matrices) => {
+  /** @type {AttributionMatrix} */
+  const merged = {}
+  for (const matrix of matrices) {
+    for (const [rawKind, counts] of Object.entries(matrix)) {
+      const kind =
+        /** @type {import('../repository/stream-schema.js').StreamEventKind} */ (
+          rawKind
+        )
+      const row = (merged[kind] ??= emptyAttributionCounts())
+      for (const cell of ATTRIBUTION_CELLS) {
+        row[cell] += counts[cell]
+      }
+    }
+  }
+  return merged
+}
+
+/**
+ * Render an attribution matrix as a stable, log-friendly string. Kinds are
+ * sorted so the line is deterministic; each kind lists its cell counts.
+ *
+ * @param {AttributionMatrix} matrix
+ * @returns {string}
+ */
+export const formatAttributionMatrix = (matrix) =>
+  Object.keys(matrix)
+    .sort((a, b) => a.localeCompare(b))
+    .map((kind) => {
+      const row =
+        matrix[
+          /** @type {import('../repository/stream-schema.js').StreamEventKind} */ (
+            kind
+          )
+        ]
+      const cells = ATTRIBUTION_CELLS.map(
+        (cell) => `${cell}:${/** @type {ActorAttributionCounts} */ (row)[cell]}`
+      ).join(',')
+      return `${kind}{${cells}}`
+    })
+    .join(';')
+
+/**
  * Recover the real submitting actor for each historical summary log from the
  * dedicated submit system-log audit. The audit names the submitter directly but
  * keys on the summary-log document id (`context.summaryLogId`); the stream keys
  * on `summaryLog.file.id`, a different namespace, so the summary-log documents
  * bridge document id → file id. Each actor is reduced to the stream's
- * `{ id, name?, email? }` summary by `toStreamActor`, which rejects actors with
- * no usable identity, keeping missing data visible downstream.
+ * `{ id, name?, email? }` summary by `toStreamActor`, which rejects only an
+ * actor with no id at all, keeping genuinely actor-less submissions visible
+ * downstream.
  *
  * A document submitted more than once keeps the most recent audit: callers
  * supply `submitActors` newest-first, so the first one seen for a file id wins.

--- a/src/waste-balances/application/summary-log-submitters.test.js
+++ b/src/waste-balances/application/summary-log-submitters.test.js
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildSystemLogSubmitters } from './summary-log-submitters.js'
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import {
+  addAttribution,
+  buildSystemLogSubmitters,
+  classifyActorAttribution,
+  emptyAttributionCounts,
+  formatAttributionMatrix,
+  mergeAttributionMatrices,
+  toStreamActor
+} from './summary-log-submitters.js'
 
 const summaryLogDoc = (docId, fileId) => ({
   id: docId,
@@ -65,7 +74,7 @@ describe('buildSystemLogSubmitters', () => {
     })
   })
 
-  it('leaves an actor unrecovered when it carries neither a name nor an email', () => {
+  it('recovers an id-only actor as a real, attributable actor', () => {
     const submitters = buildSystemLogSubmitters({
       submitActors: [
         {
@@ -76,7 +85,7 @@ describe('buildSystemLogSubmitters', () => {
       summaryLogDocs: [summaryLogDoc('doc-1', 'file-1')]
     })
 
-    expect(submitters.size).toBe(0)
+    expect(submitters.get('file-1')).toEqual({ id: 'user-1' })
   })
 
   it('ignores a submit audit whose summary-log document is absent', () => {
@@ -135,5 +144,312 @@ describe('buildSystemLogSubmitters', () => {
     })
 
     expect(submitters.size).toBe(0)
+  })
+})
+
+describe('toStreamActor', () => {
+  it('carries a name and an email distinctly when the audit holds both', () => {
+    expect(
+      toStreamActor({
+        id: 'user-1',
+        name: 'Alice Submitter',
+        email: 'alice@example.com'
+      })
+    ).toEqual({
+      id: 'user-1',
+      name: 'Alice Submitter',
+      email: 'alice@example.com'
+    })
+  })
+
+  it('carries only the name when the audit holds no email', () => {
+    expect(toStreamActor({ id: 'machine-1', name: 'worker' })).toEqual({
+      id: 'machine-1',
+      name: 'worker'
+    })
+  })
+
+  it('carries only the email when the audit holds no name', () => {
+    expect(toStreamActor({ id: 'user-1', email: 'alice@example.com' })).toEqual(
+      { id: 'user-1', email: 'alice@example.com' }
+    )
+  })
+
+  it('carries an id-only actor as a real, attributable actor', () => {
+    expect(toStreamActor({ id: 'user-1' })).toEqual({ id: 'user-1' })
+  })
+
+  it('rejects an actor that carries no id', () => {
+    expect(toStreamActor({ name: 'Alice', email: 'alice@example.com' })).toBe(
+      null
+    )
+  })
+
+  it('rejects an absent actor', () => {
+    expect(toStreamActor(undefined)).toBe(null)
+    expect(toStreamActor(null)).toBe(null)
+  })
+})
+
+describe('classifyActorAttribution', () => {
+  it('counts an actor carrying both a name and an email', () => {
+    expect(
+      classifyActorAttribution({
+        id: 'user-1',
+        name: 'Alice',
+        email: 'alice@example.com'
+      })
+    ).toEqual({
+      nameAndEmail: 1,
+      nameOnly: 0,
+      emailOnly: 0,
+      idOnly: 0,
+      noActor: 0,
+      scope: 0
+    })
+  })
+
+  it('counts a name-only actor', () => {
+    expect(classifyActorAttribution({ id: 'user-1', name: 'Alice' })).toEqual({
+      nameAndEmail: 0,
+      nameOnly: 1,
+      emailOnly: 0,
+      idOnly: 0,
+      noActor: 0,
+      scope: 0
+    })
+  })
+
+  it('counts an email-only actor', () => {
+    expect(
+      classifyActorAttribution({ id: 'user-1', email: 'alice@example.com' })
+    ).toEqual({
+      nameAndEmail: 0,
+      nameOnly: 0,
+      emailOnly: 1,
+      idOnly: 0,
+      noActor: 0,
+      scope: 0
+    })
+  })
+
+  it('counts an id-only actor as a real, attributed actor', () => {
+    expect(classifyActorAttribution({ id: 'user-1' })).toEqual({
+      nameAndEmail: 0,
+      nameOnly: 0,
+      emailOnly: 0,
+      idOnly: 1,
+      noActor: 0,
+      scope: 0
+    })
+  })
+
+  it('counts an actor-less event as a true backfill with no id', () => {
+    expect(classifyActorAttribution(null)).toEqual({
+      nameAndEmail: 0,
+      nameOnly: 0,
+      emailOnly: 0,
+      idOnly: 0,
+      noActor: 1,
+      scope: 0
+    })
+    expect(classifyActorAttribution(undefined)).toEqual({
+      nameAndEmail: 0,
+      nameOnly: 0,
+      emailOnly: 0,
+      idOnly: 0,
+      noActor: 1,
+      scope: 0
+    })
+    expect(
+      classifyActorAttribution({ name: 'Alice', email: 'alice@example.com' })
+    ).toEqual({
+      nameAndEmail: 0,
+      nameOnly: 0,
+      emailOnly: 0,
+      idOnly: 0,
+      noActor: 1,
+      scope: 0
+    })
+  })
+
+  it('counts scope presence alongside the label combination', () => {
+    expect(
+      classifyActorAttribution({
+        id: 'user-1',
+        email: 'alice@example.com',
+        scope: ['standard_user']
+      })
+    ).toEqual({
+      nameAndEmail: 0,
+      nameOnly: 0,
+      emailOnly: 1,
+      idOnly: 0,
+      noActor: 0,
+      scope: 1
+    })
+  })
+
+  it('does not count an empty scope array as scope presence', () => {
+    expect(
+      classifyActorAttribution({
+        id: 'user-1',
+        email: 'alice@example.com',
+        scope: []
+      })
+    ).toEqual({
+      nameAndEmail: 0,
+      nameOnly: 0,
+      emailOnly: 1,
+      idOnly: 0,
+      noActor: 0,
+      scope: 0
+    })
+  })
+})
+
+describe('emptyAttributionCounts', () => {
+  it('starts every cell at zero', () => {
+    expect(emptyAttributionCounts()).toEqual({
+      nameAndEmail: 0,
+      nameOnly: 0,
+      emailOnly: 0,
+      idOnly: 0,
+      noActor: 0,
+      scope: 0
+    })
+  })
+
+  it('returns a fresh object each call', () => {
+    expect(emptyAttributionCounts()).not.toBe(emptyAttributionCounts())
+  })
+})
+
+describe('addAttribution', () => {
+  it('records an actor under its event kind', () => {
+    const matrix = {}
+    addAttribution(matrix, STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED, {
+      id: 'user-1',
+      name: 'Alice',
+      email: 'alice@example.com'
+    })
+
+    expect(matrix).toEqual({
+      [STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED]: {
+        nameAndEmail: 1,
+        nameOnly: 0,
+        emailOnly: 0,
+        idOnly: 0,
+        noActor: 0,
+        scope: 0
+      }
+    })
+  })
+
+  it('accumulates several actors of the same kind', () => {
+    const matrix = {}
+    addAttribution(matrix, STREAM_EVENT_KIND.PRN_CREATED, {
+      id: 'user-1',
+      name: 'Alice'
+    })
+    addAttribution(matrix, STREAM_EVENT_KIND.PRN_CREATED, { id: 'user-2' })
+    addAttribution(matrix, STREAM_EVENT_KIND.PRN_CREATED, null)
+
+    expect(matrix[STREAM_EVENT_KIND.PRN_CREATED]).toEqual({
+      nameAndEmail: 0,
+      nameOnly: 1,
+      emailOnly: 0,
+      idOnly: 1,
+      noActor: 1,
+      scope: 0
+    })
+  })
+})
+
+describe('mergeAttributionMatrices', () => {
+  it('sums counts per kind per cell across matrices', () => {
+    const a = {
+      [STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED]: {
+        nameAndEmail: 1,
+        nameOnly: 0,
+        emailOnly: 2,
+        idOnly: 0,
+        noActor: 1,
+        scope: 3
+      }
+    }
+    const b = {
+      [STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED]: {
+        nameAndEmail: 0,
+        nameOnly: 1,
+        emailOnly: 1,
+        idOnly: 4,
+        noActor: 0,
+        scope: 1
+      },
+      [STREAM_EVENT_KIND.PRN_ACCEPTED]: {
+        nameAndEmail: 0,
+        nameOnly: 2,
+        emailOnly: 0,
+        idOnly: 0,
+        noActor: 0,
+        scope: 0
+      }
+    }
+
+    expect(mergeAttributionMatrices([a, b])).toEqual({
+      [STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED]: {
+        nameAndEmail: 1,
+        nameOnly: 1,
+        emailOnly: 3,
+        idOnly: 4,
+        noActor: 1,
+        scope: 4
+      },
+      [STREAM_EVENT_KIND.PRN_ACCEPTED]: {
+        nameAndEmail: 0,
+        nameOnly: 2,
+        emailOnly: 0,
+        idOnly: 0,
+        noActor: 0,
+        scope: 0
+      }
+    })
+  })
+
+  it('returns an empty matrix when given no matrices', () => {
+    expect(mergeAttributionMatrices([])).toEqual({})
+  })
+})
+
+describe('formatAttributionMatrix', () => {
+  it('renders each kind with its cell counts, kinds sorted', () => {
+    const matrix = {
+      [STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED]: {
+        nameAndEmail: 2,
+        nameOnly: 0,
+        emailOnly: 1,
+        idOnly: 3,
+        noActor: 1,
+        scope: 2
+      },
+      [STREAM_EVENT_KIND.PRN_CREATED]: {
+        nameAndEmail: 0,
+        nameOnly: 4,
+        emailOnly: 0,
+        idOnly: 0,
+        noActor: 2,
+        scope: 0
+      }
+    }
+
+    expect(formatAttributionMatrix(matrix)).toBe(
+      'prn-created{nameAndEmail:0,nameOnly:4,emailOnly:0,idOnly:0,noActor:2,scope:0};' +
+        'summary-log-submitted{nameAndEmail:2,nameOnly:0,emailOnly:1,idOnly:3,noActor:1,scope:2}'
+    )
+  })
+
+  it('renders an empty matrix as an empty string', () => {
+    expect(formatAttributionMatrix({})).toBe('')
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
When the rebuild recovers a historical summary-log submitter from the submit audit, an actor identified only by an `id` (no name, no email) is now treated as the real, attributable actor it is, rather than being discarded. Previously such an actor was rejected and the event fell back to the `BACKFILL_ACTOR` sentinel — a behaviour that made sense only while name was mandatory. Now that `StreamUserSummary` makes both name and email optional with id required, an id-only actor carries genuine attribution, so it reduces to `{ id }` and credits the event to that actor. Backfill is reserved for events with genuinely no actor (no id), aligning the submitter-recovery path with the PRN-history path, which already carried id-only actors correctly.

The pre-cutover diagnostic's actor accounting is replaced with a per-event-kind attribution breakdown. For each `STREAM_EVENT_KIND`, the rebuild now counts how many events carried which actor-label combination — name+email, name-only, email-only, id-only (a real but unlabelled actor) and no-actor-at-all (a true backfill with no id) — plus how many of those actors carried a non-empty role scope. This subsumes the previous binary backfilled/unusable tallies: 'backfill' collapses to the no-actor cell and 'unusable' disappears as a category because id-only is usable. The summary-log-submitted row is built from the raw submit-audit actor (so its scope is visible), and the PRN rows from each PRN history entry; the diagnostic merges them and surfaces the matrix in its summary log line.

The aggregate matrix in the summary line carries the full per-kind breakdown for measurement. The per-accreditation warning is reserved for the genuinely unexpected case — an event with no attributable actor at all (a true backfill). An id-only or name-only actor is real and merely lacks display labels, which is expected for historical data (PRN history never carries an email), so it is measured in the matrix rather than warned on.

This makes attribution quality visible per event kind before the ledger cutover — which kinds carry full name+email, which are id-only, which have no actor, and where role scope is present for System Logs render fidelity.

Builds on [#1257](https://github.com/DEFRA/epr-backend/pull/1257).

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ