### PR TITLE
PAE-1541: Add reportingDateField to table schemas

### DIFF
--- a/src/domain/summary-logs/reporting-date-fields.js
+++ b/src/domain/summary-logs/reporting-date-fields.js
@@ -1,0 +1,82 @@
+import { PROCESSING_TYPES } from './meta-fields.js'
+
+/**
+ * Central registry of date fields used for reporting period classification.
+ *
+ * Maps (processingType, tableName) to the date field names that determine
+ * which reporting period a row belongs to. This is the single source of
+ * truth consumed by both table schemas (via Object.values() for the
+ * reportingDateFields array) and the reports module (via named access
+ * for SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY).
+ *
+ * Each field name is a spreadsheet column header. The drift-guard test in
+ * table-schemas/index.test.js verifies every entry appears in the
+ * corresponding schema's requiredHeaders.
+ *
+ * Most tables have a single reporting date field. The exceptions are:
+ * - Accredited exporter received-loads: DATE_RECEIVED_FOR_EXPORT determines
+ *   the period for the "received" report section, DATE_OF_EXPORT determines
+ *   the period for the "exported" section. A single row can affect two
+ *   different reporting periods.
+ * - Registered-only exporter loads-exported: DATE_OF_EXPORT for the exported
+ *   section, DATE_THE_REFUSED_STOPPED_WASTE_REPATRIATED for the repatriated
+ *   section.
+ */
+export const REPORTING_DATE_FIELDS = Object.freeze({
+  [PROCESSING_TYPES.REPROCESSOR_INPUT]: Object.freeze({
+    RECEIVED_LOADS_FOR_REPROCESSING: Object.freeze({
+      DATE_RECEIVED_FOR_REPROCESSING: 'DATE_RECEIVED_FOR_REPROCESSING'
+    }),
+    REPROCESSED_LOADS: Object.freeze({
+      DATE_LOAD_LEFT_SITE: 'DATE_LOAD_LEFT_SITE'
+    }),
+    SENT_ON_LOADS: Object.freeze({
+      DATE_LOAD_LEFT_SITE: 'DATE_LOAD_LEFT_SITE'
+    })
+  }),
+
+  [PROCESSING_TYPES.REPROCESSOR_OUTPUT]: Object.freeze({
+    RECEIVED_LOADS_FOR_REPROCESSING: Object.freeze({
+      DATE_RECEIVED_FOR_REPROCESSING: 'DATE_RECEIVED_FOR_REPROCESSING'
+    }),
+    REPROCESSED_LOADS: Object.freeze({
+      DATE_LOAD_LEFT_SITE: 'DATE_LOAD_LEFT_SITE'
+    }),
+    SENT_ON_LOADS: Object.freeze({
+      DATE_LOAD_LEFT_SITE: 'DATE_LOAD_LEFT_SITE'
+    })
+  }),
+
+  [PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY]: Object.freeze({
+    RECEIVED_LOADS_FOR_REPROCESSING: Object.freeze({
+      MONTH_RECEIVED_FOR_REPROCESSING: 'MONTH_RECEIVED_FOR_REPROCESSING'
+    }),
+    SENT_ON_LOADS: Object.freeze({
+      DATE_LOAD_LEFT_SITE: 'DATE_LOAD_LEFT_SITE'
+    })
+  }),
+
+  [PROCESSING_TYPES.EXPORTER]: Object.freeze({
+    RECEIVED_LOADS_FOR_EXPORT: Object.freeze({
+      DATE_RECEIVED_FOR_EXPORT: 'DATE_RECEIVED_FOR_EXPORT',
+      DATE_OF_EXPORT: 'DATE_OF_EXPORT'
+    }),
+    SENT_ON_LOADS: Object.freeze({
+      DATE_LOAD_LEFT_SITE: 'DATE_LOAD_LEFT_SITE'
+    })
+  }),
+
+  [PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY]: Object.freeze({
+    RECEIVED_LOADS_FOR_EXPORT: Object.freeze({
+      MONTH_RECEIVED_FOR_EXPORT: 'MONTH_RECEIVED_FOR_EXPORT'
+    }),
+    LOADS_EXPORTED: Object.freeze({
+      DATE_OF_EXPORT: 'DATE_OF_EXPORT',
+      DATE_THE_REFUSED_STOPPED_WASTE_REPATRIATED:
+        'DATE_THE_REFUSED_STOPPED_WASTE_REPATRIATED'
+    }),
+    SENT_ON_LOADS: Object.freeze({
+      DATE_LOAD_LEFT_SITE: 'DATE_LOAD_LEFT_SITE'
+    })
+  })
+})

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/loads-exported.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/loads-exported.js
@@ -15,6 +15,7 @@ import {
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#application/waste-records/row-transformers/create-row-transformer.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 const ALL_FIELDS = Object.values(FIELDS)
 
 /**
@@ -26,10 +27,9 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const LOADS_EXPORTED = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [
-    FIELDS.DATE_OF_EXPORT,
-    FIELDS.DATE_THE_REFUSED_STOPPED_WASTE_REPATRIATED
-  ],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.EXPORTER_REGISTERED_ONLY.LOADS_EXPORTED
+  ),
   wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
   sheetName: 'Exported (sections 2 and 3)',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/loads-exported.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/loads-exported.js
@@ -26,6 +26,7 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const LOADS_EXPORTED = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_OF_EXPORT,
   wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
   sheetName: 'Exported (sections 2 and 3)',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/loads-exported.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/loads-exported.js
@@ -26,7 +26,7 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const LOADS_EXPORTED = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateField: FIELDS.DATE_OF_EXPORT,
+  reportingDateFields: [FIELDS.DATE_OF_EXPORT],
   wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
   sheetName: 'Exported (sections 2 and 3)',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/loads-exported.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/loads-exported.js
@@ -26,7 +26,10 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const LOADS_EXPORTED = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [FIELDS.DATE_OF_EXPORT],
+  reportingDateFields: [
+    FIELDS.DATE_OF_EXPORT,
+    FIELDS.DATE_THE_REFUSED_STOPPED_WASTE_REPATRIATED
+  ],
   wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
   sheetName: 'Exported (sections 2 and 3)',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/received-loads-for-export.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/received-loads-for-export.js
@@ -46,7 +46,7 @@ const transformWithMonthSlice = (rowData, rowIndex) => {
  */
 export const RECEIVED_LOADS_FOR_EXPORT = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateField: FIELDS.MONTH_RECEIVED_FOR_EXPORT,
+  reportingDateFields: [FIELDS.MONTH_RECEIVED_FOR_EXPORT],
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received (section 1)',
   rowTransformer: transformWithMonthSlice,

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/received-loads-for-export.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/received-loads-for-export.js
@@ -46,6 +46,7 @@ const transformWithMonthSlice = (rowData, rowIndex) => {
  */
 export const RECEIVED_LOADS_FOR_EXPORT = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.MONTH_RECEIVED_FOR_EXPORT,
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received (section 1)',
   rowTransformer: transformWithMonthSlice,

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/received-loads-for-export.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/received-loads-for-export.js
@@ -14,6 +14,7 @@ import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#application/waste-records/row-transformers/create-row-transformer.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { toYearMonth } from '#common/helpers/dates/year-month.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 const ALL_FIELDS = Object.values(FIELDS)
 
 const baseTransformer = createRowTransformer({
@@ -46,7 +47,9 @@ const transformWithMonthSlice = (rowData, rowIndex) => {
  */
 export const RECEIVED_LOADS_FOR_EXPORT = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [FIELDS.MONTH_RECEIVED_FOR_EXPORT],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.EXPORTER_REGISTERED_ONLY.RECEIVED_LOADS_FOR_EXPORT
+  ),
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received (section 1)',
   rowTransformer: transformWithMonthSlice,

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/sent-on-loads.js
@@ -8,6 +8,7 @@ import {
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#application/waste-records/row-transformers/create-row-transformer.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 const ALL_FIELDS = Object.values(FIELDS)
 
 /**
@@ -19,7 +20,9 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.EXPORTER_REGISTERED_ONLY.SENT_ON_LOADS
+  ),
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on (section 4)',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/sent-on-loads.js
@@ -19,6 +19,7 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on (section 4)',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter-registered-only/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/exporter-registered-only/sent-on-loads.js
@@ -19,7 +19,7 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
+  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on (section 4)',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter/received-loads-for-export.js
+++ b/src/domain/summary-logs/table-schemas/exporter/received-loads-for-export.js
@@ -39,6 +39,7 @@ import { ORS_VALIDATION_DISABLED } from '../shared/classification-reason.js'
 import { isAccreditedAtDates } from '#common/helpers/dates/accreditation.js'
 import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
 import { isOrsApprovedAtDate } from '#overseas-sites/domain/approval.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 /** @import {OverseasSitesContext} from '../validation-pipeline.js' */
@@ -103,7 +104,9 @@ const SUPPLEMENTARY_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_EXPORT = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [FIELDS.DATE_RECEIVED_FOR_EXPORT, FIELDS.DATE_OF_EXPORT],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.EXPORTER.RECEIVED_LOADS_FOR_EXPORT
+  ),
   wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
   sheetName: 'Exported',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter/received-loads-for-export.js
+++ b/src/domain/summary-logs/table-schemas/exporter/received-loads-for-export.js
@@ -103,7 +103,7 @@ const SUPPLEMENTARY_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_EXPORT = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateField: FIELDS.DATE_RECEIVED_FOR_EXPORT,
+  reportingDateFields: [FIELDS.DATE_RECEIVED_FOR_EXPORT, FIELDS.DATE_OF_EXPORT],
   wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
   sheetName: 'Exported',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter/received-loads-for-export.js
+++ b/src/domain/summary-logs/table-schemas/exporter/received-loads-for-export.js
@@ -103,6 +103,7 @@ const SUPPLEMENTARY_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_EXPORT = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_RECEIVED_FOR_EXPORT,
   wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
   sheetName: 'Exported',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/exporter/sent-on-loads.js
@@ -10,11 +10,14 @@ import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
  * Tracks waste sent on from exporters to other facilities.
  * Does not contribute to waste balance.
  */
-export const SENT_ON_LOADS = createSentOnLoadsSchema(
-  ROW_ID_MINIMUMS.SENT_ON_LOADS,
-  createRowTransformer({
-    wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
-    processingType: PROCESSING_TYPES.EXPORTER,
-    rowIdField: FIELDS.ROW_ID
-  })
-)
+export const SENT_ON_LOADS = {
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
+  ...createSentOnLoadsSchema(
+    ROW_ID_MINIMUMS.SENT_ON_LOADS,
+    createRowTransformer({
+      wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
+      processingType: PROCESSING_TYPES.EXPORTER,
+      rowIdField: FIELDS.ROW_ID
+    })
+  )
+}

--- a/src/domain/summary-logs/table-schemas/exporter/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/exporter/sent-on-loads.js
@@ -11,7 +11,7 @@ import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
  * Does not contribute to waste balance.
  */
 export const SENT_ON_LOADS = {
-  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
+  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
   ...createSentOnLoadsSchema(
     ROW_ID_MINIMUMS.SENT_ON_LOADS,
     createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/exporter/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/exporter/sent-on-loads.js
@@ -3,6 +3,7 @@ import { SENT_ON_LOADS_FIELDS as FIELDS, ROW_ID_MINIMUMS } from './fields.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#application/waste-records/row-transformers/create-row-transformer.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 
 /**
  * Table schema for SENT_ON_LOADS (EXPORTER)
@@ -11,7 +12,9 @@ import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
  * Does not contribute to waste balance.
  */
 export const SENT_ON_LOADS = {
-  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.EXPORTER.SENT_ON_LOADS
+  ),
   ...createSentOnLoadsSchema(
     ROW_ID_MINIMUMS.SENT_ON_LOADS,
     createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/index.js
+++ b/src/domain/summary-logs/table-schemas/index.js
@@ -57,6 +57,7 @@ export const MIN_TEMPLATE_VERSIONS = {
 /**
  * @typedef {Object} TableSchema
  * @property {string} rowIdField - Field name containing the row identifier
+ * @property {string} reportingDateField - Field name containing the date used for reporting period classification
  * @property {string} wasteRecordType - The waste record type this table maps to (e.g. 'received', 'exported')
  * @property {string} sheetName - The spreadsheet sheet name for this table (e.g. 'Received', 'Exported')
  * @property {(rowData: Record<string, any>, rowIndex: number) => {wasteRecordType: string, rowId: string, data: Record<string, any>}} rowTransformer - Function to transform a parsed row into waste record metadata

--- a/src/domain/summary-logs/table-schemas/index.js
+++ b/src/domain/summary-logs/table-schemas/index.js
@@ -57,7 +57,7 @@ export const MIN_TEMPLATE_VERSIONS = {
 /**
  * @typedef {Object} TableSchema
  * @property {string} rowIdField - Field name containing the row identifier
- * @property {string} reportingDateField - Field name containing the date used for reporting period classification
+ * @property {string[]} reportingDateFields - Field names containing dates used for reporting period classification
  * @property {string} wasteRecordType - The waste record type this table maps to (e.g. 'received', 'exported')
  * @property {string} sheetName - The spreadsheet sheet name for this table (e.g. 'Received', 'Exported')
  * @property {(rowData: Record<string, any>, rowIndex: number) => {wasteRecordType: string, rowId: string, data: Record<string, any>}} rowTransformer - Function to transform a parsed row into waste record metadata

--- a/src/domain/summary-logs/table-schemas/index.test.js
+++ b/src/domain/summary-logs/table-schemas/index.test.js
@@ -254,6 +254,26 @@ describe('table-schemas', () => {
     })
   })
 
+  describe('reportingDateField', () => {
+    it.each(
+      Object.entries(PROCESSING_TYPE_TABLES).flatMap(
+        ([processingType, tables]) =>
+          Object.entries(tables).map(([tableName, schema]) => ({
+            processingType,
+            tableName,
+            schema
+          }))
+      )
+    )(
+      '$processingType/$tableName has a reportingDateField in requiredHeaders',
+      ({ schema }) => {
+        expect(schema.reportingDateField).toBeDefined()
+        expect(typeof schema.reportingDateField).toBe('string')
+        expect(schema.requiredHeaders).toContain(schema.reportingDateField)
+      }
+    )
+  })
+
   describe('aggregateUnfilledValues', () => {
     it('returns empty object for registry with no unfilledValues', () => {
       const registry = {

--- a/src/domain/summary-logs/table-schemas/index.test.js
+++ b/src/domain/summary-logs/table-schemas/index.test.js
@@ -270,7 +270,7 @@ describe('table-schemas', () => {
     })
   })
 
-  describe('reportingDateField', () => {
+  describe('reportingDateFields', () => {
     it.each(
       Object.entries(PROCESSING_TYPE_TABLES).flatMap(
         ([processingType, tables]) =>
@@ -281,11 +281,16 @@ describe('table-schemas', () => {
           }))
       )
     )(
-      '$processingType/$tableName has a reportingDateField in requiredHeaders',
+      '$processingType/$tableName has reportingDateFields in requiredHeaders',
       ({ schema }) => {
-        expect(schema.reportingDateField).toBeDefined()
-        expect(typeof schema.reportingDateField).toBe('string')
-        expect(schema.requiredHeaders).toContain(schema.reportingDateField)
+        expect(schema.reportingDateFields).toBeDefined()
+        expect(Array.isArray(schema.reportingDateFields)).toBe(true)
+        expect(schema.reportingDateFields.length).toBeGreaterThan(0)
+
+        for (const field of schema.reportingDateFields) {
+          expect(typeof field).toBe('string')
+          expect(schema.requiredHeaders).toContain(field)
+        }
       }
     )
   })

--- a/src/domain/summary-logs/table-schemas/index.test.js
+++ b/src/domain/summary-logs/table-schemas/index.test.js
@@ -140,9 +140,12 @@ describe('table-schemas', () => {
       )
 
       expect(result).not.toBeNull()
-      expect(result.tableName).toBe('RECEIVED_LOADS_FOR_REPROCESSING')
-      expect(result.schema.wasteRecordType).toBe(WASTE_RECORD_TYPE.RECEIVED)
-      expect(result.schema.sheetName).toBe('Received')
+      const { tableName, schema } = /** @type {NonNullable<typeof result>} */ (
+        result
+      )
+      expect(tableName).toBe('RECEIVED_LOADS_FOR_REPROCESSING')
+      expect(schema.wasteRecordType).toBe(WASTE_RECORD_TYPE.RECEIVED)
+      expect(schema.sheetName).toBe('Received')
     })
 
     it('returns the correct table for exported waste record type', () => {
@@ -152,8 +155,11 @@ describe('table-schemas', () => {
       )
 
       expect(result).not.toBeNull()
-      expect(result.tableName).toBe('RECEIVED_LOADS_FOR_EXPORT')
-      expect(result.schema.sheetName).toBe('Exported')
+      const { tableName, schema } = /** @type {NonNullable<typeof result>} */ (
+        result
+      )
+      expect(tableName).toBe('RECEIVED_LOADS_FOR_EXPORT')
+      expect(schema.sheetName).toBe('Exported')
     })
 
     it('returns the correct table for processed waste record type', () => {
@@ -163,8 +169,11 @@ describe('table-schemas', () => {
       )
 
       expect(result).not.toBeNull()
-      expect(result.tableName).toBe('REPROCESSED_LOADS')
-      expect(result.schema.sheetName).toBe('Processed')
+      const { tableName, schema } = /** @type {NonNullable<typeof result>} */ (
+        result
+      )
+      expect(tableName).toBe('REPROCESSED_LOADS')
+      expect(schema.sheetName).toBe('Processed')
     })
 
     it('returns the correct table for sent on waste record type', () => {
@@ -174,8 +183,11 @@ describe('table-schemas', () => {
       )
 
       expect(result).not.toBeNull()
-      expect(result.tableName).toBe('SENT_ON_LOADS')
-      expect(result.schema.sheetName).toBe('Sent on')
+      const { tableName, schema } = /** @type {NonNullable<typeof result>} */ (
+        result
+      )
+      expect(tableName).toBe('SENT_ON_LOADS')
+      expect(schema.sheetName).toBe('Sent on')
     })
 
     it('returns null for an unknown waste record type', () => {
@@ -205,23 +217,25 @@ describe('table-schemas', () => {
 
   describe('findSchemaForProcessingType', () => {
     it('finds REPROCESSOR_INPUT received loads schema by waste record type', () => {
-      const schema = findSchemaForProcessingType(
+      const result = findSchemaForProcessingType(
         PROCESSING_TYPES.REPROCESSOR_INPUT,
         WASTE_RECORD_TYPE.RECEIVED
       )
 
-      expect(schema).toBeDefined()
+      expect(result).not.toBeNull()
+      const schema = /** @type {NonNullable<typeof result>} */ (result)
       expect(schema.wasteRecordType).toBe(WASTE_RECORD_TYPE.RECEIVED)
       expect(schema.sheetName).toBe('Received')
     })
 
     it('finds EXPORTER exported loads schema by waste record type', () => {
-      const schema = findSchemaForProcessingType(
+      const result = findSchemaForProcessingType(
         PROCESSING_TYPES.EXPORTER,
         WASTE_RECORD_TYPE.EXPORTED
       )
 
-      expect(schema).toBeDefined()
+      expect(result).not.toBeNull()
+      const schema = /** @type {NonNullable<typeof result>} */ (result)
       expect(schema.wasteRecordType).toBe(WASTE_RECORD_TYPE.EXPORTED)
     })
 
@@ -231,8 +245,10 @@ describe('table-schemas', () => {
         WASTE_RECORD_TYPE.SENT_ON
       )
 
-      expect(schema).toBeDefined()
-      expect(schema.wasteRecordType).toBe(WASTE_RECORD_TYPE.SENT_ON)
+      expect(schema).not.toBeNull()
+      expect(
+        /** @type {NonNullable<typeof schema>} */ (schema).wasteRecordType
+      ).toBe(WASTE_RECORD_TYPE.SENT_ON)
     })
 
     it('returns null for unknown processing type', () => {

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/received-loads-for-reprocessing.js
@@ -82,6 +82,7 @@ const SUPPLEMENTARY_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_RECEIVED_FOR_REPROCESSING,
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/received-loads-for-reprocessing.js
@@ -82,7 +82,7 @@ const SUPPLEMENTARY_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateField: FIELDS.DATE_RECEIVED_FOR_REPROCESSING,
+  reportingDateFields: [FIELDS.DATE_RECEIVED_FOR_REPROCESSING],
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/received-loads-for-reprocessing.js
@@ -32,6 +32,7 @@ import {
 } from '../shared/classify-helpers.js'
 import { isAccreditedAtDates } from '#common/helpers/dates/accreditation.js'
 import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 
@@ -82,7 +83,9 @@ const SUPPLEMENTARY_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [FIELDS.DATE_RECEIVED_FOR_REPROCESSING],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.REPROCESSOR_INPUT.RECEIVED_LOADS_FOR_REPROCESSING
+  ),
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.js
@@ -29,7 +29,7 @@ const ALL_FIELDS = [
  */
 export const REPROCESSED_LOADS = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
+  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
   wasteRecordType: WASTE_RECORD_TYPE.PROCESSED,
   sheetName: 'Processed',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.js
@@ -4,6 +4,7 @@ import { REPROCESSED_LOADS_FIELDS as FIELDS } from './fields.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#application/waste-records/row-transformers/create-row-transformer.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 /**
  * All fields - all optional for REPROCESSOR_INPUT
  */
@@ -29,7 +30,9 @@ const ALL_FIELDS = [
  */
 export const REPROCESSED_LOADS = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.REPROCESSOR_INPUT.REPROCESSED_LOADS
+  ),
   wasteRecordType: WASTE_RECORD_TYPE.PROCESSED,
   sheetName: 'Processed',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/reprocessed-loads.js
@@ -29,6 +29,7 @@ const ALL_FIELDS = [
  */
 export const REPROCESSED_LOADS = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   wasteRecordType: WASTE_RECORD_TYPE.PROCESSED,
   sheetName: 'Processed',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/sent-on-loads.js
@@ -10,6 +10,7 @@ import {
 } from '../shared/classify-helpers.js'
 import { isAccreditedAtDates } from '#common/helpers/dates/accreditation.js'
 import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 
@@ -25,7 +26,9 @@ const WASTE_BALANCE_FIELDS = [
  * Tracks waste sent on to other facilities.
  */
 export const SENT_ON_LOADS = {
-  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.REPROCESSOR_INPUT.SENT_ON_LOADS
+  ),
   ...createSentOnLoadsSchema(
     ROW_ID_MINIMUMS.SENT_ON_LOADS,
     createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/sent-on-loads.js
@@ -25,6 +25,7 @@ const WASTE_BALANCE_FIELDS = [
  * Tracks waste sent on to other facilities.
  */
 export const SENT_ON_LOADS = {
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   ...createSentOnLoadsSchema(
     ROW_ID_MINIMUMS.SENT_ON_LOADS,
     createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-input/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-input/sent-on-loads.js
@@ -25,7 +25,7 @@ const WASTE_BALANCE_FIELDS = [
  * Tracks waste sent on to other facilities.
  */
 export const SENT_ON_LOADS = {
-  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
+  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
   ...createSentOnLoadsSchema(
     ROW_ID_MINIMUMS.SENT_ON_LOADS,
     createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.js
@@ -4,6 +4,7 @@ import { RECEIVED_LOADS_FIELDS as FIELDS } from './fields.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#application/waste-records/row-transformers/create-row-transformer.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 /**
  * All fields - all optional for REPROCESSOR_OUTPUT
  */
@@ -43,7 +44,9 @@ const ALL_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [FIELDS.DATE_RECEIVED_FOR_REPROCESSING],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.REPROCESSOR_OUTPUT.RECEIVED_LOADS_FOR_REPROCESSING
+  ),
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.js
@@ -43,6 +43,7 @@ const ALL_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_RECEIVED_FOR_REPROCESSING,
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/received-loads-for-reprocessing.js
@@ -43,7 +43,7 @@ const ALL_FIELDS = [
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateField: FIELDS.DATE_RECEIVED_FOR_REPROCESSING,
+  reportingDateFields: [FIELDS.DATE_RECEIVED_FOR_REPROCESSING],
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/reprocessed-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/reprocessed-loads.js
@@ -36,7 +36,7 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
  */
 export const REPROCESSED_LOADS = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
+  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
   wasteRecordType: WASTE_RECORD_TYPE.PROCESSED,
   sheetName: 'Processed',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/reprocessed-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/reprocessed-loads.js
@@ -26,6 +26,7 @@ import {
 } from '../shared/classify-helpers.js'
 import { isAccreditedAtDates } from '#common/helpers/dates/accreditation.js'
 import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 
@@ -36,7 +37,9 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
  */
 export const REPROCESSED_LOADS = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.REPROCESSOR_OUTPUT.REPROCESSED_LOADS
+  ),
   wasteRecordType: WASTE_RECORD_TYPE.PROCESSED,
   sheetName: 'Processed',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/reprocessed-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/reprocessed-loads.js
@@ -36,6 +36,7 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
  */
 export const REPROCESSED_LOADS = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   wasteRecordType: WASTE_RECORD_TYPE.PROCESSED,
   sheetName: 'Processed',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/sent-on-loads.js
@@ -4,6 +4,7 @@ import { SENT_ON_LOADS_FIELDS as FIELDS } from './fields.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#application/waste-records/row-transformers/create-row-transformer.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 
 /**
  * All fields - all optional for REPROCESSOR_OUTPUT
@@ -30,7 +31,9 @@ const ALL_FIELDS = [
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.REPROCESSOR_OUTPUT.SENT_ON_LOADS
+  ),
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/sent-on-loads.js
@@ -30,7 +30,7 @@ const ALL_FIELDS = [
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
+  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-output/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-output/sent-on-loads.js
@@ -30,6 +30,7 @@ const ALL_FIELDS = [
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-registered-only/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-registered-only/received-loads-for-reprocessing.js
@@ -46,6 +46,7 @@ const transformWithMonthSlice = (rowData, rowIndex) => {
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.MONTH_RECEIVED_FOR_REPROCESSING,
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: transformWithMonthSlice,

--- a/src/domain/summary-logs/table-schemas/reprocessor-registered-only/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-registered-only/received-loads-for-reprocessing.js
@@ -46,7 +46,7 @@ const transformWithMonthSlice = (rowData, rowIndex) => {
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateField: FIELDS.MONTH_RECEIVED_FOR_REPROCESSING,
+  reportingDateFields: [FIELDS.MONTH_RECEIVED_FOR_REPROCESSING],
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: transformWithMonthSlice,

--- a/src/domain/summary-logs/table-schemas/reprocessor-registered-only/received-loads-for-reprocessing.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-registered-only/received-loads-for-reprocessing.js
@@ -14,6 +14,7 @@ import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#application/waste-records/row-transformers/create-row-transformer.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { toYearMonth } from '#common/helpers/dates/year-month.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 
 const ALL_FIELDS = Object.values(FIELDS)
 
@@ -46,7 +47,10 @@ const transformWithMonthSlice = (rowData, rowIndex) => {
  */
 export const RECEIVED_LOADS_FOR_REPROCESSING = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [FIELDS.MONTH_RECEIVED_FOR_REPROCESSING],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.REPROCESSOR_REGISTERED_ONLY
+      .RECEIVED_LOADS_FOR_REPROCESSING
+  ),
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   sheetName: 'Received',
   rowTransformer: transformWithMonthSlice,

--- a/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.js
@@ -20,7 +20,7 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
+  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.js
@@ -20,6 +20,7 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
+  reportingDateField: FIELDS.DATE_LOAD_LEFT_SITE,
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on',
   rowTransformer: createRowTransformer({

--- a/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.js
@@ -8,6 +8,7 @@ import {
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#application/waste-records/row-transformers/create-row-transformer.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
 
 const ALL_FIELDS = Object.values(FIELDS)
 
@@ -20,7 +21,9 @@ const ALL_FIELDS = Object.values(FIELDS)
  */
 export const SENT_ON_LOADS = {
   rowIdField: FIELDS.ROW_ID,
-  reportingDateFields: [FIELDS.DATE_LOAD_LEFT_SITE],
+  reportingDateFields: Object.values(
+    REPORTING_DATE_FIELDS.REPROCESSOR_REGISTERED_ONLY.SENT_ON_LOADS
+  ),
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   sheetName: 'Sent on',
   rowTransformer: createRowTransformer({

--- a/src/reports/domain/aggregation/fields-by-operator-category.js
+++ b/src/reports/domain/aggregation/fields-by-operator-category.js
@@ -1,33 +1,58 @@
+import { REPORTING_DATE_FIELDS } from '#domain/summary-logs/reporting-date-fields.js'
+
 /**
  * Maps (operatorCategory, reportSection) to the single date field used
  * for filtering records into that section during aggregation.
  *
- * Unlike DATE_FIELDS_BY_OPERATOR_CATEGORY (which groups by record type
- * for period discovery), this maps by report section. The distinction
- * matters for accredited exporters: their `exported` records contribute
- * to both wasteReceived (via DATE_RECEIVED_FOR_EXPORT) and wasteExported
- * (via DATE_OF_EXPORT) — a single record can span two monthly reports.
+ * Derived from REPORTING_DATE_FIELDS, the central registry of date fields
+ * on each table schema. The distinction between operator category and
+ * processing type matters for accredited reprocessors: the input/output
+ * distinction is lost at the waste record level, but both variants use
+ * identical date fields so a single REPROCESSOR mapping suffices.
+ *
+ * For accredited exporters, their received-loads table has two reporting
+ * date fields: DATE_RECEIVED_FOR_EXPORT (for the wasteReceived section)
+ * and DATE_OF_EXPORT (for the wasteExported section). A single record
+ * can appear in two different monthly reports.
  */
+
+const RDF = REPORTING_DATE_FIELDS
+
 export const SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY = Object.freeze({
   EXPORTER: {
-    wasteReceived: 'DATE_RECEIVED_FOR_EXPORT',
-    wasteExported: 'DATE_OF_EXPORT',
-    wasteRepatriated: 'DATE_THE_REFUSED_STOPPED_WASTE_REPATRIATED',
-    wasteSentOn: 'DATE_LOAD_LEFT_SITE'
+    wasteReceived:
+      RDF.EXPORTER.RECEIVED_LOADS_FOR_EXPORT.DATE_RECEIVED_FOR_EXPORT,
+    wasteExported: RDF.EXPORTER.RECEIVED_LOADS_FOR_EXPORT.DATE_OF_EXPORT,
+    // The accredited exporter template has no repatriation date field.
+    // The report's slice always returns empty. The field name is shared
+    // with the registered-only template for structural completeness.
+    wasteRepatriated:
+      RDF.EXPORTER_REGISTERED_ONLY.LOADS_EXPORTED
+        .DATE_THE_REFUSED_STOPPED_WASTE_REPATRIATED,
+    wasteSentOn: RDF.EXPORTER.SENT_ON_LOADS.DATE_LOAD_LEFT_SITE
   },
   EXPORTER_REGISTERED_ONLY: {
-    wasteReceived: 'MONTH_RECEIVED_FOR_EXPORT',
-    wasteExported: 'DATE_OF_EXPORT',
-    wasteRepatriated: 'DATE_THE_REFUSED_STOPPED_WASTE_REPATRIATED',
-    wasteSentOn: 'DATE_LOAD_LEFT_SITE'
+    wasteReceived:
+      RDF.EXPORTER_REGISTERED_ONLY.RECEIVED_LOADS_FOR_EXPORT
+        .MONTH_RECEIVED_FOR_EXPORT,
+    wasteExported: RDF.EXPORTER_REGISTERED_ONLY.LOADS_EXPORTED.DATE_OF_EXPORT,
+    wasteRepatriated:
+      RDF.EXPORTER_REGISTERED_ONLY.LOADS_EXPORTED
+        .DATE_THE_REFUSED_STOPPED_WASTE_REPATRIATED,
+    wasteSentOn: RDF.EXPORTER_REGISTERED_ONLY.SENT_ON_LOADS.DATE_LOAD_LEFT_SITE
   },
   REPROCESSOR: {
-    wasteReceived: 'DATE_RECEIVED_FOR_REPROCESSING',
-    wasteSentOn: 'DATE_LOAD_LEFT_SITE'
+    wasteReceived:
+      RDF.REPROCESSOR_INPUT.RECEIVED_LOADS_FOR_REPROCESSING
+        .DATE_RECEIVED_FOR_REPROCESSING,
+    wasteSentOn: RDF.REPROCESSOR_INPUT.SENT_ON_LOADS.DATE_LOAD_LEFT_SITE
   },
   REPROCESSOR_REGISTERED_ONLY: {
-    wasteReceived: 'MONTH_RECEIVED_FOR_REPROCESSING',
-    wasteSentOn: 'DATE_LOAD_LEFT_SITE'
+    wasteReceived:
+      RDF.REPROCESSOR_REGISTERED_ONLY.RECEIVED_LOADS_FOR_REPROCESSING
+        .MONTH_RECEIVED_FOR_REPROCESSING,
+    wasteSentOn:
+      RDF.REPROCESSOR_REGISTERED_ONLY.SENT_ON_LOADS.DATE_LOAD_LEFT_SITE
   }
 })
 

--- a/src/reports/domain/fields-by-operator-category.test.js
+++ b/src/reports/domain/fields-by-operator-category.test.js
@@ -170,9 +170,9 @@ describe('consistency with table schema reportingDateField', () => {
       )
 
       expect(schema).not.toBeNull()
-      expect(sections[section]).toBe(
-        /** @type {NonNullable<typeof schema>} */ (schema).reportingDateField
-      )
+      expect(
+        /** @type {NonNullable<typeof schema>} */ (schema).reportingDateFields
+      ).toContain(sections[section])
     }
   )
 })

--- a/src/reports/domain/fields-by-operator-category.test.js
+++ b/src/reports/domain/fields-by-operator-category.test.js
@@ -3,6 +3,9 @@ import {
   SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY,
   TONNAGE_RECEIVED_FIELD_BY_OPERATOR_CATEGORY
 } from './aggregation/fields-by-operator-category.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/index.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
 describe('SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY', () => {
   it('is frozen', () => {
@@ -92,4 +95,84 @@ describe('TONNAGE_RECEIVED_FIELD_BY_OPERATOR_CATEGORY', () => {
       TONNAGE_RECEIVED_FIELD_BY_OPERATOR_CATEGORY.EXPORTER_REGISTERED_ONLY
     ).toBe('TONNAGE_RECEIVED_FOR_EXPORT')
   })
+})
+
+/**
+ * Operator categories map to one or more processing types in the
+ * summary-log table schemas. For accredited reprocessors, both
+ * input and output use identical date fields so either suffices.
+ */
+const PROCESSING_TYPES_FOR_OPERATOR_CATEGORY = {
+  REPROCESSOR: [PROCESSING_TYPES.REPROCESSOR_INPUT],
+  REPROCESSOR_REGISTERED_ONLY: [PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY],
+  EXPORTER: [PROCESSING_TYPES.EXPORTER],
+  EXPORTER_REGISTERED_ONLY: [PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY]
+}
+
+/**
+ * Report sections whose date field should match a table schema's
+ * reportingDateField. wasteExported and wasteRepatriated are
+ * excluded: wasteExported uses a different date field than the
+ * table's reportingDateField (accredited exporters slice by
+ * DATE_OF_EXPORT, not DATE_RECEIVED_FOR_EXPORT), and
+ * wasteRepatriated has no corresponding table schema.
+ *
+ * For accredited exporters, wasteReceived draws from the table
+ * whose wasteRecordType is EXPORTED (received-loads-for-export),
+ * not RECEIVED. The registered-only exporter variant has a
+ * distinct received-loads table with wasteRecordType RECEIVED.
+ */
+const SECTION_TO_WASTE_RECORD_TYPE = {
+  REPROCESSOR: {
+    wasteReceived: WASTE_RECORD_TYPE.RECEIVED,
+    wasteSentOn: WASTE_RECORD_TYPE.SENT_ON
+  },
+  REPROCESSOR_REGISTERED_ONLY: {
+    wasteReceived: WASTE_RECORD_TYPE.RECEIVED,
+    wasteSentOn: WASTE_RECORD_TYPE.SENT_ON
+  },
+  EXPORTER: {
+    wasteReceived: WASTE_RECORD_TYPE.EXPORTED,
+    wasteSentOn: WASTE_RECORD_TYPE.SENT_ON
+  },
+  EXPORTER_REGISTERED_ONLY: {
+    wasteReceived: WASTE_RECORD_TYPE.RECEIVED,
+    wasteSentOn: WASTE_RECORD_TYPE.SENT_ON
+  }
+}
+
+describe('consistency with table schema reportingDateField', () => {
+  const cases = Object.entries(
+    SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY
+  ).flatMap(([operatorCategory, sections]) =>
+    Object.entries(SECTION_TO_WASTE_RECORD_TYPE[operatorCategory])
+      .filter(([section]) => sections[section] !== undefined)
+      .flatMap(([section, wasteRecordType]) =>
+        PROCESSING_TYPES_FOR_OPERATOR_CATEGORY[operatorCategory].map(
+          (processingType) => ({
+            operatorCategory,
+            section,
+            processingType,
+            wasteRecordType
+          })
+        )
+      )
+  )
+
+  it.each(cases)(
+    '$operatorCategory/$section matches $processingType schema',
+    ({ operatorCategory, section, processingType, wasteRecordType }) => {
+      const sections =
+        SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY[operatorCategory]
+      const schema = findSchemaForProcessingType(
+        processingType,
+        wasteRecordType
+      )
+
+      expect(schema).not.toBeNull()
+      expect(sections[section]).toBe(
+        /** @type {NonNullable<typeof schema>} */ (schema).reportingDateField
+      )
+    }
+  )
 })

--- a/src/reports/domain/fields-by-operator-category.test.js
+++ b/src/reports/domain/fields-by-operator-category.test.js
@@ -110,12 +110,13 @@ const PROCESSING_TYPES_FOR_OPERATOR_CATEGORY = {
 }
 
 /**
- * Report sections whose date field should match a table schema's
- * reportingDateField. wasteExported and wasteRepatriated are
- * excluded: wasteExported uses a different date field than the
- * table's reportingDateField (accredited exporters slice by
- * DATE_OF_EXPORT, not DATE_RECEIVED_FOR_EXPORT), and
- * wasteRepatriated has no corresponding table schema.
+ * Report sections whose date field should appear in a table schema's
+ * reportingDateFields array. Each entry maps a report section to the
+ * wasteRecordType used to look up the corresponding table schema.
+ *
+ * Excluded sections:
+ * - EXPORTER wasteRepatriated: the accredited exporter template has
+ *   no repatriation date field; the report's slice returns empty.
  *
  * For accredited exporters, wasteReceived draws from the table
  * whose wasteRecordType is EXPORTED (received-loads-for-export),
@@ -137,6 +138,8 @@ const SECTION_TO_WASTE_RECORD_TYPE = {
   },
   EXPORTER_REGISTERED_ONLY: {
     wasteReceived: WASTE_RECORD_TYPE.RECEIVED,
+    wasteExported: WASTE_RECORD_TYPE.EXPORTED,
+    wasteRepatriated: WASTE_RECORD_TYPE.EXPORTED,
     wasteSentOn: WASTE_RECORD_TYPE.SENT_ON
   }
 }

--- a/src/reports/domain/fields-by-operator-category.test.js
+++ b/src/reports/domain/fields-by-operator-category.test.js
@@ -3,9 +3,6 @@ import {
   SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY,
   TONNAGE_RECEIVED_FIELD_BY_OPERATOR_CATEGORY
 } from './aggregation/fields-by-operator-category.js'
-import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
-import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/index.js'
-import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
 describe('SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY', () => {
   it('is frozen', () => {
@@ -95,87 +92,4 @@ describe('TONNAGE_RECEIVED_FIELD_BY_OPERATOR_CATEGORY', () => {
       TONNAGE_RECEIVED_FIELD_BY_OPERATOR_CATEGORY.EXPORTER_REGISTERED_ONLY
     ).toBe('TONNAGE_RECEIVED_FOR_EXPORT')
   })
-})
-
-/**
- * Operator categories map to one or more processing types in the
- * summary-log table schemas. For accredited reprocessors, both
- * input and output use identical date fields so either suffices.
- */
-const PROCESSING_TYPES_FOR_OPERATOR_CATEGORY = {
-  REPROCESSOR: [PROCESSING_TYPES.REPROCESSOR_INPUT],
-  REPROCESSOR_REGISTERED_ONLY: [PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY],
-  EXPORTER: [PROCESSING_TYPES.EXPORTER],
-  EXPORTER_REGISTERED_ONLY: [PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY]
-}
-
-/**
- * Report sections whose date field should appear in a table schema's
- * reportingDateFields array. Each entry maps a report section to the
- * wasteRecordType used to look up the corresponding table schema.
- *
- * Excluded sections:
- * - EXPORTER wasteRepatriated: the accredited exporter template has
- *   no repatriation date field; the report's slice returns empty.
- *
- * For accredited exporters, wasteReceived draws from the table
- * whose wasteRecordType is EXPORTED (received-loads-for-export),
- * not RECEIVED. The registered-only exporter variant has a
- * distinct received-loads table with wasteRecordType RECEIVED.
- */
-const SECTION_TO_WASTE_RECORD_TYPE = {
-  REPROCESSOR: {
-    wasteReceived: WASTE_RECORD_TYPE.RECEIVED,
-    wasteSentOn: WASTE_RECORD_TYPE.SENT_ON
-  },
-  REPROCESSOR_REGISTERED_ONLY: {
-    wasteReceived: WASTE_RECORD_TYPE.RECEIVED,
-    wasteSentOn: WASTE_RECORD_TYPE.SENT_ON
-  },
-  EXPORTER: {
-    wasteReceived: WASTE_RECORD_TYPE.EXPORTED,
-    wasteSentOn: WASTE_RECORD_TYPE.SENT_ON
-  },
-  EXPORTER_REGISTERED_ONLY: {
-    wasteReceived: WASTE_RECORD_TYPE.RECEIVED,
-    wasteExported: WASTE_RECORD_TYPE.EXPORTED,
-    wasteRepatriated: WASTE_RECORD_TYPE.EXPORTED,
-    wasteSentOn: WASTE_RECORD_TYPE.SENT_ON
-  }
-}
-
-describe('consistency with table schema reportingDateField', () => {
-  const cases = Object.entries(
-    SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY
-  ).flatMap(([operatorCategory, sections]) =>
-    Object.entries(SECTION_TO_WASTE_RECORD_TYPE[operatorCategory])
-      .filter(([section]) => sections[section] !== undefined)
-      .flatMap(([section, wasteRecordType]) =>
-        PROCESSING_TYPES_FOR_OPERATOR_CATEGORY[operatorCategory].map(
-          (processingType) => ({
-            operatorCategory,
-            section,
-            processingType,
-            wasteRecordType
-          })
-        )
-      )
-  )
-
-  it.each(cases)(
-    '$operatorCategory/$section matches $processingType schema',
-    ({ operatorCategory, section, processingType, wasteRecordType }) => {
-      const sections =
-        SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY[operatorCategory]
-      const schema = findSchemaForProcessingType(
-        processingType,
-        wasteRecordType
-      )
-
-      expect(schema).not.toBeNull()
-      expect(
-        /** @type {NonNullable<typeof schema>} */ (schema).reportingDateFields
-      ).toContain(sections[section])
-    }
-  )
 })


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)

## Summary

- Introduces `reporting-date-fields.js`, a central registry mapping `(processingType, tableName)` to the date field names that determine which reporting period a row belongs to
- All 13 table schemas declare `reportingDateFields` by referencing this registry via `Object.values()`
- The reports module's `SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY` derives its per-section date field mapping from the same registry by named access
- Adds a drift-guard test ensuring every schema's `reportingDateFields` is a non-empty array whose entries all appear in `requiredHeaders`
- Updates the `TableSchema` JSDoc typedef with the new property
- Fixes pre-existing type errors in `index.test.js` (nullable narrowing on a file we touched)

## Why

To classify waste records by reporting period (open vs closed), we need to know which date fields on each table determine the period a record belongs to. Until now, this knowledge lived in two independent places: the table schemas had no concept of reporting dates, and the reports module hardcoded a parallel mapping in `SECTION_DATE_FIELDS_BY_OPERATOR_CATEGORY`. Any code needing to assign a record to a period (e.g. the upcoming period-status classification) would have had to duplicate these rules or pick one of the two sources.

The new `reporting-date-fields.js` module is the single source of truth. Both consumers import from it, so the date field mappings can't drift apart.

## Design

The registry uses named objects at the leaf level:

```js
EXPORTER: {
  RECEIVED_LOADS_FOR_EXPORT: {
    DATE_RECEIVED_FOR_EXPORT: 'DATE_RECEIVED_FOR_EXPORT',
    DATE_OF_EXPORT: 'DATE_OF_EXPORT'
  }
}
```

- **Table schemas** call `Object.values()` to produce the `string[]` array for `reportingDateFields`
- **Reports module** accesses fields by name (e.g. `RDF.EXPORTER.RECEIVED_LOADS_FOR_EXPORT.DATE_RECEIVED_FOR_EXPORT`), avoiding fragile array indexing

The property is an array because some tables have multiple date fields relevant for period classification in different report sections. For accredited exporters, `RECEIVED_LOADS_FOR_EXPORT` has `DATE_RECEIVED_FOR_EXPORT` (determines the period for the received section) and `DATE_OF_EXPORT` (determines the period for the exported section). Changing either date on a row could affect a different closed period. Similarly, the registered-only exporter's `LOADS_EXPORTED` declares both `DATE_OF_EXPORT` and `DATE_THE_REFUSED_STOPPED_WASTE_REPATRIATED`. Most schemas have a single entry.

[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ