### PR TITLE
PAE-1556 Consistently return role and scopes for users authorising with either Defra ID or Entra ID tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "#adapters/*": "./src/adapters/*",
     "#application/*": "./src/application/*",
     "#auditing/*": "./src/auditing/*",
+    "#auth/*": "./src/common/helpers/auth/*",
     "#common/*": "./src/common/*",
     "#data/*": "./src/data/*",
     "#domain/*": "./src/domain/*",

--- a/src/common/helpers/auth/get-defra-user-roles.js
+++ b/src/common/helpers/auth/get-defra-user-roles.js
@@ -15,13 +15,13 @@ import { getRolesForOrganisationAccess } from './get-roles-for-org-access.js'
  * Determines the roles for a Defra ID user based on their token and request context
  * @param {DefraIdTokenPayload} tokenPayload - The Defra ID token payload
  * @param {import('#common/hapi-types.js').HapiRequest} request - The Hapi request object
- * @returns {Promise<string[]>} Array of role strings
+ * @returns {Promise<import('#auth/types.js').UserRoleAndScopes>}
  */
 export async function getDefraUserRoles(tokenPayload, request) {
   const { email } = tokenPayload
 
   if (!email) {
-    return []
+    return { role: null, scopes: [] }
   }
 
   // This throws if the user is unauthorised
@@ -33,14 +33,14 @@ export async function getDefraUserRoles(tokenPayload, request) {
   if (isValidLinkingReq) {
     request.server.app.orgInToken = getDefraTokenSummary(tokenPayload)
 
-    return [ROLES.linker]
+    return { role: null, scopes: [ROLES.linker] } // this highlights how this code has mixed up roles/scopes - needs fixing!
   }
 
   const { organisationsRepository } = request
 
   // The endpoint will show info based on the user's email and contactId
   if (isOrganisationsDiscoveryReq(request)) {
-    return [ROLES.inquirer]
+    return { role: null, scopes: [ROLES.inquirer] } // this highlights how this code has mixed up roles/scopes - needs fixing!
   }
 
   const linkedEprOrg = await getOrgMatchingUsersToken(
@@ -63,5 +63,5 @@ export async function getDefraUserRoles(tokenPayload, request) {
     tokenPayload
   )
 
-  return roles
+  return { role: null, scopes: roles } // this highlights how this code has mixed up roles/scopes - needs fixing!
 }

--- a/src/common/helpers/auth/get-defra-user-roles.test.js
+++ b/src/common/helpers/auth/get-defra-user-roles.test.js
@@ -10,23 +10,46 @@ const mockGetRolesForOrganisationAccess = vi.fn()
 const mockGetDefraTokenSummary = vi.fn()
 
 vi.mock('./is-authorised-org-linking-req.js', () => ({
-  isAuthorisedOrgLinkingReq: (...args) => mockIsAuthorisedOrgLinkingReq(...args)
+  isAuthorisedOrgLinkingReq: (/** @type {any} */ ...args) =>
+    mockIsAuthorisedOrgLinkingReq(...args)
 }))
 
 vi.mock('./roles/helpers.js', () => ({
-  isOrganisationsDiscoveryReq: (...args) =>
+  isOrganisationsDiscoveryReq: (/** @type {any} */ ...args) =>
     mockIsOrganisationsDiscoveryReq(...args),
-  getDefraTokenSummary: (...args) => mockGetDefraTokenSummary(...args)
+  getDefraTokenSummary: (/** @type {any} */ ...args) =>
+    mockGetDefraTokenSummary(...args)
 }))
 
 vi.mock('./get-users-org-info.js', () => ({
-  getOrgMatchingUsersToken: (...args) => mockGetOrgMatchingUsersToken(...args)
+  getOrgMatchingUsersToken: (/** @type {any} */ ...args) =>
+    mockGetOrgMatchingUsersToken(...args)
 }))
 
 vi.mock('./get-roles-for-org-access.js', () => ({
-  getRolesForOrganisationAccess: (...args) =>
+  getRolesForOrganisationAccess: (/** @type {any} */ ...args) =>
     mockGetRolesForOrganisationAccess(...args)
 }))
+
+/**
+ *
+ * @returns {import('#auth/types.js').DefraIdTokenPayload}
+ */
+function createTokenPayload(overrides = {}) {
+  return {
+    contactId: '',
+    email: '',
+    currentRelationshipId: '',
+    relationships: [],
+    firstName: '',
+    lastName: '',
+    iss: '',
+    aud: '',
+    exp: 0,
+    iat: 0,
+    ...overrides
+  }
+}
 
 describe('#getDefraUserRoles', () => {
   const mockOrganisationsRepository = {}
@@ -57,31 +80,31 @@ describe('#getDefraUserRoles', () => {
 
       const result = await getDefraUserRoles(tokenPayload, mockRequest)
 
-      expect(result).toEqual([])
+      expect(result.scopes).toEqual([])
       expect(mockIsAuthorisedOrgLinkingReq).not.toHaveBeenCalled()
     })
 
     test('returns empty array when email is null', async () => {
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: null
-      }
+      })
 
       const result = await getDefraUserRoles(tokenPayload, mockRequest)
 
-      expect(result).toEqual([])
+      expect(result.scopes).toEqual([])
       expect(mockIsAuthorisedOrgLinkingReq).not.toHaveBeenCalled()
     })
 
     test('returns empty array when email is empty string', async () => {
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: ''
-      }
+      })
 
       const result = await getDefraUserRoles(tokenPayload, mockRequest)
 
-      expect(result).toEqual([])
+      expect(result.scopes).toEqual([])
       expect(mockIsAuthorisedOrgLinkingReq).not.toHaveBeenCalled()
     })
   })
@@ -92,14 +115,14 @@ describe('#getDefraUserRoles', () => {
     })
 
     test('returns linker role when linking request is valid', async () => {
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       const result = await getDefraUserRoles(tokenPayload, mockRequest)
 
-      expect(result).toEqual([ROLES.linker])
+      expect(result.scopes).toEqual([ROLES.linker])
       expect(mockIsAuthorisedOrgLinkingReq).toHaveBeenCalledWith(
         mockRequest,
         tokenPayload
@@ -109,10 +132,10 @@ describe('#getDefraUserRoles', () => {
     })
 
     test('calls isAuthorisedOrgLinkingReq with correct parameters', async () => {
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-456',
         email: 'another@example.com'
-      }
+      })
       const customRequest = {
         ...mockRequest,
         path: '/api/v1/organisations/link'
@@ -134,24 +157,24 @@ describe('#getDefraUserRoles', () => {
     })
 
     test('returns inquirer role for discovery request', async () => {
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       const result = await getDefraUserRoles(tokenPayload, mockRequest)
 
-      expect(result).toEqual([ROLES.inquirer])
+      expect(result.scopes).toEqual([ROLES.inquirer])
       expect(mockIsOrganisationsDiscoveryReq).toHaveBeenCalledWith(mockRequest)
       expect(mockIsOrganisationsDiscoveryReq).toHaveBeenCalledTimes(1)
       expect(mockGetOrgMatchingUsersToken).not.toHaveBeenCalled()
     })
 
     test('calls isOrganisationsDiscoveryReq with correct request', async () => {
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-456',
         email: 'another@example.com'
-      }
+      })
       const customRequest = {
         ...mockRequest,
         path: '/api/v1/organisations/linked'
@@ -179,17 +202,17 @@ describe('#getDefraUserRoles', () => {
     })
 
     test('returns roles for organisation access', async () => {
-      const expectedRoles = [ROLES.editor, ROLES.viewer]
+      const expectedRoles = [ROLES.standardUser, ROLES.inquirer]
       mockGetRolesForOrganisationAccess.mockResolvedValue(expectedRoles)
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       const result = await getDefraUserRoles(tokenPayload, mockRequest)
 
-      expect(result).toEqual(expectedRoles)
+      expect(result.scopes).toEqual(expectedRoles)
       expect(mockGetOrgMatchingUsersToken).toHaveBeenCalledWith(
         tokenPayload,
         mockOrganisationsRepository
@@ -202,12 +225,12 @@ describe('#getDefraUserRoles', () => {
     })
 
     test('calls getUsersOrganisationInfo with correct parameters', async () => {
-      mockGetRolesForOrganisationAccess.mockResolvedValue([ROLES.viewer])
+      mockGetRolesForOrganisationAccess.mockResolvedValue([ROLES.standardUser])
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-456',
         email: 'another@example.com'
-      }
+      })
 
       await getDefraUserRoles(tokenPayload, mockRequest)
 
@@ -219,13 +242,13 @@ describe('#getDefraUserRoles', () => {
     })
 
     test('calls getRolesForOrganisationAccess with request and linked org', async () => {
-      const customRoles = [ROLES.editor]
+      const customRoles = [ROLES.standardUser]
       mockGetRolesForOrganisationAccess.mockResolvedValue(customRoles)
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-789',
         email: 'third@example.com'
-      }
+      })
       const customRequest = {
         ...mockRequest,
         params: { organisationId: 'org-123' }
@@ -244,41 +267,41 @@ describe('#getDefraUserRoles', () => {
     test('returns empty array when getRolesForOrganisationAccess returns empty', async () => {
       mockGetRolesForOrganisationAccess.mockResolvedValue([])
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       const result = await getDefraUserRoles(tokenPayload, mockRequest)
 
-      expect(result).toEqual([])
+      expect(result.scopes).toEqual([])
     })
 
     test('returns single role when user has one permission', async () => {
-      mockGetRolesForOrganisationAccess.mockResolvedValue([ROLES.viewer])
+      mockGetRolesForOrganisationAccess.mockResolvedValue([ROLES.standardUser])
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       const result = await getDefraUserRoles(tokenPayload, mockRequest)
 
-      expect(result).toEqual([ROLES.viewer])
+      expect(result.scopes).toEqual([ROLES.standardUser])
     })
 
     test('returns multiple roles when user has multiple permissions', async () => {
-      const multipleRoles = [ROLES.editor, ROLES.viewer, ROLES.admin]
+      const multipleRoles = [ROLES.standardUser, ROLES.inquirer]
       mockGetRolesForOrganisationAccess.mockResolvedValue(multipleRoles)
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       const result = await getDefraUserRoles(tokenPayload, mockRequest)
 
-      expect(result).toEqual(multipleRoles)
+      expect(result.scopes).toEqual(multipleRoles)
     })
   })
 
@@ -290,10 +313,10 @@ describe('#getDefraUserRoles', () => {
     })
 
     test('throws forbidden error when user token is not linked to an organisation', async () => {
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       await expect(
         getDefraUserRoles(tokenPayload, mockRequest)
@@ -305,10 +328,10 @@ describe('#getDefraUserRoles', () => {
     })
 
     test('does not call getRolesForOrganisationAccess', async () => {
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       try {
         await getDefraUserRoles(tokenPayload, mockRequest)
@@ -330,10 +353,10 @@ describe('#getDefraUserRoles', () => {
       const error = new Error('Organisation not found')
       mockGetOrgMatchingUsersToken.mockRejectedValue(error)
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       await expect(
         getDefraUserRoles(tokenPayload, mockRequest)
@@ -345,10 +368,10 @@ describe('#getDefraUserRoles', () => {
       mockGetOrgMatchingUsersToken.mockResolvedValue({ id: 'org-123' })
       mockGetRolesForOrganisationAccess.mockRejectedValue(error)
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       await expect(
         getDefraUserRoles(tokenPayload, mockRequest)
@@ -359,10 +382,10 @@ describe('#getDefraUserRoles', () => {
       const error = new Error('Unauthorised linking request')
       mockIsAuthorisedOrgLinkingReq.mockRejectedValue(error)
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       await expect(
         getDefraUserRoles(tokenPayload, mockRequest)
@@ -372,10 +395,10 @@ describe('#getDefraUserRoles', () => {
 
   describe('flow control', () => {
     test('short-circuits at email check before calling any other functions', async () => {
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: ''
-      }
+      })
 
       await getDefraUserRoles(tokenPayload, mockRequest)
 
@@ -388,10 +411,10 @@ describe('#getDefraUserRoles', () => {
     test('short-circuits at linking check when valid linking request', async () => {
       mockIsAuthorisedOrgLinkingReq.mockResolvedValue(true)
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       await getDefraUserRoles(tokenPayload, mockRequest)
 
@@ -405,10 +428,10 @@ describe('#getDefraUserRoles', () => {
       mockIsAuthorisedOrgLinkingReq.mockResolvedValue(false)
       mockIsOrganisationsDiscoveryReq.mockReturnValue(true)
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       await getDefraUserRoles(tokenPayload, mockRequest)
 
@@ -422,12 +445,12 @@ describe('#getDefraUserRoles', () => {
       mockIsAuthorisedOrgLinkingReq.mockResolvedValue(false)
       mockIsOrganisationsDiscoveryReq.mockReturnValue(false)
       mockGetOrgMatchingUsersToken.mockResolvedValue({ id: 'org-123' })
-      mockGetRolesForOrganisationAccess.mockResolvedValue([ROLES.viewer])
+      mockGetRolesForOrganisationAccess.mockResolvedValue([ROLES.standardUser])
 
-      const tokenPayload = {
+      const tokenPayload = createTokenPayload({
         id: 'user-123',
         email: 'user@example.com'
-      }
+      })
 
       await getDefraUserRoles(tokenPayload, mockRequest)
 

--- a/src/common/helpers/auth/get-entra-user-roles.js
+++ b/src/common/helpers/auth/get-entra-user-roles.js
@@ -12,14 +12,10 @@ const ADMIN_ROLE_RESOLUTION_ORDER = [
 ]
 
 /**
- * @typedef {{ role: string | null, scopes: string[] }} ResolvedAdminRole
- */
-
-/**
  * Resolves an Entra ID user's admin role and bundled scopes from
  * email-list config. Email comparison is case-insensitive.
  * @param {string | undefined | null} userEmail - Email from the validated Entra access token.
- * @returns {Promise<ResolvedAdminRole>}
+ * @returns {Promise<import('#auth/types.js').UserRoleAndScopes>}
  */
 export async function getEntraUserRoles(userEmail) {
   if (!userEmail) {

--- a/src/common/helpers/auth/get-jwt-strategy-config.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.js
@@ -72,16 +72,16 @@ export function getJwtStrategyConfig(oidcConfigs) {
           .filter(Boolean)
           .map((s) => s.trim())
           .join(' ')
-        const scope = await getDefraUserRoles(tokenPayload, request)
+        const { scopes } = await getDefraUserRoles(tokenPayload, request)
 
         return {
-          isValid: scope.length > 0,
+          isValid: scopes.length > 0,
           credentials: {
             id: tokenPayload.contactId,
             email,
             name,
             issuer,
-            scope,
+            scope: scopes,
             currentRelationshipId: tokenPayload?.currentRelationshipId
           }
         }

--- a/src/common/helpers/auth/types.js
+++ b/src/common/helpers/auth/types.js
@@ -76,4 +76,8 @@
  * }} DefraIdRelationship
  */
 
+/**
+ * @typedef {{ role: string | null, scopes: string[] }} UserRoleAndScopes
+ */
+
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import


### PR DESCRIPTION
Ticket: [PAE-1556](https://eaflood.atlassian.net/browse/PAE-1556)
## Description

Ensures both `getEntraUserRoles` and `getDefraUserRoles` return the same type

This change highlights how the Defra ID codepath has mixed up roles/scopes - this will be addressed in subsequent changes

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1556]: https://eaflood.atlassian.net/browse/PAE-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ