### PR TITLE
PAE-1550: Validate organisation registration and accreditation graph on startup

### DIFF
--- a/src/domain/organisations/validation/find-duplicates.js
+++ b/src/domain/organisations/validation/find-duplicates.js
@@ -1,0 +1,19 @@
+/**
+ * Returns the values that appear more than once, each listed a single time in
+ * the order their duplication was first detected.
+ *
+ * @param {string[]} values
+ * @returns {string[]}
+ */
+export const findDuplicates = (values) => {
+  const seen = new Set()
+  const duplicates = new Set()
+  for (const value of values) {
+    if (seen.has(value)) {
+      duplicates.add(value)
+    } else {
+      seen.add(value)
+    }
+  }
+  return [...duplicates]
+}

--- a/src/domain/organisations/validation/find-duplicates.test.js
+++ b/src/domain/organisations/validation/find-duplicates.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { findDuplicates } from './find-duplicates.js'
+
+describe('findDuplicates', () => {
+  it('returns an empty array when every value is unique', () => {
+    expect(findDuplicates(['a', 'b', 'c'])).toEqual([])
+  })
+
+  it('returns an empty array for no values', () => {
+    expect(findDuplicates([])).toEqual([])
+  })
+
+  it('returns a value that appears more than once', () => {
+    expect(findDuplicates(['a', 'b', 'a'])).toEqual(['a'])
+  })
+
+  it('returns each duplicated value only once regardless of repetitions', () => {
+    expect(findDuplicates(['a', 'a', 'a'])).toEqual(['a'])
+  })
+
+  it('preserves first-seen order of the duplicated values', () => {
+    expect(findDuplicates(['b', 'a', 'a', 'b'])).toEqual(['a', 'b'])
+  })
+})

--- a/src/domain/organisations/validation/issue.js
+++ b/src/domain/organisations/validation/issue.js
@@ -1,0 +1,60 @@
+/**
+ * @typedef {'warning'|'error'} IssueSeverity
+ */
+
+export const SEVERITY = Object.freeze({
+  WARNING: 'warning',
+  ERROR: 'error'
+})
+
+/**
+ * @typedef {'organisation'|'registration'|'accreditation'} IssueTargetType
+ */
+
+export const TARGET_TYPE = Object.freeze({
+  ORGANISATION: 'organisation',
+  REGISTRATION: 'registration',
+  ACCREDITATION: 'accreditation'
+})
+
+/**
+ * @typedef {{ type: IssueTargetType, id: string }} IssueTarget
+ */
+
+/**
+ * @typedef {{
+ *   code: string,
+ *   severity: IssueSeverity,
+ *   target: IssueTarget,
+ *   message: string
+ * }} ValidationIssue
+ */
+
+/**
+ * @param {string} id
+ * @returns {IssueTarget}
+ */
+export const registrationTarget = (id) => ({
+  type: TARGET_TYPE.REGISTRATION,
+  id
+})
+
+/**
+ * @param {string} id
+ * @returns {IssueTarget}
+ */
+export const accreditationTarget = (id) => ({
+  type: TARGET_TYPE.ACCREDITATION,
+  id
+})
+
+/**
+ * @param {{ code: string, severity: IssueSeverity, target: IssueTarget, message: string }} issue
+ * @returns {ValidationIssue}
+ */
+export const createIssue = ({ code, severity, target, message }) => ({
+  code,
+  severity,
+  target,
+  message
+})

--- a/src/domain/organisations/validation/rules/dangling-accreditation-ref.js
+++ b/src/domain/organisations/validation/rules/dangling-accreditation-ref.js
@@ -1,0 +1,38 @@
+import {
+  SEVERITY,
+  createIssue,
+  registrationTarget
+} from '#domain/organisations/validation/issue.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const CODE = 'DANGLING_ACCREDITATION_REF'
+const SEVERITY_LEVEL = SEVERITY.ERROR
+
+/**
+ * @param {Organisation} org
+ * @returns {import('#domain/organisations/validation/issue.js').ValidationIssue[]}
+ */
+const evaluate = (org) => {
+  const accreditationIds = new Set(org.accreditations.map((acc) => acc.id))
+  return org.registrations
+    .filter(
+      (reg) =>
+        reg.accreditationId !== undefined &&
+        !accreditationIds.has(reg.accreditationId)
+    )
+    .map((reg) =>
+      createIssue({
+        code: CODE,
+        severity: SEVERITY_LEVEL,
+        target: registrationTarget(reg.id),
+        message: `Registration ${reg.id} references accreditation ${reg.accreditationId}, which does not exist on the organisation`
+      })
+    )
+}
+
+export const danglingAccreditationRefRule = {
+  code: CODE,
+  severity: SEVERITY_LEVEL,
+  evaluate
+}

--- a/src/domain/organisations/validation/rules/dangling-accreditation-ref.test.js
+++ b/src/domain/organisations/validation/rules/dangling-accreditation-ref.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { danglingAccreditationRefRule } from './dangling-accreditation-ref.js'
+import {
+  SEVERITY,
+  TARGET_TYPE
+} from '#domain/organisations/validation/issue.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const organisation = (registrations, accreditations) =>
+  /** @type {Organisation} */ (
+    /** @type {unknown} */ ({ id: 'org-1', registrations, accreditations })
+  )
+
+describe('danglingAccreditationRefRule', () => {
+  it('is an error-severity rule', () => {
+    expect(danglingAccreditationRefRule.code).toBe('DANGLING_ACCREDITATION_REF')
+    expect(danglingAccreditationRefRule.severity).toBe(SEVERITY.ERROR)
+  })
+
+  it('flags a registration whose accreditationId matches no accreditation', () => {
+    const org = organisation(
+      [{ id: 'reg-1', accreditationId: 'acc-missing' }],
+      [{ id: 'acc-other' }]
+    )
+
+    expect(danglingAccreditationRefRule.evaluate(org)).toEqual([
+      {
+        code: 'DANGLING_ACCREDITATION_REF',
+        severity: SEVERITY.ERROR,
+        target: { type: TARGET_TYPE.REGISTRATION, id: 'reg-1' },
+        message:
+          'Registration reg-1 references accreditation acc-missing, which does not exist on the organisation'
+      }
+    ])
+  })
+
+  it('does not flag a registration whose accreditationId resolves', () => {
+    const org = organisation(
+      [{ id: 'reg-1', accreditationId: 'acc-1' }],
+      [{ id: 'acc-1' }]
+    )
+
+    expect(danglingAccreditationRefRule.evaluate(org)).toEqual([])
+  })
+
+  it('does not flag a registration with no accreditationId', () => {
+    const org = organisation([{ id: 'reg-1' }], [])
+
+    expect(danglingAccreditationRefRule.evaluate(org)).toEqual([])
+  })
+})

--- a/src/domain/organisations/validation/rules/duplicate-accreditation-id.js
+++ b/src/domain/organisations/validation/rules/duplicate-accreditation-id.js
@@ -1,0 +1,31 @@
+import {
+  SEVERITY,
+  createIssue,
+  accreditationTarget
+} from '#domain/organisations/validation/issue.js'
+import { findDuplicates } from '#domain/organisations/validation/find-duplicates.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const CODE = 'DUPLICATE_ACCREDITATION_ID'
+const SEVERITY_LEVEL = SEVERITY.ERROR
+
+/**
+ * @param {Organisation} org
+ * @returns {import('#domain/organisations/validation/issue.js').ValidationIssue[]}
+ */
+const evaluate = (org) =>
+  findDuplicates(org.accreditations.map((acc) => acc.id)).map((id) =>
+    createIssue({
+      code: CODE,
+      severity: SEVERITY_LEVEL,
+      target: accreditationTarget(id),
+      message: `Accreditation id ${id} is used by more than one accreditation`
+    })
+  )
+
+export const duplicateAccreditationIdRule = {
+  code: CODE,
+  severity: SEVERITY_LEVEL,
+  evaluate
+}

--- a/src/domain/organisations/validation/rules/duplicate-accreditation-id.test.js
+++ b/src/domain/organisations/validation/rules/duplicate-accreditation-id.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { duplicateAccreditationIdRule } from './duplicate-accreditation-id.js'
+import {
+  SEVERITY,
+  TARGET_TYPE
+} from '#domain/organisations/validation/issue.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const organisation = (accreditations) =>
+  /** @type {Organisation} */ (
+    /** @type {unknown} */ ({ id: 'org-1', registrations: [], accreditations })
+  )
+
+describe('duplicateAccreditationIdRule', () => {
+  it('is an error-severity rule', () => {
+    expect(duplicateAccreditationIdRule.code).toBe('DUPLICATE_ACCREDITATION_ID')
+    expect(duplicateAccreditationIdRule.severity).toBe(SEVERITY.ERROR)
+  })
+
+  it('flags an id shared by more than one accreditation, once', () => {
+    const org = organisation([
+      { id: 'acc-1' },
+      { id: 'acc-1' },
+      { id: 'acc-1' }
+    ])
+
+    expect(duplicateAccreditationIdRule.evaluate(org)).toEqual([
+      {
+        code: 'DUPLICATE_ACCREDITATION_ID',
+        severity: SEVERITY.ERROR,
+        target: { type: TARGET_TYPE.ACCREDITATION, id: 'acc-1' },
+        message: 'Accreditation id acc-1 is used by more than one accreditation'
+      }
+    ])
+  })
+
+  it('does not flag distinct accreditation ids', () => {
+    const org = organisation([{ id: 'acc-1' }, { id: 'acc-2' }])
+
+    expect(duplicateAccreditationIdRule.evaluate(org)).toEqual([])
+  })
+})

--- a/src/domain/organisations/validation/rules/duplicate-registration-id.js
+++ b/src/domain/organisations/validation/rules/duplicate-registration-id.js
@@ -1,0 +1,31 @@
+import {
+  SEVERITY,
+  createIssue,
+  registrationTarget
+} from '#domain/organisations/validation/issue.js'
+import { findDuplicates } from '#domain/organisations/validation/find-duplicates.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const CODE = 'DUPLICATE_REGISTRATION_ID'
+const SEVERITY_LEVEL = SEVERITY.ERROR
+
+/**
+ * @param {Organisation} org
+ * @returns {import('#domain/organisations/validation/issue.js').ValidationIssue[]}
+ */
+const evaluate = (org) =>
+  findDuplicates(org.registrations.map((reg) => reg.id)).map((id) =>
+    createIssue({
+      code: CODE,
+      severity: SEVERITY_LEVEL,
+      target: registrationTarget(id),
+      message: `Registration id ${id} is used by more than one registration`
+    })
+  )
+
+export const duplicateRegistrationIdRule = {
+  code: CODE,
+  severity: SEVERITY_LEVEL,
+  evaluate
+}

--- a/src/domain/organisations/validation/rules/duplicate-registration-id.test.js
+++ b/src/domain/organisations/validation/rules/duplicate-registration-id.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { duplicateRegistrationIdRule } from './duplicate-registration-id.js'
+import {
+  SEVERITY,
+  TARGET_TYPE
+} from '#domain/organisations/validation/issue.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const organisation = (registrations) =>
+  /** @type {Organisation} */ (
+    /** @type {unknown} */ ({ id: 'org-1', registrations, accreditations: [] })
+  )
+
+describe('duplicateRegistrationIdRule', () => {
+  it('is an error-severity rule', () => {
+    expect(duplicateRegistrationIdRule.code).toBe('DUPLICATE_REGISTRATION_ID')
+    expect(duplicateRegistrationIdRule.severity).toBe(SEVERITY.ERROR)
+  })
+
+  it('flags an id shared by more than one registration, once', () => {
+    const org = organisation([{ id: 'reg-1' }, { id: 'reg-1' }])
+
+    expect(duplicateRegistrationIdRule.evaluate(org)).toEqual([
+      {
+        code: 'DUPLICATE_REGISTRATION_ID',
+        severity: SEVERITY.ERROR,
+        target: { type: TARGET_TYPE.REGISTRATION, id: 'reg-1' },
+        message: 'Registration id reg-1 is used by more than one registration'
+      }
+    ])
+  })
+
+  it('does not flag distinct registration ids', () => {
+    const org = organisation([{ id: 'reg-1' }, { id: 'reg-2' }])
+
+    expect(duplicateRegistrationIdRule.evaluate(org)).toEqual([])
+  })
+})

--- a/src/domain/organisations/validation/rules/index.js
+++ b/src/domain/organisations/validation/rules/index.js
@@ -1,0 +1,25 @@
+import { danglingAccreditationRefRule } from './dangling-accreditation-ref.js'
+import { duplicateAccreditationIdRule } from './duplicate-accreditation-id.js'
+import { duplicateRegistrationIdRule } from './duplicate-registration-id.js'
+import { sharedAccreditationRule } from './shared-accreditation.js'
+import { orphanAccreditationRule } from './orphan-accreditation.js'
+import { materialMismatchRule } from './material-mismatch.js'
+
+/**
+ * @typedef {{
+ *   code: string,
+ *   severity: import('#domain/organisations/validation/issue.js').IssueSeverity,
+ *   evaluate: (org: import('#domain/organisations/model.js').Organisation) =>
+ *     import('#domain/organisations/validation/issue.js').ValidationIssue[]
+ * }} ValidationRule
+ */
+
+/** @type {ValidationRule[]} */
+export const rules = [
+  danglingAccreditationRefRule,
+  duplicateAccreditationIdRule,
+  duplicateRegistrationIdRule,
+  sharedAccreditationRule,
+  orphanAccreditationRule,
+  materialMismatchRule
+]

--- a/src/domain/organisations/validation/rules/material-mismatch.js
+++ b/src/domain/organisations/validation/rules/material-mismatch.js
@@ -17,29 +17,26 @@ const evaluate = (org) => {
   const accreditationsById = new Map(
     org.accreditations.map((acc) => [acc.id, acc])
   )
-  /** @type {import('#domain/organisations/validation/issue.js').ValidationIssue[]} */
-  const issues = []
-  for (const reg of org.registrations) {
-    if (reg.accreditationId === undefined) {
-      continue
+  return org.registrations.flatMap((reg) => {
+    const accreditation =
+      reg.accreditationId === undefined
+        ? undefined
+        : accreditationsById.get(reg.accreditationId)
+    if (
+      accreditation === undefined ||
+      reg.material === accreditation.material
+    ) {
+      return []
     }
-    const accreditation = accreditationsById.get(reg.accreditationId)
-    if (accreditation === undefined) {
-      continue
-    }
-    if (reg.material === accreditation.material) {
-      continue
-    }
-    issues.push(
+    return [
       createIssue({
         code: CODE,
         severity: SEVERITY_LEVEL,
         target: registrationTarget(reg.id),
         message: `Registration ${reg.id} material ${reg.material} does not match linked accreditation ${accreditation.id} material ${accreditation.material}`
       })
-    )
-  }
-  return issues
+    ]
+  })
 }
 
 export const materialMismatchRule = {

--- a/src/domain/organisations/validation/rules/material-mismatch.js
+++ b/src/domain/organisations/validation/rules/material-mismatch.js
@@ -1,0 +1,49 @@
+import {
+  SEVERITY,
+  createIssue,
+  registrationTarget
+} from '#domain/organisations/validation/issue.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const CODE = 'MATERIAL_MISMATCH'
+const SEVERITY_LEVEL = SEVERITY.WARNING
+
+/**
+ * @param {Organisation} org
+ * @returns {import('#domain/organisations/validation/issue.js').ValidationIssue[]}
+ */
+const evaluate = (org) => {
+  const accreditationsById = new Map(
+    org.accreditations.map((acc) => [acc.id, acc])
+  )
+  /** @type {import('#domain/organisations/validation/issue.js').ValidationIssue[]} */
+  const issues = []
+  for (const reg of org.registrations) {
+    if (reg.accreditationId === undefined) {
+      continue
+    }
+    const accreditation = accreditationsById.get(reg.accreditationId)
+    if (accreditation === undefined) {
+      continue
+    }
+    if (reg.material === accreditation.material) {
+      continue
+    }
+    issues.push(
+      createIssue({
+        code: CODE,
+        severity: SEVERITY_LEVEL,
+        target: registrationTarget(reg.id),
+        message: `Registration ${reg.id} material ${reg.material} does not match linked accreditation ${accreditation.id} material ${accreditation.material}`
+      })
+    )
+  }
+  return issues
+}
+
+export const materialMismatchRule = {
+  code: CODE,
+  severity: SEVERITY_LEVEL,
+  evaluate
+}

--- a/src/domain/organisations/validation/rules/material-mismatch.test.js
+++ b/src/domain/organisations/validation/rules/material-mismatch.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { materialMismatchRule } from './material-mismatch.js'
+import {
+  SEVERITY,
+  TARGET_TYPE
+} from '#domain/organisations/validation/issue.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const organisation = (registrations, accreditations) =>
+  /** @type {Organisation} */ (
+    /** @type {unknown} */ ({ id: 'org-1', registrations, accreditations })
+  )
+
+describe('materialMismatchRule', () => {
+  it('is a warning-severity rule', () => {
+    expect(materialMismatchRule.code).toBe('MATERIAL_MISMATCH')
+    expect(materialMismatchRule.severity).toBe(SEVERITY.WARNING)
+  })
+
+  it('flags a registration whose material differs from its linked accreditation', () => {
+    const org = organisation(
+      [{ id: 'reg-1', accreditationId: 'acc-1', material: 'plastic' }],
+      [{ id: 'acc-1', material: 'glass' }]
+    )
+
+    expect(materialMismatchRule.evaluate(org)).toEqual([
+      {
+        code: 'MATERIAL_MISMATCH',
+        severity: SEVERITY.WARNING,
+        target: { type: TARGET_TYPE.REGISTRATION, id: 'reg-1' },
+        message:
+          'Registration reg-1 material plastic does not match linked accreditation acc-1 material glass'
+      }
+    ])
+  })
+
+  it('does not flag a registration whose material matches its linked accreditation', () => {
+    const org = organisation(
+      [{ id: 'reg-1', accreditationId: 'acc-1', material: 'glass' }],
+      [{ id: 'acc-1', material: 'glass' }]
+    )
+
+    expect(materialMismatchRule.evaluate(org)).toEqual([])
+  })
+
+  it('does not flag a registration with no accreditation link', () => {
+    const org = organisation([{ id: 'reg-1', material: 'glass' }], [])
+
+    expect(materialMismatchRule.evaluate(org)).toEqual([])
+  })
+
+  it('leaves a dangling reference to the dangling-reference rule', () => {
+    const org = organisation(
+      [{ id: 'reg-1', accreditationId: 'acc-missing', material: 'glass' }],
+      [{ id: 'acc-1', material: 'plastic' }]
+    )
+
+    expect(materialMismatchRule.evaluate(org)).toEqual([])
+  })
+})

--- a/src/domain/organisations/validation/rules/orphan-accreditation.js
+++ b/src/domain/organisations/validation/rules/orphan-accreditation.js
@@ -1,0 +1,38 @@
+import {
+  SEVERITY,
+  createIssue,
+  accreditationTarget
+} from '#domain/organisations/validation/issue.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const CODE = 'ORPHAN_ACCREDITATION'
+const SEVERITY_LEVEL = SEVERITY.WARNING
+
+/**
+ * @param {Organisation} org
+ * @returns {import('#domain/organisations/validation/issue.js').ValidationIssue[]}
+ */
+const evaluate = (org) => {
+  const referencedIds = new Set(
+    org.registrations.flatMap((reg) =>
+      reg.accreditationId === undefined ? [] : [reg.accreditationId]
+    )
+  )
+  return org.accreditations
+    .filter((acc) => !referencedIds.has(acc.id))
+    .map((acc) =>
+      createIssue({
+        code: CODE,
+        severity: SEVERITY_LEVEL,
+        target: accreditationTarget(acc.id),
+        message: `Accreditation ${acc.id} is not referenced by any registration`
+      })
+    )
+}
+
+export const orphanAccreditationRule = {
+  code: CODE,
+  severity: SEVERITY_LEVEL,
+  evaluate
+}

--- a/src/domain/organisations/validation/rules/orphan-accreditation.test.js
+++ b/src/domain/organisations/validation/rules/orphan-accreditation.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { orphanAccreditationRule } from './orphan-accreditation.js'
+import {
+  SEVERITY,
+  TARGET_TYPE
+} from '#domain/organisations/validation/issue.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const organisation = (registrations, accreditations) =>
+  /** @type {Organisation} */ (
+    /** @type {unknown} */ ({ id: 'org-1', registrations, accreditations })
+  )
+
+describe('orphanAccreditationRule', () => {
+  it('is a warning-severity rule', () => {
+    expect(orphanAccreditationRule.code).toBe('ORPHAN_ACCREDITATION')
+    expect(orphanAccreditationRule.severity).toBe(SEVERITY.WARNING)
+  })
+
+  it('flags an accreditation referenced by no registration', () => {
+    const org = organisation(
+      [{ id: 'reg-1', accreditationId: 'acc-1' }],
+      [{ id: 'acc-1' }, { id: 'acc-orphan' }]
+    )
+
+    expect(orphanAccreditationRule.evaluate(org)).toEqual([
+      {
+        code: 'ORPHAN_ACCREDITATION',
+        severity: SEVERITY.WARNING,
+        target: { type: TARGET_TYPE.ACCREDITATION, id: 'acc-orphan' },
+        message:
+          'Accreditation acc-orphan is not referenced by any registration'
+      }
+    ])
+  })
+
+  it('does not flag accreditations that are referenced', () => {
+    const org = organisation(
+      [{ id: 'reg-1', accreditationId: 'acc-1' }],
+      [{ id: 'acc-1' }]
+    )
+
+    expect(orphanAccreditationRule.evaluate(org)).toEqual([])
+  })
+})

--- a/src/domain/organisations/validation/rules/shared-accreditation.js
+++ b/src/domain/organisations/validation/rules/shared-accreditation.js
@@ -1,0 +1,35 @@
+import {
+  SEVERITY,
+  createIssue,
+  accreditationTarget
+} from '#domain/organisations/validation/issue.js'
+import { findDuplicates } from '#domain/organisations/validation/find-duplicates.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const CODE = 'SHARED_ACCREDITATION'
+const SEVERITY_LEVEL = SEVERITY.WARNING
+
+/**
+ * @param {Organisation} org
+ * @returns {import('#domain/organisations/validation/issue.js').ValidationIssue[]}
+ */
+const evaluate = (org) => {
+  const referencedIds = org.registrations.flatMap((reg) =>
+    reg.accreditationId === undefined ? [] : [reg.accreditationId]
+  )
+  return findDuplicates(referencedIds).map((id) =>
+    createIssue({
+      code: CODE,
+      severity: SEVERITY_LEVEL,
+      target: accreditationTarget(id),
+      message: `Accreditation ${id} is shared by more than one registration`
+    })
+  )
+}
+
+export const sharedAccreditationRule = {
+  code: CODE,
+  severity: SEVERITY_LEVEL,
+  evaluate
+}

--- a/src/domain/organisations/validation/rules/shared-accreditation.test.js
+++ b/src/domain/organisations/validation/rules/shared-accreditation.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { sharedAccreditationRule } from './shared-accreditation.js'
+import {
+  SEVERITY,
+  TARGET_TYPE
+} from '#domain/organisations/validation/issue.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const organisation = (registrations, accreditations) =>
+  /** @type {Organisation} */ (
+    /** @type {unknown} */ ({ id: 'org-1', registrations, accreditations })
+  )
+
+describe('sharedAccreditationRule', () => {
+  it('is a warning-severity rule', () => {
+    expect(sharedAccreditationRule.code).toBe('SHARED_ACCREDITATION')
+    expect(sharedAccreditationRule.severity).toBe(SEVERITY.WARNING)
+  })
+
+  it('flags an accreditation referenced by more than one registration, once', () => {
+    const org = organisation(
+      [
+        { id: 'reg-1', accreditationId: 'acc-1' },
+        { id: 'reg-2', accreditationId: 'acc-1' }
+      ],
+      [{ id: 'acc-1' }]
+    )
+
+    expect(sharedAccreditationRule.evaluate(org)).toEqual([
+      {
+        code: 'SHARED_ACCREDITATION',
+        severity: SEVERITY.WARNING,
+        target: { type: TARGET_TYPE.ACCREDITATION, id: 'acc-1' },
+        message: 'Accreditation acc-1 is shared by more than one registration'
+      }
+    ])
+  })
+
+  it('does not flag accreditations referenced at most once', () => {
+    const org = organisation(
+      [
+        { id: 'reg-1', accreditationId: 'acc-1' },
+        { id: 'reg-2', accreditationId: 'acc-2' },
+        { id: 'reg-3' }
+      ],
+      [{ id: 'acc-1' }, { id: 'acc-2' }]
+    )
+
+    expect(sharedAccreditationRule.evaluate(org)).toEqual([])
+  })
+})

--- a/src/domain/organisations/validation/validate-organisation.js
+++ b/src/domain/organisations/validation/validate-organisation.js
@@ -1,0 +1,16 @@
+import { rules } from '#domain/organisations/validation/rules/index.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+/**
+ * Validates an organisation as a graph: cross-references between its embedded
+ * registrations and accreditations that the per-item Joi schema never checks.
+ * Pure — operates on the stored shape (registration.accreditationId +
+ * org.accreditations[]), performs no I/O, and returns every issue every rule
+ * raises.
+ *
+ * @param {Organisation} org
+ * @returns {import('#domain/organisations/validation/issue.js').ValidationIssue[]}
+ */
+export const validateOrganisation = (org) =>
+  rules.flatMap((rule) => rule.evaluate(org))

--- a/src/domain/organisations/validation/validate-organisation.test.js
+++ b/src/domain/organisations/validation/validate-organisation.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { validateOrganisation } from './validate-organisation.js'
+import { SEVERITY } from './issue.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const organisation = (registrations, accreditations) =>
+  /** @type {Organisation} */ (
+    /** @type {unknown} */ ({ id: 'org-1', registrations, accreditations })
+  )
+
+describe('validateOrganisation', () => {
+  it('returns no issues for a conforming organisation', () => {
+    const org = organisation(
+      [{ id: 'reg-1', accreditationId: 'acc-1', material: 'glass' }],
+      [{ id: 'acc-1', material: 'glass' }]
+    )
+
+    expect(validateOrganisation(org)).toEqual([])
+  })
+
+  it('returns no issues for an organisation with no registrations or accreditations', () => {
+    expect(validateOrganisation(organisation([], []))).toEqual([])
+  })
+
+  it('aggregates issues from every rule', () => {
+    const org = organisation(
+      [
+        { id: 'reg-1', accreditationId: 'acc-missing', material: 'glass' },
+        { id: 'reg-1', accreditationId: 'acc-1', material: 'plastic' }
+      ],
+      [
+        { id: 'acc-1', material: 'glass' },
+        { id: 'acc-orphan', material: 'glass' }
+      ]
+    )
+
+    const codes = validateOrganisation(org).map((issue) => issue.code)
+
+    expect(codes).toContain('DANGLING_ACCREDITATION_REF')
+    expect(codes).toContain('DUPLICATE_REGISTRATION_ID')
+    expect(codes).toContain('ORPHAN_ACCREDITATION')
+    expect(codes).toContain('MATERIAL_MISMATCH')
+  })
+
+  it('classifies structural breakages as errors and relationship oddities as warnings', () => {
+    const org = organisation(
+      [
+        { id: 'reg-1', accreditationId: 'acc-1', material: 'glass' },
+        { id: 'reg-2', accreditationId: 'acc-1', material: 'glass' }
+      ],
+      [
+        { id: 'acc-1', material: 'glass' },
+        { id: 'acc-1', material: 'glass' }
+      ]
+    )
+
+    const bySeverity = validateOrganisation(org).reduce((acc, issue) => {
+      acc[issue.severity] = (acc[issue.severity] ?? 0) + 1
+      return acc
+    }, /** @type {Record<string, number>} */ ({}))
+
+    expect(bySeverity[SEVERITY.ERROR]).toBeGreaterThan(0)
+    expect(bySeverity[SEVERITY.WARNING]).toBeGreaterThan(0)
+  })
+})

--- a/src/server/run-organisation-validation-sweep.js
+++ b/src/server/run-organisation-validation-sweep.js
@@ -60,7 +60,10 @@ const runSweep = async (server) => {
  * classification, followed by a single info summary line.
  *
  * Read-only, safe under live traffic. Runs under a cross-instance lock so a
- * single pod per deploy executes the scan.
+ * single pod per deploy executes the scan. Loads the whole organisation
+ * population with `findAll` — deliberate, and consistent with the reporting and
+ * export paths: organisations are a bounded top-level set, unlike the
+ * per-transaction waste-balance population the sibling diagnostics stream.
  *
  * @param {Object} server - Hapi server instance
  */

--- a/src/server/run-organisation-validation-sweep.js
+++ b/src/server/run-organisation-validation-sweep.js
@@ -55,9 +55,8 @@ const runSweep = async (server) => {
  * One-shot startup diagnostic that validates every organisation as a graph and
  * logs anomalies in its embedded registration/accreditation cross-references —
  * the shapes the per-item Joi schema never checks and that only hand-edited
- * production data reaches. Every issue is logged at warn (non-paging; CDP
- * alerts fire only on error-level logs) regardless of its severity
- * classification, followed by a single info summary line.
+ * production data reaches. Every issue is logged at warn regardless of its
+ * severity classification, followed by a single info summary line.
  *
  * Read-only, safe under live traffic. Runs under a cross-instance lock so a
  * single pod per deploy executes the scan. Loads the whole organisation

--- a/src/server/run-organisation-validation-sweep.js
+++ b/src/server/run-organisation-validation-sweep.js
@@ -1,0 +1,87 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
+import { validateOrganisation } from '#domain/organisations/validation/validate-organisation.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+/** @import { ValidationIssue } from '#domain/organisations/validation/issue.js' */
+
+const LOCK_NAME = 'organisation-validation-sweep'
+
+/**
+ * @param {Organisation} org
+ * @param {ValidationIssue} issue
+ */
+const formatIssueLine = (org, issue) =>
+  [
+    'Organisation validation issue:',
+    `organisationId=${org.id}`,
+    `code=${issue.code}`,
+    `severity=${issue.severity}`,
+    `targetType=${issue.target.type}`,
+    `targetId=${issue.target.id}`,
+    `message="${issue.message}"`
+  ].join(' ')
+
+/**
+ * @param {Object} server - Hapi server instance
+ */
+const runSweep = async (server) => {
+  const repository = (await createOrganisationsRepository(server.db))()
+  const organisations = await repository.findAll()
+
+  let scanned = 0
+  let flagged = 0
+  let issueCount = 0
+
+  for (const org of organisations) {
+    scanned += 1
+    const issues = validateOrganisation(org)
+    if (issues.length === 0) {
+      continue
+    }
+    flagged += 1
+    issueCount += issues.length
+    for (const issue of issues) {
+      logger.warn({ message: formatIssueLine(org, issue) })
+    }
+  }
+
+  logger.info({
+    message: `Organisation validation sweep: scanned=${scanned} flagged=${flagged} issues=${issueCount}`
+  })
+}
+
+/**
+ * One-shot startup diagnostic that validates every organisation as a graph and
+ * logs anomalies in its embedded registration/accreditation cross-references —
+ * the shapes the per-item Joi schema never checks and that only hand-edited
+ * production data reaches. Every issue is logged at warn (non-paging; CDP
+ * alerts fire only on error-level logs) regardless of its severity
+ * classification, followed by a single info summary line.
+ *
+ * Read-only, safe under live traffic. Runs under a cross-instance lock so a
+ * single pod per deploy executes the scan.
+ *
+ * @param {Object} server - Hapi server instance
+ */
+export const runOrganisationValidationSweep = async (server) => {
+  try {
+    const lock = await server.locker.lock(LOCK_NAME)
+    if (!lock) {
+      logger.info({
+        message: 'Unable to obtain lock, skipping organisation validation sweep'
+      })
+      return
+    }
+    try {
+      await runSweep(server)
+    } finally {
+      await lock.free()
+    }
+  } catch (error) {
+    logger.error({
+      err: error,
+      message: 'Failed to run organisation validation sweep'
+    })
+  }
+}

--- a/src/server/run-organisation-validation-sweep.test.js
+++ b/src/server/run-organisation-validation-sweep.test.js
@@ -5,7 +5,8 @@ import { createOrganisationsRepository } from '#repositories/organisations/mongo
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import {
   buildOrganisation,
-  buildRegistration
+  buildRegistration,
+  buildAccreditation
 } from '#repositories/organisations/contract/test-data.js'
 
 import { runOrganisationValidationSweep } from './run-organisation-validation-sweep.js'
@@ -96,6 +97,49 @@ describe('runOrganisationValidationSweep', () => {
     })
     expect(logger.info).toHaveBeenCalledWith({
       message: 'Organisation validation sweep: scanned=1 flagged=1 issues=1'
+    })
+  })
+
+  it('logs a warning-severity issue at warn, regardless of its severity classification', async () => {
+    const org = buildOrganisation({
+      registrations: [buildRegistration({ accreditationId: undefined })],
+      accreditations: [buildAccreditation({ id: 'acc-orphan' })]
+    })
+    seedRepositoryWith([org])
+
+    await runOrganisationValidationSweep(mockServer)
+
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledWith({
+      message: `Organisation validation issue: organisationId=${org.id} code=ORPHAN_ACCREDITATION severity=warning targetType=accreditation targetId=acc-orphan message="Accreditation acc-orphan is not referenced by any registration"`
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Organisation validation sweep: scanned=1 flagged=1 issues=1'
+    })
+  })
+
+  it('logs every issue and accumulates the count when one organisation has several', async () => {
+    const org = buildOrganisation({
+      registrations: [buildRegistration({ accreditationId: 'acc-missing' })],
+      accreditations: [buildAccreditation({ id: 'acc-orphan' })]
+    })
+    seedRepositoryWith([org])
+
+    await runOrganisationValidationSweep(mockServer)
+
+    expect(logger.warn).toHaveBeenCalledTimes(2)
+    expect(logger.warn).toHaveBeenCalledWith({
+      message: expect.stringContaining(
+        'code=DANGLING_ACCREDITATION_REF severity=error'
+      )
+    })
+    expect(logger.warn).toHaveBeenCalledWith({
+      message: expect.stringContaining(
+        'code=ORPHAN_ACCREDITATION severity=warning'
+      )
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Organisation validation sweep: scanned=1 flagged=1 issues=2'
     })
   })
 

--- a/src/server/run-organisation-validation-sweep.test.js
+++ b/src/server/run-organisation-validation-sweep.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { logger } from '#common/helpers/logging/logger.js'
+import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
+import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
+import {
+  buildOrganisation,
+  buildRegistration
+} from '#repositories/organisations/contract/test-data.js'
+
+import { runOrganisationValidationSweep } from './run-organisation-validation-sweep.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+vi.mock('#repositories/organisations/mongodb.js', () => ({
+  createOrganisationsRepository: vi.fn()
+}))
+
+const seedRepositoryWith = (organisations) => {
+  vi.mocked(createOrganisationsRepository).mockResolvedValue(
+    createInMemoryOrganisationsRepository(organisations)
+  )
+}
+
+describe('runOrganisationValidationSweep', () => {
+  let mockServer
+  let mockLock
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockLock = { free: vi.fn().mockResolvedValue(undefined) }
+    mockServer = {
+      db: {},
+      locker: {
+        lock: vi.fn().mockResolvedValue(mockLock)
+      }
+    }
+  })
+
+  it('acquires a lock scoped to the sweep and releases it afterwards', async () => {
+    seedRepositoryWith([])
+
+    await runOrganisationValidationSweep(mockServer)
+
+    expect(mockServer.locker.lock).toHaveBeenCalledWith(
+      'organisation-validation-sweep'
+    )
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('skips the sweep when the lock is held by another instance', async () => {
+    mockServer.locker.lock.mockResolvedValue(null)
+
+    await runOrganisationValidationSweep(mockServer)
+
+    expect(createOrganisationsRepository).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Unable to obtain lock, skipping organisation validation sweep'
+    })
+  })
+
+  it('emits no warnings and a zero-flagged summary for conforming organisations', async () => {
+    const org = buildOrganisation({
+      registrations: [buildRegistration({ accreditationId: undefined })],
+      accreditations: []
+    })
+    seedRepositoryWith([org])
+
+    await runOrganisationValidationSweep(mockServer)
+
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Organisation validation sweep: scanned=1 flagged=0 issues=0'
+    })
+  })
+
+  it('logs a warning per issue with the org, code, severity and target for a non-conforming organisation', async () => {
+    const org = buildOrganisation({
+      registrations: [buildRegistration({ accreditationId: 'acc-missing' })],
+      accreditations: []
+    })
+    seedRepositoryWith([org])
+
+    await runOrganisationValidationSweep(mockServer)
+
+    const [registration] = org.registrations
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledWith({
+      message: `Organisation validation issue: organisationId=${org.id} code=DANGLING_ACCREDITATION_REF severity=error targetType=registration targetId=${registration.id} message="Registration ${registration.id} references accreditation acc-missing, which does not exist on the organisation"`
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Organisation validation sweep: scanned=1 flagged=1 issues=1'
+    })
+  })
+
+  it('counts orgs and issues across a mixed population', async () => {
+    const conforming = buildOrganisation({
+      registrations: [buildRegistration({ accreditationId: undefined })],
+      accreditations: []
+    })
+    const nonConforming = buildOrganisation({
+      registrations: [buildRegistration({ accreditationId: 'acc-missing' })],
+      accreditations: []
+    })
+    seedRepositoryWith([conforming, nonConforming])
+
+    await runOrganisationValidationSweep(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Organisation validation sweep: scanned=2 flagged=1 issues=1'
+    })
+  })
+
+  it('releases the lock and logs an error when building the repository throws', async () => {
+    const error = new Error('mongo unavailable')
+    vi.mocked(createOrganisationsRepository).mockRejectedValue(error)
+
+    await runOrganisationValidationSweep(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run organisation validation sweep'
+    })
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('tolerates the locker itself throwing', async () => {
+    const error = new Error('locker unavailable')
+    mockServer.locker.lock.mockRejectedValue(error)
+
+    await runOrganisationValidationSweep(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run organisation validation sweep'
+    })
+  })
+})

--- a/src/server/run-promotion-then-diagnostics.js
+++ b/src/server/run-promotion-then-diagnostics.js
@@ -4,6 +4,7 @@ import { runRowIdCollisionDiagnostic } from '#server/run-row-id-collision-diagno
 import { runBalanceDivergenceDiagnostic } from '#server/run-balance-divergence-diagnostic.js'
 import { runBalanceSizeDiagnostic } from '#server/run-balance-size-diagnostic.js'
 import { runCanonicalSourceCensus } from '#server/run-canonical-source-census.js'
+import { runOrganisationValidationSweep } from '#server/run-organisation-validation-sweep.js'
 
 /**
  * Sequences ledger promotion before diagnostics. Called as a floating
@@ -23,4 +24,5 @@ export async function runPromotionThenDiagnostics(server) {
   runBalanceDivergenceDiagnostic(server)
   runBalanceSizeDiagnostic(server)
   runCanonicalSourceCensus(server)
+  runOrganisationValidationSweep(server)
 }

--- a/src/server/run-promotion-then-diagnostics.test.js
+++ b/src/server/run-promotion-then-diagnostics.test.js
@@ -5,6 +5,7 @@ import { runRowIdCollisionDiagnostic } from './run-row-id-collision-diagnostic.j
 import { runBalanceDivergenceDiagnostic } from './run-balance-divergence-diagnostic.js'
 import { runBalanceSizeDiagnostic } from './run-balance-size-diagnostic.js'
 import { runCanonicalSourceCensus } from './run-canonical-source-census.js'
+import { runOrganisationValidationSweep } from './run-organisation-validation-sweep.js'
 
 import { runPromotionThenDiagnostics } from './run-promotion-then-diagnostics.js'
 
@@ -22,6 +23,9 @@ vi.mock('./run-balance-size-diagnostic.js', () => ({
 }))
 vi.mock('./run-canonical-source-census.js', () => ({
   runCanonicalSourceCensus: vi.fn()
+}))
+vi.mock('./run-organisation-validation-sweep.js', () => ({
+  runOrganisationValidationSweep: vi.fn()
 }))
 
 describe('runPromotionThenDiagnostics', () => {
@@ -51,6 +55,7 @@ describe('runPromotionThenDiagnostics', () => {
     expect(runBalanceDivergenceDiagnostic).not.toHaveBeenCalled()
     expect(runBalanceSizeDiagnostic).not.toHaveBeenCalled()
     expect(runCanonicalSourceCensus).not.toHaveBeenCalled()
+    expect(runOrganisationValidationSweep).not.toHaveBeenCalled()
 
     // Now let promotion finish
     resolvePromotion()
@@ -60,6 +65,7 @@ describe('runPromotionThenDiagnostics', () => {
     expect(runBalanceDivergenceDiagnostic).toHaveBeenCalledWith(server)
     expect(runBalanceSizeDiagnostic).toHaveBeenCalledWith(server)
     expect(runCanonicalSourceCensus).toHaveBeenCalledWith(server)
+    expect(runOrganisationValidationSweep).toHaveBeenCalledWith(server)
   })
 
   it('should still run diagnostics if promotion rejects', async () => {
@@ -73,5 +79,6 @@ describe('runPromotionThenDiagnostics', () => {
     expect(runBalanceDivergenceDiagnostic).toHaveBeenCalledWith(server)
     expect(runBalanceSizeDiagnostic).toHaveBeenCalledWith(server)
     expect(runCanonicalSourceCensus).toHaveBeenCalledWith(server)
+    expect(runOrganisationValidationSweep).toHaveBeenCalledWith(server)
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1550](https://eaflood.atlassian.net/browse/PAE-1550)
An organisation is stored as a single document with embedded `registrations[]` and `accreditations[]`, where a registration links to an accreditation by `accreditationId`. The per-item Joi schema validates each registration and accreditation in isolation, but nothing validates the organisation as a graph — the cross-references between them. Because the admin JSON editor lets production organisations be hand-edited almost directly, data can drift into shapes the code does not expect (a registration pointing at an accreditation that no longer exists, duplicate ids, an accreditation shared by two registrations or referenced by none, a registration whose material disagrees with its linked accreditation). These never appear in dev or test, where seed data is always clean, so they go unnoticed until they cause a bug in production.

This adds graph-level validation as observability first, with stricter enforcement deferred to later work.

## Organisation graph validator

A pure validator under `src/domain/organisations/validation/` built as a rule registry: `validateOrganisation(org)` runs every rule and returns the combined list of issues. Each rule is an independent module operating on the stored shape (`registration.accreditationId` plus `org.accreditations[]`), not the read-time-hydrated `registration.accreditation`. An issue carries a `code`, a `severity` (`error` for structural breakages, `warning` for relationship oddities), the `target` entity it concerns, and a human-readable message. Severity is a classification of the data problem and is independent of how it is logged.

The initial rules are:

- **Dangling accreditation reference** (error) — a registration references an accreditation id that no accreditation has.
- **Duplicate accreditation id** / **duplicate registration id** (error) — two embedded items share an id, which makes id-based resolution ambiguous.
- **Shared accreditation** (warning) — one accreditation is referenced by more than one registration.
- **Orphan accreditation** (warning) — an accreditation no registration references.
- **Material mismatch** (warning) — a registration’s material differs from its linked accreditation’s. A dangling reference is left to the dangling-reference rule rather than double-reported.

## Startup validation sweep

`run-organisation-validation-sweep.js` joins the existing `onPostStart` diagnostics chain as a floating promise, so it never blocks startup. It runs under a cross-instance lock so a single pod per deploy performs the scan, loads the organisation population read-only, validates each one, and logs every issue at `warn` — regardless of severity, since paging alerts fire only on error-level logs — followed by a single info summary of how many organisations were scanned and flagged. The full load mirrors the reporting and export paths: organisations are a bounded top-level set, unlike the per-transaction populations the sibling diagnostics stream.

Surfacing these issues through the API for the admin UI, and rejecting invalid submissions at the write boundary, are deliberately out of scope here and tracked separately.

[PAE-1550]: https://eaflood.atlassian.net/browse/PAE-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ