### PR TITLE
PAE-1382: Capture stack trace in waste-balance divergence per-row failure log

### DIFF
--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -250,7 +250,7 @@ const runDiagnostic = async (db, deps) => {
       }
     } catch (error) {
       failed += 1
-      logger.info({ message: formatErrorLine(row, error) })
+      logger.warn({ err: error, message: formatErrorLine(row, error) })
     }
   }
 

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -474,7 +474,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining(
           'No registration links to accreditation acc-1'
@@ -503,14 +503,14 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining(
           'Waste-balance divergence rebuild failed: organisationId=org-1 accreditationId=acc-orphan'
         )
       })
     )
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining(
           'No registration links to accreditation acc-orphan'
@@ -558,7 +558,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     await runBalanceDivergenceDiagnostic(mockServer)
 
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining(
           'Waste-balance divergence rebuild failed: organisationId=org-1 accreditationId=acc-bad'
@@ -568,6 +568,40 @@ describe('runBalanceDivergenceDiagnostic', () => {
     expect(logger.info).toHaveBeenCalledWith({
       message:
         'Waste-balance divergence diagnostic: scanned=2 changed=0 failed=1 attributionMatrix='
+    })
+  })
+
+  it('logs the error with its stack and the accreditation identifiers when a rebuild throws', async () => {
+    setEmbeddedBalances([
+      {
+        accreditationId: 'acc-throws',
+        organisationId: 'org-throws',
+        amount: 10,
+        availableAmount: 10
+      }
+    ])
+    registrations['org-throws'] = [
+      {
+        id: 'reg-throws',
+        accreditationId: 'acc-throws',
+        registrationNumber: 'REG-throws',
+        status: 'approved'
+      }
+    ]
+    accreditations['org-throws'] = [
+      { id: 'acc-throws', accreditationNumber: 'ACC-throws' }
+    ]
+    const rebuildError = new Error('boom rebuilding stream')
+    vi.mocked(computeRebuiltStream).mockImplementation(() => {
+      throw rebuildError
+    })
+
+    await runBalanceDivergenceDiagnostic(mockServer)
+
+    expect(logger.warn).toHaveBeenCalledWith({
+      err: rebuildError,
+      message:
+        'Waste-balance divergence rebuild failed: organisationId=org-throws accreditationId=acc-throws error="boom rebuilding stream"'
     })
   })
 


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
The pre-cutover waste-balance divergence diagnostic rebuilds each accreditation's balance from authoritative sources and logs any that fail. The per-accreditation failure path logged only the error message (`logger.info({ message })`), discarding the stack — so when a single accreditation's rebuild threw, OpenSearch showed *what* went wrong but not *where*. The outer catch already logs with an `err` field; this brings the per-row path in line.

The per-row catch now logs with `logger.warn({ err: error, message })`. Passing `err` lets the logging layer serialise the full stack, while the message still carries `organisationId` and `accreditationId` for correlation. The level is `warn` rather than `error` because a per-row rebuild failure is an expected outcome of scanning historical data pre-cutover (e.g. a registration in a non-active status) — it should be visible and carry its stack without being alarmed on as a hard error.

This matters for cutover: replaying historical data across all environments will surface representation drift that does not appear in dev as rebuild failures in test and prod. When that happens the stack and accreditation id need to be in the log immediately, rather than reconstructed by git archaeology after the fact.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ