### PR TITLE
PAE-1549: Fix summary-log validation stack overflow on high error volumes

### DIFF
--- a/src/application/summary-logs/validations/data-syntax.js
+++ b/src/application/summary-logs/validations/data-syntax.js
@@ -453,12 +453,8 @@ export const createDataSyntaxValidator = (schemaRegistry) => (parsed) => {
   const data = parsed?.data || {}
   const processingType = parsed?.meta?.PROCESSING_TYPE?.value
   const getTableSchema = createTableSchemaGetter(processingType, schemaRegistry)
-  /** @type {ValidatedSummaryLog['data']} */
-  const validatedTables = {}
-  /** @type {ValidationIssue[]} */
-  const allIssues = []
 
-  for (const [tableName, tableData] of Object.entries(data)) {
+  const tableResults = Object.entries(data).map(([tableName, tableData]) => {
     const domainSchema = getTableSchema(tableName)
 
     if (!domainSchema) {
@@ -466,36 +462,43 @@ export const createDataSyntaxValidator = (schemaRegistry) => (parsed) => {
         ? { sheet: tableData.location.sheet, table: tableName }
         : { table: tableName }
 
-      allIssues.push({
+      /** @type {ValidationIssue} */
+      const unrecognisedTableIssue = {
         severity: VALIDATION_SEVERITY.FATAL,
         category: VALIDATION_CATEGORY.TECHNICAL,
         message: `Unrecognised table '${tableName}' has no schema for this processing type`,
         code: VALIDATION_CODE.TABLE_UNRECOGNISED,
         context: { location }
-      })
+      }
 
-      // Keep unvalidated tables as-is for downstream processing.
-      validatedTables[tableName] = /** @type {ValidatedTableSection} */ (
-        /** @type {unknown} */ (tableData)
-      )
-      continue
+      return {
+        tableName,
+        // Keep unvalidated tables as-is for downstream processing.
+        table: /** @type {ValidatedTableSection} */ (
+          /** @type {unknown} */ (tableData)
+        ),
+        issues: [unrecognisedTableIssue]
+      }
     }
 
-    const { issues: tableIssues, table } = validateTable({
+    const { issues, table } = validateTable({
       tableName,
       tableData,
       domainSchema
     })
 
-    validatedTables[tableName] = table
-    allIssues.push(...tableIssues)
-  }
+    return { tableName, table, issues }
+  })
 
   return {
-    issues: createValidationIssues(allIssues),
+    issues: createValidationIssues(
+      tableResults.flatMap((entry) => entry.issues)
+    ),
     validatedData: {
       ...parsed,
-      data: validatedTables
+      data: Object.fromEntries(
+        tableResults.map((entry) => [entry.tableName, entry.table])
+      )
     }
   }
 }

--- a/src/application/summary-logs/validations/data-syntax.test.js
+++ b/src/application/summary-logs/validations/data-syntax.test.js
@@ -1286,3 +1286,62 @@ describe('JOI_MESSAGE_TO_ERROR_CODE coverage', () => {
     }
   })
 })
+
+describe('createDataSyntaxValidator with high issue volume', () => {
+  const FIELD_COUNT = 20
+  const ROW_COUNT = 10_000
+  const EXPECTED_ISSUES = FIELD_COUNT * ROW_COUNT
+
+  const fieldNames = Array.from(
+    { length: FIELD_COUNT },
+    (_, index) => `FIELD_${index}`
+  )
+  const headers = ['ROW_ID', ...fieldNames]
+
+  const buildSchemaShape = () => {
+    /** @type {Record<string, import('joi').Schema>} */
+    const shape = { ROW_ID: Joi.number().optional() }
+    for (const name of fieldNames) {
+      shape[name] = Joi.number().greater(0).optional().messages({
+        'number.greater': 'must be greater than 0'
+      })
+    }
+    return shape
+  }
+
+  const registry = {
+    TEST: {
+      WIDE_TABLE: {
+        requiredHeaders: headers,
+        rowIdField: 'ROW_ID',
+        unfilledValues: {},
+        validationSchema: Joi.object(buildSchemaShape())
+          .unknown(true)
+          .prefs({ abortEarly: false }),
+        classifyForWasteBalance: buildClassifyForWasteBalance(headers, {})
+      }
+    }
+  }
+
+  it('accumulates a table’s issues without overflowing the call stack', () => {
+    const rows = Array.from({ length: ROW_COUNT }, (_, index) => ({
+      rowNumber: index + 2,
+      values: [1000 + index, ...Array.from({ length: FIELD_COUNT }, () => -1)]
+    }))
+
+    const parsed = /** @type {ParsedSummaryLog} */ ({
+      meta: {
+        PROCESSING_TYPE: { value: 'TEST', location: DEFAULT_TEST_LOCATION }
+      },
+      data: {
+        WIDE_TABLE: { headers, rows, location: DEFAULT_TEST_LOCATION }
+      }
+    })
+
+    const validate = createDataSyntaxValidator(registry)
+
+    const result = validate(parsed)
+
+    expect(result.issues.getAllIssues()).toHaveLength(EXPECTED_ISSUES)
+  }, 30_000)
+})


### PR DESCRIPTION
Ticket: [PAE-1549](https://eaflood.atlassian.net/browse/PAE-1549)
Uploading a summary log whose data fails validation on thousands of rows was rejected with an internal system error instead of the organisation's actual validation errors. A single error has been observed repeatedly in production for an exporter file: `RangeError: Maximum call stack size exceeded`, thrown during data-syntax validation. The upload self-recovers (no crash loop) but the submission is wrongly marked invalid with a system error.

The cause was the way per-table validation issues were accumulated. Each table's issues were appended with a call-position spread (`allIssues.push(...tableIssues)`), which passes every element as a separate function argument. V8 enforces a limit on the number of call arguments, so once a single table produced more than roughly 113,000 issues the spread threw. A table is unbounded in issue count: the exporter template pre-sizes around 15,000 data rows, and a row that fails validation on most of its fields yields about 22 issues, so a file with several thousand invalid rows crosses the limit. Clean files of the same size validate fine — the trigger is the volume of validation errors, not the file size.

Issue accumulation is now an iterator-based functional transform (`map` over the tables, then `flatMap` for the combined issue list and `Object.fromEntries` for the validated-tables map). Iterator spread has no call-argument limit, so a table can carry arbitrarily many issues and the user receives their full set of validation errors rather than a system error. Behaviour is otherwise unchanged: issue ordering, the unrecognised-table handling, and the validated-data shape are all preserved.

A regression test drives one table to 200,000 issues and asserts the validator returns them all without overflowing.

[PAE-1549]: https://eaflood.atlassian.net/browse/PAE-1549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ