### PR TITLE
PAE-1487: Collapse journey-test matrix and drop ledger flag CI plumbing

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -93,14 +93,10 @@ jobs:
           fail-on-severity: moderate
 
   test-journey:
-    name: Run Journey Tests (ledger=${{ matrix.ledger }})
+    name: Build and run journey tests
     runs-on: ubuntu-latest
     needs: pr-prep
     if: needs.pr-prep.outputs.docs-only != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        ledger: [false, true]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -129,8 +125,6 @@ jobs:
         with:
           epr-backend: ${{github.sha}}
           branch: ${{ steps.journey-branch.outputs.ref }}
-          waste-balance-ledger: ${{ matrix.ledger }}
-          artifact-suffix: -ledger-${{ matrix.ledger }}
 
       - name: Write journey test summary
         if: always()

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -93,7 +93,7 @@ jobs:
           fail-on-severity: moderate
 
   test-journey:
-    name: Build and run journey tests
+    name: Run Journey Tests
     runs-on: ubuntu-latest
     needs: pr-prep
     if: needs.pr-prep.outputs.docs-only != 'true'
@@ -179,18 +179,3 @@ jobs:
           EOF
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-
-  journey-tests:
-    name: Run Journey Tests
-    runs-on: ubuntu-latest
-    needs: test-journey
-    if: always()
-    steps:
-      - name: Check journey test results
-        run: |
-          RESULT="${{ needs.test-journey.result }}"
-          if [ "$RESULT" = "failure" ] || [ "$RESULT" = "cancelled" ]; then
-            echo "Journey tests reported '$RESULT'"
-            exit 1
-          fi
-          echo "Journey tests reported '$RESULT'"


### PR DESCRIPTION
Ticket: [PAE-1487](https://eaflood.atlassian.net/browse/PAE-1487)
## Summary

`FEATURE_FLAG_WASTE_BALANCE_LEDGER` has been removed from the backend (PAE-1487), so running the journey-test suite under both flag values (`ledger: [false, true]`) is now identical work done twice. This collapses the matrix to a single run and stops passing the now-ignored `waste-balance-ledger` input and its `-ledger-` artifact suffix.

## Branch protection

The required `Run Journey Tests` status check is the aggregator job, which is unchanged. The matrix-expanded check names (`Run Journey Tests (ledger=false)` / `(ledger=true)`) were never required checks, so collapsing the matrix does not affect branch protection.

## Coordination

Pairs with DEFRA/epr-backend-journey-tests#505, which removes the matching `waste-balance-ledger` input from the `run-journey-tests` action. The two can merge in either order.

[PAE-1487]: https://eaflood.atlassian.net/browse/PAE-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ