### PR TITLE
PAE-1542: Drive summary-logs route tests through the in-memory repository

### DIFF
--- a/src/routes/v1/organisations/registrations/summary-logs/submit/post.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/submit/post.test.js
@@ -1,4 +1,5 @@
-import Boom from '@hapi/boom'
+import { randomUUID } from 'node:crypto'
+
 import { StatusCodes } from 'http-status-codes'
 
 import {
@@ -6,14 +7,19 @@ import {
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/event.js'
 import {
+  NO_PRIOR_SUBMISSION,
   SUMMARY_LOG_STATUS,
-  NO_PRIOR_SUBMISSION
+  transitionStatus
 } from '#domain/summary-logs/status.js'
 import {
   PROCESSING_TYPES,
   SUMMARY_LOG_META_FIELDS
 } from '#domain/summary-logs/meta-fields.js'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
+import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
+import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
+import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
+import { createMockLogger } from '#test/mock-logger.js'
 import { createTestServer } from '#test/create-test-server.js'
 import { asStandardUser } from '#test/inject-auth.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
@@ -33,9 +39,28 @@ vi.mock('#common/helpers/metrics/summary-logs.js', () => ({
   }
 }))
 
-const summaryLogId = 'summary-log-123'
-const organisationId = 'org-123'
-const registrationId = 'reg-456'
+const seedValidatingSummaryLog = async (repository, id, overrides = {}) => {
+  await repository.insert(id, summaryLogFactory.validating(overrides))
+  return waitForVersion(repository, id, 1)
+}
+
+const seedValidatedSummaryLog = async (repository, id, overrides = {}) => {
+  const inserted = await seedValidatingSummaryLog(repository, id, overrides)
+  await repository.update(
+    id,
+    inserted.version,
+    transitionStatus(inserted.summaryLog, SUMMARY_LOG_STATUS.VALIDATED)
+  )
+  return waitForVersion(repository, id, inserted.version + 1)
+}
+
+const seedSubmittedSummaryLog = async (repository, id, overrides = {}) => {
+  await repository.insert(id, summaryLogFactory.submitted(overrides))
+  return waitForVersion(repository, id, 1)
+}
+
+const submitUrl = (organisationId, registrationId, summaryLogId) =>
+  `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`
 
 describe(`${summaryLogsSubmitPath} route`, () => {
   setupAuthContext()
@@ -44,12 +69,8 @@ describe(`${summaryLogsSubmitPath} route`, () => {
   let summaryLogsWorker
 
   beforeAll(async () => {
-    summaryLogsRepository = {
-      findById: vi.fn(),
-      update: vi.fn().mockResolvedValue(undefined),
-      transitionToSubmittingExclusive: vi.fn(),
-      findLatestSubmittedForOrgReg: vi.fn()
-    }
+    const summaryLogsRepositoryFactory = createInMemorySummaryLogsRepository()
+    summaryLogsRepository = summaryLogsRepositoryFactory(createMockLogger())
 
     summaryLogsWorker = {
       submit: vi.fn().mockResolvedValue(undefined)
@@ -59,34 +80,17 @@ describe(`${summaryLogsSubmitPath} route`, () => {
 
     server = await createTestServer({
       repositories: {
-        summaryLogsRepository: (_logger) => summaryLogsRepository
+        summaryLogsRepository: summaryLogsRepositoryFactory
       },
       workers: {
         summaryLogsWorker
       },
       featureFlags
     })
-
-    await server.initialize()
   })
 
   beforeEach(() => {
-    // Default happy path: transition succeeds
-    summaryLogsRepository.transitionToSubmittingExclusive.mockResolvedValue({
-      success: true,
-      summaryLog: {
-        status: SUMMARY_LOG_STATUS.SUBMITTING,
-        organisationId,
-        registrationId,
-        validatedAgainstSummaryLogId: NO_PRIOR_SUBMISSION,
-        meta: {
-          [SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]:
-            PROCESSING_TYPES.REPROCESSOR_INPUT
-        }
-      },
-      version: 2
-    })
-    summaryLogsRepository.findLatestSubmittedForOrgReg.mockResolvedValue(null)
+    summaryLogsWorker.submit.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -103,448 +107,281 @@ describe(`${summaryLogsSubmitPath} route`, () => {
     await server.stop()
   })
 
-  describe('happy path', () => {
-    it('returns OK when summary log is validated', async () => {
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
+  it('transitions a validated summary log to submitting and records its side-effects', async () => {
+    const organisationId = randomUUID()
+    const registrationId = randomUUID()
+    const summaryLogId = randomUUID()
 
-      expect(response.statusCode).toBe(StatusCodes.OK)
+    const validated = await seedValidatedSummaryLog(
+      summaryLogsRepository,
+      summaryLogId,
+      {
+        organisationId,
+        registrationId,
+        validatedAgainstSummaryLogId: NO_PRIOR_SUBMISSION,
+        meta: {
+          [SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]:
+            PROCESSING_TYPES.REPROCESSOR_INPUT
+        }
+      }
+    )
+
+    const response = await server.inject({
+      method: 'POST',
+      url: submitUrl(organisationId, registrationId, summaryLogId),
+      ...asStandardUser({ linkedOrgId: organisationId })
     })
 
-    it('returns submitting status in response body', async () => {
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
+    expect(response.statusCode).toBe(StatusCodes.OK)
+    expect(JSON.parse(response.payload)).toEqual({ status: 'submitting' })
+    expect(response.headers.location).toBe(
+      `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}`
+    )
 
-      const body = JSON.parse(response.payload)
-      expect(body).toEqual({ status: 'submitting' })
-    })
+    const stored = await waitForVersion(
+      summaryLogsRepository,
+      summaryLogId,
+      validated.version + 1
+    )
+    expect(stored.summaryLog.status).toBe(SUMMARY_LOG_STATUS.SUBMITTING)
+    expect(stored.summaryLog.submittedAt).toEqual(expect.any(String))
 
-    it('returns Location header pointing to GET endpoint', async () => {
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(response.headers.location).toBe(
-        `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}`
-      )
-    })
-
-    it('calls transitionToSubmittingExclusive to atomically transition status', async () => {
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(
-        summaryLogsRepository.transitionToSubmittingExclusive
-      ).toHaveBeenCalledWith(summaryLogId)
-    })
-
-    it('calls validator submit with summary log ID', async () => {
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(summaryLogsWorker.submit).toHaveBeenCalledWith(
-        summaryLogId,
-        expect.objectContaining({
-          auth: expect.objectContaining({
-            credentials: expect.objectContaining({
-              id: 'test-user-id',
-              email: 'test@example.com'
-            })
+    expect(summaryLogsWorker.submit).toHaveBeenCalledWith(
+      summaryLogId,
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          credentials: expect.objectContaining({
+            id: 'test-user-id',
+            email: 'test@example.com'
           })
         })
-      )
-    })
-
-    it('logs submission initiation', async () => {
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
       })
-
-      expect(server.loggerMocks.info).toHaveBeenCalledWith({
-        message: `Summary log submission initiated: summaryLogId=${summaryLogId}, organisationId=${organisationId}, registrationId=${registrationId}`,
-        event: {
-          category: LOGGING_EVENT_CATEGORIES.SERVER,
-          action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS,
-          reference: summaryLogId
-        }
-      })
-    })
-
-    it('calls findLatestSubmittedForOrgReg with correct org/reg IDs', async () => {
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(
-        summaryLogsRepository.findLatestSubmittedForOrgReg
-      ).toHaveBeenCalledWith(organisationId, registrationId)
-    })
-
-    it('succeeds when validatedAgainstSummaryLogId matches current latest submitted', async () => {
-      const baselineId = 'matching-submission-id'
-
-      summaryLogsRepository.transitionToSubmittingExclusive.mockResolvedValue({
-        success: true,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.SUBMITTING,
-          organisationId,
-          registrationId,
-          validatedAgainstSummaryLogId: baselineId
-        },
-        version: 2
-      })
-
-      summaryLogsRepository.findLatestSubmittedForOrgReg.mockResolvedValue({
-        id: baselineId,
-        version: 1,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.SUBMITTED,
-          organisationId,
-          registrationId
-        }
-      })
-
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.OK)
-    })
-  })
-
-  describe('error cases', () => {
-    it('returns 404 when summary log does not exist', async () => {
-      summaryLogsRepository.transitionToSubmittingExclusive.mockRejectedValue(
-        Boom.notFound(`Summary log ${summaryLogId} not found`)
-      )
-
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
-      const body = JSON.parse(response.payload)
-      expect(body.message).toBe(`Summary log ${summaryLogId} not found`)
-    })
-
-    it('returns 409 when summary log status is not VALIDATED', async () => {
-      summaryLogsRepository.transitionToSubmittingExclusive.mockRejectedValue(
-        Boom.conflict(
-          `Summary log must be validated before submission. Current status: ${SUMMARY_LOG_STATUS.VALIDATING}`
-        )
-      )
-
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.CONFLICT)
-      const body = JSON.parse(response.payload)
-      expect(body.message).toBe(
-        `Summary log must be validated before submission. Current status: ${SUMMARY_LOG_STATUS.VALIDATING}`
-      )
-    })
-
-    it('returns 409 when another submission is in progress', async () => {
-      summaryLogsRepository.transitionToSubmittingExclusive.mockResolvedValue({
-        success: false
-      })
-
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.CONFLICT)
-      const body = JSON.parse(response.payload)
-      expect(body.message).toBe(
-        'Another submission is in progress. Please try again.'
-      )
-    })
-
-    it('returns 409 when preview is stale (another submission completed since preview)', async () => {
-      // Preview was generated when 'old-submission-id' was the latest submitted log
-      summaryLogsRepository.transitionToSubmittingExclusive.mockResolvedValue({
-        success: true,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.SUBMITTING,
-          organisationId,
-          registrationId,
-          validatedAgainstSummaryLogId: 'old-submission-id'
-        },
-        version: 2
-      })
-
-      // But now there's a newer submitted log
-      summaryLogsRepository.findLatestSubmittedForOrgReg.mockResolvedValue({
-        id: 'new-submission-id',
-        version: 1,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.SUBMITTED,
-          organisationId,
-          registrationId
-        }
-      })
-
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.CONFLICT)
-      const body = JSON.parse(response.payload)
-      expect(body.message).toBe(
-        'Waste records have changed since preview was generated. Please re-upload.'
-      )
-    })
-
-    it('supersedes stale summary log when preview is stale', async () => {
-      summaryLogsRepository.transitionToSubmittingExclusive.mockResolvedValue({
-        success: true,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.SUBMITTING,
-          organisationId,
-          registrationId,
-          validatedAgainstSummaryLogId: 'old-submission-id'
-        },
-        version: 2
-      })
-
-      summaryLogsRepository.findLatestSubmittedForOrgReg.mockResolvedValue({
-        id: 'new-submission-id',
-        version: 1,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.SUBMITTED,
-          organisationId,
-          registrationId
-        }
-      })
-
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(summaryLogsRepository.update).toHaveBeenCalledWith(
-        summaryLogId,
-        2,
-        { status: SUMMARY_LOG_STATUS.SUPERSEDED, expiresAt: expect.any(Date) }
-      )
-    })
-
-    it('returns 500 when validator submit throws non-Boom error', async () => {
-      const testError = new Error('Unexpected error')
-      summaryLogsWorker.submit.mockRejectedValue(testError)
-
-      // Suppress Hapi debug output for this test
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
-
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      consoleErrorSpy.mockRestore()
-
-      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
-    })
-
-    it('logs error when validator submit throws non-Boom error', async () => {
-      const testError = new Error('Unexpected error')
-      summaryLogsWorker.submit.mockRejectedValue(testError)
-
-      // Suppress Hapi debug output for this test
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
-
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      consoleErrorSpy.mockRestore()
-
-      expect(server.loggerMocks.error).toHaveBeenCalledWith({
-        err: testError,
-        message: `Failure on ${summaryLogsSubmitPath}`,
-        event: {
-          category: LOGGING_EVENT_CATEGORIES.SERVER,
-          action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
-        },
-        http: {
-          response: {
-            status_code: StatusCodes.INTERNAL_SERVER_ERROR
-          }
-        }
-      })
-    })
-  })
-
-  describe('auditing', () => {
-    it('records audit event on successful submit', async () => {
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(mockAuditSummaryLogSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          auth: expect.objectContaining({
-            credentials: expect.objectContaining({
-              linkedOrgId: organisationId
-            })
+    )
+    expect(mockAuditSummaryLogSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          credentials: expect.objectContaining({
+            linkedOrgId: organisationId
           })
-        }),
-        {
-          summaryLogId,
-          organisationId,
-          registrationId
-        }
-      )
+        })
+      }),
+      { summaryLogId, organisationId, registrationId }
+    )
+    expect(mockRecordStatusTransition).toHaveBeenCalledWith({
+      status: SUMMARY_LOG_STATUS.SUBMITTING,
+      processingType: PROCESSING_TYPES.REPROCESSOR_INPUT
     })
-
-    it('does not record audit event when submission is in progress (409)', async () => {
-      summaryLogsRepository.transitionToSubmittingExclusive.mockResolvedValue({
-        success: false
-      })
-
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(mockAuditSummaryLogSubmit).not.toHaveBeenCalled()
-    })
-
-    it('does not record audit event when preview is stale', async () => {
-      summaryLogsRepository.transitionToSubmittingExclusive.mockResolvedValue({
-        success: true,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.SUBMITTING,
-          organisationId,
-          registrationId,
-          validatedAgainstSummaryLogId: 'old-submission-id'
-        },
-        version: 2
-      })
-
-      summaryLogsRepository.findLatestSubmittedForOrgReg.mockResolvedValue({
-        id: 'new-submission-id',
-        version: 1,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.SUBMITTED,
-          organisationId,
-          registrationId
-        }
-      })
-
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(mockAuditSummaryLogSubmit).not.toHaveBeenCalled()
+    expect(server.loggerMocks.info).toHaveBeenCalledWith({
+      message: `Summary log submission initiated: summaryLogId=${summaryLogId}, organisationId=${organisationId}, registrationId=${registrationId}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS,
+        reference: summaryLogId
+      }
     })
   })
 
-  describe('metrics', () => {
-    it('records status transition metric for submitting on successful submit', async () => {
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
+  it('submits when the preview baseline still matches the latest submitted log', async () => {
+    const organisationId = randomUUID()
+    const registrationId = randomUUID()
+    const baselineId = randomUUID()
+    const summaryLogId = randomUUID()
 
-      expect(mockRecordStatusTransition).toHaveBeenCalledWith({
-        status: SUMMARY_LOG_STATUS.SUBMITTING,
-        processingType: PROCESSING_TYPES.REPROCESSOR_INPUT
-      })
+    await seedSubmittedSummaryLog(summaryLogsRepository, baselineId, {
+      organisationId,
+      registrationId
+    })
+    const validated = await seedValidatedSummaryLog(
+      summaryLogsRepository,
+      summaryLogId,
+      {
+        organisationId,
+        registrationId,
+        validatedAgainstSummaryLogId: baselineId
+      }
+    )
+
+    const response = await server.inject({
+      method: 'POST',
+      url: submitUrl(organisationId, registrationId, summaryLogId),
+      ...asStandardUser({ linkedOrgId: organisationId })
     })
 
-    it('records status transition metric for superseded when preview is stale', async () => {
-      summaryLogsRepository.transitionToSubmittingExclusive.mockResolvedValue({
-        success: true,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.SUBMITTING,
-          organisationId,
-          registrationId,
-          validatedAgainstSummaryLogId: 'old-submission-id',
-          meta: {
-            [SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]: PROCESSING_TYPES.EXPORTER
-          }
-        },
-        version: 2
-      })
+    expect(response.statusCode).toBe(StatusCodes.OK)
 
-      summaryLogsRepository.findLatestSubmittedForOrgReg.mockResolvedValue({
-        id: 'new-submission-id',
-        version: 1,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.SUBMITTED,
-          organisationId,
-          registrationId
+    const stored = await waitForVersion(
+      summaryLogsRepository,
+      summaryLogId,
+      validated.version + 1
+    )
+    expect(stored.summaryLog.status).toBe(SUMMARY_LOG_STATUS.SUBMITTING)
+  })
+
+  it('returns 404 when the summary log does not exist', async () => {
+    const organisationId = randomUUID()
+    const registrationId = randomUUID()
+    const summaryLogId = randomUUID()
+
+    const response = await server.inject({
+      method: 'POST',
+      url: submitUrl(organisationId, registrationId, summaryLogId),
+      ...asStandardUser({ linkedOrgId: organisationId })
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    expect(JSON.parse(response.payload).message).toBe(
+      `Summary log with id ${summaryLogId} not found`
+    )
+  })
+
+  it('returns 409 and leaves the log untouched when it is not yet validated', async () => {
+    const organisationId = randomUUID()
+    const registrationId = randomUUID()
+    const summaryLogId = randomUUID()
+
+    await seedValidatingSummaryLog(summaryLogsRepository, summaryLogId, {
+      organisationId,
+      registrationId
+    })
+
+    const response = await server.inject({
+      method: 'POST',
+      url: submitUrl(organisationId, registrationId, summaryLogId),
+      ...asStandardUser({ linkedOrgId: organisationId })
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+    expect(JSON.parse(response.payload).message).toBe(
+      `Summary log must be validated before submission. Current status: ${SUMMARY_LOG_STATUS.VALIDATING}`
+    )
+
+    const stored = await summaryLogsRepository.findById(summaryLogId)
+    expect(stored.summaryLog.status).toBe(SUMMARY_LOG_STATUS.VALIDATING)
+  })
+
+  it('returns 409 without auditing or recording a metric when another submission is in progress', async () => {
+    const organisationId = randomUUID()
+    const registrationId = randomUUID()
+    const inProgressId = randomUUID()
+    const summaryLogId = randomUUID()
+
+    await seedValidatedSummaryLog(summaryLogsRepository, inProgressId, {
+      organisationId,
+      registrationId
+    })
+    await summaryLogsRepository.transitionToSubmittingExclusive(inProgressId)
+
+    await seedValidatedSummaryLog(summaryLogsRepository, summaryLogId, {
+      organisationId,
+      registrationId
+    })
+
+    const response = await server.inject({
+      method: 'POST',
+      url: submitUrl(organisationId, registrationId, summaryLogId),
+      ...asStandardUser({ linkedOrgId: organisationId })
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+    expect(JSON.parse(response.payload).message).toBe(
+      'Another submission is in progress. Please try again.'
+    )
+
+    const stored = await summaryLogsRepository.findById(summaryLogId)
+    expect(stored.summaryLog.status).toBe(SUMMARY_LOG_STATUS.VALIDATED)
+
+    expect(mockAuditSummaryLogSubmit).not.toHaveBeenCalled()
+    expect(mockRecordStatusTransition).not.toHaveBeenCalled()
+  })
+
+  it('supersedes the log and returns 409 when the preview is stale', async () => {
+    const organisationId = randomUUID()
+    const registrationId = randomUUID()
+    const newerSubmittedId = randomUUID()
+    const staleBaselineId = randomUUID()
+    const summaryLogId = randomUUID()
+
+    await seedSubmittedSummaryLog(summaryLogsRepository, newerSubmittedId, {
+      organisationId,
+      registrationId
+    })
+    const validated = await seedValidatedSummaryLog(
+      summaryLogsRepository,
+      summaryLogId,
+      {
+        organisationId,
+        registrationId,
+        validatedAgainstSummaryLogId: staleBaselineId,
+        meta: {
+          [SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]: PROCESSING_TYPES.EXPORTER
         }
-      })
+      }
+    )
 
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-
-      expect(mockRecordStatusTransition).toHaveBeenCalledWith({
-        status: SUMMARY_LOG_STATUS.SUPERSEDED,
-        processingType: PROCESSING_TYPES.EXPORTER
-      })
+    const response = await server.inject({
+      method: 'POST',
+      url: submitUrl(organisationId, registrationId, summaryLogId),
+      ...asStandardUser({ linkedOrgId: organisationId })
     })
 
-    it('does not record submitting metric when another submission is in progress', async () => {
-      summaryLogsRepository.transitionToSubmittingExclusive.mockResolvedValue({
-        success: false
-      })
+    expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+    expect(JSON.parse(response.payload).message).toBe(
+      'Waste records have changed since preview was generated. Please re-upload.'
+    )
 
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/submit`,
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
+    const stored = await waitForVersion(
+      summaryLogsRepository,
+      summaryLogId,
+      validated.version + 2
+    )
+    expect(stored.summaryLog.status).toBe(SUMMARY_LOG_STATUS.SUPERSEDED)
+    expect(stored.summaryLog.expiresAt).toBeInstanceOf(Date)
 
-      expect(mockRecordStatusTransition).not.toHaveBeenCalled()
+    expect(mockRecordStatusTransition).toHaveBeenCalledWith({
+      status: SUMMARY_LOG_STATUS.SUPERSEDED,
+      processingType: PROCESSING_TYPES.EXPORTER
+    })
+    expect(mockAuditSummaryLogSubmit).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 and logs the failure when the submission worker throws a non-Boom error', async () => {
+    const organisationId = randomUUID()
+    const registrationId = randomUUID()
+    const summaryLogId = randomUUID()
+
+    await seedValidatedSummaryLog(summaryLogsRepository, summaryLogId, {
+      organisationId,
+      registrationId
+    })
+
+    const testError = new Error('Unexpected error')
+    summaryLogsWorker.submit.mockRejectedValue(testError)
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    const response = await server.inject({
+      method: 'POST',
+      url: submitUrl(organisationId, registrationId, summaryLogId),
+      ...asStandardUser({ linkedOrgId: organisationId })
+    })
+
+    consoleErrorSpy.mockRestore()
+
+    expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+    expect(server.loggerMocks.error).toHaveBeenCalledWith({
+      err: testError,
+      message: `Failure on ${summaryLogsSubmitPath}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE
+      },
+      http: {
+        response: {
+          status_code: StatusCodes.INTERNAL_SERVER_ERROR
+        }
+      }
     })
   })
 })

--- a/src/routes/v1/organisations/registrations/summary-logs/upload-completed/post.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/upload-completed/post.test.js
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto'
+
 import { StatusCodes } from 'http-status-codes'
 
 import {
@@ -6,7 +8,9 @@ import {
   UPLOAD_STATUS
 } from '#domain/summary-logs/status.js'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
+import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
+import { createMockLogger } from '#test/mock-logger.js'
 import { createTestServer } from '#test/create-test-server.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 
@@ -19,8 +23,6 @@ vi.mock('#common/helpers/metrics/summary-logs.js', () => ({
     recordStatusTransition: (...args) => mockRecordStatusTransition(...args)
   }
 }))
-
-const summaryLogId = 'summary-log-123'
 
 const organisationId = 'org-123'
 const registrationId = 'reg-456'
@@ -113,25 +115,21 @@ const createCompletePayload = (
     orgId
   )
 
+const uploadCompletedUrl = (summaryLogId) =>
+  `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`
+
 describe(`${summaryLogsUploadCompletedPath} route`, () => {
   // Mock OIDC servers are needed for server startup (auth plugin fetches configs)
-  // but we inject credentials directly so don't need tokens or org setup
+  // but the route itself is unauthenticated.
   setupAuthContext()
 
   let server
-  let payload
-
   let summaryLogsRepository
   let summaryLogsWorker
 
   beforeAll(async () => {
-    summaryLogsRepository = {
-      insert: vi.fn().mockResolvedValue(undefined),
-      update: vi.fn().mockResolvedValue(undefined),
-      findById: vi.fn().mockResolvedValue(null),
-      findLatestSubmittedForOrgReg: vi.fn().mockResolvedValue(null),
-      updateStatus: vi.fn().mockResolvedValue(undefined)
-    }
+    const summaryLogsRepositoryFactory = createInMemorySummaryLogsRepository()
+    summaryLogsRepository = summaryLogsRepositoryFactory(createMockLogger())
 
     summaryLogsWorker = {
       validate: vi.fn()
@@ -141,35 +139,13 @@ describe(`${summaryLogsUploadCompletedPath} route`, () => {
 
     server = await createTestServer({
       repositories: {
-        summaryLogsRepository: (_logger) => summaryLogsRepository
+        summaryLogsRepository: summaryLogsRepositoryFactory
       },
       workers: {
         summaryLogsWorker
       },
       featureFlags
     })
-  })
-
-  beforeEach(() => {
-    payload = {
-      uploadStatus: 'ready',
-      metadata: {
-        organisationId,
-        registrationId
-      },
-      form: {
-        summaryLogUpload: {
-          fileId,
-          filename,
-          fileStatus,
-          s3Bucket,
-          s3Key
-        }
-      },
-      numberOfRejectedFiles: 0
-    }
-
-    summaryLogsRepository.findById.mockResolvedValue(null)
   })
 
   afterEach(() => {
@@ -185,370 +161,290 @@ describe(`${summaryLogsUploadCompletedPath} route`, () => {
     await server.stop()
   })
 
-  it('should return expected response when uploaded file was accepted', async () => {
-    summaryLogsRepository.findById.mockResolvedValueOnce(null)
-    summaryLogsRepository.findById.mockResolvedValueOnce({
-      version: 1,
-      summaryLog: {
-        status: SUMMARY_LOG_STATUS.VALIDATING,
-        file: {
-          id: fileId,
-          name: filename,
-          status: fileStatus,
-          s3: {
-            bucket: s3Bucket,
-            key: s3Key
-          }
-        }
-      }
-    })
+  it('stores a validating summary log, validates it and records the side-effects when the file is accepted', async () => {
+    const summaryLogId = randomUUID()
 
     const response = await server.inject({
       method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-      payload
+      url: uploadCompletedUrl(summaryLogId),
+      payload: createCompletePayload(fileId)
     })
 
     expect(response.statusCode).toBe(StatusCodes.ACCEPTED)
-  })
 
-  it('should add expected summary log to repository when uploaded file was accepted', async () => {
-    await server.inject({
-      method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-      payload
-    })
-
-    expect(summaryLogsRepository.insert).toHaveBeenCalledWith(summaryLogId, {
+    const stored = await waitForVersion(summaryLogsRepository, summaryLogId, 1)
+    expect(stored.summaryLog).toMatchObject({
       status: SUMMARY_LOG_STATUS.VALIDATING,
-      expiresAt: expect.any(Date),
-      createdAt: expect.any(String),
       organisationId,
       registrationId,
+      validatedAgainstSummaryLogId: NO_PRIOR_SUBMISSION,
       file: {
         id: fileId,
         name: filename,
         status: fileStatus,
         uri: `s3://${s3Bucket}/${s3Key}`
-      },
-      validatedAgainstSummaryLogId: NO_PRIOR_SUBMISSION
+      }
     })
+    expect(stored.summaryLog.createdAt).toEqual(expect.any(String))
+    expect(stored.summaryLog.expiresAt).toBeInstanceOf(Date)
+
+    expect(summaryLogsWorker.validate).toHaveBeenCalledWith(summaryLogId)
+    expect(mockRecordStatusTransition).toHaveBeenCalledWith({
+      status: SUMMARY_LOG_STATUS.VALIDATING
+    })
+    expect(server.loggerMocks.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: `File upload completed: summaryLogId=${summaryLogId}, fileId=${fileId}, filename=${filename}, status=${fileStatus}, s3Bucket=${s3Bucket}, s3Key=${s3Key}`,
+        event: {
+          category: 'server',
+          action: 'request_success',
+          reference: summaryLogId
+        }
+      })
+    )
   })
 
-  it('should add expected summary log to repository with validation when uploaded file was rejected', async () => {
-    payload.form.summaryLogUpload.fileStatus = UPLOAD_STATUS.REJECTED
-    delete payload.form.summaryLogUpload.s3Bucket
-    delete payload.form.summaryLogUpload.s3Key
-    payload.numberOfRejectedFiles = 1
+  it('stores a rejected summary log without validating when the file is rejected', async () => {
+    const summaryLogId = randomUUID()
 
-    await server.inject({
+    const response = await server.inject({
       method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-      payload
+      url: uploadCompletedUrl(summaryLogId),
+      payload: createRejectedPayload('file-rejected-virus')
     })
 
-    expect(summaryLogsRepository.insert).toHaveBeenCalledWith(summaryLogId, {
+    expect(response.statusCode).toBe(StatusCodes.ACCEPTED)
+
+    const stored = await waitForVersion(summaryLogsRepository, summaryLogId, 1)
+    expect(stored.summaryLog).toMatchObject({
       status: SUMMARY_LOG_STATUS.REJECTED,
-      expiresAt: expect.any(Date),
-      createdAt: expect.any(String),
       organisationId,
       registrationId,
       file: {
-        id: fileId,
-        name: filename,
+        id: 'file-rejected-virus',
         status: UPLOAD_STATUS.REJECTED
       },
       validation: {
-        failures: [{ code: 'FILE_REJECTED' }]
+        failures: [{ code: 'FILE_VIRUS_DETECTED' }]
       }
+    })
+    expect(stored.summaryLog.file.uri).toBeUndefined()
+
+    expect(summaryLogsWorker.validate).not.toHaveBeenCalled()
+    expect(mockRecordStatusTransition).toHaveBeenCalledWith({
+      status: SUMMARY_LOG_STATUS.REJECTED
+    })
+    expect(server.loggerMocks.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: `File upload completed: summaryLogId=${summaryLogId}, fileId=file-rejected-virus, filename=virus.xlsx, status=${UPLOAD_STATUS.REJECTED}`,
+        event: {
+          category: 'server',
+          action: 'request_success',
+          reference: summaryLogId
+        }
+      })
+    )
+  })
+
+  it('maps the uploader error message to a validation code on the stored rejection', async () => {
+    const summaryLogId = randomUUID()
+
+    const payload = createRejectedPayload('file-rejected-empty')
+    payload.form.summaryLogUpload.errorMessage = 'The selected file is empty'
+
+    await server.inject({
+      method: 'POST',
+      url: uploadCompletedUrl(summaryLogId),
+      payload
+    })
+
+    const stored = await waitForVersion(summaryLogsRepository, summaryLogId, 1)
+    expect(stored.summaryLog.validation).toEqual({
+      failures: [{ code: 'FILE_EMPTY' }]
     })
   })
 
-  it('should invoke validation as expected when uploaded file was accepted', async () => {
-    summaryLogsRepository.findById.mockResolvedValueOnce(null)
-    summaryLogsRepository.findById.mockResolvedValueOnce({
-      version: 1,
-      summaryLog: {
+  it('stores a preprocessing summary log without validating when the file is still pending', async () => {
+    const summaryLogId = randomUUID()
+
+    const response = await server.inject({
+      method: 'POST',
+      url: uploadCompletedUrl(summaryLogId),
+      payload: createPendingPayload('file-pending-scan')
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.ACCEPTED)
+
+    const stored = await waitForVersion(summaryLogsRepository, summaryLogId, 1)
+    expect(stored.summaryLog).toMatchObject({
+      status: SUMMARY_LOG_STATUS.PREPROCESSING,
+      organisationId,
+      registrationId,
+      file: {
+        id: 'file-pending-scan',
+        status: UPLOAD_STATUS.PENDING
+      }
+    })
+    expect(stored.summaryLog).not.toHaveProperty('validatedAgainstSummaryLogId')
+
+    expect(summaryLogsWorker.validate).not.toHaveBeenCalled()
+    expect(mockRecordStatusTransition).toHaveBeenCalledWith({
+      status: SUMMARY_LOG_STATUS.PREPROCESSING
+    })
+  })
+
+  describe('payload validation', () => {
+    it('returns 400 if payload is not an object', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(randomUUID()),
+        payload: 'not-an-object'
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+      const body = JSON.parse(response.payload)
+      expect(body.message).toMatch(/Invalid request payload JSON format/)
+    })
+
+    it('returns 422 if payload is null', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(randomUUID()),
+        payload: null
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+    })
+
+    it('returns 422 if payload is missing form.summaryLogUpload', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(randomUUID()),
+        payload: {
+          uploadStatus: 'ready'
+        }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      const body = JSON.parse(response.payload)
+      expect(body.message).toContain('"form" is required')
+    })
+
+    it('returns 422 when file is complete but missing S3 info', async () => {
+      const payload = createCompletePayload(fileId)
+      delete payload.form.summaryLogUpload.s3Bucket
+      delete payload.form.summaryLogUpload.s3Key
+
+      const response = await server.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(randomUUID()),
+        payload
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      const body = JSON.parse(response.payload)
+      expect(body.message).toContain('s3Bucket')
+    })
+  })
+
+  describe('state transitions', () => {
+    it('allows preprocessing -> preprocessing when receiving multiple pending callbacks', async () => {
+      const summaryLogId = randomUUID()
+
+      const firstResponse = await server.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(summaryLogId),
+        payload: createPendingPayload('file-pending-456')
+      })
+
+      expect(firstResponse.statusCode).toBe(StatusCodes.ACCEPTED)
+
+      const secondResponse = await server.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(summaryLogId),
+        payload: createPendingPayload('file-pending-456')
+      })
+
+      expect(secondResponse.statusCode).toBe(StatusCodes.ACCEPTED)
+
+      const stored = await waitForVersion(
+        summaryLogsRepository,
+        summaryLogId,
+        2
+      )
+      expect(stored.summaryLog.status).toBe(SUMMARY_LOG_STATUS.PREPROCESSING)
+    })
+
+    it('allows preprocessing -> validating, carrying the file through the transition', async () => {
+      const summaryLogId = randomUUID()
+
+      await server.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(summaryLogId),
+        payload: createPendingPayload('file-pending-101')
+      })
+
+      const secondResponse = await server.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(summaryLogId),
+        payload: createCompletePayload('file-complete-101')
+      })
+
+      expect(secondResponse.statusCode).toBe(StatusCodes.ACCEPTED)
+
+      const stored = await waitForVersion(
+        summaryLogsRepository,
+        summaryLogId,
+        2
+      )
+      expect(stored.summaryLog).toMatchObject({
         status: SUMMARY_LOG_STATUS.VALIDATING,
         file: {
-          id: fileId,
-          name: filename,
+          id: 'file-complete-101',
           status: fileStatus,
-          s3: {
-            bucket: s3Bucket,
-            key: s3Key
-          }
-        }
-      }
-    })
-
-    await server.inject({
-      method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-      payload
-    })
-
-    expect(summaryLogsWorker.validate).toHaveBeenCalledWith(summaryLogId)
-  })
-
-  it('should not invoke validation when uploaded file is still pending', async () => {
-    payload.form.summaryLogUpload.fileStatus = UPLOAD_STATUS.PENDING
-    delete payload.form.summaryLogUpload.s3Bucket
-    delete payload.form.summaryLogUpload.s3Key
-
-    await server.inject({
-      method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-      payload
-    })
-
-    expect(summaryLogsWorker.validate).not.toHaveBeenCalled()
-  })
-
-  it('should not invoke validation when uploaded file was rejected', async () => {
-    payload.form.summaryLogUpload.fileStatus = UPLOAD_STATUS.REJECTED
-    delete payload.form.summaryLogUpload.s3Bucket
-    delete payload.form.summaryLogUpload.s3Key
-    payload.numberOfRejectedFiles = 1
-
-    await server.inject({
-      method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-      payload
-    })
-
-    expect(summaryLogsWorker.validate).not.toHaveBeenCalled()
-  })
-
-  it('returns 400 if payload is not an object', async () => {
-    const response = await server.inject({
-      method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-      payload: 'not-an-object'
-    })
-
-    expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
-    const body = JSON.parse(response.payload)
-    expect(body.message).toMatch(/Invalid request payload JSON format/)
-  })
-
-  it('returns 422 if payload is null', async () => {
-    const response = await server.inject({
-      method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-      payload: null
-    })
-
-    expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
-  })
-
-  it('returns 422 if payload is missing form.summaryLogUpload', async () => {
-    const response = await server.inject({
-      method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-      payload: {
-        uploadStatus: 'ready'
-      }
-    })
-
-    expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
-    const body = JSON.parse(response.payload)
-    expect(body.message).toContain('"form" is required')
-  })
-
-  it('returns 422 when file is complete but missing S3 info', async () => {
-    delete payload.form.summaryLogUpload.s3Bucket
-    delete payload.form.summaryLogUpload.s3Key
-
-    const response = await server.inject({
-      method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-      payload
-    })
-
-    expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
-    const body = JSON.parse(response.payload)
-    expect(body.message).toContain('s3Bucket')
-  })
-
-  it('returns 202 when file is rejected without S3 info', async () => {
-    payload.form.summaryLogUpload.fileStatus = UPLOAD_STATUS.REJECTED
-    delete payload.form.summaryLogUpload.s3Bucket
-    delete payload.form.summaryLogUpload.s3Key
-    payload.numberOfRejectedFiles = 1
-
-    const response = await server.inject({
-      method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-      payload
-    })
-
-    expect(response.statusCode).toBe(StatusCodes.ACCEPTED)
-  })
-
-  it('returns 202 when file is pending without S3 info', async () => {
-    payload.form.summaryLogUpload.fileStatus = UPLOAD_STATUS.PENDING
-    delete payload.form.summaryLogUpload.s3Bucket
-    delete payload.form.summaryLogUpload.s3Key
-
-    const response = await server.inject({
-      method: 'POST',
-      url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/pending-${summaryLogId}/upload-completed`,
-      payload
-    })
-
-    expect(response.statusCode).toBe(StatusCodes.ACCEPTED)
-  })
-
-  describe('logging', () => {
-    it('should log as expected when uploaded file was accepted', async () => {
-      summaryLogsRepository.findById.mockResolvedValueOnce(null)
-      summaryLogsRepository.findById.mockResolvedValueOnce({
-        version: 1,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.VALIDATING,
-          file: {
-            id: fileId,
-            name: filename,
-            status: fileStatus,
-            s3: {
-              bucket: s3Bucket,
-              key: s3Key
-            }
-          }
+          uri: 's3://test-bucket/test-key'
         }
       })
+    })
+
+    it('allows preprocessing -> rejected transition', async () => {
+      const summaryLogId = randomUUID()
 
       await server.inject({
         method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-        payload
+        url: uploadCompletedUrl(summaryLogId),
+        payload: createPendingPayload('file-pending-789')
       })
 
-      expect(server.loggerMocks.info).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: `File upload completed: summaryLogId=${summaryLogId}, fileId=${fileId}, filename=${filename}, status=${fileStatus}, s3Bucket=${s3Bucket}, s3Key=${s3Key}`,
-          event: {
-            category: 'server',
-            action: 'request_success',
-            reference: summaryLogId
-          }
-        })
+      const secondResponse = await server.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(summaryLogId),
+        payload: createRejectedPayload('file-rejected-789')
+      })
+
+      expect(secondResponse.statusCode).toBe(StatusCodes.ACCEPTED)
+
+      const stored = await waitForVersion(
+        summaryLogsRepository,
+        summaryLogId,
+        2
       )
+      expect(stored.summaryLog.status).toBe(SUMMARY_LOG_STATUS.REJECTED)
     })
 
-    it('should log as expected when uploaded file was rejected', async () => {
-      payload.form.summaryLogUpload.fileStatus = UPLOAD_STATUS.REJECTED
-      delete payload.form.summaryLogUpload.s3Bucket
-      delete payload.form.summaryLogUpload.s3Key
-      payload.numberOfRejectedFiles = 1
+    it('rejects validating -> preprocessing transition with a conflict and an error log', async () => {
+      const summaryLogId = randomUUID()
 
       await server.inject({
         method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-        payload
+        url: uploadCompletedUrl(summaryLogId),
+        payload: createCompletePayload('file-complete-202')
       })
-
-      expect(server.loggerMocks.info).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: `File upload completed: summaryLogId=${summaryLogId}, fileId=${fileId}, filename=${filename}, status=${UPLOAD_STATUS.REJECTED}`,
-          event: {
-            category: 'server',
-            action: 'request_success',
-            reference: summaryLogId
-          }
-        })
-      )
-    })
-
-    it('should log as expected when uploaded file was rejected with a specific error message', async () => {
-      payload.form.summaryLogUpload.fileStatus = UPLOAD_STATUS.REJECTED
-      payload.form.summaryLogUpload.errorMessage = 'The selected file is empty'
-      delete payload.form.summaryLogUpload.s3Bucket
-      delete payload.form.summaryLogUpload.s3Key
-      payload.numberOfRejectedFiles = 1
-
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-        payload
-      })
-
-      expect(summaryLogsRepository.insert).toHaveBeenCalledWith(summaryLogId, {
-        status: SUMMARY_LOG_STATUS.REJECTED,
-        expiresAt: expect.any(Date),
-        createdAt: expect.any(String),
-        organisationId,
-        registrationId,
-        file: {
-          id: fileId,
-          name: filename,
-          status: UPLOAD_STATUS.REJECTED
-        },
-        validation: {
-          failures: [{ code: 'FILE_EMPTY' }]
-        }
-      })
-    })
-
-    it('should log as expected when repository insert fails', async () => {
-      const testError = new Error('Database connection failed')
-      summaryLogsRepository.insert.mockRejectedValue(testError)
-
-      // Suppress Hapi debug output for this test
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
 
       const response = await server.inject({
         method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-        payload
-      })
-
-      consoleErrorSpy.mockRestore()
-
-      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
-      expect(server.loggerMocks.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          err: testError,
-          message: `Failure on ${summaryLogsUploadCompletedPath}`,
-          event: {
-            category: 'server',
-            action: 'response_failure'
-          },
-          http: {
-            response: {
-              status_code: StatusCodes.INTERNAL_SERVER_ERROR
-            }
-          }
-        })
-      )
-    })
-
-    it('should log an error when a state transition conflict is detected', async () => {
-      summaryLogsRepository.findById.mockResolvedValue({
-        version: 1,
-        summaryLog: {
-          status: SUMMARY_LOG_STATUS.VALIDATING,
-          file: {
-            id: 'existing-file-123',
-            name: 'existing.xlsx',
-            status: 'complete',
-            s3: {
-              bucket: 'existing-bucket',
-              key: 'existing-key'
-            }
-          }
-        }
-      })
-
-      payload.form.summaryLogUpload.fileStatus = UPLOAD_STATUS.PENDING
-
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-        payload
+        url: uploadCompletedUrl(summaryLogId),
+        payload: createPendingPayload('file-pending-202')
       })
 
       expect(response.statusCode).toBe(StatusCodes.CONFLICT)
@@ -567,181 +463,96 @@ describe(`${summaryLogsUploadCompletedPath} route`, () => {
           }
         })
       )
+
+      const stored = await summaryLogsRepository.findById(summaryLogId)
+      expect(stored.summaryLog.status).toBe(SUMMARY_LOG_STATUS.VALIDATING)
+    })
+
+    it('rejects rejected -> validating transition with a conflict', async () => {
+      const summaryLogId = randomUUID()
+
+      await server.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(summaryLogId),
+        payload: createRejectedPayload('file-rejected-505')
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(summaryLogId),
+        payload: createCompletePayload('file-complete-505')
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+
+      const stored = await summaryLogsRepository.findById(summaryLogId)
+      expect(stored.summaryLog.status).toBe(SUMMARY_LOG_STATUS.REJECTED)
     })
   })
 
-  describe('metrics', () => {
-    it('should record status transition metric when file upload completes with validating status', async () => {
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-        payload
-      })
-
-      expect(mockRecordStatusTransition).toHaveBeenCalledWith({
-        status: SUMMARY_LOG_STATUS.VALIDATING
-      })
-    })
-
-    it('should record status transition metric when file upload completes with rejected status', async () => {
-      payload.form.summaryLogUpload.fileStatus = UPLOAD_STATUS.REJECTED
-      delete payload.form.summaryLogUpload.s3Bucket
-      delete payload.form.summaryLogUpload.s3Key
-      payload.numberOfRejectedFiles = 1
-
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}/upload-completed`,
-        payload
-      })
-
-      expect(mockRecordStatusTransition).toHaveBeenCalledWith({
-        status: SUMMARY_LOG_STATUS.REJECTED
-      })
-    })
-
-    it('should record status transition metric when file upload completes with preprocessing status', async () => {
-      payload.form.summaryLogUpload.fileStatus = UPLOAD_STATUS.PENDING
-      delete payload.form.summaryLogUpload.s3Bucket
-      delete payload.form.summaryLogUpload.s3Key
-
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/pending-${summaryLogId}/upload-completed`,
-        payload
-      })
-
-      expect(mockRecordStatusTransition).toHaveBeenCalledWith({
-        status: SUMMARY_LOG_STATUS.PREPROCESSING
-      })
-    })
-  })
-
-  describe('state transitions', () => {
-    let transitionServer
+  describe('when the repository fails unexpectedly', () => {
+    let failingServer
+    const insertError = new Error('Database connection failed')
 
     beforeAll(async () => {
-      const transitionValidator = {
-        validate: vi.fn()
-      }
-
       const featureFlags = createInMemoryFeatureFlags()
 
-      transitionServer = await createTestServer({
+      failingServer = await createTestServer({
         repositories: {
-          summaryLogsRepository: createInMemorySummaryLogsRepository()
+          summaryLogsRepository: () => ({
+            findById: async () => null,
+            findLatestSubmittedForOrgReg: async () => null,
+            insert: async () => {
+              throw insertError
+            }
+          })
         },
         workers: {
-          summaryLogsWorker: transitionValidator
+          summaryLogsWorker: { validate: vi.fn() }
         },
         featureFlags
       })
+    })
 
-      await transitionServer.initialize()
+    afterEach(() => {
+      failingServer.loggerMocks.error.mockClear()
     })
 
     afterAll(async () => {
-      await transitionServer.stop()
+      await failingServer.stop()
     })
 
-    describe('valid transitions (representative samples - exhaustive tests in domain layer)', () => {
-      it('allows preprocessing -> preprocessing when receiving multiple pending callbacks', async () => {
-        const summaryLogId = 'multi-pending-log-123'
+    it('returns 500 and logs the failure', async () => {
+      const summaryLogId = randomUUID()
 
-        const firstResponse = await transitionServer.inject({
-          method: 'POST',
-          url: `/v1/organisations/${organisationId}/registrations/reg-456/summary-logs/${summaryLogId}/upload-completed`,
-          payload: createPendingPayload('file-pending-456')
-        })
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
 
-        expect(firstResponse.statusCode).toBe(StatusCodes.ACCEPTED)
-
-        const secondResponse = await transitionServer.inject({
-          method: 'POST',
-          url: `/v1/organisations/${organisationId}/registrations/reg-456/summary-logs/${summaryLogId}/upload-completed`,
-          payload: createPendingPayload('file-pending-456')
-        })
-
-        expect(secondResponse.statusCode).toBe(StatusCodes.ACCEPTED)
+      const response = await failingServer.inject({
+        method: 'POST',
+        url: uploadCompletedUrl(summaryLogId),
+        payload: createCompletePayload(fileId)
       })
 
-      it('allows preprocessing -> rejected transition', async () => {
-        const summaryLogId = 'preprocessing-to-rejected-123'
+      consoleErrorSpy.mockRestore()
 
-        const firstResponse = await transitionServer.inject({
-          method: 'POST',
-          url: `/v1/organisations/${organisationId}/registrations/reg-456/summary-logs/${summaryLogId}/upload-completed`,
-          payload: createPendingPayload('file-pending-789')
+      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(failingServer.loggerMocks.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: insertError,
+          message: `Failure on ${summaryLogsUploadCompletedPath}`,
+          event: {
+            category: 'server',
+            action: 'response_failure'
+          },
+          http: {
+            response: {
+              status_code: StatusCodes.INTERNAL_SERVER_ERROR
+            }
+          }
         })
-
-        expect(firstResponse.statusCode).toBe(StatusCodes.ACCEPTED)
-
-        const secondResponse = await transitionServer.inject({
-          method: 'POST',
-          url: `/v1/organisations/${organisationId}/registrations/reg-456/summary-logs/${summaryLogId}/upload-completed`,
-          payload: createRejectedPayload('file-rejected-789')
-        })
-
-        expect(secondResponse.statusCode).toBe(StatusCodes.ACCEPTED)
-      })
-
-      it('allows preprocessing -> validating transition', async () => {
-        const summaryLogId = 'preprocessing-to-validating-123'
-
-        const firstResponse = await transitionServer.inject({
-          method: 'POST',
-          url: `/v1/organisations/${organisationId}/registrations/reg-456/summary-logs/${summaryLogId}/upload-completed`,
-          payload: createPendingPayload('file-pending-101')
-        })
-
-        expect(firstResponse.statusCode).toBe(StatusCodes.ACCEPTED)
-
-        const secondResponse = await transitionServer.inject({
-          method: 'POST',
-          url: `/v1/organisations/${organisationId}/registrations/reg-456/summary-logs/${summaryLogId}/upload-completed`,
-          payload: createCompletePayload('file-complete-101')
-        })
-
-        expect(secondResponse.statusCode).toBe(StatusCodes.ACCEPTED)
-      })
-    })
-
-    describe('invalid transitions (representative samples - exhaustive tests in domain layer)', () => {
-      it('rejects validating -> preprocessing transition', async () => {
-        const summaryLogId = 'validating-to-preprocessing-123'
-
-        await transitionServer.inject({
-          method: 'POST',
-          url: `/v1/organisations/${organisationId}/registrations/reg-456/summary-logs/${summaryLogId}/upload-completed`,
-          payload: createCompletePayload('file-complete-202')
-        })
-
-        const response = await transitionServer.inject({
-          method: 'POST',
-          url: `/v1/organisations/${organisationId}/registrations/reg-456/summary-logs/${summaryLogId}/upload-completed`,
-          payload: createPendingPayload('file-pending-202')
-        })
-
-        expect(response.statusCode).toBe(StatusCodes.CONFLICT)
-      })
-
-      it('rejects rejected -> validating transition', async () => {
-        const summaryLogId = 'rejected-to-validating-123'
-
-        await transitionServer.inject({
-          method: 'POST',
-          url: `/v1/organisations/${organisationId}/registrations/reg-456/summary-logs/${summaryLogId}/upload-completed`,
-          payload: createRejectedPayload('file-rejected-505')
-        })
-
-        const response = await transitionServer.inject({
-          method: 'POST',
-          url: `/v1/organisations/${organisationId}/registrations/reg-456/summary-logs/${summaryLogId}/upload-completed`,
-          payload: createCompletePayload('file-complete-505')
-        })
-
-        expect(response.statusCode).toBe(StatusCodes.CONFLICT)
-      })
+      )
     })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1542](https://eaflood.atlassian.net/browse/PAE-1542)
The two summary-logs route test suites — `submit` and `upload-completed` — previously stubbed the summary-logs repository with `vi.fn()` and asserted on how the handler called it (`expect(repo.insert).toHaveBeenCalledWith(...)`). Those assertions pin the tests to the handler's interaction with the repository rather than to the behaviour that matters: after the request, the stored summary log is retrievable with the right data in the right state.

Both suites now run against the real in-memory summary-logs adapter (`createInMemorySummaryLogsRepository`). Each test seeds state, makes the request, then reads the document back from the repository to assert on the persisted result. To set up states the insert schema forbids seeding directly (`validatedAgainstSummaryLogId` is forbidden outside `validating`), the tests drive the real state machine — insert as `validating`, then transition — rather than fabricating documents the schema would reject. The `upload-completed` suite extends its existing in-memory `state transitions` block so the whole file shares one approach.

Collaborators with no in-memory equivalent stay mocked: the logger, metrics, auditing, the submission/validation worker, and the unexpected-repository-failure path (which the in-memory adapter, throwing only Boom errors, cannot reproduce).

This is part of replacing `vi.fn()` repository stubs across the epr-backend test suite with the real in-memory adapters and asserting on observable persisted state.


[PAE-1542]: https://eaflood.atlassian.net/browse/PAE-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ