### PR TITLE
PAE-1382: Sweep waste-balances with no canonicalSource marker into the ledger cutover

### DIFF
--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -43,7 +43,14 @@ const findEmbeddedBalances = async (db) => {
   const docs = await db
     .collection(WASTE_BALANCES_COLLECTION)
     .find(
-      { canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED },
+      {
+        // A missing canonicalSource reads as embedded everywhere else
+        // (read path, census, divergence diagnostic); $in with null matches
+        // documents that have no field so the sweep enumerates them too.
+        canonicalSource: {
+          $in: [WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED, null]
+        }
+      },
       {
         projection: {
           _id: 0,

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -233,6 +233,26 @@ describe('runStreamPromotion', () => {
     })
   })
 
+  it('enumerates legacy documents with no canonicalSource as embedded so the sweep migrates them too', async () => {
+    await runStreamPromotion(mockServer)
+
+    expect(mockFindBalances).toHaveBeenNthCalledWith(
+      2,
+      {
+        canonicalSource: {
+          $in: [WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED, null]
+        }
+      },
+      expect.objectContaining({
+        projection: expect.objectContaining({
+          accreditationId: 1,
+          organisationId: 1,
+          registrationId: 1
+        })
+      })
+    )
+  })
+
   it('promotes an embedded accreditation through the full lifecycle', async () => {
     const migratingToArray = vi.fn().mockResolvedValue([])
     const embeddedToArray = vi.fn().mockResolvedValue([

--- a/src/waste-balances/repository/inmemory.js
+++ b/src/waste-balances/repository/inmemory.js
@@ -104,6 +104,9 @@ const performFlipCanonicalSourceToMigrating =
     if (!current) {
       return null
     }
+    // The mongodb adapter also treats an absent canonicalSource as embedded;
+    // in memory every balance carries a marker from save onwards, so a strict
+    // equality check covers the only states that can occur here.
     if (
       current.version === capturedVersion &&
       current.canonicalSource === WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED

--- a/src/waste-balances/repository/mongodb.js
+++ b/src/waste-balances/repository/mongodb.js
@@ -76,7 +76,11 @@ const performFlipCanonicalSourceToMigrating =
       {
         accreditationId: validatedAccreditationId,
         version: capturedVersion,
-        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+        // A missing canonicalSource reads as embedded; $in with null matches
+        // legacy documents that have no field so the flip lands on them too.
+        canonicalSource: {
+          $in: [WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED, null]
+        }
       },
       {
         $set: {

--- a/src/waste-balances/repository/mongodb.test.js
+++ b/src/waste-balances/repository/mongodb.test.js
@@ -26,11 +26,7 @@ const it = mongoIt.extend({
     await client.close()
   },
 
-  streamRepository: async (
-    // @ts-expect-error -- vitest .extend() fixture typing
-    { mongoClient },
-    use
-  ) => {
+  streamRepository: async ({ mongoClient }, use) => {
     const database = /** @type {import('mongodb').MongoClient} */ (
       mongoClient
     ).db(DATABASE_NAME)
@@ -38,11 +34,7 @@ const it = mongoIt.extend({
     await use(factory())
   },
 
-  wasteBalancesRepository: async (
-    // @ts-expect-error -- vitest .extend() fixture typing
-    { mongoClient, streamRepository },
-    use
-  ) => {
+  wasteBalancesRepository: async ({ mongoClient, streamRepository }, use) => {
     const database = /** @type {import('mongodb').MongoClient} */ (
       mongoClient
     ).db(DATABASE_NAME)
@@ -55,11 +47,7 @@ const it = mongoIt.extend({
     await use(factory)
   },
 
-  insertWasteBalance: async (
-    // @ts-expect-error -- vitest .extend() fixture typing
-    { mongoClient },
-    use
-  ) => {
+  insertWasteBalance: async ({ mongoClient }, use) => {
     await use(async (wasteBalance) => {
       await /** @type {import('mongodb').MongoClient} */ (mongoClient)
         .db(DATABASE_NAME)
@@ -68,11 +56,7 @@ const it = mongoIt.extend({
     })
   },
 
-  insertWasteBalances: async (
-    // @ts-expect-error -- vitest .extend() fixture typing
-    { mongoClient },
-    use
-  ) => {
+  insertWasteBalances: async ({ mongoClient }, use) => {
     await use(async (wasteBalances) => {
       await /** @type {import('mongodb').MongoClient} */ (mongoClient)
         .db(DATABASE_NAME)
@@ -170,7 +154,9 @@ describe('MongoDB waste balances repository', () => {
       expect(result).toEqual({
         canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
       })
-      const after = await repository.findByAccreditationId('acc-legacy-unmarked')
+      const after = await repository.findByAccreditationId(
+        'acc-legacy-unmarked'
+      )
       expect(after?.canonicalSource).toBe(
         WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
       )

--- a/src/waste-balances/repository/mongodb.test.js
+++ b/src/waste-balances/repository/mongodb.test.js
@@ -121,6 +121,90 @@ describe('MongoDB waste balances repository', () => {
     })
   })
 
+  describe('legacy documents with no canonicalSource marker', () => {
+    beforeEach(
+      async (
+        // @ts-expect-error -- vitest .extend() fixture typing
+        { mongoClient }
+      ) => {
+        await /** @type {import('mongodb').MongoClient} */ (mongoClient)
+          .db(DATABASE_NAME)
+          .collection(WASTE_BALANCE_COLLECTION_NAME)
+          .deleteMany({})
+      }
+    )
+
+    const buildRepository = async (mongoClient) => {
+      const db = /** @type {import('mongodb').MongoClient} */ (mongoClient).db(
+        DATABASE_NAME
+      )
+      const streamRepository = (await createMongoStreamRepository(db))()
+      const factory = await createWasteBalancesRepository(db, {
+        streamRepository
+      })
+      return { db, repository: factory() }
+    }
+
+    it('flips a document that has no canonicalSource field to migrating — absence reads as embedded', async ({
+      mongoClient
+    }) => {
+      const { db, repository } = await buildRepository(mongoClient)
+      await db.collection(WASTE_BALANCE_COLLECTION_NAME).insertOne(
+        /** @type {*} */ ({
+          _id: '00000000-0000-0000-0000-000000000020',
+          accreditationId: 'acc-legacy-unmarked',
+          organisationId: 'org-legacy',
+          amount: 0,
+          availableAmount: 0,
+          transactions: [],
+          version: 2,
+          schemaVersion: 1
+        })
+      )
+
+      const result = await repository.flipCanonicalSourceToMigrating({
+        accreditationId: 'acc-legacy-unmarked',
+        capturedVersion: 2
+      })
+
+      expect(result).toEqual({
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      })
+      const after = await repository.findByAccreditationId('acc-legacy-unmarked')
+      expect(after?.canonicalSource).toBe(
+        WASTE_BALANCE_CANONICAL_SOURCE.MIGRATING
+      )
+      expect(after?.migratingSince).toBeDefined()
+    })
+
+    it('leaves a fieldless document untouched when the captured version diverges', async ({
+      mongoClient
+    }) => {
+      const { db, repository } = await buildRepository(mongoClient)
+      await db.collection(WASTE_BALANCE_COLLECTION_NAME).insertOne(
+        /** @type {*} */ ({
+          _id: '00000000-0000-0000-0000-000000000021',
+          accreditationId: 'acc-legacy-stale',
+          organisationId: 'org-legacy',
+          amount: 0,
+          availableAmount: 0,
+          transactions: [],
+          version: 5,
+          schemaVersion: 1
+        })
+      )
+
+      await repository.flipCanonicalSourceToMigrating({
+        accreditationId: 'acc-legacy-stale',
+        capturedVersion: 4
+      })
+
+      const after = await repository.findByAccreditationId('acc-legacy-stale')
+      expect(after?.canonicalSource).toBeUndefined()
+      expect(after?.migratingSince).toBeUndefined()
+    })
+  })
+
   describe('document growth observability', () => {
     beforeEach(
       async (


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## What

The ledger cutover sweep (`run-stream-promotion`) migrates each accreditation's waste balance from the embedded model to the event-sourced stream. Its two selection points — the embedded-balance enumerate and the `flipCanonicalSourceToMigrating` optimistic-lock filter — matched `canonicalSource: 'embedded'` *exactly*. Documents written before the `canonicalSource` marker was introduced carry no such field at all, so the sweep was blind to them: it would report success against an empty selection while leaving every marker-less balance permanently un-migrated.

This aligns both queries with the invariant the rest of the system already follows — **a missing `canonicalSource` reads as embedded** (the read path, the canonical-source census, and the balance-divergence diagnostic all treat absence as embedded). Both now match `{ canonicalSource: { $in: ['embedded', null] } }`; in MongoDB `$in` with `null` matches the literal value, an explicit null, and a missing field, so legacy documents flow through `embedded → migrating → ledger` exactly like freshly-written ones.

## Why this and not a data backfill

A one-shot `updateMany` to stamp the marker onto legacy documents would work, but it mutates production data to satisfy a query that is simply stricter than every other reader of the field. It also wouldn't let us remove the absence-handling that the read path keeps for correctness regardless. Honouring the existing "absent means embedded" semantic in the two outlier queries is the smaller, lower-risk change and keeps the rule in one conceptual place.

## Changes

- `findEmbeddedBalances` (sweep enumerate) and the `flipCanonicalSourceToMigrating` CAS filter now select embedded-or-absent documents via `{ $in: ['embedded', null] }`, each with a comment explaining the `null`-matches-missing-field behaviour so it isn't "simplified" back to exact-match.
- The in-memory repository's flip keeps its strict equality check, with a note recording why: in-memory balances always carry a marker, so the absent case only arises against MongoDB. The divergence is deliberate, not an oversight.
- A query-shape assertion on the enumerate (mirroring the divergence diagnostic's own guard), plus real-MongoDB cases proving the flip promotes a marker-less document and still no-ops under a diverged captured version — the load-bearing half of the fix that the existing contract cases, all seeded with an explicit marker, left unverified.

The flip-to-ledger and reset-to-embedded primitives are unaffected: once a document is enumerated and flipped, it carries an explicit marker and the rest of the lifecycle already matches on concrete values.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ