### PR TITLE
PAE-1544: node/npm toolchain tune-up

### DIFF
--- a/.github/actions/test-and-scan/action.yml
+++ b/.github/actions/test-and-scan/action.yml
@@ -18,10 +18,6 @@ runs:
         node-version-file: .nvmrc
         cache: npm
 
-    - name: Upgrade npm
-      shell: bash
-      run: npm install -g npm@11.12.1
-
     - name: Install dependencies
       shell: bash
       run: npm ci --ignore-scripts

--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,4 @@ save-exact=true
 engine-strict=true
 allow-git=none
 ignore-scripts=true
-min-release-age=7
+min-release-age=3

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 gitleaks = "8.30.0"
-node = "24.14.0"
+node = "24.15.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,8 +74,7 @@
         "vitest-mongodb": "1.0.3"
       },
       "engines": {
-        "node": ">=24.15.0 <25",
-        "npm": ">=11.12.1"
+        "node": ">=24.15.0 <25"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "#waste-records-export/*": "./src/waste-records-export/*"
   },
   "engines": {
-    "node": ">=24.15.0 <25",
-    "npm": ">=11.12.1"
+    "node": ">=24.15.0 <25"
   },
   "scripts": {
     "docker:dev": "NODE_ENV=development npm run server:watch",

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,5 @@
     "github>DEFRA/epr-re-ex-service//renovate-presets/default",
     "github>DEFRA/epr-re-ex-service//renovate-presets/defra-node"
   ],
-  "enabledManagers": ["dockerfile", "nvm", "custom.regex"]
+  "enabledManagers": ["dockerfile", "nvm", "custom.regex", "mise"]
 }


### PR DESCRIPTION
Ticket: [PAE-1544](https://eaflood.atlassian.net/browse/PAE-1544)
- pin node in mise + enable renovate mise manager
- drop redundant engines.npm + ci npm-upgrade step
- align npm min-release-age cooldown to 3 days

[PAE-1544]: https://eaflood.atlassian.net/browse/PAE-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ