### PR TITLE
PAE-1382: Test id-only actor and align mise node version

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 gitleaks = "8.30.0"
-node = "24.14.0"
+node = "24.15.0"

--- a/src/waste-balances/repository/stream-schema.test.js
+++ b/src/waste-balances/repository/stream-schema.test.js
@@ -142,6 +142,13 @@ describe('stream event insert schema', () => {
     expect(error).toBeUndefined()
   })
 
+  it('accepts createdBy with id only — no name, no email', () => {
+    const { error } = validate(
+      buildStreamEvent({ createdBy: { id: 'user-1' } })
+    )
+    expect(error).toBeUndefined()
+  })
+
   it('accepts accreditationId: null for registered-only streams', () => {
     const { error } = validate(buildStreamEvent({ accreditationId: null }))
     expect(error).toBeUndefined()


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary
- Adds test coverage for id-only actors in the stream event schema (no name, no email)
- Bumps mise.toml node from 24.14.0 to 24.15.0 to match the package.json engine constraint

## Test plan
- [ ] All existing stream schema tests still pass
- [ ] New test verifies `createdBy: { id }` (no name/email) passes validation

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ