### PR TITLE
PAE-1550: Log organisation validation anomalies at info, not warn

### DIFF
--- a/src/server/run-organisation-validation-sweep.js
+++ b/src/server/run-organisation-validation-sweep.js
@@ -42,7 +42,7 @@ const runSweep = async (server) => {
     flagged += 1
     issueCount += issues.length
     for (const issue of issues) {
-      logger.warn({ message: formatIssueLine(org, issue) })
+      logger.info({ message: formatIssueLine(org, issue) })
     }
   }
 
@@ -55,8 +55,10 @@ const runSweep = async (server) => {
  * One-shot startup diagnostic that validates every organisation as a graph and
  * logs anomalies in its embedded registration/accreditation cross-references —
  * the shapes the per-item Joi schema never checks and that only hand-edited
- * production data reaches. Every issue is logged at warn regardless of its
- * severity classification, followed by a single info summary line.
+ * production data reaches. Every issue is logged at info regardless of its
+ * severity classification, followed by a single info summary line. Info keeps
+ * the anomalies queryable without tripping the warn/error OpenSearch alerts on
+ * known legacy data.
  *
  * Read-only, safe under live traffic. Runs under a cross-instance lock so a
  * single pod per deploy executes the scan. Loads the whole organisation

--- a/src/server/run-organisation-validation-sweep.test.js
+++ b/src/server/run-organisation-validation-sweep.test.js
@@ -66,7 +66,7 @@ describe('runOrganisationValidationSweep', () => {
     })
   })
 
-  it('emits no warnings and a zero-flagged summary for conforming organisations', async () => {
+  it('emits no issue lines and a zero-flagged summary for conforming organisations', async () => {
     const org = buildOrganisation({
       registrations: [buildRegistration({ accreditationId: undefined })],
       accreditations: []
@@ -76,12 +76,13 @@ describe('runOrganisationValidationSweep', () => {
     await runOrganisationValidationSweep(mockServer)
 
     expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledTimes(1)
     expect(logger.info).toHaveBeenCalledWith({
       message: 'Organisation validation sweep: scanned=1 flagged=0 issues=0'
     })
   })
 
-  it('logs a warning per issue with the org, code, severity and target for a non-conforming organisation', async () => {
+  it('logs an issue line at info with the org, code, severity and target for a non-conforming organisation', async () => {
     const org = buildOrganisation({
       registrations: [buildRegistration({ accreditationId: 'acc-missing' })],
       accreditations: []
@@ -91,8 +92,8 @@ describe('runOrganisationValidationSweep', () => {
     await runOrganisationValidationSweep(mockServer)
 
     const [registration] = org.registrations
-    expect(logger.warn).toHaveBeenCalledTimes(1)
-    expect(logger.warn).toHaveBeenCalledWith({
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
       message: `Organisation validation issue: organisationId=${org.id} code=DANGLING_ACCREDITATION_REF severity=error targetType=registration targetId=${registration.id} message="Registration ${registration.id} references accreditation acc-missing, which does not exist on the organisation"`
     })
     expect(logger.info).toHaveBeenCalledWith({
@@ -100,7 +101,7 @@ describe('runOrganisationValidationSweep', () => {
     })
   })
 
-  it('logs a warning-severity issue at warn, regardless of its severity classification', async () => {
+  it('logs a warning-severity issue at info, regardless of its severity classification', async () => {
     const org = buildOrganisation({
       registrations: [buildRegistration({ accreditationId: undefined })],
       accreditations: [buildAccreditation({ id: 'acc-orphan' })]
@@ -109,8 +110,8 @@ describe('runOrganisationValidationSweep', () => {
 
     await runOrganisationValidationSweep(mockServer)
 
-    expect(logger.warn).toHaveBeenCalledTimes(1)
-    expect(logger.warn).toHaveBeenCalledWith({
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
       message: `Organisation validation issue: organisationId=${org.id} code=ORPHAN_ACCREDITATION severity=warning targetType=accreditation targetId=acc-orphan message="Accreditation acc-orphan is not referenced by any registration"`
     })
     expect(logger.info).toHaveBeenCalledWith({
@@ -127,13 +128,13 @@ describe('runOrganisationValidationSweep', () => {
 
     await runOrganisationValidationSweep(mockServer)
 
-    expect(logger.warn).toHaveBeenCalledTimes(2)
-    expect(logger.warn).toHaveBeenCalledWith({
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
       message: expect.stringContaining(
         'code=DANGLING_ACCREDITATION_REF severity=error'
       )
     })
-    expect(logger.warn).toHaveBeenCalledWith({
+    expect(logger.info).toHaveBeenCalledWith({
       message: expect.stringContaining(
         'code=ORPHAN_ACCREDITATION severity=warning'
       )


### PR DESCRIPTION
Ticket: [PAE-1550](https://eaflood.atlassian.net/browse/PAE-1550)
The organisation validation sweep (added in #1279) logs each cross-reference anomaly it finds on startup. Those per-issue lines were emitted at `warn`, on the assumption that only `error` trips OpenSearch alerting. That assumption was wrong: epr-backend also has a "Backend warnings" alert on `log.level: "warn"`, so flagging known-legacy data on every deploy risks alert noise.

This lowers the per-issue lines from `warn` to `info`. The anomalies stay fully queryable in OpenSearch and the single summary line is unchanged — `info` simply sits below both the warn and error alert thresholds, which matches the diagnostic's intent of surfacing legacy data shapes without paging anyone.

No behavioural change beyond the log level: the sweep is still read-only, still runs under the cross-instance lock, and still logs every issue regardless of its severity classification.


[PAE-1550]: https://eaflood.atlassian.net/browse/PAE-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ