### PR TITLE
PAE-1382: Render attribution cells under masking-safe log labels

### DIFF
--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -770,7 +770,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{nameAndEmail:0,nameOnly:0,emailOnly:1,idOnly:0,noActor:0,scope:0}'
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{displayAndContact:0,displayOnly:0,contactOnly:1,idOnly:0,noActor:0,scope:0}'
     })
   })
 
@@ -843,7 +843,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{nameAndEmail:1,nameOnly:0,emailOnly:0,idOnly:0,noActor:0,scope:1}'
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{displayAndContact:1,displayOnly:0,contactOnly:0,idOnly:0,noActor:0,scope:1}'
     })
   })
 
@@ -903,7 +903,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{nameAndEmail:0,nameOnly:0,emailOnly:0,idOnly:1,noActor:0,scope:0}'
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{displayAndContact:0,displayOnly:0,contactOnly:0,idOnly:1,noActor:0,scope:0}'
     })
   })
 
@@ -1049,7 +1049,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.warn).toHaveBeenCalledWith({
       message:
-        'Waste-balance rebuild has unattributed events: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-1 attributionMatrix=prn-created{nameAndEmail:0,nameOnly:1,emailOnly:0,idOnly:1,noActor:1,scope:0} streamEventCount=3'
+        'Waste-balance rebuild has unattributed events: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=ACC-1 attributionMatrix=prn-created{displayAndContact:0,displayOnly:1,contactOnly:0,idOnly:1,noActor:1,scope:0} streamEventCount=3'
     })
   })
 

--- a/src/waste-balances/application/summary-log-submitters.js
+++ b/src/waste-balances/application/summary-log-submitters.js
@@ -144,6 +144,24 @@ export const mergeAttributionMatrices = (matrices) => {
 }
 
 /**
+ * Log labels for each cell. CDP's ingestion pipeline regex-masks log tokens
+ * containing `name` or `email` as potential PII, which would redact those cells
+ * out of the rendered matrix. Render the name/email cells under masking-safe
+ * aliases (`display` for the name label, `contact` for the email label) so the
+ * matrix survives into OpenSearch; the in-memory model keeps its own names.
+ *
+ * @type {Record<typeof ATTRIBUTION_CELLS[number], string>}
+ */
+const CELL_LOG_LABELS = {
+  nameAndEmail: 'displayAndContact',
+  nameOnly: 'displayOnly',
+  emailOnly: 'contactOnly',
+  idOnly: 'idOnly',
+  noActor: 'noActor',
+  scope: 'scope'
+}
+
+/**
  * Render an attribution matrix as a stable, log-friendly string. Kinds are
  * sorted so the line is deterministic; each kind lists its cell counts.
  *
@@ -161,7 +179,8 @@ export const formatAttributionMatrix = (matrix) =>
           )
         ]
       const cells = ATTRIBUTION_CELLS.map(
-        (cell) => `${cell}:${/** @type {ActorAttributionCounts} */ (row)[cell]}`
+        (cell) =>
+          `${CELL_LOG_LABELS[cell]}:${/** @type {ActorAttributionCounts} */ (row)[cell]}`
       ).join(',')
       return `${kind}{${cells}}`
     })

--- a/src/waste-balances/application/summary-log-submitters.test.js
+++ b/src/waste-balances/application/summary-log-submitters.test.js
@@ -444,12 +444,27 @@ describe('formatAttributionMatrix', () => {
     }
 
     expect(formatAttributionMatrix(matrix)).toBe(
-      'prn-created{nameAndEmail:0,nameOnly:4,emailOnly:0,idOnly:0,noActor:2,scope:0};' +
-        'summary-log-submitted{nameAndEmail:2,nameOnly:0,emailOnly:1,idOnly:3,noActor:1,scope:2}'
+      'prn-created{displayAndContact:0,displayOnly:4,contactOnly:0,idOnly:0,noActor:2,scope:0};' +
+        'summary-log-submitted{displayAndContact:2,displayOnly:0,contactOnly:1,idOnly:3,noActor:1,scope:2}'
     )
   })
 
   it('renders an empty matrix as an empty string', () => {
     expect(formatAttributionMatrix({})).toBe('')
+  })
+
+  it('renders no cell label that CDP PII masking would redact', () => {
+    const matrix = {
+      [STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED]: {
+        nameAndEmail: 1,
+        nameOnly: 1,
+        emailOnly: 1,
+        idOnly: 1,
+        noActor: 1,
+        scope: 1
+      }
+    }
+
+    expect(formatAttributionMatrix(matrix)).not.toMatch(/name|email/i)
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
The balance-divergence startup diagnostic logs a per-event-kind actor `attributionMatrix` so attribution quality can be read before the waste-balance ledger cutover. CDP's log-ingestion pipeline applies regex PII masking, and three of the matrix cell labels — `nameAndEmail`, `nameOnly`, `emailOnly` — contain the substrings "name"/"email" that the masking targets. In the deployed OpenSearch logs those cells are redacted to `******` and adjacent ones collapse, so each kind renders five cells instead of six and the name/email attribution breakdown — the most useful signal for the cutover briefing — is unreadable.

This renders the three affected cells under masking-safe aliases at logging time only: `nameAndEmail`→`displayAndContact`, `nameOnly`→`displayOnly`, `emailOnly`→`contactOnly` (`display` for the name label, `contact` for the email label). `idOnly`, `noActor` and `scope` already pass the masking unchanged and keep their names. The in-memory attribution model — the typedef, classification and accumulation — is untouched; only the rendered log string changes.

A regression test asserts the rendered line carries no token matching `/name|email/i`, so the masking-survival property is enforced rather than just the current label spellings.

Note: the masking regex is owned by the CDP platform and cannot be exercised locally, so the aliases must be confirmed against the deployed logs once a build carrying this change reaches dev/test.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ