### PR TITLE
PAE-1382: Exclude registered-only accreditations from waste balances

### DIFF
--- a/src/domain/organisations/accreditation.js
+++ b/src/domain/organisations/accreditation.js
@@ -1,3 +1,5 @@
+import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+
 /** @import {RegAccStatus, User} from '#domain/organisations/model.js' */
 
 /**
@@ -76,4 +78,22 @@
  * @typedef {AccreditationApproved | AccreditationOther} Accreditation
  */
 
-export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import
+const REGISTERED_ONLY_STATUSES = /** @type {Set<RegAccStatus>} */ (
+  new Set([REG_ACC_STATUS.CREATED, REG_ACC_STATUS.REJECTED])
+)
+
+/**
+ * Returns true when an accreditation has never reached an accredited state —
+ * it is still 'created' or was 'rejected'. Such a registered-only entity holds
+ * no waste balance: it never had a valid accreditation period to accrue
+ * against. A 'cancelled' accreditation was once approved (cancelled is only
+ * reachable via approved -> suspended -> cancelled) and so is not
+ * registered-only — its historical balance is legitimate.
+ *
+ * @param {{ status?: string } | null | undefined} accreditation
+ * @returns {boolean}
+ */
+export const isRegisteredOnlyAccreditation = (accreditation) =>
+  REGISTERED_ONLY_STATUSES.has(
+    /** @type {RegAccStatus} */ (accreditation?.status)
+  )

--- a/src/domain/organisations/accreditation.test.js
+++ b/src/domain/organisations/accreditation.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { isRegisteredOnlyAccreditation } from './accreditation.js'
+
+describe('isRegisteredOnlyAccreditation', () => {
+  it.each([
+    { status: 'created', expected: true },
+    { status: 'rejected', expected: true },
+    { status: 'approved', expected: false },
+    { status: 'suspended', expected: false },
+    { status: 'cancelled', expected: false }
+  ])(
+    'returns $expected when accreditation status is $status',
+    ({ status, expected }) => {
+      expect(isRegisteredOnlyAccreditation({ status })).toBe(expected)
+    }
+  )
+
+  it('returns false when accreditation is null', () => {
+    expect(isRegisteredOnlyAccreditation(null)).toBe(false)
+  })
+
+  it('returns false when accreditation is undefined', () => {
+    expect(isRegisteredOnlyAccreditation(undefined)).toBe(false)
+  })
+})

--- a/src/server/load-accreditation-sources.js
+++ b/src/server/load-accreditation-sources.js
@@ -1,5 +1,6 @@
 import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+import { isRegisteredOnlyAccreditation } from '#domain/organisations/accreditation.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import {
   addAttribution,
@@ -27,6 +28,10 @@ export const toStreamSummaryLog = ({ summaryLog }) => ({
   status: summaryLog.status,
   submittedAt: summaryLog.submittedAt
 })
+
+/**
+ * @typedef {{ skipped: 'registered-only', accreditation: import('#domain/organisations/accreditation.js').Accreditation }} RegisteredOnlySkip
+ */
 
 /**
  * @typedef {Object} AccreditationSourceDeps
@@ -113,6 +118,12 @@ const recoverSubmitters = ({ submitActors, summaryLogDocs }) => {
  * at all, plus scope presence — so coverage is measurable per kind before
  * cutover.
  *
+ * A registered-only accreditation (status 'created' or 'rejected') holds no
+ * waste balance and has no authoritative history to rebuild, so it returns the
+ * `{ skipped: 'registered-only' }` discriminant before the active-registration
+ * lookup. Callers count it as skipped rather than treating the absent active
+ * registration as a rebuild failure.
+ *
  * @param {{ accreditationId: string, organisationId: string }} row
  * @param {AccreditationSourceDeps} deps
  */
@@ -136,6 +147,12 @@ export const loadAccreditationSources = async (row, deps) => {
     throw new Error(
       `Accreditation ${row.accreditationId} not found on organisation ${row.organisationId}`
     )
+  }
+  if (isRegisteredOnlyAccreditation(accreditation)) {
+    return /** @type {RegisteredOnlySkip} */ ({
+      skipped: 'registered-only',
+      accreditation
+    })
   }
   const registration = organisation.registrations.find(
     (r) =>

--- a/src/server/load-accreditation-sources.js
+++ b/src/server/load-accreditation-sources.js
@@ -30,7 +30,7 @@ export const toStreamSummaryLog = ({ summaryLog }) => ({
 })
 
 /**
- * @typedef {{ skipped: 'registered-only', accreditation: import('#domain/organisations/accreditation.js').Accreditation }} RegisteredOnlySkip
+ * @typedef {{ skipped: 'registered-only' }} RegisteredOnlySkip
  */
 
 /**
@@ -149,10 +149,7 @@ export const loadAccreditationSources = async (row, deps) => {
     )
   }
   if (isRegisteredOnlyAccreditation(accreditation)) {
-    return /** @type {RegisteredOnlySkip} */ ({
-      skipped: 'registered-only',
-      accreditation
-    })
+    return /** @type {RegisteredOnlySkip} */ ({ skipped: 'registered-only' })
   }
   const registration = organisation.registrations.find(
     (r) =>

--- a/src/server/run-balance-divergence-diagnostic.js
+++ b/src/server/run-balance-divergence-diagnostic.js
@@ -78,6 +78,9 @@ const formatDelta = (current, rebuilt) =>
  */
 export const compareForEmbedded = async (embedded, deps) => {
   const sources = await loadAccreditationSources(embedded, deps)
+  if ('skipped' in sources) {
+    return { skipped: sources.skipped }
+  }
   const { accreditation, registration, wasteRecords, prns, overseasSites } =
     sources
 
@@ -229,6 +232,7 @@ const runDiagnostic = async (db, deps) => {
 
   let scanned = 0
   let changed = 0
+  let skipped = 0
   let failed = 0
   /** @type {import('#waste-balances/application/summary-log-submitters.js').AttributionMatrix} */
   let attributionTotals = {}
@@ -237,6 +241,10 @@ const runDiagnostic = async (db, deps) => {
     scanned += 1
     try {
       const comparison = await compareForEmbedded(row, deps)
+      if ('skipped' in comparison) {
+        skipped += 1
+        continue
+      }
       attributionTotals = mergeAttributionMatrices([
         attributionTotals,
         comparison.attributionMatrix
@@ -255,7 +263,7 @@ const runDiagnostic = async (db, deps) => {
   }
 
   logger.info({
-    message: `Waste-balance divergence diagnostic: scanned=${scanned} changed=${changed} failed=${failed} attributionMatrix=${formatAttributionMatrix(attributionTotals)}`
+    message: `Waste-balance divergence diagnostic: scanned=${scanned} changed=${changed} skipped=${skipped} failed=${failed} attributionMatrix=${formatAttributionMatrix(attributionTotals)}`
   })
 }
 

--- a/src/server/run-balance-divergence-diagnostic.test.js
+++ b/src/server/run-balance-divergence-diagnostic.test.js
@@ -198,7 +198,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=0 changed=0 failed=0 attributionMatrix='
+        'Waste-balance divergence diagnostic: scanned=0 changed=0 skipped=0 failed=0 attributionMatrix='
     })
   })
 
@@ -244,7 +244,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     expect(perAccreditationLines).toHaveLength(0)
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix='
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 skipped=0 failed=0 attributionMatrix='
     })
   })
 
@@ -290,7 +290,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     })
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=1 failed=0 attributionMatrix='
+        'Waste-balance divergence diagnostic: scanned=1 changed=1 skipped=0 failed=0 attributionMatrix='
     })
   })
 
@@ -375,7 +375,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     )
   })
 
-  it('logs accreditationNumber=<none> for accreditations that have not been issued one yet', async () => {
+  it('logs accreditationNumber=<none> for an accreditation with no number', async () => {
     setEmbeddedBalances([
       {
         accreditationId: 'acc-pending',
@@ -392,7 +392,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
         status: 'approved'
       }
     ]
-    accreditations['org-1'] = [{ id: 'acc-pending', status: 'created' }]
+    accreditations['org-1'] = [{ id: 'acc-pending', status: 'cancelled' }]
     vi.mocked(computeRebuiltTotals).mockReturnValue({
       amount: 7,
       availableAmount: 7,
@@ -411,7 +411,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=<none> currentAmount=10 rebuiltAmount=7 deltaAmount=-3 currentAvailableAmount=10 rebuiltAvailableAmount=7 deltaAvailableAmount=-3 registrationStatus=approved accreditationStatus=created wasteRecordCount=0 wasteRecordContribution=7 prnCount=0 prnAmountContribution=0 prnAvailableAmountContribution=0 streamAmount=7 streamAvailableAmount=7 streamDeltaAmount=0 streamDeltaAvailableAmount=0 streamEventCount=0'
+        'Waste-balance divergence affected accreditation: organisationId=org-1 registrationNumber=REG-1 accreditationNumber=<none> currentAmount=10 rebuiltAmount=7 deltaAmount=-3 currentAvailableAmount=10 rebuiltAvailableAmount=7 deltaAvailableAmount=-3 registrationStatus=approved accreditationStatus=cancelled wasteRecordCount=0 wasteRecordContribution=7 prnCount=0 prnAmountContribution=0 prnAvailableAmountContribution=0 streamAmount=7 streamAvailableAmount=7 streamDeltaAmount=0 streamDeltaAvailableAmount=0 streamEventCount=0'
     })
   })
 
@@ -462,7 +462,9 @@ describe('runBalanceDivergenceDiagnostic', () => {
         availableAmount: 10
       }
     ])
-    accreditations['org-1'] = [{ id: 'acc-1', accreditationNumber: 'ACC-1' }]
+    accreditations['org-1'] = [
+      { id: 'acc-1', accreditationNumber: 'ACC-1', status: 'approved' }
+    ]
     registrations['org-1'] = [
       {
         id: 'reg-1',
@@ -483,7 +485,35 @@ describe('runBalanceDivergenceDiagnostic', () => {
     )
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=1 attributionMatrix='
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 skipped=0 failed=1 attributionMatrix='
+    })
+  })
+
+  it('counts a registered-only accreditation as skipped without logging a failure', async () => {
+    setEmbeddedBalances([
+      {
+        accreditationId: 'acc-regonly',
+        organisationId: 'org-1',
+        amount: 40458.86,
+        availableAmount: 40458.86
+      }
+    ])
+    accreditations['org-1'] = [{ id: 'acc-regonly', status: 'created' }]
+    registrations['org-1'] = [
+      {
+        id: 'reg-1',
+        accreditationId: 'acc-regonly',
+        registrationNumber: 'REG-1',
+        status: 'created'
+      }
+    ]
+
+    await runBalanceDivergenceDiagnostic(mockServer)
+
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 skipped=1 failed=0 attributionMatrix='
     })
   })
 
@@ -567,7 +597,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
     )
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=2 changed=0 failed=1 attributionMatrix='
+        'Waste-balance divergence diagnostic: scanned=2 changed=0 skipped=0 failed=1 attributionMatrix='
     })
   })
 
@@ -804,7 +834,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{displayAndContact:0,displayOnly:0,contactOnly:1,idOnly:0,noActor:0,scope:0}'
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 skipped=0 failed=0 attributionMatrix=summary-log-submitted{displayAndContact:0,displayOnly:0,contactOnly:1,idOnly:0,noActor:0,scope:0}'
     })
   })
 
@@ -877,7 +907,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{displayAndContact:1,displayOnly:0,contactOnly:0,idOnly:0,noActor:0,scope:1}'
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 skipped=0 failed=0 attributionMatrix=summary-log-submitted{displayAndContact:1,displayOnly:0,contactOnly:0,idOnly:0,noActor:0,scope:1}'
     })
   })
 
@@ -937,7 +967,7 @@ describe('runBalanceDivergenceDiagnostic', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Waste-balance divergence diagnostic: scanned=1 changed=0 failed=0 attributionMatrix=summary-log-submitted{displayAndContact:0,displayOnly:0,contactOnly:0,idOnly:1,noActor:0,scope:0}'
+        'Waste-balance divergence diagnostic: scanned=1 changed=0 skipped=0 failed=0 attributionMatrix=summary-log-submitted{displayAndContact:0,displayOnly:0,contactOnly:0,idOnly:1,noActor:0,scope:0}'
     })
   })
 

--- a/src/server/run-stream-promotion.js
+++ b/src/server/run-stream-promotion.js
@@ -81,10 +81,13 @@ const findEmbeddedBalances = async (db) => {
 /**
  * @param {{ accreditationId: string, organisationId: string }} row
  * @param {PromotionDependencies} deps
- * @returns {Promise<{ events: Array, registration: { id: string } }>}
+ * @returns {Promise<{ skipped: 'registered-only' } | { events: Array, registration: { id: string } }>}
  */
 const rebuildEvents = async (row, deps) => {
   const sources = await loadAccreditationSources(row, deps)
+  if ('skipped' in sources) {
+    return { skipped: sources.skipped }
+  }
   const { events } = computeRebuiltStream({
     accreditation: sources.accreditation,
     registrationId: sources.registration.id,
@@ -117,6 +120,17 @@ export const promoteAccreditation = async (row, deps) => {
   }
 
   const rebuildResult = await rebuildEvents(row, deps)
+
+  // Registered-only accreditation (status 'created'/'rejected') holds no waste
+  // balance and has nothing to rebuild. Skip it rather than failing on the
+  // absent active registration, so a stray invalid embedded doc never re-trips
+  // the per-boot error alarm.
+  if ('skipped' in rebuildResult) {
+    logger.info({
+      message: `Stream promotion: skipping registered-only accreditation ${row.accreditationId}`
+    })
+    return 'skipped'
+  }
 
   // Invariant: a non-zero embedded balance must reconstruct to a non-empty
   // stream. An empty rebuild from authoritative sources that don't account

--- a/src/server/run-stream-promotion.test.js
+++ b/src/server/run-stream-promotion.test.js
@@ -533,6 +533,56 @@ describe('runStreamPromotion', () => {
     ).toHaveBeenCalled()
   })
 
+  it('skips a registered-only accreditation without erroring', async () => {
+    const migratingToArray = vi.fn().mockResolvedValue([])
+    const embeddedToArray = vi.fn().mockResolvedValue([
+      {
+        accreditationId: 'acc-regonly',
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+    ])
+
+    mockFindBalances
+      .mockReturnValueOnce({ toArray: migratingToArray })
+      .mockReturnValueOnce({ toArray: embeddedToArray })
+
+    wasteBalancesRepository.findByAccreditationId.mockResolvedValue({
+      accreditationId: 'acc-regonly',
+      version: 1,
+      amount: 40458.86,
+      availableAmount: 40458.86,
+      canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.EMBEDDED
+    })
+
+    organisationsRepository.findById.mockResolvedValue({
+      id: 'org-1',
+      registrations: [
+        {
+          id: 'reg-1',
+          accreditationId: 'acc-regonly',
+          registrationNumber: 'CBDU1',
+          status: 'created'
+        }
+      ],
+      accreditations: [{ id: 'acc-regonly', status: 'created' }]
+    })
+
+    await runStreamPromotion(mockServer)
+
+    expect(
+      wasteBalancesRepository.flipCanonicalSourceToMigrating
+    ).not.toHaveBeenCalled()
+    expect(streamRepository.deleteByPartition).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('promoted=0 skipped=1 failed=0')
+      })
+    )
+  })
+
   it('counts as failed when accreditation is not found on organisation', async () => {
     const migratingToArray = vi.fn().mockResolvedValue([])
     const embeddedToArray = vi.fn().mockResolvedValue([

--- a/src/waste-balances/application/compute-rebuilt-totals.test.js
+++ b/src/waste-balances/application/compute-rebuilt-totals.test.js
@@ -134,8 +134,10 @@ const prn = ({
 /** @type {import('#domain/organisations/accreditation.js').Accreditation} */
 const accreditation = {
   id: 'acc-1',
-  status: 'created',
-  statusHistory: [{ status: 'created', updatedAt: '2025-01-01T00:00:00.000Z' }],
+  status: 'cancelled',
+  statusHistory: [
+    { status: 'approved', updatedAt: '2025-01-01T00:00:00.000Z' }
+  ],
   formSubmission: { id: 'form-1', time: new Date('2025-01-01T00:00:00.000Z') },
   material: 'glass',
   prnIssuance: {

--- a/src/waste-balances/application/target-amount.js
+++ b/src/waste-balances/application/target-amount.js
@@ -1,5 +1,6 @@
 import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/index.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { isRegisteredOnlyAccreditation } from '#domain/organisations/accreditation.js'
 
 /**
  * Per-record waste-balance contribution shared between the embedded
@@ -8,6 +9,13 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
  * inputs). Both must consult the same classification, otherwise the
  * stored embedded balance and its rebuilt counterpart drift apart.
  *
+ * A registered-only accreditation (status 'created' or 'rejected') never
+ * contributes: it holds no waste balance because it never reached an
+ * accredited period to accrue against. The date-range classification keys
+ * off validFrom/validTo, which a registered-only accreditation can still
+ * carry, so the status is gated explicitly here rather than relying on the
+ * dates being absent.
+ *
  * @param {import('#domain/waste-records/model.js').WasteRecord} record
  * @param {Object} accreditation
  * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} overseasSites
@@ -15,6 +23,9 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
  */
 export const getTargetAmount = (record, accreditation, overseasSites) => {
   if (record.excludedFromWasteBalance) {
+    return 0
+  }
+  if (isRegisteredOnlyAccreditation(accreditation)) {
     return 0
   }
   const schema = findSchemaForProcessingType(

--- a/src/waste-balances/application/target-amount.test.js
+++ b/src/waste-balances/application/target-amount.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { getTargetAmount } from './target-amount.js'
+import { RECEIVED_LOADS_FIELDS as FIELDS } from '#domain/summary-logs/table-schemas/exporter/fields.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
+import { buildWasteRecord } from '#repositories/waste-records/contract/test-data.js'
+
+const includedExportRecord = buildWasteRecord({
+  type: WASTE_RECORD_TYPE.EXPORTED,
+  data: {
+    processingType: PROCESSING_TYPES.EXPORTER,
+    [FIELDS.ROW_ID]: 1000,
+    [FIELDS.DATE_RECEIVED_FOR_EXPORT]: '2023-01-15',
+    [FIELDS.EWC_CODE]: '15 01 01',
+    [FIELDS.DESCRIPTION_WASTE]: 'Aluminium - other',
+    [FIELDS.WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE]: 'No',
+    [FIELDS.GROSS_WEIGHT]: 12,
+    [FIELDS.TARE_WEIGHT]: 1,
+    [FIELDS.PALLET_WEIGHT]: 0.5,
+    [FIELDS.NET_WEIGHT]: 10.5,
+    [FIELDS.BAILING_WIRE_PROTOCOL]: 'No',
+    [FIELDS.HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION]: 'AAIG percentage',
+    [FIELDS.WEIGHT_OF_NON_TARGET_MATERIALS]: 0,
+    [FIELDS.RECYCLABLE_PROPORTION_PERCENTAGE]: 1,
+    [FIELDS.TONNAGE_RECEIVED_FOR_EXPORT]: 10.5,
+    [FIELDS.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED]: 10.5,
+    [FIELDS.DATE_OF_EXPORT]: '2023-06-01',
+    [FIELDS.BASEL_EXPORT_CODE]: 'B3020',
+    [FIELDS.CUSTOMS_CODES]: '4707',
+    [FIELDS.CONTAINER_NUMBER]: 'CONT001',
+    [FIELDS.DATE_RECEIVED_BY_OSR]: '2023-06-15',
+    [FIELDS.OSR_ID]: '001',
+    [FIELDS.DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE]: 'No'
+  }
+})
+
+const dateRange = {
+  validFrom: '2023-01-01',
+  validTo: '2023-12-31',
+  statusHistory: [
+    { status: 'created', updatedAt: '2022-12-01T00:00:00.000Z' },
+    { status: 'approved', updatedAt: '2022-12-15T00:00:00.000Z' }
+  ]
+}
+
+describe('getTargetAmount', () => {
+  it('credits the export tonnage for an approved accreditation', () => {
+    const accreditation = { ...dateRange, status: 'approved' }
+
+    expect(
+      getTargetAmount(
+        includedExportRecord,
+        accreditation,
+        ORS_VALIDATION_DISABLED
+      )
+    ).toBe(10.5)
+  })
+
+  it('returns 0 for a created (registered-only) accreditation even within its dates', () => {
+    const accreditation = { ...dateRange, status: 'created' }
+
+    expect(
+      getTargetAmount(
+        includedExportRecord,
+        accreditation,
+        ORS_VALIDATION_DISABLED
+      )
+    ).toBe(0)
+  })
+
+  it('returns 0 for a rejected accreditation even within its dates', () => {
+    const accreditation = { ...dateRange, status: 'rejected' }
+
+    expect(
+      getTargetAmount(
+        includedExportRecord,
+        accreditation,
+        ORS_VALIDATION_DISABLED
+      )
+    ).toBe(0)
+  })
+})

--- a/src/waste-balances/repository/helpers.js
+++ b/src/waste-balances/repository/helpers.js
@@ -8,6 +8,7 @@ import {
   ROW_OUTCOME
 } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/index.js'
+import { isRegisteredOnlyAccreditation } from '#domain/organisations/accreditation.js'
 
 /** @import {OverseasSitesContext} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '../domain/model.js'
@@ -247,6 +248,14 @@ export const performUpdateWasteBalanceTransactions = async ({
   const annotatedRecords = markExcludedRecords(wasteRecords)
 
   if (annotatedRecords.length === 0) {
+    return
+  }
+
+  // A registered-only accreditation (status 'created'/'rejected') holds no
+  // waste balance. Return before either write path so no balance doc is
+  // created or maintained — neither an embedded array nor a ledger shell doc
+  // with its stream event — keeping reg-only at zero per the committed design.
+  if (isRegisteredOnlyAccreditation(accreditation)) {
     return
   }
 

--- a/src/waste-balances/repository/helpers.test.js
+++ b/src/waste-balances/repository/helpers.test.js
@@ -703,6 +703,44 @@ describe('src/waste-balances/repository/helpers.js', () => {
         expect(saveBalance.mock.calls[0][1]).toEqual([])
       })
 
+      it('creates no balance doc or stream event for a registered-only accreditation even with the ledger flag on', async () => {
+        const wasteRecords = [
+          {
+            id: 'rec-1',
+            organisationId: 'org-1',
+            registrationId: 'reg-1',
+            data: {}
+          }
+        ]
+        const accreditation = { id: 'acc-1', status: 'created' }
+        const streamRepository = { appendEvent: vi.fn() }
+        const featureFlags = {
+          isWasteBalanceLedgerEnabled: () => true
+        }
+        const findBalance = vi.fn().mockResolvedValue(null)
+        const saveBalance = vi.fn().mockResolvedValue(undefined)
+        vi.mocked(performUpdateViaStream).mockClear()
+        vi.mocked(calculateWasteBalanceUpdates).mockClear()
+
+        await callPerformUpdate({
+          wasteRecords,
+          accreditation,
+          dependencies: {
+            streamRepository,
+            featureFlags
+          },
+          findBalance,
+          saveBalance,
+          user: { id: 'user-1', email: 'user@test.com' },
+          overseasSites: ORS_VALIDATION_DISABLED,
+          summaryLogId: 'log-1'
+        })
+
+        expect(performUpdateViaStream).not.toHaveBeenCalled()
+        expect(calculateWasteBalanceUpdates).not.toHaveBeenCalled()
+        expect(saveBalance).not.toHaveBeenCalled()
+      })
+
       it('uses the embedded path when canonicalSource is ledger but no streamRepository is provided', async () => {
         const wasteRecords = [
           {

--- a/src/waste-records-export/domain/is-included-in-waste-balance.js
+++ b/src/waste-records-export/domain/is-included-in-waste-balance.js
@@ -1,5 +1,6 @@
 import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/index.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { isRegisteredOnlyAccreditation } from '#domain/organisations/accreditation.js'
 
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 /** @import {OverseasSitesContext} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
@@ -9,7 +10,9 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
  * Boolean version of waste-balances/application/calculator#getTargetAmount.
  * Returns true iff the record currently counts toward the waste balance for
  * its accreditation. Mirrors the same logic; differs only by returning a
- * boolean rather than a tonnage.
+ * boolean rather than a tonnage — including the registered-only accreditation
+ * gate, so an accreditation that never reached an accredited state includes
+ * no records.
  *
  * @param {WasteRecord} record
  * @param {Accreditation | null} accreditation
@@ -22,6 +25,10 @@ export const isIncludedInWasteBalance = (
   overseasSites
 ) => {
   if (record.excludedFromWasteBalance) {
+    return false
+  }
+
+  if (isRegisteredOnlyAccreditation(accreditation)) {
     return false
   }
 

--- a/src/waste-records-export/domain/is-included-in-waste-balance.test.js
+++ b/src/waste-records-export/domain/is-included-in-waste-balance.test.js
@@ -70,6 +70,37 @@ describe('isIncludedInWasteBalance', () => {
     ).toBe(true)
   })
 
+  it('returns false for a registered-only accreditation even when the record would otherwise be INCLUDED', () => {
+    const registeredOnlyAccreditation = { ...accreditation, status: 'created' }
+    const record = {
+      type: WASTE_RECORD_TYPE.RECEIVED,
+      data: {
+        processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+        ROW_ID: '1001',
+        DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01',
+        EWC_CODE: '15 01 02',
+        DESCRIPTION_WASTE: 'Plastic packaging',
+        WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+        GROSS_WEIGHT: 10,
+        TARE_WEIGHT: 1,
+        PALLET_WEIGHT: 0,
+        NET_WEIGHT: 9,
+        BAILING_WIRE_PROTOCOL: 'No',
+        HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
+        WEIGHT_OF_NON_TARGET_MATERIALS: 0,
+        RECYCLABLE_PROPORTION_PERCENTAGE: 100,
+        TONNAGE_RECEIVED_FOR_RECYCLING: 9
+      }
+    }
+    expect(
+      isIncludedInWasteBalance(
+        record,
+        registeredOnlyAccreditation,
+        ORS_VALIDATION_DISABLED
+      )
+    ).toBe(false)
+  })
+
   it('returns false when classifyForWasteBalance returns EXCLUDED (PRN already issued)', () => {
     const record = {
       type: WASTE_RECORD_TYPE.EXPORTED,

--- a/src/waste-records-export/domain/is-included-in-waste-balance.test.js
+++ b/src/waste-records-export/domain/is-included-in-waste-balance.test.js
@@ -2,31 +2,56 @@ import { isIncludedInWasteBalance } from './is-included-in-waste-balance.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
+import { buildWasteRecord } from '#repositories/waste-records/contract/test-data.js'
 
 describe('isIncludedInWasteBalance', () => {
-  const accreditation = {
+  const accreditationBase = {
     id: 'acc-1',
+    accreditationNumber: 'ACC-1',
     validFrom: '2026-01-01',
     validTo: '2027-01-01',
-    statusHistory: []
+    statusHistory: [],
+    formSubmission: { id: 'fs-1', time: new Date('2026-01-01T00:00:00.000Z') },
+    material: 'plastic',
+    prnIssuance: {
+      incomeBusinessPlan: [],
+      signatories: [],
+      tonnageBand: 'up_to_500'
+    },
+    submittedToRegulator: 'ea',
+    submitterContactDetails: {
+      fullName: 'Test User',
+      email: 'test@example.com',
+      phone: '01234567890'
+    },
+    wasteProcessingType: 'reprocessor'
+  }
+
+  /** @type {import('#domain/organisations/accreditation.js').Accreditation} */
+  const accreditation = { ...accreditationBase, status: 'approved' }
+
+  /** @type {import('#domain/organisations/accreditation.js').Accreditation} */
+  const registeredOnlyAccreditation = {
+    ...accreditationBase,
+    status: 'created'
   }
 
   it('returns false when record.excludedFromWasteBalance is true', () => {
-    const record = {
+    const record = buildWasteRecord({
       type: WASTE_RECORD_TYPE.RECEIVED,
       data: { processingType: PROCESSING_TYPES.REPROCESSOR_INPUT },
       excludedFromWasteBalance: true
-    }
+    })
     expect(
       isIncludedInWasteBalance(record, accreditation, ORS_VALIDATION_DISABLED)
     ).toBe(false)
   })
 
   it('returns false when no schema can be found for the record', () => {
-    const record = {
+    const record = buildWasteRecord({
       type: WASTE_RECORD_TYPE.RECEIVED,
       data: { processingType: 'NOT_A_REAL_TYPE' }
-    }
+    })
     expect(
       isIncludedInWasteBalance(record, accreditation, ORS_VALIDATION_DISABLED)
     ).toBe(false)
@@ -34,10 +59,10 @@ describe('isIncludedInWasteBalance', () => {
 
   it('returns false when the schema does not have classifyForWasteBalance', () => {
     // SENT_ON records typically lack classifyForWasteBalance
-    const record = {
+    const record = buildWasteRecord({
       type: WASTE_RECORD_TYPE.SENT_ON,
       data: { processingType: PROCESSING_TYPES.EXPORTER }
-    }
+    })
     expect(
       isIncludedInWasteBalance(record, accreditation, ORS_VALIDATION_DISABLED)
     ).toBe(false)
@@ -45,7 +70,7 @@ describe('isIncludedInWasteBalance', () => {
 
   it('returns true when classifyForWasteBalance returns INCLUDED', () => {
     // A reprocessor RECEIVED record with all required fields should classify INCLUDED
-    const record = {
+    const record = buildWasteRecord({
       type: WASTE_RECORD_TYPE.RECEIVED,
       data: {
         processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
@@ -64,15 +89,14 @@ describe('isIncludedInWasteBalance', () => {
         RECYCLABLE_PROPORTION_PERCENTAGE: 100,
         TONNAGE_RECEIVED_FOR_RECYCLING: 9
       }
-    }
+    })
     expect(
       isIncludedInWasteBalance(record, accreditation, ORS_VALIDATION_DISABLED)
     ).toBe(true)
   })
 
   it('returns false for a registered-only accreditation even when the record would otherwise be INCLUDED', () => {
-    const registeredOnlyAccreditation = { ...accreditation, status: 'created' }
-    const record = {
+    const record = buildWasteRecord({
       type: WASTE_RECORD_TYPE.RECEIVED,
       data: {
         processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
@@ -91,7 +115,7 @@ describe('isIncludedInWasteBalance', () => {
         RECYCLABLE_PROPORTION_PERCENTAGE: 100,
         TONNAGE_RECEIVED_FOR_RECYCLING: 9
       }
-    }
+    })
     expect(
       isIncludedInWasteBalance(
         record,
@@ -102,7 +126,7 @@ describe('isIncludedInWasteBalance', () => {
   })
 
   it('returns false when classifyForWasteBalance returns EXCLUDED (PRN already issued)', () => {
-    const record = {
+    const record = buildWasteRecord({
       type: WASTE_RECORD_TYPE.EXPORTED,
       data: {
         processingType: PROCESSING_TYPES.EXPORTER,
@@ -129,7 +153,7 @@ describe('isIncludedInWasteBalance', () => {
         OSR_ID: '099',
         DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE: 'No'
       }
-    }
+    })
     expect(
       isIncludedInWasteBalance(record, accreditation, ORS_VALIDATION_DISABLED)
     ).toBe(false)


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
A registered-only accreditation — one whose status is still `created` (or was `rejected`) and so never reached an accredited period — holds no waste balance. The waste-balance classification gates on the accreditation's dates (`validFrom`/`validTo`), not its status, and those date fields are optional when not approved, so a `created` accreditation that carries dates would accrue a real, non-zero embedded balance against an entity that should have none. This brings the write path and the ledger cutover sweep into agreement with the already-committed "reg-only = zero / empty stream" design.

## Write path

- `getTargetAmount` and its `isIncludedInWasteBalance` mirror now return 0 / false for a registered-only accreditation, so its records never contribute. Both the embedded calculator and the authoritative-sources rebuild route through `getTargetAmount`, so they stay consistent.
- `performUpdateWasteBalanceTransactions` returns early for a registered-only accreditation, so no balance document is created or maintained at all — neither an embedded `transactions[]` document nor a ledger shell document with its stream event — regardless of the waste-balance-ledger feature flag.

## Cutover sweep and divergence diagnostic

- `loadAccreditationSources` returns a `{ skipped: 'registered-only' }` discriminant for a registered-only accreditation, before the active-registration lookup that previously threw.
- The stream-promotion startup sweep counts these as `skipped` at info level instead of throwing `No registration links to accreditation …` once per affected document on every boot — which was tripping the OpenSearch error-log alert in Test.
- The balance-divergence diagnostic gains a matching `skipped` count and no longer logs these as per-row failures.

## Predicate

The new `isRegisteredOnlyAccreditation` predicate matches only the never-accredited statuses `{created, rejected}`. A `cancelled` accreditation was once approved (cancellation is reachable only via approved → suspended → cancelled), so it keeps its legitimate historical balance and is not gated.

Cleaning up any existing spurious reg-only balance documents already in an environment is tracked separately; this change stops new ones forming and makes the sweep skip rather than error on any that remain.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ