### PR TITLE
PAE-1551: Read ledger stream balance in waste-balance availability aggregate

### DIFF
--- a/src/application/waste-balance-availability/aggregate-available-balance.js
+++ b/src/application/waste-balance-availability/aggregate-available-balance.js
@@ -60,6 +60,9 @@ const buildLatestStreamEventLookupStage = () => ({
   }
 })
 
+// Mirrors resolveBalanceAmounts (waste-balances/repository/marker-aware-read.js):
+// 'ledger' resolves to the latest stream closing balance (zero when the stream
+// is empty); every other marker keeps the document's own availableAmount.
 const buildLedgerAwareAvailableAmountStage = () => ({
   $addFields: {
     availableAmount: {

--- a/src/application/waste-balance-availability/aggregate-available-balance.js
+++ b/src/application/waste-balance-availability/aggregate-available-balance.js
@@ -2,6 +2,8 @@ import {
   buildEffectiveMaterialStages,
   formatMaterialResults
 } from '#application/common/material-aggregation.js'
+import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
+import { WASTE_BALANCE_EVENTS_COLLECTION_NAME } from '#waste-balances/repository/stream-mongodb.js'
 
 const ORGANISATIONS_COLLECTION = 'epr-organisations'
 const WASTE_BALANCES_COLLECTION = 'waste-balances'
@@ -33,9 +35,55 @@ const buildMaterialLookupStage = () => ({
   }
 })
 
+const buildLatestStreamEventLookupStage = () => ({
+  $lookup: {
+    from: WASTE_BALANCE_EVENTS_COLLECTION_NAME,
+    let: { regId: '$registrationId', accId: '$accreditationId' },
+    pipeline: [
+      {
+        $match: {
+          $expr: {
+            $and: [
+              { $eq: ['$registrationId', '$$regId'] },
+              { $eq: ['$accreditationId', '$$accId'] }
+            ]
+          }
+        }
+      },
+      { $sort: { number: -1 } },
+      { $limit: 1 },
+      {
+        $project: { _id: 0, availableAmount: '$closingBalance.availableAmount' }
+      }
+    ],
+    as: 'latestStreamEvent'
+  }
+})
+
+const buildLedgerAwareAvailableAmountStage = () => ({
+  $addFields: {
+    availableAmount: {
+      $cond: {
+        if: {
+          $eq: ['$canonicalSource', WASTE_BALANCE_CANONICAL_SOURCE.LEDGER]
+        },
+        then: {
+          $ifNull: [
+            { $arrayElemAt: ['$latestStreamEvent.availableAmount', 0] },
+            0
+          ]
+        },
+        else: '$availableAmount'
+      }
+    }
+  }
+})
+
 const buildAggregationPipeline = () => [
   buildMaterialLookupStage(),
   ...buildEffectiveMaterialStages(),
+  buildLatestStreamEventLookupStage(),
+  buildLedgerAwareAvailableAmountStage(),
   {
     $group: {
       _id: '$effectiveMaterial',

--- a/src/application/waste-balance-availability/aggregate-available-balance.js
+++ b/src/application/waste-balance-availability/aggregate-available-balance.js
@@ -7,13 +7,14 @@ import { WASTE_BALANCE_EVENTS_COLLECTION_NAME } from '#waste-balances/repository
 
 const ORGANISATIONS_COLLECTION = 'epr-organisations'
 const WASTE_BALANCES_COLLECTION = 'waste-balances'
+const ACCREDITATION_ID_FIELD = '$accreditationId'
 
 const buildMaterialLookupStage = () => ({
   $lookup: {
     from: ORGANISATIONS_COLLECTION,
     let: {
       orgId: { $toObjectId: '$organisationId' },
-      accId: '$accreditationId'
+      accId: ACCREDITATION_ID_FIELD
     },
     pipeline: [
       { $match: { $expr: { $eq: ['$_id', '$$orgId'] } } },
@@ -38,14 +39,14 @@ const buildMaterialLookupStage = () => ({
 const buildLatestStreamEventLookupStage = () => ({
   $lookup: {
     from: WASTE_BALANCE_EVENTS_COLLECTION_NAME,
-    let: { regId: '$registrationId', accId: '$accreditationId' },
+    let: { regId: '$registrationId', accId: ACCREDITATION_ID_FIELD },
     pipeline: [
       {
         $match: {
           $expr: {
             $and: [
               { $eq: ['$registrationId', '$$regId'] },
-              { $eq: ['$accreditationId', '$$accId'] }
+              { $eq: [ACCREDITATION_ID_FIELD, '$$accId'] }
             ]
           }
         }

--- a/src/application/waste-balance-availability/integration.test.js
+++ b/src/application/waste-balance-availability/integration.test.js
@@ -10,6 +10,8 @@ import {
 const DATABASE_NAME = 'epr-backend'
 const ORGANISATIONS_COLLECTION = 'epr-organisations'
 const WASTE_BALANCES_COLLECTION = 'waste-balances'
+const WASTE_BALANCE_EVENTS_COLLECTION = 'waste-balance-events'
+const CANONICAL_SOURCE_LEDGER = 'ledger'
 
 const it = mongoIt.extend({
   mongoClient: async ({ db }, use) => {
@@ -54,6 +56,32 @@ const createWasteBalance = (
   transactions: []
 })
 
+const createLedgerWasteBalance = (
+  organisationId,
+  registrationId,
+  accreditationId,
+  staleAvailableAmount
+) => ({
+  ...createWasteBalance(organisationId, accreditationId, staleAvailableAmount),
+  registrationId,
+  canonicalSource: CANONICAL_SOURCE_LEDGER
+})
+
+const createStreamEvent = (
+  registrationId,
+  accreditationId,
+  number,
+  closingAvailableAmount
+) => ({
+  registrationId,
+  accreditationId,
+  number,
+  closingBalance: {
+    amount: closingAvailableAmount,
+    availableAmount: closingAvailableAmount
+  }
+})
+
 describe('aggregateAvailableBalance - Integration', () => {
   const orgId1 = '507f1f77bcf86cd799439011'
   const orgId2 = '507f1f77bcf86cd799439012'
@@ -70,6 +98,7 @@ describe('aggregateAvailableBalance - Integration', () => {
     db = mongoClient.db(DATABASE_NAME)
     await db.collection(ORGANISATIONS_COLLECTION).deleteMany({})
     await db.collection(WASTE_BALANCES_COLLECTION).deleteMany({})
+    await db.collection(WASTE_BALANCE_EVENTS_COLLECTION).deleteMany({})
   })
 
   it('aggregates available balance by material', async () => {
@@ -311,5 +340,86 @@ describe('aggregateAvailableBalance - Integration', () => {
       availableAmount: 100
     })
     expect(result.total).toBe(100)
+  })
+
+  it('uses the latest stream closing balance for a ledger accreditation, not the stale document field', async () => {
+    await db
+      .collection(ORGANISATIONS_COLLECTION)
+      .insertOne(
+        createOrganisation(orgId1, [
+          createRegistration(regId1, MATERIAL.PLASTIC, null, accId1)
+        ])
+      )
+
+    await db
+      .collection(WASTE_BALANCES_COLLECTION)
+      .insertOne(createLedgerWasteBalance(orgId1, regId1, accId1, 100))
+
+    await db
+      .collection(WASTE_BALANCE_EVENTS_COLLECTION)
+      .insertMany([
+        createStreamEvent(regId1, accId1, 1, 250),
+        createStreamEvent(regId1, accId1, 2, 175)
+      ])
+
+    const result = await aggregateAvailableBalance(db)
+
+    expect(result.materials).toContainEqual({
+      material: MATERIAL.PLASTIC,
+      availableAmount: 175
+    })
+    expect(result.total).toBe(175)
+  })
+
+  it('reports zero for a ledger accreditation whose stream is empty, ignoring the stale document field', async () => {
+    await db
+      .collection(ORGANISATIONS_COLLECTION)
+      .insertOne(
+        createOrganisation(orgId1, [
+          createRegistration(regId1, MATERIAL.PLASTIC, null, accId1)
+        ])
+      )
+
+    await db
+      .collection(WASTE_BALANCES_COLLECTION)
+      .insertOne(createLedgerWasteBalance(orgId1, regId1, accId1, 100))
+
+    const result = await aggregateAvailableBalance(db)
+
+    expect(result.materials).toContainEqual({
+      material: MATERIAL.PLASTIC,
+      availableAmount: 0
+    })
+    expect(result.total).toBe(0)
+  })
+
+  it('sums an embedded document balance and a ledger stream balance together', async () => {
+    await db
+      .collection(ORGANISATIONS_COLLECTION)
+      .insertOne(
+        createOrganisation(orgId1, [
+          createRegistration(regId1, MATERIAL.PLASTIC, null, accId1),
+          createRegistration(regId2, MATERIAL.PLASTIC, null, accId2)
+        ])
+      )
+
+    await db
+      .collection(WASTE_BALANCES_COLLECTION)
+      .insertMany([
+        createWasteBalance(orgId1, accId1, 100),
+        createLedgerWasteBalance(orgId1, regId2, accId2, 999)
+      ])
+
+    await db
+      .collection(WASTE_BALANCE_EVENTS_COLLECTION)
+      .insertOne(createStreamEvent(regId2, accId2, 1, 50))
+
+    const result = await aggregateAvailableBalance(db)
+
+    expect(result.materials).toContainEqual({
+      material: MATERIAL.PLASTIC,
+      availableAmount: 150
+    })
+    expect(result.total).toBe(150)
   })
 })

--- a/src/application/waste-balance-availability/integration.test.js
+++ b/src/application/waste-balance-availability/integration.test.js
@@ -12,6 +12,8 @@ const ORGANISATIONS_COLLECTION = 'epr-organisations'
 const WASTE_BALANCES_COLLECTION = 'waste-balances'
 const WASTE_BALANCE_EVENTS_COLLECTION = 'waste-balance-events'
 const CANONICAL_SOURCE_LEDGER = 'ledger'
+const CANONICAL_SOURCE_EMBEDDED = 'embedded'
+const CANONICAL_SOURCE_MIGRATING = 'migrating'
 
 const it = mongoIt.extend({
   mongoClient: async ({ db }, use) => {
@@ -56,30 +58,46 @@ const createWasteBalance = (
   transactions: []
 })
 
+const createMarkedWasteBalance = (
+  organisationId,
+  registrationId,
+  accreditationId,
+  documentAvailableAmount,
+  canonicalSource
+) => ({
+  ...createWasteBalance(
+    organisationId,
+    accreditationId,
+    documentAvailableAmount
+  ),
+  registrationId,
+  canonicalSource
+})
+
 const createLedgerWasteBalance = (
   organisationId,
   registrationId,
   accreditationId,
   staleAvailableAmount
-) => ({
-  ...createWasteBalance(organisationId, accreditationId, staleAvailableAmount),
-  registrationId,
-  canonicalSource: CANONICAL_SOURCE_LEDGER
-})
+) =>
+  createMarkedWasteBalance(
+    organisationId,
+    registrationId,
+    accreditationId,
+    staleAvailableAmount,
+    CANONICAL_SOURCE_LEDGER
+  )
 
 const createStreamEvent = (
   registrationId,
   accreditationId,
   number,
-  closingAvailableAmount
+  closingBalance
 ) => ({
   registrationId,
   accreditationId,
   number,
-  closingBalance: {
-    amount: closingAvailableAmount,
-    availableAmount: closingAvailableAmount
-  }
+  closingBalance
 })
 
 describe('aggregateAvailableBalance - Integration', () => {
@@ -358,8 +376,14 @@ describe('aggregateAvailableBalance - Integration', () => {
     await db
       .collection(WASTE_BALANCE_EVENTS_COLLECTION)
       .insertMany([
-        createStreamEvent(regId1, accId1, 1, 250),
-        createStreamEvent(regId1, accId1, 2, 175)
+        createStreamEvent(regId1, accId1, 1, {
+          amount: 900,
+          availableAmount: 250
+        }),
+        createStreamEvent(regId1, accId1, 2, {
+          amount: 800,
+          availableAmount: 175
+        })
       ])
 
     const result = await aggregateAvailableBalance(db)
@@ -412,7 +436,12 @@ describe('aggregateAvailableBalance - Integration', () => {
 
     await db
       .collection(WASTE_BALANCE_EVENTS_COLLECTION)
-      .insertOne(createStreamEvent(regId2, accId2, 1, 50))
+      .insertOne(
+        createStreamEvent(regId2, accId2, 1, {
+          amount: 700,
+          availableAmount: 50
+        })
+      )
 
     const result = await aggregateAvailableBalance(db)
 
@@ -421,5 +450,83 @@ describe('aggregateAvailableBalance - Integration', () => {
       availableAmount: 150
     })
     expect(result.total).toBe(150)
+  })
+
+  it('keeps the document field for an explicit embedded marker, ignoring any stream', async () => {
+    await db
+      .collection(ORGANISATIONS_COLLECTION)
+      .insertOne(
+        createOrganisation(orgId1, [
+          createRegistration(regId1, MATERIAL.PLASTIC, null, accId1)
+        ])
+      )
+
+    await db
+      .collection(WASTE_BALANCES_COLLECTION)
+      .insertOne(
+        createMarkedWasteBalance(
+          orgId1,
+          regId1,
+          accId1,
+          100,
+          CANONICAL_SOURCE_EMBEDDED
+        )
+      )
+
+    await db
+      .collection(WASTE_BALANCE_EVENTS_COLLECTION)
+      .insertOne(
+        createStreamEvent(regId1, accId1, 1, {
+          amount: 999,
+          availableAmount: 999
+        })
+      )
+
+    const result = await aggregateAvailableBalance(db)
+
+    expect(result.materials).toContainEqual({
+      material: MATERIAL.PLASTIC,
+      availableAmount: 100
+    })
+    expect(result.total).toBe(100)
+  })
+
+  it('keeps the document field for a migrating marker, ignoring any stream', async () => {
+    await db
+      .collection(ORGANISATIONS_COLLECTION)
+      .insertOne(
+        createOrganisation(orgId1, [
+          createRegistration(regId1, MATERIAL.PLASTIC, null, accId1)
+        ])
+      )
+
+    await db
+      .collection(WASTE_BALANCES_COLLECTION)
+      .insertOne(
+        createMarkedWasteBalance(
+          orgId1,
+          regId1,
+          accId1,
+          100,
+          CANONICAL_SOURCE_MIGRATING
+        )
+      )
+
+    await db
+      .collection(WASTE_BALANCE_EVENTS_COLLECTION)
+      .insertOne(
+        createStreamEvent(regId1, accId1, 1, {
+          amount: 999,
+          availableAmount: 999
+        })
+      )
+
+    const result = await aggregateAvailableBalance(db)
+
+    expect(result.materials).toContainEqual({
+      material: MATERIAL.PLASTIC,
+      availableAmount: 100
+    })
+    expect(result.total).toBe(100)
   })
 })

--- a/src/application/waste-balance-availability/integration.test.js
+++ b/src/application/waste-balance-availability/integration.test.js
@@ -16,7 +16,7 @@ const CANONICAL_SOURCE_EMBEDDED = 'embedded'
 const CANONICAL_SOURCE_MIGRATING = 'migrating'
 
 const it = mongoIt.extend({
-  mongoClient: async ({ db }, use) => {
+  mongoClient: async (/** @type {{ db: string }} */ { db }, use) => {
     const client = await MongoClient.connect(db)
     await use(client)
     await client.close()
@@ -112,12 +112,18 @@ describe('aggregateAvailableBalance - Integration', () => {
 
   let db
 
-  beforeEach(async ({ mongoClient }) => {
-    db = mongoClient.db(DATABASE_NAME)
-    await db.collection(ORGANISATIONS_COLLECTION).deleteMany({})
-    await db.collection(WASTE_BALANCES_COLLECTION).deleteMany({})
-    await db.collection(WASTE_BALANCE_EVENTS_COLLECTION).deleteMany({})
-  })
+  beforeEach(
+    async (
+      /** @type {{ mongoClient: import('mongodb').MongoClient }} */ {
+        mongoClient
+      }
+    ) => {
+      db = mongoClient.db(DATABASE_NAME)
+      await db.collection(ORGANISATIONS_COLLECTION).deleteMany({})
+      await db.collection(WASTE_BALANCES_COLLECTION).deleteMany({})
+      await db.collection(WASTE_BALANCE_EVENTS_COLLECTION).deleteMany({})
+    }
+  )
 
   it('aggregates available balance by material', async () => {
     await db
@@ -306,9 +312,10 @@ describe('aggregateAvailableBalance - Integration', () => {
   it('returns all materials with zero balance when no data exists', async () => {
     const result = await aggregateAvailableBalance(db)
 
-    const expectedMaterials = Object.values(MATERIAL)
-      .filter((m) => m !== MATERIAL.GLASS)
-      .concat(Object.values(GLASS_RECYCLING_PROCESS))
+    const expectedMaterials = [
+      ...Object.values(MATERIAL).filter((m) => m !== MATERIAL.GLASS),
+      ...Object.values(GLASS_RECYCLING_PROCESS)
+    ]
 
     expect(result.materials).toHaveLength(expectedMaterials.length)
     expectedMaterials.forEach((material) => {
@@ -373,18 +380,16 @@ describe('aggregateAvailableBalance - Integration', () => {
       .collection(WASTE_BALANCES_COLLECTION)
       .insertOne(createLedgerWasteBalance(orgId1, regId1, accId1, 100))
 
-    await db
-      .collection(WASTE_BALANCE_EVENTS_COLLECTION)
-      .insertMany([
-        createStreamEvent(regId1, accId1, 1, {
-          amount: 900,
-          availableAmount: 250
-        }),
-        createStreamEvent(regId1, accId1, 2, {
-          amount: 800,
-          availableAmount: 175
-        })
-      ])
+    await db.collection(WASTE_BALANCE_EVENTS_COLLECTION).insertMany([
+      createStreamEvent(regId1, accId1, 1, {
+        amount: 900,
+        availableAmount: 250
+      }),
+      createStreamEvent(regId1, accId1, 2, {
+        amount: 800,
+        availableAmount: 175
+      })
+    ])
 
     const result = await aggregateAvailableBalance(db)
 
@@ -434,14 +439,12 @@ describe('aggregateAvailableBalance - Integration', () => {
         createLedgerWasteBalance(orgId1, regId2, accId2, 999)
       ])
 
-    await db
-      .collection(WASTE_BALANCE_EVENTS_COLLECTION)
-      .insertOne(
-        createStreamEvent(regId2, accId2, 1, {
-          amount: 700,
-          availableAmount: 50
-        })
-      )
+    await db.collection(WASTE_BALANCE_EVENTS_COLLECTION).insertOne(
+      createStreamEvent(regId2, accId2, 1, {
+        amount: 700,
+        availableAmount: 50
+      })
+    )
 
     const result = await aggregateAvailableBalance(db)
 
@@ -473,14 +476,12 @@ describe('aggregateAvailableBalance - Integration', () => {
         )
       )
 
-    await db
-      .collection(WASTE_BALANCE_EVENTS_COLLECTION)
-      .insertOne(
-        createStreamEvent(regId1, accId1, 1, {
-          amount: 999,
-          availableAmount: 999
-        })
-      )
+    await db.collection(WASTE_BALANCE_EVENTS_COLLECTION).insertOne(
+      createStreamEvent(regId1, accId1, 1, {
+        amount: 999,
+        availableAmount: 999
+      })
+    )
 
     const result = await aggregateAvailableBalance(db)
 
@@ -512,14 +513,12 @@ describe('aggregateAvailableBalance - Integration', () => {
         )
       )
 
-    await db
-      .collection(WASTE_BALANCE_EVENTS_COLLECTION)
-      .insertOne(
-        createStreamEvent(regId1, accId1, 1, {
-          amount: 999,
-          availableAmount: 999
-        })
-      )
+    await db.collection(WASTE_BALANCE_EVENTS_COLLECTION).insertOne(
+      createStreamEvent(regId1, accId1, 1, {
+        amount: 999,
+        availableAmount: 999
+      })
+    )
 
     const result = await aggregateAvailableBalance(db)
 


### PR DESCRIPTION
Ticket: [PAE-1551](https://eaflood.atlassian.net/browse/PAE-1551)
The admin `GET /v1/waste-balance-availability` endpoint aggregates available waste tonnage by material. It summed the `availableAmount` field held on each `waste-balances` document, but on the event-sourced ledger path (`canonicalSource: 'ledger'`) that field is stale: the flip to the ledger freezes the embedded amount at its pre-migration value and nothing updates it afterwards, so the authoritative figure is the latest stream event's `closingBalance.availableAmount`. Every accreditation is now on the ledger, so the aggregate diverges from the true available balance and the gap widens with each summary-log submission and PRN transition.

This makes the aggregate marker-aware. The existing pipeline — organisation-material lookup, effective-material derivation and test-organisation filtering — is unchanged; two stages are added before the grouping that fetch the latest stream event per `(registrationId, accreditationId)` and substitute its closing available balance for ledger documents, falling back to zero when the stream is empty. Documents marked `embedded`, `migrating` or with no marker keep their own `availableAmount`. The substitution mirrors `resolveBalanceAmounts`, the marker-aware read every other balance read already routes through.

New integration tests exercise the ledger cases against MongoDB: a ledger balance whose latest stream event differs from the stale document field, an empty-stream ledger balance resolving to zero, explicit `embedded` and `migrating` markers retaining the document field while ignoring a populated stream, and an embedded balance summed together with a ledger balance. Pre-existing type errors in the touched test file are also resolved.


[PAE-1551]: https://eaflood.atlassian.net/browse/PAE-1551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ