### PR TITLE
PAE-1553: Stop the read fold advancing the PRN CAS version

### DIFF
--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
@@ -49,7 +49,6 @@ const applyEvent = (prn, event) => {
 
   return {
     ...prn,
-    version: (prn.version ?? 0) + 1,
     updatedAt: event.createdAt,
     updatedBy: by,
     lastAppliedEventNumber: event.number,
@@ -69,7 +68,9 @@ const applyEvent = (prn, event) => {
 /**
  * Left-fold over persisted stream tail events: applies each event in turn,
  * stamping its slot, appending a history entry, advancing currentStatus,
- * updatedAt/By, version and the lastAppliedEventNumber watermark.
+ * updatedAt/By and the lastAppliedEventNumber watermark. The persisted-document
+ * version is owned by the repository's optimistic-concurrency guard, so the
+ * fold leaves it untouched.
  *
  * Pure: returns a new PRN, does not mutate the input. Returns the input
  * reference unchanged when no events are supplied.

--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
@@ -59,7 +59,7 @@ describe('foldPrnFromTailEvents', () => {
   })
 
   describe('per-event projection', () => {
-    it('prn-created sets status, slot, history, version, updatedAt/By and watermark', () => {
+    it('prn-created sets status, slot, history, updatedAt/By and watermark, leaving version to storage', () => {
       const prn = basePrn()
       const event = buildEvent(
         STREAM_EVENT_KIND.PRN_CREATED,
@@ -85,10 +85,28 @@ describe('foldPrnFromTailEvents', () => {
           by: event.createdBy
         }
       ])
-      expect(result.version).toBe(2)
+      expect(result.version).toBe(prn.version)
       expect(result.updatedAt).toEqual(event.createdAt)
       expect(result.updatedBy).toEqual(event.createdBy)
       expect(result.lastAppliedEventNumber).toBe(1)
+    })
+
+    it('leaves version untouched: the persisted-document version is owned by storage, not the fold', () => {
+      const prn = basePrn()
+      const created = buildEvent(
+        STREAM_EVENT_KIND.PRN_CREATED,
+        1,
+        '2026-02-01T12:00:00.000Z'
+      )
+      const issued = buildEvent(
+        STREAM_EVENT_KIND.PRN_ISSUED,
+        2,
+        '2026-02-02T12:00:00.000Z'
+      )
+
+      const result = foldPrnFromTailEvents(prn, [created, issued])
+
+      expect(result.version).toBe(prn.version)
     })
 
     it('narrows the event actor to id and name, dropping the stream-only email', () => {
@@ -265,7 +283,7 @@ describe('foldPrnFromTailEvents', () => {
           by: issued.createdBy
         }
       ])
-      expect(result.version).toBe(3)
+      expect(result.version).toBe(prn.version)
       expect(result.updatedAt).toEqual(issued.createdAt)
       expect(result.updatedBy).toEqual(issued.createdBy)
       expect(result.lastAppliedEventNumber).toBe(2)

--- a/src/packaging-recycling-notes/application/get-projected-prn.test.js
+++ b/src/packaging-recycling-notes/application/get-projected-prn.test.js
@@ -183,10 +183,11 @@ describe('getProjectedPrnById', () => {
       prnId: PRN_ID
     })
 
-    // Only event 2 is folded (event 1 is at the watermark): one version bump.
+    // Only event 2 is folded (event 1 is at the watermark): status and the
+    // watermark advance, but version stays with the stored document.
     expect(result?.status.currentStatus).toBe(PRN_STATUS.ACCEPTED)
     expect(result?.lastAppliedEventNumber).toBe(2)
-    expect(result?.version).toBe(2)
+    expect(result?.version).toBe(1)
   })
 
   it('does not fold for an embedded-marker accreditation', async () => {

--- a/src/packaging-recycling-notes/application/update-status-stream.test.js
+++ b/src/packaging-recycling-notes/application/update-status-stream.test.js
@@ -8,6 +8,9 @@ import {
 import { REGULATOR } from '#domain/organisations/model.js'
 import { WASTE_BALANCE_CANONICAL_SOURCE } from '#waste-balances/domain/model.js'
 import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
+import { createInMemoryWasteBalancesRepository } from '#waste-balances/repository/inmemory.js'
+import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
 
 vi.mock('./metrics.js', () => ({
   prnMetrics: {
@@ -16,11 +19,13 @@ vi.mock('./metrics.js', () => ({
 }))
 
 const { updatePrnStatus } = await import('./update-status.js')
+const { getProjectedPrnByNumber } = await import('./get-projected-prn.js')
 
 const ORG_ID = 'org-123'
 const ACC_ID = 'acc-456'
 const REG_ID = 'reg-789'
 const PRN_ID = '507f1f77bcf86cd799439011'
+const PRN_NUMBER = 'ER2600001'
 const TONNAGE = 50
 const APPENDED_WATERMARK = 5
 const USER = { id: 'user-789', name: 'Test User' }
@@ -32,7 +37,8 @@ const buildLogger = () => ({
   warn: vi.fn(),
   debug: vi.fn(),
   trace: vi.fn(),
-  fatal: vi.fn()
+  fatal: vi.fn(),
+  child: vi.fn()
 })
 
 const buildLedgerBalance = (overrides = {}) => ({
@@ -43,17 +49,35 @@ const buildLedgerBalance = (overrides = {}) => ({
   ...overrides
 })
 
+/**
+ * @returns {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote}
+ */
 const buildPrn = (overrides = {}) => ({
   id: PRN_ID,
-  organisation: { id: ORG_ID },
-  accreditation: { id: ACC_ID, accreditationYear: 2026, material: 'plastic' },
-  isExport: false,
-  tonnage: TONNAGE,
+  schemaVersion: 2,
   version: 3,
+  registrationId: REG_ID,
+  organisation: { id: ORG_ID, name: 'Test Reprocessor' },
+  accreditation: {
+    id: ACC_ID,
+    accreditationNumber: 'ACC-1',
+    accreditationYear: 2026,
+    material: 'plastic',
+    submittedToRegulator: REGULATOR.EA
+  },
+  issuedToOrganisation: { id: 'producer-1', name: 'Producer Org' },
+  tonnage: TONNAGE,
+  isExport: false,
+  isDecemberWaste: false,
   status: {
     currentStatus: PRN_STATUS.DRAFT,
+    currentStatusAt: EVENT_AT,
     history: []
   },
+  createdAt: EVENT_AT,
+  createdBy: USER,
+  updatedAt: EVENT_AT,
+  updatedBy: USER,
   ...overrides
 })
 
@@ -78,6 +102,29 @@ const buildOrganisationsRepository = (accreditation = {}) => ({
   })
 })
 
+const buildLedgerRepositories = (storedPrn, events = []) => {
+  const packagingRecyclingNotesRepository =
+    createInMemoryPackagingRecyclingNotesRepository([storedPrn])(buildLogger())
+  const streamRepository = createInMemoryStreamRepository(events)()
+  const wasteBalancesRepository = createInMemoryWasteBalancesRepository(
+    [
+      {
+        id: 'wb-1',
+        accreditationId: ACC_ID,
+        organisationId: ORG_ID,
+        amount: 1000,
+        availableAmount: 1000,
+        transactions: [],
+        version: 0,
+        schemaVersion: 1,
+        canonicalSource: WASTE_BALANCE_CANONICAL_SOURCE.LEDGER
+      }
+    ],
+    { streamRepository }
+  )()
+  return { packagingRecyclingNotesRepository, wasteBalancesRepository }
+}
+
 const callUpdate = (overrides) =>
   updatePrnStatus({
     logger: buildLogger(),
@@ -95,10 +142,14 @@ afterEach(() => {
 
 describe('updatePrnStatus on the ledger (event-first) path', () => {
   it('persists a projection carrying the appended watermark when creating', async () => {
-    const persistProjection = vi
-      .fn()
-      .mockImplementation(async ({ projection }) => projection)
-    const prnRepository = { findById: vi.fn(), persistProjection }
+    const storedPrn = buildPrn({
+      version: 1,
+      status: { currentStatus: PRN_STATUS.DRAFT, history: [] }
+    })
+    const packagingRecyclingNotesRepository =
+      createInMemoryPackagingRecyclingNotesRepository([storedPrn])(
+        buildLogger()
+      )
     const wasteBalancesRepository = {
       findByAccreditationId: vi.fn().mockResolvedValue(buildLedgerBalance()),
       deductAvailableBalanceForPrnCreation: vi
@@ -107,23 +158,18 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
     }
 
     await callUpdate({
-      prnRepository,
+      prnRepository: packagingRecyclingNotesRepository,
       wasteBalancesRepository,
       organisationsRepository: buildOrganisationsRepository(),
-      providedPrn: buildPrn({
-        status: { currentStatus: PRN_STATUS.DRAFT, history: [] }
-      }),
+      providedPrn: storedPrn,
       newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
       actor: PRN_ACTOR.REPROCESSOR_EXPORTER
     })
 
-    expect(persistProjection).toHaveBeenCalledWith(
-      expect.objectContaining({
-        projection: expect.objectContaining({
-          lastAppliedEventNumber: APPENDED_WATERMARK
-        })
-      })
-    )
+    const reread = await packagingRecyclingNotesRepository.findById(PRN_ID)
+    expect(reread?.status.currentStatus).toBe(PRN_STATUS.AWAITING_AUTHORISATION)
+    expect(reread?.lastAppliedEventNumber).toBe(APPENDED_WATERMARK)
+    expect(reread?.version).toBe(2)
   })
 
   it('appends the balance event before persisting the projection when issuing', async () => {
@@ -446,5 +492,48 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
     ).rejects.toThrow('doc write failed')
 
     expect(creditFullBalanceForIssuedPrnCancellation).not.toHaveBeenCalled()
+  })
+})
+
+describe('updatePrnStatus composes the read fold with the real CAS-enforcing repository', () => {
+  it('accepts a PRN whose stored document trails the stream without a version conflict', async () => {
+    const storedPrn = buildPrn({
+      prnNumber: PRN_NUMBER,
+      registrationId: REG_ID,
+      version: 1,
+      lastAppliedEventNumber: 1,
+      status: {
+        currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
+        currentStatusAt: EVENT_AT,
+        history: []
+      }
+    })
+    const { packagingRecyclingNotesRepository, wasteBalancesRepository } =
+      buildLedgerRepositories(storedPrn, [
+        buildStreamEvent(STREAM_EVENT_KIND.PRN_CREATED, 1),
+        buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED, 2)
+      ])
+
+    const projected = await getProjectedPrnByNumber({
+      packagingRecyclingNotesRepository,
+      wasteBalancesRepository,
+      prnNumber: PRN_NUMBER
+    })
+    expect(projected?.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
+
+    const accepted = await callUpdate({
+      prnRepository: packagingRecyclingNotesRepository,
+      wasteBalancesRepository,
+      organisationsRepository: buildOrganisationsRepository(),
+      providedPrn: projected,
+      newStatus: PRN_STATUS.ACCEPTED,
+      actor: PRN_ACTOR.PRODUCER
+    })
+
+    expect(accepted.status.currentStatus).toBe(PRN_STATUS.ACCEPTED)
+
+    const reread = await packagingRecyclingNotesRepository.findById(PRN_ID)
+    expect(reread?.status.currentStatus).toBe(PRN_STATUS.ACCEPTED)
+    expect(reread?.version).toBe(2)
   })
 })

--- a/src/packaging-recycling-notes/repository/contract/persistProjection.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/persistProjection.contract.js
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import { describe, beforeEach, expect } from 'vitest'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { PrnNumberConflictError } from '#packaging-recycling-notes/repository/port.js'
@@ -54,6 +55,7 @@ export const testPersistProjectionBehaviour = (it) => {
           projection,
           expectedVersion: created.version
         })
+        assert(persisted)
 
         expect(persisted.id).toBe(created.id)
         expect(persisted.version).toBe(created.version + 1)
@@ -84,9 +86,10 @@ export const testPersistProjectionBehaviour = (it) => {
           projection,
           expectedVersion: created.version
         })
+        assert(persisted)
 
         expect(persisted.id).toBe(created.id)
-        expect(persisted._id).toBeUndefined()
+        expect(Object.keys(persisted)).not.toContain('_id')
       })
 
       it('returns null when no PRN exists with the given id', async () => {
@@ -103,6 +106,28 @@ export const testPersistProjectionBehaviour = (it) => {
         })
 
         expect(result).toBeNull()
+      })
+    })
+
+    describe('version ownership', () => {
+      it('derives the persisted version from expectedVersion, ignoring the version the projection carries', async () => {
+        const created = await repository.create(buildDraftPrn())
+        const projection = buildProjection(created, {
+          version: created.version + 99,
+          lastAppliedEventNumber: 3
+        })
+
+        const persisted = await repository.persistProjection({
+          projection,
+          expectedVersion: created.version
+        })
+        assert(persisted)
+
+        expect(persisted.version).toBe(created.version + 1)
+
+        const refetched = await repository.findById(created.id)
+        assert(refetched)
+        expect(refetched.version).toBe(created.version + 1)
       })
     })
 
@@ -189,9 +214,11 @@ export const testPersistProjectionBehaviour = (it) => {
           projection: buildProjection(created, { prnNumber }),
           expectedVersion: created.version
         })
+        assert(persisted)
 
         expect(persisted.prnNumber).toBe(prnNumber)
         const refetched = await repository.findById(created.id)
+        assert(refetched)
         expect(refetched.prnNumber).toBe(prnNumber)
       })
     })
@@ -230,6 +257,7 @@ export const testPersistProjectionBehaviour = (it) => {
           projection,
           expectedVersion: created.version
         })
+        assert(persisted)
 
         expect(persisted.status.issued).toEqual({ at, by: ISSUE_USER })
         expect(persisted.status.currentStatus).toBe(

--- a/src/packaging-recycling-notes/repository/contract/update-status.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/update-status.contract.js
@@ -31,6 +31,7 @@ export const testUpdateStatusBehaviour = (it) => {
         expect(updated.status.currentStatus).toBe(
           PRN_STATUS.AWAITING_AUTHORISATION
         )
+        expect(updated.version).toBe(created.version + 1)
       })
 
       it('adds to status history', async () => {

--- a/src/packaging-recycling-notes/repository/inmemory.plugin.js
+++ b/src/packaging-recycling-notes/repository/inmemory.plugin.js
@@ -299,7 +299,7 @@ const performPersistProjection =
       }
     }
 
-    const persisted = { ...projection, id }
+    const persisted = { ...projection, id, version: expectedVersion + 1 }
     storage.set(id, structuredClone(persisted))
     return structuredClone(persisted)
   }

--- a/src/packaging-recycling-notes/repository/mongodb.js
+++ b/src/packaging-recycling-notes/repository/mongodb.js
@@ -423,7 +423,11 @@ const performPersistProjection = async (
   { projection, expectedVersion }
 ) => {
   const objectId = ObjectId.createFromHexString(projection.id)
-  const { id: _id, ...replacement } = projection
+  // The stored version is the optimistic-concurrency token, owned by this
+  // guard: advance it from the version we matched on, ignoring whatever version
+  // the projection content carries.
+  const { id: _id, version: _version, ...content } = projection
+  const replacement = { ...content, version: expectedVersion + 1 }
 
   try {
     const result = await db.collection(COLLECTION_NAME).findOneAndReplace(


### PR DESCRIPTION
Ticket: [PAE-1553](https://eaflood.atlassian.net/browse/PAE-1553)
## What

When a PRN's stored document trailed its event stream by one or more events, accepting (or otherwise transitioning) the PRN raised a spurious `409 Conflict` even though no concurrent write had occurred.

`version` was overloaded. It is the persisted document's optimistic-concurrency token, but the read-side fold (`foldPrnFromTailEvents`) also advanced it by one per folded tail event. So when the stored document lagged the stream by N events, the projected PRN carried `storedVersion + N`, and the subsequent write used that inflated value as its `expectedVersion`. The compare-and-set then matched against a version the document never had, and the write was rejected.

This change makes `version` solely the storage envelope's concurrency token:

- `foldPrnFromTailEvents` no longer touches `version`. The fold advances `currentStatus`, the status slots, history, `updatedAt`/`updatedBy` and the `lastAppliedEventNumber` watermark, and leaves `version` as read from the stored document.
- `persistProjection` in both the MongoDB and in-memory repository implementations owns the increment. It matches on the caller's `expectedVersion` and writes `expectedVersion + 1`, ignoring whatever `version` the projection content carries.

## Why

The fix mirrors the summary-logs repository, where the version is a storage envelope kept out of the document content and incremented by the repository on write. Centralising the increment in `persistProjection` means there is exactly one place that owns the concurrency token, and the read path can fold the stream as many events forward as it likes without ever disturbing it.

This is the minimal slice of separating the optimistic-concurrency version from the projected document content. The fuller separation (lifting `version` out of the in-memory PRN shape entirely, as summary-logs does) is tracked separately.

## Tests

A composition regression test exercises the real in-memory repository (not stubs): it seeds a PRN whose stored document trails the stream, reads it through the projecting fold, then accepts it and asserts the write succeeds and the stored version advances by one. The fold and projection unit tests are updated to assert the fold leaves `version` with the stored document.

The repository contract gains a `persistProjection` case that feeds a projection carrying a deliberately wrong version and asserts the persisted version is exactly `expectedVersion + 1`, pinning the version-ownership invariant across both the MongoDB and in-memory adapters. The `updateStatus` and rollback contract paths likewise assert the exact resulting version to close the symmetric "forgot to increment" gap.

[PAE-1553]: https://eaflood.atlassian.net/browse/PAE-1553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
