### PR TITLE
PAE-1542: Assert system-log audits via in-memory read-back

### DIFF
--- a/src/auditing/form-submission-lineage-migration.test.js
+++ b/src/auditing/form-submission-lineage-migration.test.js
@@ -1,9 +1,10 @@
 import { auditFormSubmissionLineageMigration } from './form-submission-lineage-migration.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { logger } from '#common/helpers/logging/logger.js'
 import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest'
 import { ObjectId } from 'mongodb'
 
 const mockAudit = vi.fn()
-const mockInsert = vi.fn()
 
 vi.mock('@defra/cdp-auditing', () => ({
   audit: (...args) => mockAudit(...args)
@@ -29,9 +30,12 @@ vi.mock('#root/config.js', () => ({
 describe('auditFormSubmissionLineageMigration', () => {
   const now = new Date('2026-02-11T12:00:00.000Z')
 
+  let systemLogsRepository
+
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(now)
+    systemLogsRepository = createSystemLogsRepository()(logger)
   })
 
   afterEach(() => {
@@ -42,9 +46,10 @@ describe('auditFormSubmissionLineageMigration', () => {
   const organisationId = new ObjectId().toString()
   const systemUser = { id: 'system', email: 'system', scope: [] }
 
-  const createMockSystemLogsRepository = () => ({
-    insert: mockInsert
-  })
+  const findStoredLog = async () => {
+    const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+    return systemLogs[0]
+  }
 
   it('logs full previous/next state to both CDP audit and system log', async () => {
     const previous = {
@@ -67,7 +72,7 @@ describe('auditFormSubmissionLineageMigration', () => {
     }
 
     await auditFormSubmissionLineageMigration(
-      createMockSystemLogsRepository(),
+      systemLogsRepository,
       organisationId,
       previous,
       next
@@ -87,7 +92,8 @@ describe('auditFormSubmissionLineageMigration', () => {
       user: systemUser
     })
 
-    expect(mockInsert).toHaveBeenCalledWith({
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
       createdAt: now,
       createdBy: systemUser,
       event: {
@@ -132,7 +138,7 @@ describe('auditFormSubmissionLineageMigration', () => {
     }
 
     await auditFormSubmissionLineageMigration(
-      createMockSystemLogsRepository(),
+      systemLogsRepository,
       organisationId,
       previous,
       next
@@ -148,7 +154,8 @@ describe('auditFormSubmissionLineageMigration', () => {
       user: systemUser
     })
 
-    expect(mockInsert).toHaveBeenCalledWith({
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
       createdAt: now,
       createdBy: systemUser,
       event: {

--- a/src/auditing/incremental-form-migration.test.js
+++ b/src/auditing/incremental-form-migration.test.js
@@ -1,9 +1,10 @@
 import { auditIncrementalFormMigration } from './incremental-form-migration.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { logger } from '#common/helpers/logging/logger.js'
 import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest'
 import { ObjectId } from 'mongodb'
 
 const mockAudit = vi.fn()
-const mockInsert = vi.fn()
 
 vi.mock('@defra/cdp-auditing', () => ({
   audit: (...args) => mockAudit(...args)
@@ -29,9 +30,12 @@ vi.mock('#root/config.js', () => ({
 describe('auditIncrementalFormMigration', () => {
   const now = new Date('2026-02-11T12:00:00.000Z')
 
+  let systemLogsRepository
+
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(now)
+    systemLogsRepository = createSystemLogsRepository()(logger)
   })
 
   afterEach(() => {
@@ -42,9 +46,10 @@ describe('auditIncrementalFormMigration', () => {
   const organisationId = new ObjectId().toString()
   const systemUser = { id: 'system', email: 'system', scope: [] }
 
-  const createMockSystemLogsRepository = () => ({
-    insert: mockInsert
-  })
+  const findStoredLog = async () => {
+    const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+    return systemLogs[0]
+  }
 
   it('logs full previous/next state to both CDP audit and system log', async () => {
     const previous = {
@@ -67,7 +72,7 @@ describe('auditIncrementalFormMigration', () => {
     }
 
     await auditIncrementalFormMigration(
-      createMockSystemLogsRepository(),
+      systemLogsRepository,
       organisationId,
       previous,
       next
@@ -89,7 +94,8 @@ describe('auditIncrementalFormMigration', () => {
     })
 
     // Verify system log stores full state
-    expect(mockInsert).toHaveBeenCalledWith({
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
       createdAt: now,
       createdBy: systemUser,
       event: {
@@ -135,7 +141,7 @@ describe('auditIncrementalFormMigration', () => {
     }
 
     await auditIncrementalFormMigration(
-      createMockSystemLogsRepository(),
+      systemLogsRepository,
       organisationId,
       previous,
       next
@@ -153,7 +159,8 @@ describe('auditIncrementalFormMigration', () => {
     })
 
     // Verify system log still stores full state (no size limit)
-    expect(mockInsert).toHaveBeenCalledWith({
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
       createdAt: now,
       createdBy: systemUser,
       event: {

--- a/src/auditing/organisations-discovery.test.js
+++ b/src/auditing/organisations-discovery.test.js
@@ -1,9 +1,10 @@
 import { auditOrganisationsDiscovery } from './organisations-discovery.js'
-import { vi, describe, it, beforeEach, afterEach } from 'vitest'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { logger } from '#common/helpers/logging/logger.js'
+import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest'
 import { randomBytes } from 'crypto'
 
 const mockAudit = vi.fn()
-const mockInsert = vi.fn()
 
 vi.mock('@defra/cdp-auditing', () => ({
   audit: (...args) => mockAudit(...args)
@@ -12,9 +13,12 @@ vi.mock('@defra/cdp-auditing', () => ({
 describe('auditOrganisationsDiscovery', () => {
   const now = new Date('2026-01-06T15:47:00.000Z')
 
+  let systemLogsRepository
+
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(now)
+    systemLogsRepository = createSystemLogsRepository()(logger)
   })
 
   afterEach(() => {
@@ -22,16 +26,28 @@ describe('auditOrganisationsDiscovery', () => {
     vi.clearAllMocks()
   })
 
-  const createMockRequest = () => ({
-    systemLogsRepository: { insert: mockInsert },
-    auth: {
-      credentials: {
-        id: 'contact-123',
-        email: 'user@example.com',
-        scope: ['inquirer']
+  const createMockRequest = () =>
+    /** @type {import('#common/hapi-types.js').HapiRequest & { systemLogsRepository: import('#repositories/system-logs/port.js').SystemLogsRepository }} */ ({
+      systemLogsRepository,
+      auth: {
+        credentials: {
+          id: 'contact-123',
+          email: 'user@example.com',
+          scope: ['inquirer']
+        }
       }
-    }
-  })
+    })
+
+  const findStoredLog = async () => {
+    const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+    return systemLogs[0]
+  }
+
+  const expectedEvent = {
+    category: 'identity',
+    subCategory: 'defra-id-reconciliation',
+    action: 'organisations-discovered'
+  }
 
   /** @type {import('#domain/organisations/model.js').Organisation} */
   const linkedOrg = /** @type {any} */ ({
@@ -62,10 +78,18 @@ describe('auditOrganisationsDiscovery', () => {
     linkableOrgs: /** @type {any[]} */ ([])
   }
 
-  it('maps a linked org into the audit context', async () => {
+  it('records a linked org with full context in the system log', async () => {
     await auditOrganisationsDiscovery(createMockRequest(), baseParams)
 
-    const expectedContext = {
+    const storedLog = await findStoredLog()
+    expect(storedLog.event).toEqual(expectedEvent)
+    expect(storedLog.createdAt).toEqual(now)
+    expect(storedLog.createdBy).toEqual({
+      id: 'contact-123',
+      email: 'user@example.com',
+      scope: ['inquirer']
+    })
+    expect(storedLog.context).toEqual({
       organisationId: 'epr-org-1',
       defraIdOrg: baseParams.defraIdOrg,
       defraIdRelationships,
@@ -78,26 +102,10 @@ describe('auditOrganisationsDiscovery', () => {
         linkedAt: '2026-01-01T00:00:00.000Z'
       },
       unlinked: []
-    }
-
-    expect(mockInsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: {
-          category: 'identity',
-          subCategory: 'defra-id-reconciliation',
-          action: 'organisations-discovered'
-        },
-        context: expectedContext,
-        createdBy: {
-          id: 'contact-123',
-          email: 'user@example.com',
-          scope: ['inquirer']
-        }
-      })
-    )
+    })
   })
 
-  it('sets linked to null and maps linkable orgs with status when no linked org exists', async () => {
+  it('records null linked and maps linkable orgs with status when no linked org exists', async () => {
     /** @type {any[]} */
     const linkableOrgs = [
       {
@@ -114,40 +122,38 @@ describe('auditOrganisationsDiscovery', () => {
       linkableOrgs
     })
 
-    expect(mockInsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        context: expect.objectContaining({
-          organisationId: null,
-          linked: null,
-          unlinked: [
-            {
-              id: 'epr-org-2',
-              name: 'Unlinked Corp',
-              orgId: 2002,
-              status: 'approved'
-            }
-          ]
-        })
-      })
-    )
+    const storedLog = await findStoredLog()
+    expect(storedLog.context).toEqual({
+      organisationId: null,
+      defraIdOrg: baseParams.defraIdOrg,
+      defraIdRelationships,
+      linked: null,
+      unlinked: [
+        {
+          id: 'epr-org-2',
+          name: 'Unlinked Corp',
+          orgId: 2002,
+          status: 'approved'
+        }
+      ]
+    })
   })
 
-  it('sets linked and unlinked to null/empty when there are no EPR organisations', async () => {
+  it('records null linked and empty unlinked when there are no EPR organisations', async () => {
     await auditOrganisationsDiscovery(createMockRequest(), {
       ...baseParams,
       linkedOrg: null,
       linkableOrgs: []
     })
 
-    expect(mockInsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        context: expect.objectContaining({
-          organisationId: null,
-          linked: null,
-          unlinked: []
-        })
-      })
-    )
+    const storedLog = await findStoredLog()
+    expect(storedLog.context).toEqual({
+      organisationId: null,
+      defraIdOrg: baseParams.defraIdOrg,
+      defraIdRelationships,
+      linked: null,
+      unlinked: []
+    })
   })
 
   it('sends full context to CDP audit for normal-sized payloads', async () => {
@@ -176,11 +182,7 @@ describe('auditOrganisationsDiscovery', () => {
 
     // CDP audit receives stripped payload (event + user only)
     expect(mockAudit).toHaveBeenCalledWith({
-      event: {
-        category: 'identity',
-        subCategory: 'defra-id-reconciliation',
-        action: 'organisations-discovered'
-      },
+      event: expectedEvent,
       user: {
         id: 'contact-123',
         email: 'user@example.com',
@@ -189,12 +191,20 @@ describe('auditOrganisationsDiscovery', () => {
     })
 
     // System log always gets full context
-    expect(mockInsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        context: expect.objectContaining({
-          defraIdRelationships: oversizedParams.defraIdRelationships
-        })
-      })
-    )
+    const storedLog = await findStoredLog()
+    expect(storedLog.context).toEqual({
+      organisationId: 'epr-org-1',
+      defraIdOrg: baseParams.defraIdOrg,
+      defraIdRelationships: oversizedParams.defraIdRelationships,
+      linked: {
+        id: 'epr-org-1',
+        name: 'Linked Ltd',
+        orgId: 1001,
+        status: 'approved',
+        linkedBy: { email: 'linker@example.com', id: 'linker-id' },
+        linkedAt: '2026-01-01T00:00:00.000Z'
+      },
+      unlinked: []
+    })
   })
 })

--- a/src/auditing/public-register.test.js
+++ b/src/auditing/public-register.test.js
@@ -1,7 +1,8 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { logger } from '#common/helpers/logging/logger.js'
 
 const mockAudit = vi.fn()
-const mockInsert = vi.fn()
 
 vi.mock('@defra/cdp-auditing', () => ({
   audit: (...args) => mockAudit(...args)
@@ -17,29 +18,35 @@ describe('auditPublicRegisterGenerate', () => {
   const userEmail = 'test@example.gov.uk'
   const userScope = ['service_maintainer']
 
-  const createMockRequest = () => ({
-    auth: {
-      credentials: {
-        id: userId,
-        email: userEmail,
-        scope: userScope
-      }
-    },
-    systemLogsRepository: {
-      insert: mockInsert
-    }
-  })
+  let systemLogsRepository
+
+  const createMockRequest = () =>
+    /** @type {import('#common/hapi-types.js').HapiRequest & { systemLogsRepository: import('#repositories/system-logs/port.js').SystemLogsRepository }} */ ({
+      auth: {
+        credentials: {
+          id: userId,
+          email: userEmail,
+          scope: userScope
+        }
+      },
+      systemLogsRepository
+    })
 
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2025-12-22T10:00:00.000Z'))
-    mockInsert.mockResolvedValue(undefined)
+    systemLogsRepository = createSystemLogsRepository()(logger)
   })
 
   afterEach(() => {
     vi.useRealTimers()
     vi.clearAllMocks()
   })
+
+  const findStoredLog = async () => {
+    const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+    return systemLogs[0]
+  }
 
   it('sends audit event to CDP auditing with correct payload', async () => {
     const request = createMockRequest()
@@ -78,7 +85,8 @@ describe('auditPublicRegisterGenerate', () => {
       expiresAt
     })
 
-    expect(mockInsert).toHaveBeenCalledWith({
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
       createdAt: new Date('2025-12-22T10:00:00.000Z'),
       createdBy: {
         id: userId,

--- a/src/auditing/summary-logs.test.js
+++ b/src/auditing/summary-logs.test.js
@@ -1,7 +1,8 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { logger } from '#common/helpers/logging/logger.js'
 
 const mockAudit = vi.fn()
-const mockInsert = vi.fn()
 
 vi.mock('@defra/cdp-auditing', () => ({
   audit: (...args) => mockAudit(...args)
@@ -18,29 +19,35 @@ describe('auditSummaryLogSubmit', () => {
   const userEmail = 'test@example.gov.uk'
   const userScope = ['standardUser']
 
-  const createMockRequest = () => ({
-    auth: {
-      credentials: {
-        id: userId,
-        email: userEmail,
-        scope: userScope
-      }
-    },
-    systemLogsRepository: {
-      insert: mockInsert
-    }
-  })
+  let systemLogsRepository
+
+  const createMockRequest = () =>
+    /** @type {import('#common/hapi-types.js').HapiRequest & { systemLogsRepository: import('#repositories/system-logs/port.js').SystemLogsRepository }} */ ({
+      auth: {
+        credentials: {
+          id: userId,
+          email: userEmail,
+          scope: userScope
+        }
+      },
+      systemLogsRepository
+    })
 
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2025-12-22T10:00:00.000Z'))
-    mockInsert.mockResolvedValue(undefined)
+    systemLogsRepository = createSystemLogsRepository()(logger)
   })
 
   afterEach(() => {
     vi.useRealTimers()
     vi.clearAllMocks()
   })
+
+  const findStoredLog = async () => {
+    const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+    return systemLogs[0]
+  }
 
   it('sends audit event to CDP auditing with correct payload', async () => {
     const request = createMockRequest()
@@ -79,7 +86,8 @@ describe('auditSummaryLogSubmit', () => {
       registrationId
     })
 
-    expect(mockInsert).toHaveBeenCalledWith({
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
       createdAt: new Date('2025-12-22T10:00:00.000Z'),
       createdBy: {
         id: userId,
@@ -108,29 +116,35 @@ describe('auditSummaryLogDownload', () => {
   const userEmail = 'test@example.gov.uk'
   const userScope = ['serviceMaintainer']
 
-  const createMockRequest = () => ({
-    auth: {
-      credentials: {
-        id: userId,
-        email: userEmail,
-        scope: userScope
-      }
-    },
-    systemLogsRepository: {
-      insert: mockInsert
-    }
-  })
+  let systemLogsRepository
+
+  const createMockRequest = () =>
+    /** @type {import('#common/hapi-types.js').HapiRequest & { systemLogsRepository: import('#repositories/system-logs/port.js').SystemLogsRepository }} */ ({
+      auth: {
+        credentials: {
+          id: userId,
+          email: userEmail,
+          scope: userScope
+        }
+      },
+      systemLogsRepository
+    })
 
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2025-12-22T10:00:00.000Z'))
-    mockInsert.mockResolvedValue(undefined)
+    systemLogsRepository = createSystemLogsRepository()(logger)
   })
 
   afterEach(() => {
     vi.useRealTimers()
     vi.clearAllMocks()
   })
+
+  const findStoredLog = async () => {
+    const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+    return systemLogs[0]
+  }
 
   it('sends audit event with download action', async () => {
     const request = createMockRequest()
@@ -169,7 +183,8 @@ describe('auditSummaryLogDownload', () => {
       registrationId
     })
 
-    expect(mockInsert).toHaveBeenCalledWith({
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
       createdAt: new Date('2025-12-22T10:00:00.000Z'),
       createdBy: {
         id: userId,

--- a/src/overseas-sites/auditing.test.js
+++ b/src/overseas-sites/auditing.test.js
@@ -6,27 +6,14 @@ import {
   auditOverseasSiteDelete,
   auditOverseasSiteImport
 } from './auditing.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { logger } from '#common/helpers/logging/logger.js'
 
 const mockAudit = vi.fn()
-const mockInsert = vi.fn()
 
 vi.mock('@defra/cdp-auditing', () => ({
   audit: (...args) => mockAudit(...args)
 }))
-
-const createMockRequest = (overrides = {}) => ({
-  systemLogsRepository: {
-    insert: mockInsert
-  },
-  auth: {
-    credentials: {
-      id: 'user-123',
-      email: 'test@defra.gov.uk',
-      scope: ['service-maintainer']
-    }
-  },
-  ...overrides
-})
 
 const expectedUser = {
   id: 'user-123',
@@ -37,9 +24,30 @@ const expectedUser = {
 describe('overseas sites auditing', () => {
   const now = new Date('2026-03-18T10:00:00.000Z')
 
+  let systemLogsRepository
+
+  const createMockRequest = (overrides = {}) =>
+    /** @type {import('#common/hapi-types.js').HapiRequest & { systemLogsRepository: import('#repositories/system-logs/port.js').SystemLogsRepository }} */ ({
+      systemLogsRepository,
+      auth: {
+        credentials: {
+          id: 'user-123',
+          email: 'test@defra.gov.uk',
+          scope: ['service-maintainer']
+        }
+      },
+      ...overrides
+    })
+
+  const findStoredLog = async () => {
+    const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+    return systemLogs[0]
+  }
+
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(now)
+    systemLogsRepository = createSystemLogsRepository()(logger)
   })
 
   afterEach(() => {
@@ -65,18 +73,17 @@ describe('overseas sites auditing', () => {
         })
       )
 
-      expect(mockInsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          createdAt: now,
-          createdBy: expectedUser,
-          event: {
-            category: 'entity',
-            subCategory: 'overseas-sites',
-            action: 'create'
-          },
-          context: { site }
-        })
-      )
+      const storedLog = await findStoredLog()
+      expect(storedLog).toEqual({
+        createdAt: now,
+        createdBy: expectedUser,
+        event: {
+          category: 'entity',
+          subCategory: 'overseas-sites',
+          action: 'create'
+        },
+        context: { site }
+      })
     })
   })
 
@@ -100,18 +107,17 @@ describe('overseas sites auditing', () => {
         })
       )
 
-      expect(mockInsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          createdAt: now,
-          createdBy: expectedUser,
-          event: {
-            category: 'entity',
-            subCategory: 'overseas-sites',
-            action: 'update'
-          },
-          context: { siteId, previous, next }
-        })
-      )
+      const storedLog = await findStoredLog()
+      expect(storedLog).toEqual({
+        createdAt: now,
+        createdBy: expectedUser,
+        event: {
+          category: 'entity',
+          subCategory: 'overseas-sites',
+          action: 'update'
+        },
+        context: { siteId, previous, next }
+      })
     })
 
     it('omits previous and next from audit event for large payloads', async () => {
@@ -133,16 +139,13 @@ describe('overseas sites auditing', () => {
         })
       )
 
-      expect(mockInsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          event: {
-            category: 'entity',
-            subCategory: 'overseas-sites',
-            action: 'update'
-          },
-          context: { siteId, previous, next }
-        })
-      )
+      const storedLog = await findStoredLog()
+      expect(storedLog.event).toEqual({
+        category: 'entity',
+        subCategory: 'overseas-sites',
+        action: 'update'
+      })
+      expect(storedLog.context).toEqual({ siteId, previous, next })
     })
   })
 
@@ -165,18 +168,17 @@ describe('overseas sites auditing', () => {
         })
       )
 
-      expect(mockInsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          createdAt: now,
-          createdBy: expectedUser,
-          event: {
-            category: 'entity',
-            subCategory: 'overseas-sites',
-            action: 'delete'
-          },
-          context: { siteId, site }
-        })
-      )
+      const storedLog = await findStoredLog()
+      expect(storedLog).toEqual({
+        createdAt: now,
+        createdBy: expectedUser,
+        event: {
+          category: 'entity',
+          subCategory: 'overseas-sites',
+          action: 'delete'
+        },
+        context: { siteId, site }
+      })
     })
   })
 
@@ -198,18 +200,17 @@ describe('overseas sites auditing', () => {
         })
       )
 
-      expect(mockInsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          createdAt: now,
-          createdBy: expectedUser,
-          event: {
-            category: 'entity',
-            subCategory: 'overseas-sites',
-            action: 'import-initiated'
-          },
-          context: { importId }
-        })
-      )
+      const storedLog = await findStoredLog()
+      expect(storedLog).toEqual({
+        createdAt: now,
+        createdBy: expectedUser,
+        event: {
+          category: 'entity',
+          subCategory: 'overseas-sites',
+          action: 'import-initiated'
+        },
+        context: { importId }
+      })
     })
   })
 })

--- a/src/packaging-recycling-notes/application/audit.test.js
+++ b/src/packaging-recycling-notes/application/audit.test.js
@@ -1,7 +1,8 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { logger } from '#common/helpers/logging/logger.js'
 
 const mockAudit = vi.fn()
-const mockInsert = vi.fn()
 
 vi.mock('@defra/cdp-auditing', () => ({
   audit: (...args) => mockAudit(...args)
@@ -33,29 +34,35 @@ describe('auditPrnStatusTransition', () => {
     prnNumber: 'ER2600001'
   }
 
-  const createMockRequest = () => ({
-    auth: {
-      credentials: {
-        id: userId,
-        email: userEmail,
-        scope: userScope
-      }
-    },
-    systemLogsRepository: {
-      insert: mockInsert
-    }
-  })
+  let systemLogsRepository
+
+  const createMockRequest = () =>
+    /** @type {import('#common/hapi-types.js').HapiRequest & { systemLogsRepository: import('#repositories/system-logs/port.js').SystemLogsRepository }} */ ({
+      auth: {
+        credentials: {
+          id: userId,
+          email: userEmail,
+          scope: userScope
+        }
+      },
+      systemLogsRepository
+    })
 
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2025-12-22T10:00:00.000Z'))
-    mockInsert.mockResolvedValue(undefined)
+    systemLogsRepository = createSystemLogsRepository()(logger)
   })
 
   afterEach(() => {
     vi.useRealTimers()
     vi.clearAllMocks()
   })
+
+  const findStoredLog = async () => {
+    const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+    return systemLogs[0]
+  }
 
   it('sends audit event to CDP auditing with full previous and next state', async () => {
     const request = createMockRequest()
@@ -87,7 +94,8 @@ describe('auditPrnStatusTransition', () => {
 
     await auditPrnStatusTransition(request, prnId, previousPrn, nextPrn)
 
-    expect(mockInsert).toHaveBeenCalledWith({
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
       createdAt: new Date('2025-12-22T10:00:00.000Z'),
       createdBy: {
         id: userId,
@@ -138,15 +146,12 @@ describe('auditPrnStatusTransition', () => {
     })
 
     // System log should still receive full payload
-    expect(mockInsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        context: {
-          organisationId: 'org-456',
-          prnId,
-          previous: largePreviousPrn,
-          next: nextPrn
-        }
-      })
-    )
+    const storedLog = await findStoredLog()
+    expect(storedLog.context).toEqual({
+      organisationId: 'org-456',
+      prnId,
+      previous: largePreviousPrn,
+      next: nextPrn
+    })
   })
 })

--- a/src/reports/application/audit.test.js
+++ b/src/reports/application/audit.test.js
@@ -1,8 +1,9 @@
 import { randomBytes } from 'crypto'
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { logger } from '#common/helpers/logging/logger.js'
 
 const mockAudit = vi.fn()
-const mockInsert = vi.fn()
 
 vi.mock('@defra/cdp-auditing', () => ({
   audit: (...args) => mockAudit(...args)
@@ -11,16 +12,24 @@ vi.mock('@defra/cdp-auditing', () => ({
 const { auditReportStatusTransition, auditReportCreate, auditReportDelete } =
   await import('./audit.js')
 
-const createMockRequest = () => ({
-  auth: {
-    credentials: {
-      id: 'user-1',
-      email: 'user@example.gov.uk',
-      scope: ['standardUser']
-    }
-  },
-  systemLogsRepository: { insert: mockInsert }
-})
+let systemLogsRepository
+
+const createMockRequest = () =>
+  /** @type {import('#common/hapi-types.js').HapiRequest & { systemLogsRepository: import('#repositories/system-logs/port.js').SystemLogsRepository }} */ ({
+    auth: {
+      credentials: {
+        id: 'user-1',
+        email: 'user@example.gov.uk',
+        scope: ['standardUser']
+      }
+    },
+    systemLogsRepository
+  })
+
+const findStoredLog = async () => {
+  const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+  return systemLogs[0]
+}
 
 const user = {
   id: 'user-1',
@@ -31,7 +40,7 @@ const user = {
 beforeEach(() => {
   vi.useFakeTimers()
   vi.setSystemTime(new Date('2025-06-01T12:00:00.000Z'))
-  mockInsert.mockResolvedValue(undefined)
+  systemLogsRepository = createSystemLogsRepository()(logger)
 })
 
 afterEach(() => {
@@ -46,7 +55,7 @@ describe('auditReportStatusTransition', () => {
     year: 2025,
     cadence: 'quarterly',
     period: 1,
-    submissionNumber: 'sub-1',
+    submissionNumber: 1,
     reportId: 'rep-1',
     previous: {
       id: 'rep-1',
@@ -77,7 +86,8 @@ describe('auditReportStatusTransition', () => {
   it('records system log', async () => {
     await auditReportStatusTransition(createMockRequest(), params)
 
-    expect(mockInsert).toHaveBeenCalledWith({
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
       createdAt: new Date('2025-06-01T12:00:00.000Z'),
       createdBy: user,
       event: {
@@ -97,7 +107,7 @@ describe('auditReportStatusTransition', () => {
       year: 2025,
       cadence: 'quarterly',
       period: 1,
-      submissionNumber: 'sub-1',
+      submissionNumber: 1,
       reportId: 'rep-1',
       previous: {
         id: 'rep-1',
@@ -128,7 +138,7 @@ describe('auditReportStatusTransition', () => {
           year: 2025,
           cadence: 'quarterly',
           period: 1,
-          submissionNumber: 'sub-1',
+          submissionNumber: 1,
           reportId: 'rep-1',
           previous: { status: 'in_progress' },
           next: { status: 'ready_to_submit' }
@@ -136,16 +146,13 @@ describe('auditReportStatusTransition', () => {
       })
     )
 
-    expect(mockInsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: {
-          category: 'waste-reporting',
-          subCategory: 'reports',
-          action: 'status-transition'
-        },
-        context: oversizedParams
-      })
-    )
+    const storedLog = await findStoredLog()
+    expect(storedLog.event).toEqual({
+      category: 'waste-reporting',
+      subCategory: 'reports',
+      action: 'status-transition'
+    })
+    expect(storedLog.context).toEqual(oversizedParams)
   })
 })
 
@@ -156,7 +163,7 @@ describe('auditReportDelete', () => {
     year: 2025,
     cadence: 'quarterly',
     period: 1,
-    submissionNumber: 'sub-1',
+    submissionNumber: 1,
     reportId: 'rep-1',
     previous: {
       id: 'rep-1',
@@ -182,7 +189,8 @@ describe('auditReportDelete', () => {
   it('records system log', async () => {
     await auditReportDelete(createMockRequest(), params)
 
-    expect(mockInsert).toHaveBeenCalledWith({
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
       createdAt: new Date('2025-06-01T12:00:00.000Z'),
       createdBy: user,
       event: {
@@ -195,7 +203,6 @@ describe('auditReportDelete', () => {
   })
 
   it('strips previous to { status } in CDP audit event when payload is oversized', async () => {
-    const { randomBytes } = await import('crypto')
     const veryLongString = randomBytes(1e6).toString('hex')
     const oversizedParams = {
       organisationId: 'org-1',
@@ -203,7 +210,7 @@ describe('auditReportDelete', () => {
       year: 2025,
       cadence: 'quarterly',
       period: 1,
-      submissionNumber: 'sub-1',
+      submissionNumber: 1,
       reportId: 'rep-1',
       previous: {
         id: 'rep-1',
@@ -228,23 +235,20 @@ describe('auditReportDelete', () => {
           year: 2025,
           cadence: 'quarterly',
           period: 1,
-          submissionNumber: 'sub-1',
+          submissionNumber: 1,
           reportId: 'rep-1',
           previous: { status: 'in_progress' }
         }
       })
     )
 
-    expect(mockInsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: {
-          category: 'waste-reporting',
-          subCategory: 'reports',
-          action: 'delete'
-        },
-        context: oversizedParams
-      })
-    )
+    const storedLog = await findStoredLog()
+    expect(storedLog.event).toEqual({
+      category: 'waste-reporting',
+      subCategory: 'reports',
+      action: 'delete'
+    })
+    expect(storedLog.context).toEqual(oversizedParams)
   })
 })
 
@@ -255,7 +259,7 @@ describe('auditReportCreate', () => {
     year: 2025,
     cadence: 'quarterly',
     period: 1,
-    submissionNumber: 'sub-1',
+    submissionNumber: 1,
     reportId: 'rep-1',
     createdAt: '2025-06-01T10:00:00.000Z'
   }
@@ -277,7 +281,8 @@ describe('auditReportCreate', () => {
   it('records system log', async () => {
     await auditReportCreate(createMockRequest(), params)
 
-    expect(mockInsert).toHaveBeenCalledWith({
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
       createdAt: new Date('2025-06-01T12:00:00.000Z'),
       createdBy: user,
       event: {

--- a/src/waste-balances/application/update-via-stream.test.js
+++ b/src/waste-balances/application/update-via-stream.test.js
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createInMemoryStreamRepository } from '../repository/stream-inmemory.js'
 import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
 import { performUpdateViaStream } from './update-via-stream.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { logger } from '#common/helpers/logging/logger.js'
 import {
   WASTE_RECORD_TYPE,
   VERSION_STATUS
@@ -87,7 +89,7 @@ describe('performUpdateViaStream', () => {
 
   beforeEach(async () => {
     streamRepository = createInMemoryStreamRepository()()
-    systemLogsRepository = { insert: vi.fn().mockResolvedValue(undefined) }
+    systemLogsRepository = createSystemLogsRepository()(logger)
     const { findSchemaForProcessingType } =
       await import('#domain/summary-logs/table-schemas/index.js')
     vi.mocked(findSchemaForProcessingType).mockReturnValue(includingSchema)
@@ -215,7 +217,8 @@ describe('performUpdateViaStream', () => {
       })
 
       expect(appendSpy).not.toHaveBeenCalled()
-      expect(systemLogsRepository.insert).not.toHaveBeenCalled()
+      const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+      expect(systemLogs).toHaveLength(0)
     })
   })
 
@@ -234,17 +237,27 @@ describe('performUpdateViaStream', () => {
         summaryLogId: 'log-A'
       })
 
-      expect(systemLogsRepository.insert).toHaveBeenCalledTimes(1)
-      const [entry] = systemLogsRepository.insert.mock.calls[0]
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        accreditationId
+      )
+
+      const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+      expect(systemLogs).toHaveLength(1)
+      const [entry] = systemLogs
+      expect(entry.createdBy).toEqual(user)
+      expect(entry.createdAt).toBeInstanceOf(Date)
       expect(entry.event).toEqual({
         category: 'waste-reporting',
         subCategory: 'waste-balance',
         action: 'update'
       })
-      expect(entry.context.accreditationId).toBe(accreditationId)
-      expect(entry.context.amount).toBe(150)
-      expect(entry.context.availableAmount).toBe(150)
-      expect(entry.context.newTransactions).toHaveLength(1)
+      expect(entry.context).toEqual({
+        accreditationId,
+        amount: 150,
+        availableAmount: 150,
+        newTransactions: [latest]
+      })
     })
   })
 


### PR DESCRIPTION
Ticket: [PAE-1542](https://eaflood.atlassian.net/browse/PAE-1542)
The audit test suites verified system-log writes by spying on `systemLogsRepository.insert` and asserting `toHaveBeenCalledWith(...)`. That pins each test to *how* the auditor talks to the repository and can only confirm a call was made — it cannot catch a field landing in the wrong place, a lost field, or an overwrite.

This replaces the `vi.fn()` insert stubs and the per-file hand-rolled `createMockSystemLogsRepository` factories with the real in-memory system-logs adapter across the auditing, overseas-sites, packaging-recycling-notes, reports and waste-balances suites. Each test now drives the auditor and reads the stored log back via `find()`, asserting the full stored document (event, context, actor, timestamp) is what landed — observable state rather than the interaction.

The `@defra/cdp-auditing` mock and the logger mocks stay in place, as they have no in-memory twin. Where a test asserts the divergence between the size-reduced audit payload and the full system-log payload, the audit-side assertion is unchanged and only the system-log half becomes a read-back.

Two type fixes fall out of touching these files: the mock requests are annotated as `HapiRequest` where they drive request-shaped auditors (matching the existing exemplar), and the reports `submissionNumber` test data is corrected from a string to the number the auditor's type expects. Both clear pre-existing errors that the tests type-check CI job attributes to any PR touching the file.

This is the system-logs slice of the wider move to in-memory repository adapters in epr-backend tests; the ORS imports slice is in [#1267](https://github.com/DEFRA/epr-backend/pull/1267).


[PAE-1542]: https://eaflood.atlassian.net/browse/PAE-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ