### PR TITLE
PAE-1552: Add basic auth to single-org and overseas-site GETs

### DIFF
--- a/src/overseas-sites/routes/get-by-id.js
+++ b/src/overseas-sites/routes/get-by-id.js
@@ -6,7 +6,7 @@ import {
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
 import { SCOPES } from '#common/helpers/auth/constants.js'
-import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
+import { STRATEGY_NAME as BASIC_AUTH } from '#plugins/auth/basic-auth-plugin.js'
 
 /** @import { OverseasSitesRepository } from '#overseas-sites/repository/port.js' */
 
@@ -16,7 +16,10 @@ export const overseasSiteById = {
   method: 'GET',
   path: overseasSiteByIdPath,
   options: {
-    auth: getAuthConfig([SCOPES.adminRead]),
+    auth: {
+      strategies: ['access-token', BASIC_AUTH],
+      scope: [SCOPES.adminRead, SCOPES.organisationRead]
+    },
     tags: ['api']
   },
   /**

--- a/src/overseas-sites/routes/get-by-id.test.js
+++ b/src/overseas-sites/routes/get-by-id.test.js
@@ -128,4 +128,69 @@ describe(`${overseasSiteByIdPath} route`, () => {
       })
     })
   })
+
+  describe('basic-auth strategy', () => {
+    const validCredentials = Buffer.from('basic-auth-user:changeme').toString(
+      'base64'
+    )
+
+    const buildBasicAuthServer = (basicAuth, repository) =>
+      createTestServer({
+        config: { basicAuth },
+        repositories: { overseasSitesRepository: () => repository },
+        featureFlags: createInMemoryFeatureFlags({})
+      })
+
+    it('returns 200 with valid Basic Auth credentials', async () => {
+      const repository = createInMemoryOverseasSitesRepository()()
+      const created = await repository.create(buildOverseasSite())
+      const server = await buildBasicAuthServer(
+        { username: 'basic-auth-user', password: 'changeme' },
+        repository
+      )
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `/v1/overseas-sites/${created.id}`,
+        headers: { Authorization: `Basic ${validCredentials}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+
+    it('returns 401 with wrong password', async () => {
+      const repository = createInMemoryOverseasSitesRepository()()
+      const created = await repository.create(buildOverseasSite())
+      const server = await buildBasicAuthServer(
+        { username: 'basic-auth-user', password: 'changeme' },
+        repository
+      )
+      const encoded = Buffer.from('basic-auth-user:wrong').toString('base64')
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `/v1/overseas-sites/${created.id}`,
+        headers: { Authorization: `Basic ${encoded}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+    })
+
+    it('returns 401 with valid credentials when basic-auth is not configured', async () => {
+      const repository = createInMemoryOverseasSitesRepository()()
+      const created = await repository.create(buildOverseasSite())
+      const server = await buildBasicAuthServer(
+        { username: '', password: '' },
+        repository
+      )
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `/v1/overseas-sites/${created.id}`,
+        headers: { Authorization: `Basic ${validCredentials}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+    })
+  })
 })

--- a/src/overseas-sites/routes/list.js
+++ b/src/overseas-sites/routes/list.js
@@ -7,7 +7,7 @@ import {
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
 import { SCOPES } from '#common/helpers/auth/constants.js'
-import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
+import { STRATEGY_NAME as BASIC_AUTH } from '#plugins/auth/basic-auth-plugin.js'
 
 /** @import { OverseasSitesRepository } from '#overseas-sites/repository/port.js' */
 
@@ -17,7 +17,10 @@ export const overseasSitesList = {
   method: 'GET',
   path: overseasSitesListPath,
   options: {
-    auth: getAuthConfig([SCOPES.adminRead]),
+    auth: {
+      strategies: ['access-token', BASIC_AUTH],
+      scope: [SCOPES.adminRead, SCOPES.organisationRead]
+    },
     tags: ['api'],
     validate: {
       query: Joi.object({

--- a/src/overseas-sites/routes/list.test.js
+++ b/src/overseas-sites/routes/list.test.js
@@ -166,4 +166,63 @@ describe(`${overseasSitesListPath} route`, () => {
       })
     })
   })
+
+  describe('basic-auth strategy', () => {
+    const validCredentials = Buffer.from('basic-auth-user:changeme').toString(
+      'base64'
+    )
+
+    const buildBasicAuthServer = (basicAuth) =>
+      createTestServer({
+        config: { basicAuth },
+        repositories: {
+          overseasSitesRepository: () =>
+            createInMemoryOverseasSitesRepository()()
+        },
+        featureFlags: createInMemoryFeatureFlags({})
+      })
+
+    it('returns 200 with valid Basic Auth credentials', async () => {
+      const server = await buildBasicAuthServer({
+        username: 'basic-auth-user',
+        password: 'changeme'
+      })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/v1/overseas-sites',
+        headers: { Authorization: `Basic ${validCredentials}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+
+    it('returns 401 with wrong password', async () => {
+      const server = await buildBasicAuthServer({
+        username: 'basic-auth-user',
+        password: 'changeme'
+      })
+      const encoded = Buffer.from('basic-auth-user:wrong').toString('base64')
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/v1/overseas-sites',
+        headers: { Authorization: `Basic ${encoded}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+    })
+
+    it('returns 401 with valid credentials when basic-auth is not configured', async () => {
+      const server = await buildBasicAuthServer({ username: '', password: '' })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/v1/overseas-sites',
+        headers: { Authorization: `Basic ${validCredentials}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+    })
+  })
 })

--- a/src/routes/v1/organisations/get-by-id.js
+++ b/src/routes/v1/organisations/get-by-id.js
@@ -1,6 +1,7 @@
 import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
 import { ROLES, SCOPES } from '#common/helpers/auth/constants.js'
+import { STRATEGY_NAME as BASIC_AUTH } from '#plugins/auth/basic-auth-plugin.js'
 
 /** @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository */
 
@@ -11,7 +12,8 @@ export const organisationsGetById = {
   path: organisationsGetByIdPath,
   options: {
     auth: {
-      scope: [ROLES.standardUser, SCOPES.adminRead]
+      strategies: ['access-token', BASIC_AUTH],
+      scope: [ROLES.standardUser, SCOPES.adminRead, SCOPES.organisationRead]
     },
     tags: ['api', 'admin']
   },

--- a/src/routes/v1/organisations/get-by-id.test.js
+++ b/src/routes/v1/organisations/get-by-id.test.js
@@ -136,4 +136,86 @@ describe('GET /v1/organisations/{id}', () => {
       }
     }
   })
+
+  describe('basic-auth strategy', () => {
+    const validCredentials = Buffer.from('basic-auth-user:changeme').toString(
+      'base64'
+    )
+
+    describe('when basic-auth credentials are configured', () => {
+      let basicAuthServer
+      let basicAuthRepository
+
+      beforeEach(async () => {
+        const factory = createInMemoryOrganisationsRepository([])
+        basicAuthRepository = factory()
+
+        basicAuthServer = await createTestServer({
+          config: {
+            basicAuth: {
+              username: 'basic-auth-user',
+              password: 'changeme'
+            }
+          },
+          repositories: { organisationsRepository: factory },
+          featureFlags: createInMemoryFeatureFlags()
+        })
+      })
+
+      it('returns 200 with valid Basic Auth credentials', async () => {
+        const org = buildOrganisation()
+        await basicAuthRepository.insert(org)
+
+        const response = await basicAuthServer.inject({
+          method: 'GET',
+          url: `/v1/organisations/${org.id}`,
+          headers: { Authorization: `Basic ${validCredentials}` }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+      })
+
+      it('returns 401 with wrong password', async () => {
+        const org = buildOrganisation()
+        await basicAuthRepository.insert(org)
+        const encoded = Buffer.from('basic-auth-user:wrong').toString('base64')
+
+        const response = await basicAuthServer.inject({
+          method: 'GET',
+          url: `/v1/organisations/${org.id}`,
+          headers: { Authorization: `Basic ${encoded}` }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+      })
+    })
+
+    describe('when basic-auth credentials are not configured', () => {
+      it('returns 401 with valid Basic Auth credentials', async () => {
+        const factory = createInMemoryOrganisationsRepository([])
+        const repository = factory()
+        const org = buildOrganisation()
+        await repository.insert(org)
+
+        const basicAuthServer = await createTestServer({
+          config: {
+            basicAuth: {
+              username: '', // matches default value in config.js
+              password: '' // matches default value in config.js
+            }
+          },
+          repositories: { organisationsRepository: factory },
+          featureFlags: createInMemoryFeatureFlags()
+        })
+
+        const response = await basicAuthServer.inject({
+          method: 'GET',
+          url: `/v1/organisations/${org.id}`,
+          headers: { Authorization: `Basic ${validCredentials}` }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+      })
+    })
+  })
 })


### PR DESCRIPTION
Ticket: [PAE-1552](https://eaflood.atlassian.net/browse/PAE-1552)
## Description

Adds the basic-auth strategy to three read endpoints so the registration/accreditation team can read organisation and overseas-site data using the same credentials already configured for `GET /v1/organisations`.

## Summary

- Enables the `basic-auth` strategy on `GET /v1/organisations/{organisationId}`, `GET /v1/overseas-sites` and `GET /v1/overseas-sites/{id}`, mirroring the already-shipped `GET /v1/organisations`.
- Each route's scope now includes `organisation.read` (the scope the basic-auth plugin issues), alongside the existing access-token scopes — existing access-token callers are unaffected.
- The two overseas-site GETs move from the `getAuthConfig([...])` helper to an inline `auth` object, since the helper only expresses `scope` and cannot declare the additional `strategies`. The non-GET overseas-site routes keep `getAuthConfig` and do not accept basic auth.

## Changes

- `src/routes/v1/organisations/get-by-id.js` — add `['access-token', BASIC_AUTH]` strategies and `organisation.read` scope.
- `src/overseas-sites/routes/list.js` — replace `getAuthConfig` with inline auth including the basic-auth strategy and `organisation.read` scope.
- `src/overseas-sites/routes/get-by-id.js` — same change as `list.js`.
- `*.test.js` for the three routes — add a `basic-auth strategy` suite covering valid credentials (200), wrong password (401), and unconfigured credentials (401).


[PAE-1552]: https://eaflood.atlassian.net/browse/PAE-1552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ