### PR TITLE
PAE-1240: Downgrade basic-auth missing-credentials log from warn to info

### DIFF
--- a/src/plugins/auth/basic-auth-plugin.js
+++ b/src/plugins/auth/basic-auth-plugin.js
@@ -39,7 +39,7 @@ export const basicAuthPlugin = {
           const basicAuthConfigured = options?.username && options?.password
 
           if (!basicAuthConfigured) {
-            server.logger.warn(
+            server.logger.info(
               'Basic Auth strategy registered without credentials - it will reject all requests'
             )
             return {

--- a/src/plugins/auth/basic-auth-plugin.test.js
+++ b/src/plugins/auth/basic-auth-plugin.test.js
@@ -1,0 +1,35 @@
+import { getConfig } from '#root/config.js'
+import Hapi from '@hapi/hapi'
+import hapiPino from 'hapi-pino'
+import { describe, expect, it, vi } from 'vitest'
+import { basicAuthPlugin } from './basic-auth-plugin.js'
+
+describe('basic-auth-plugin — without credentials configured', () => {
+  it('logs at info level when no credentials are configured', async () => {
+    const server = Hapi.server({ port: 0 })
+    await server.register({ plugin: hapiPino, options: { enabled: false } })
+
+    const infoSpy = vi.spyOn(server.logger, 'info')
+    const warnSpy = vi.spyOn(server.logger, 'warn')
+
+    await server.register({
+      plugin: basicAuthPlugin.plugin,
+      options: {
+        config: getConfig({ basicAuth: { username: '', password: '' } })
+      }
+    })
+
+    await server.stop()
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Basic Auth strategy registered without credentials'
+      )
+    )
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Basic Auth strategy registered without credentials'
+      )
+    )
+  })
+})


### PR DESCRIPTION
Ticket: [PAE-1240](https://eaflood.atlassian.net/browse/PAE-1240)
- Downgrade the log level from `warn` to `info` when basic auth plugin is registered without credentials, to avoid spurious alerts in prod environments where credentials are intentionally omitted
- Add unit test for `basic-auth-plugin` that asserts the log fires at `info` (not `warn`) level when no credentials are configured

[PAE-1240]: https://eaflood.atlassian.net/browse/PAE-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ