### PR TITLE
PAE-1541: Classify loads by reporting period status

### DIFF
--- a/src/application/summary-logs/classify-and-persist.js
+++ b/src/application/summary-logs/classify-and-persist.js
@@ -24,7 +24,7 @@ import {
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 /** @typedef {import('./load-counts.js').Loads} Loads */
-/** @typedef {import('./period-status.js').LoadsByPeriodStatus} LoadsByPeriodStatus */
+/** @typedef {import('./period-status.js').LoadsByReportingPeriod} LoadsByReportingPeriod */
 /** @typedef {string} ProcessingType */
 /** @typedef {import('#reports/repository/port.js').ReportsRepository} ReportsRepository */
 
@@ -53,7 +53,7 @@ export const filterWasteBalanceRecords = (wasteRecords, processingType) =>
  * @param {import('#reports/repository/port.js').PeriodicReport[]} params.periodicReports
  * @param {Registration} [params.registration]
  * @param {Map<string, WasteRecord>} [params.existingRecordsMap]
- * @returns {{ loads: Loads | null, loadsByWasteRecordType: import('./load-counts.js').LoadsByWasteRecordType | null, loadsByPeriodStatus: LoadsByPeriodStatus | null }}
+ * @returns {{ loads: Loads | null, loadsByWasteRecordType: import('./load-counts.js').LoadsByWasteRecordType | null, loadsByReportingPeriod: LoadsByReportingPeriod | null }}
  */
 export const classifyLoads = ({
   processingType,
@@ -69,7 +69,7 @@ export const classifyLoads = ({
     return {
       loads: null,
       loadsByWasteRecordType: null,
-      loadsByPeriodStatus: null
+      loadsByReportingPeriod: null
     }
   }
 
@@ -91,7 +91,7 @@ export const classifyLoads = ({
   })
 
   /* v8 ignore start -- defensive guard: all three are always set when status is VALIDATED */
-  const loadsByPeriodStatus =
+  const loadsByReportingPeriod =
     registration && existingRecordsMap && tableSchemas
       ? classifyByPeriodStatus({
           wasteRecords,
@@ -110,7 +110,7 @@ export const classifyLoads = ({
       : null
   /* v8 ignore stop */
 
-  return { loads, loadsByWasteRecordType, loadsByPeriodStatus }
+  return { loads, loadsByWasteRecordType, loadsByReportingPeriod }
 }
 
 /**

--- a/src/application/summary-logs/classify-and-persist.js
+++ b/src/application/summary-logs/classify-and-persist.js
@@ -1,0 +1,154 @@
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/index.js'
+import { isNil } from '#common/helpers/is-nil.js'
+import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
+import {
+  findSchemaForProcessingType,
+  PROCESSING_TYPE_TABLES
+} from '#domain/summary-logs/table-schemas/index.js'
+import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
+import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
+import { classifyByPeriodStatus } from './period-status.js'
+import {
+  countByValidity,
+  countByWasteBalanceInclusion,
+  countByWasteRecordType,
+  mergeLoads
+} from './load-counts.js'
+
+/** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
+/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {WasteRecord} from '#domain/waste-records/model.js' */
+/** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
+/** @typedef {import('./load-counts.js').Loads} Loads */
+/** @typedef {import('./period-status.js').LoadsByPeriodStatus} LoadsByPeriodStatus */
+/** @typedef {string} ProcessingType */
+/** @typedef {import('#reports/repository/port.js').ReportsRepository} ReportsRepository */
+
+/**
+ * Filters waste records to only those from tables that participate in waste balance.
+ *
+ * @param {ValidatedWasteRecord[] | null} wasteRecords
+ * @param {string} processingType
+ * @returns {ValidatedWasteRecord[]}
+ */
+export const filterWasteBalanceRecords = (wasteRecords, processingType) =>
+  wasteRecords?.filter((wr) => {
+    const schema = findSchemaForProcessingType(processingType, wr.record.type)
+    return !isNil(schema?.classifyForWasteBalance)
+  }) ?? []
+
+/**
+ * Computes all load classifications for validated summary logs.
+ *
+ * @param {Object} params
+ * @param {string} params.status - Summary log status after validation
+ * @param {ValidatedWasteRecord[] | null} params.wasteRecords - All waste records
+ * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords - Waste-balance-eligible records
+ * @param {string} params.summaryLogId
+ * @param {ProcessingType} params.processingType
+ * @param {import('#reports/repository/port.js').PeriodicReport[]} params.periodicReports
+ * @param {Registration} [params.registration]
+ * @param {Map<string, WasteRecord>} [params.existingRecordsMap]
+ * @returns {{ loads: Loads | null, loadsByWasteRecordType: import('./load-counts.js').LoadsByWasteRecordType | null, loadsByPeriodStatus: LoadsByPeriodStatus | null }}
+ */
+export const classifyLoads = ({
+  processingType,
+  status,
+  summaryLogId,
+  wasteBalanceRecords,
+  wasteRecords,
+  periodicReports,
+  registration,
+  existingRecordsMap
+}) => {
+  if (status !== SUMMARY_LOG_STATUS.VALIDATED || !wasteRecords) {
+    return {
+      loads: null,
+      loadsByWasteRecordType: null,
+      loadsByPeriodStatus: null
+    }
+  }
+
+  const loads = mergeLoads(
+    countByValidity({ wasteRecords, summaryLogId }),
+    countByWasteBalanceInclusion({
+      wasteRecords: wasteBalanceRecords,
+      summaryLogId
+    })
+  )
+
+  const tableSchemas = PROCESSING_TYPE_TABLES[processingType]
+
+  const loadsByWasteRecordType = countByWasteRecordType({
+    wasteRecords,
+    wasteBalanceRecords,
+    summaryLogId,
+    tableSchemas
+  })
+
+  /* v8 ignore start -- defensive guard: all three are always set when status is VALIDATED */
+  const loadsByPeriodStatus =
+    registration && existingRecordsMap && tableSchemas
+      ? classifyByPeriodStatus({
+          wasteRecords,
+          existingRecordsMap,
+          periodicReports,
+          cadence: isRegistrationAccredited(registration)
+            ? 'monthly'
+            : 'quarterly',
+          summaryLogId,
+          tableSchemas,
+          classificationContext: {
+            accreditation: registration.accreditation ?? null,
+            overseasSites: ORS_VALIDATION_DISABLED
+          }
+        })
+      : null
+  /* v8 ignore stop */
+
+  return { loads, loadsByWasteRecordType, loadsByPeriodStatus }
+}
+
+/**
+ * Fetches periodic reports for the validated summary log, swallowing errors.
+ *
+ * @param {Object} params
+ * @param {Registration} [params.registration]
+ * @param {string} params.status
+ * @param {SubmittedSummaryLog} params.summaryLog
+ * @param {ReportsRepository} params.reportsRepository
+ * @param {string} params.loggingContext
+ * @param {TypedLogger} params.logger
+ * @returns {Promise<import('#reports/repository/port.js').PeriodicReport[]>}
+ */
+export const fetchPeriodicReportsSafe = async ({
+  registration,
+  status,
+  summaryLog,
+  reportsRepository,
+  loggingContext,
+  logger
+}) => {
+  try {
+    if (registration && status === SUMMARY_LOG_STATUS.VALIDATED) {
+      return await reportsRepository.findPeriodicReports({
+        organisationId: summaryLog.organisationId,
+        registrationId: summaryLog.registrationId
+      })
+    }
+  } catch (err) {
+    logger.warn({
+      message: `Failed to fetch periodic reports: ${loggingContext}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
+      },
+      err
+    })
+  }
+  return []
+}

--- a/src/application/summary-logs/classify-and-persist.js
+++ b/src/application/summary-logs/classify-and-persist.js
@@ -10,6 +10,7 @@ import {
 } from '#domain/summary-logs/table-schemas/index.js'
 import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
 import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
+import { CADENCE } from '#reports/domain/cadence.js'
 import { classifyByPeriodStatus } from './period-status.js'
 import {
   countByValidity,
@@ -98,8 +99,8 @@ export const classifyLoads = ({
           existingRecordsMap,
           periodicReports,
           cadence: isRegistrationAccredited(registration)
-            ? 'monthly'
-            : 'quarterly',
+            ? CADENCE.monthly
+            : CADENCE.quarterly,
           summaryLogId,
           tableSchemas,
           classificationContext: {

--- a/src/application/summary-logs/classify-and-persist.js
+++ b/src/application/summary-logs/classify-and-persist.js
@@ -1,7 +1,3 @@
-import {
-  LOGGING_EVENT_ACTIONS,
-  LOGGING_EVENT_CATEGORIES
-} from '#common/enums/index.js'
 import { isNil } from '#common/helpers/is-nil.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import {
@@ -19,7 +15,6 @@ import {
   mergeLoads
 } from './load-counts.js'
 
-/** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
@@ -115,40 +110,30 @@ export const classifyLoads = ({
 }
 
 /**
- * Fetches periodic reports for the validated summary log, swallowing errors.
+ * Fetches periodic reports for the validated summary log.
+ *
+ * The period-status split is core flow once the feature is live, so a failure
+ * here must propagate: the queue consumer's onFailure marks the log
+ * validation_failed rather than persisting a result with every load
+ * misclassified as open.
  *
  * @param {Object} params
  * @param {Registration} [params.registration]
  * @param {string} params.status
  * @param {SubmittedSummaryLog} params.summaryLog
  * @param {ReportsRepository} params.reportsRepository
- * @param {string} params.loggingContext
- * @param {TypedLogger} params.logger
  * @returns {Promise<import('#reports/repository/port.js').PeriodicReport[]>}
  */
-export const fetchPeriodicReportsSafe = async ({
+export const fetchPeriodicReports = async ({
   registration,
   status,
   summaryLog,
-  reportsRepository,
-  loggingContext,
-  logger
+  reportsRepository
 }) => {
-  try {
-    if (registration && status === SUMMARY_LOG_STATUS.VALIDATED) {
-      return await reportsRepository.findPeriodicReports({
-        organisationId: summaryLog.organisationId,
-        registrationId: summaryLog.registrationId
-      })
-    }
-  } catch (err) {
-    logger.warn({
-      message: `Failed to fetch periodic reports: ${loggingContext}`,
-      event: {
-        category: LOGGING_EVENT_CATEGORIES.SERVER,
-        action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
-      },
-      err
+  if (registration && status === SUMMARY_LOG_STATUS.VALIDATED) {
+    return await reportsRepository.findPeriodicReports({
+      organisationId: summaryLog.organisationId,
+      registrationId: summaryLog.registrationId
     })
   }
   return []

--- a/src/application/summary-logs/classify-and-persist.js
+++ b/src/application/summary-logs/classify-and-persist.js
@@ -131,7 +131,7 @@ export const fetchPeriodicReports = async ({
   reportsRepository
 }) => {
   if (registration && status === SUMMARY_LOG_STATUS.VALIDATED) {
-    return await reportsRepository.findPeriodicReports({
+    return reportsRepository.findPeriodicReports({
       organisationId: summaryLog.organisationId,
       registrationId: summaryLog.registrationId
     })

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -6,7 +6,8 @@ import { REPORT_STATUS } from '#reports/domain/report-status.js'
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {PeriodicReport} from '#reports/repository/port.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
-/** @import {WasteBalanceClassificationResult, OverseasSitesContext} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
+/** @import {OverseasSitesContext} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
+/** @import {TableSchema} from '#domain/summary-logs/table-schemas/index.js' */
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 
 /**
@@ -289,6 +290,52 @@ const reduceEntries = (entries) => {
 }
 
 /**
+ * Produces fold entries for a single adjusted record.
+ *
+ * @param {Object} params
+ * @param {ValidatedWasteRecord} params.wasteRecord
+ * @param {Map<string, WasteRecord>} params.existingRecordsMap
+ * @param {TableSchema} params.schema
+ * @param {boolean} params.isIncluded
+ * @param {(data: Record<string, string | Date | null | undefined>, fields: string[]) => 'open' | 'closed' | null} params.classify
+ * @param {ClassificationContext} params.context
+ * @returns {PeriodStatusEntry[]}
+ */
+const classifyAdjustedWasteRecord = ({
+  wasteRecord,
+  existingRecordsMap,
+  schema,
+  isIncluded,
+  classify,
+  context
+}) => {
+  const { record } = wasteRecord
+  const { reportingDateFields } = schema
+
+  const newPeriod = classify(record.data, reportingDateFields)
+  const existingKey = `${record.type}:${record.rowId}`
+  const existing = existingRecordsMap.get(existingKey)
+  const oldPeriod = existing
+    ? classify(existing.data, reportingDateFields)
+    : null
+
+  if (!newPeriod && !oldPeriod) return []
+
+  const newAmount = getTransactionAmount(schema, record.data, context)
+  const oldAmount = existing
+    ? getTransactionAmount(schema, existing.data, context)
+    : 0
+
+  return classifyAdjustedRecord({
+    oldPeriod,
+    newPeriod,
+    isIncluded,
+    oldAmount,
+    newAmount
+  })
+}
+
+/**
  * Classifies waste records by reporting period status (open/closed).
  *
  * Each record produces 0-2 fold entries which are then reduced into the
@@ -300,7 +347,7 @@ const reduceEntries = (entries) => {
  * @param {PeriodicReport[]} params.periodicReports
  * @param {'monthly' | 'quarterly'} params.cadence
  * @param {string} params.summaryLogId
- * @param {Record<string, { reportingDateFields: string[], wasteRecordType: string, classifyForWasteBalance?: Function }>} params.tableSchemas
+ * @param {Record<string, TableSchema>} params.tableSchemas
  * @param {ClassificationContext} params.classificationContext
  * @returns {LoadsByPeriodStatus}
  */
@@ -334,52 +381,37 @@ export const classifyByPeriodStatus = ({
     const schema = tableSchemas[wasteRecord.tableName]
     if (!schema) continue
 
-    const { reportingDateFields } = schema
     const isIncluded = outcome === ROW_OUTCOME.INCLUDED
 
     if (status === 'added') {
-      const period = classify(record.data, reportingDateFields)
+      const period = classify(record.data, schema.reportingDateFields)
       if (period) {
-        const transactionAmount = getTransactionAmount(
+        const amount = getTransactionAmount(
           schema,
           record.data,
           classificationContext
         )
         entries.push(
-          ...classifyAddedRecord({ period, isIncluded, transactionAmount })
+          ...classifyAddedRecord({
+            period,
+            isIncluded,
+            transactionAmount: amount
+          })
         )
       }
       continue
     }
 
-    // Adjusted record: classify old and new dates independently
-    const newPeriod = classify(record.data, reportingDateFields)
-    const existingKey = `${record.type}:${record.rowId}`
-    const existing = existingRecordsMap.get(existingKey)
-    const oldPeriod = existing
-      ? classify(existing.data, reportingDateFields)
-      : null
-
-    const newAmount = getTransactionAmount(
-      schema,
-      record.data,
-      classificationContext
+    entries.push(
+      ...classifyAdjustedWasteRecord({
+        wasteRecord,
+        existingRecordsMap,
+        schema,
+        isIncluded,
+        classify,
+        context: classificationContext
+      })
     )
-    const oldAmount = existing
-      ? getTransactionAmount(schema, existing.data, classificationContext)
-      : 0
-
-    if (newPeriod || oldPeriod) {
-      entries.push(
-        ...classifyAdjustedRecord({
-          oldPeriod,
-          newPeriod,
-          isIncluded,
-          oldAmount,
-          newAmount
-        })
-      )
-    }
   }
 
   return reduceEntries(entries)

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -27,7 +27,7 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
  */
 
 /**
- * @typedef {{ open: PeriodStatusByRecordChange, closed: PeriodStatusByRecordChange }} LoadsByPeriodStatus
+ * @typedef {{ openPeriodLoads: PeriodStatusByRecordChange, closedPeriodLoads: PeriodStatusByRecordChange }} LoadsByReportingPeriod
  */
 
 /**
@@ -46,9 +46,9 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
  * @property {number} tonnageDelta
  */
 
-/** @returns {LoadsByPeriodStatus} */
+/** @returns {LoadsByReportingPeriod} */
 const emptyResult = () => ({
-  open: {
+  openPeriodLoads: {
     added: {
       balanceAffecting: { count: 0, tonnageDelta: 0 },
       nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
@@ -58,7 +58,7 @@ const emptyResult = () => ({
       nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
     }
   },
-  closed: {
+  closedPeriodLoads: {
     added: {
       balanceAffecting: { count: 0, tonnageDelta: 0 },
       nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
@@ -280,16 +280,22 @@ const classifyAdjustedRecord = ({
 }
 
 /**
- * Folds an array of entries into the LoadsByPeriodStatus structure.
+ * Maps a record's internal period status to its output bucket key.
+ * @type {Record<'open' | 'closed', 'openPeriodLoads' | 'closedPeriodLoads'>}
+ */
+const PERIOD_TO_KEY = { open: 'openPeriodLoads', closed: 'closedPeriodLoads' }
+
+/**
+ * Folds an array of entries into the LoadsByReportingPeriod structure.
  *
  * @param {PeriodStatusEntry[]} entries
- * @returns {LoadsByPeriodStatus}
+ * @returns {LoadsByReportingPeriod}
  */
 const reduceEntries = (entries) => {
   const result = emptyResult()
 
   for (const { period, change, inclusion, count, tonnageDelta } of entries) {
-    const bucket = result[period][change][inclusion]
+    const bucket = result[PERIOD_TO_KEY[period]][change][inclusion]
     bucket.count += count
     bucket.tonnageDelta += tonnageDelta
   }
@@ -382,7 +388,7 @@ const classifyAdjustedWasteRecord = ({
  * @param {string} params.summaryLogId
  * @param {ProcessingTypeSchemas} params.tableSchemas
  * @param {ClassificationContext} params.classificationContext
- * @returns {LoadsByPeriodStatus}
+ * @returns {LoadsByReportingPeriod}
  */
 export const classifyByPeriodStatus = ({
   wasteRecords,

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -304,7 +304,8 @@ const reduceEntries = (entries) => {
  * @param {Map<string, WasteRecord>} params.existingRecordsMap
  * @param {TableSchema} params.schema
  * @param {boolean} params.isIncluded
- * @param {(data: Record<string, string | Date | null | undefined>, fields: string[]) => 'open' | 'closed' | null} params.classify
+ * @param {Set<string>} params.closedPeriods
+ * @param {'monthly' | 'quarterly'} params.cadence
  * @param {ClassificationContext} params.context
  * @returns {PeriodStatusEntry[]}
  */
@@ -313,17 +314,28 @@ const classifyAdjustedWasteRecord = ({
   existingRecordsMap,
   schema,
   isIncluded,
-  classify,
+  closedPeriods,
+  cadence,
   context
 }) => {
   const { record } = wasteRecord
   const { reportingDateFields } = schema
 
-  const newPeriod = classify(record.data, reportingDateFields)
+  const newPeriod = classifyPeriodStatus(
+    record.data,
+    reportingDateFields,
+    closedPeriods,
+    cadence
+  )
   const existingKey = `${record.type}:${record.rowId}`
   const existing = existingRecordsMap.get(existingKey)
   const oldPeriod = existing
-    ? classify(existing.data, reportingDateFields)
+    ? classifyPeriodStatus(
+        existing.data,
+        reportingDateFields,
+        closedPeriods,
+        cadence
+      )
     : null
 
   if (!newPeriod && !oldPeriod) {
@@ -371,11 +383,6 @@ export const classifyByPeriodStatus = ({
 }) => {
   const closedPeriods = buildClosedPeriods(periodicReports, cadence)
 
-  const classify = (
-    /** @type {Record<string, string | Date | null | undefined>} */ data,
-    /** @type {string[]} */ reportingDateFields
-  ) => classifyPeriodStatus(data, reportingDateFields, closedPeriods, cadence)
-
   /** @type {PeriodStatusEntry[]} */
   const entries = []
 
@@ -391,7 +398,12 @@ export const classifyByPeriodStatus = ({
     const isIncluded = outcome === ROW_OUTCOME.INCLUDED
 
     if (status === 'added') {
-      const period = classify(record.data, schema.reportingDateFields)
+      const period = classifyPeriodStatus(
+        record.data,
+        schema.reportingDateFields,
+        closedPeriods,
+        cadence
+      )
       if (period) {
         const amount = getTransactionAmount(
           schema,
@@ -413,7 +425,8 @@ export const classifyByPeriodStatus = ({
           existingRecordsMap,
           schema,
           isIncluded,
-          classify,
+          closedPeriods,
+          cadence,
           context: classificationContext
         })
       )

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -15,11 +15,15 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
 /** @typedef {typeof PROCESSING_TYPE_TABLES[keyof typeof PROCESSING_TYPE_TABLES]} ProcessingTypeSchemas */
 
 /**
- * @typedef {{ count: number, tonnageDelta: number }} PeriodStatusBucket
+ * @typedef {{ count: number, tonnageDelta: number }} BalanceAffectingBucket
  */
 
 /**
- * @typedef {{ balanceAffecting: PeriodStatusBucket, nonBalanceAffecting: PeriodStatusBucket }} PeriodStatusGroup
+ * @typedef {{ count: number }} NonBalanceAffectingBucket
+ */
+
+/**
+ * @typedef {{ balanceAffecting: BalanceAffectingBucket, nonBalanceAffecting: NonBalanceAffectingBucket }} PeriodStatusGroup
  */
 
 /**
@@ -37,37 +41,32 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
  */
 
 /**
- * A single fold entry produced by classifying one record.
+ * A single fold entry produced by classifying one record. Each entry is one
+ * leg: a record's net contribution to a single period's balance. Inclusion is
+ * derived from tonnageDelta at fold time, not stored here.
  * @typedef {Object} PeriodStatusEntry
  * @property {'open' | 'closed'} period
  * @property {'added' | 'adjusted'} change
- * @property {'balanceAffecting' | 'nonBalanceAffecting'} inclusion
- * @property {number} count - 1 for the record's home bucket, 0 for reversal-only entries
- * @property {number} tonnageDelta
+ * @property {number} count - 1 for the record's home leg, 0 for reversal-only legs
+ * @property {number} tonnageDelta - rounded to 2dp; non-zero means balanceAffecting
  */
+
+/** @returns {PeriodStatusByRecordChange} */
+const emptyChange = () => ({
+  added: {
+    balanceAffecting: { count: 0, tonnageDelta: 0 },
+    nonBalanceAffecting: { count: 0 }
+  },
+  adjusted: {
+    balanceAffecting: { count: 0, tonnageDelta: 0 },
+    nonBalanceAffecting: { count: 0 }
+  }
+})
 
 /** @returns {LoadsByReportingPeriod} */
 const emptyResult = () => ({
-  openPeriodLoads: {
-    added: {
-      balanceAffecting: { count: 0, tonnageDelta: 0 },
-      nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
-    },
-    adjusted: {
-      balanceAffecting: { count: 0, tonnageDelta: 0 },
-      nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
-    }
-  },
-  closedPeriodLoads: {
-    added: {
-      balanceAffecting: { count: 0, tonnageDelta: 0 },
-      nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
-    },
-    adjusted: {
-      balanceAffecting: { count: 0, tonnageDelta: 0 },
-      nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
-    }
-  }
+  openPeriodLoads: emptyChange(),
+  closedPeriodLoads: emptyChange()
 })
 
 /** Position of the year portion end in an ISO date string (YYYY-MM-DD) */
@@ -204,35 +203,34 @@ const getTransactionAmount = (schema, data, context) => {
 }
 
 /**
- * Classifies an added record into a single entry.
+ * Classifies an added record into a single leg. The transaction amount is
+ * already 0 for records excluded from the waste balance, so a zero delta
+ * naturally falls into nonBalanceAffecting at fold time.
  *
  * @param {Object} params
  * @param {'open' | 'closed'} params.period
- * @param {boolean} params.isIncluded
  * @param {number} params.transactionAmount
  * @returns {PeriodStatusEntry[]}
  */
-const classifyAddedRecord = ({ period, isIncluded, transactionAmount }) => [
+const classifyAddedRecord = ({ period, transactionAmount }) => [
   {
     period,
     change: 'added',
-    inclusion: isIncluded ? 'balanceAffecting' : 'nonBalanceAffecting',
     count: 1,
-    tonnageDelta: isIncluded ? transactionAmount : 0
+    tonnageDelta: roundToTwoDecimalPlaces(transactionAmount)
   }
 ]
 
 /**
- * Classifies an adjusted record into 1-2 entries.
- *
- * When old and new dates map to the same period, this produces a single
- * entry with the net delta (newAmount - oldAmount). When they differ,
- * the old period gets -oldAmount and the new period gets +newAmount.
+ * Classifies an adjusted record into 1-2 legs by accumulating each period's
+ * net delta. When old and new dates map to the same period the reversal
+ * (-oldAmount) and addition (+newAmount) merge into one net leg; when they
+ * differ the old period gets -oldAmount and the new period gets +newAmount.
+ * Each leg's delta is rounded to 2dp so the fold can decide inclusion from it.
  *
  * @param {Object} params
  * @param {'open' | 'closed' | null} params.oldPeriod
  * @param {'open' | 'closed' | null} params.newPeriod
- * @param {boolean} params.isIncluded
  * @param {number} params.oldAmount
  * @param {number} params.newAmount
  * @returns {PeriodStatusEntry[]}
@@ -240,43 +238,28 @@ const classifyAddedRecord = ({ period, isIncluded, transactionAmount }) => [
 const classifyAdjustedRecord = ({
   oldPeriod,
   newPeriod,
-  isIncluded,
   oldAmount,
   newAmount
 }) => {
-  const inclusion = isIncluded ? 'balanceAffecting' : 'nonBalanceAffecting'
-  const countedPeriod = newPeriod ?? oldPeriod
-  /** @type {PeriodStatusEntry[]} */
-  const entries = []
-
+  /** @type {Map<'open' | 'closed', number>} */
+  const legs = new Map()
   if (oldPeriod) {
-    entries.push({
-      period: oldPeriod,
-      change: 'adjusted',
-      inclusion,
-      count: 0,
-      tonnageDelta: -oldAmount
-    })
+    legs.set(oldPeriod, (legs.get(oldPeriod) ?? 0) - oldAmount)
   }
-
   if (newPeriod) {
-    entries.push({
-      period: newPeriod,
-      change: 'adjusted',
-      inclusion,
-      count: 0,
-      tonnageDelta: newAmount
-    })
+    legs.set(newPeriod, (legs.get(newPeriod) ?? 0) + newAmount)
   }
 
-  // Assign the count to the record's "home" bucket (new period, or old if new is null).
-  // The caller guards with (newPeriod || oldPeriod), so countedPeriod is always defined.
-  const countEntry = /** @type {PeriodStatusEntry} */ (
-    entries.find((e) => e.period === countedPeriod)
-  )
-  countEntry.count = 1
+  // The record's count lives on its "home" leg (new period, or old if new is
+  // null). The caller guards with (newPeriod || oldPeriod), so it is defined.
+  const homePeriod = newPeriod ?? oldPeriod
 
-  return entries
+  return [...legs].map(([period, tonnageDelta]) => ({
+    period,
+    change: 'adjusted',
+    count: period === homePeriod ? 1 : 0,
+    tonnageDelta: roundToTwoDecimalPlaces(tonnageDelta)
+  }))
 }
 
 /**
@@ -294,20 +277,24 @@ const PERIOD_TO_KEY = { open: 'openPeriodLoads', closed: 'closedPeriodLoads' }
 const reduceEntries = (entries) => {
   const result = emptyResult()
 
-  for (const { period, change, inclusion, count, tonnageDelta } of entries) {
-    const bucket = result[PERIOD_TO_KEY[period]][change][inclusion]
-    bucket.count += count
-    bucket.tonnageDelta += tonnageDelta
+  for (const { period, change, count, tonnageDelta } of entries) {
+    const group = result[PERIOD_TO_KEY[period]][change]
+    // A leg is balanceAffecting iff its (rounded) net delta moved the balance.
+    if (tonnageDelta !== 0) {
+      group.balanceAffecting.count += count
+      group.balanceAffecting.tonnageDelta += tonnageDelta
+    } else {
+      group.nonBalanceAffecting.count += count
+    }
   }
 
-  // Tonnages are reported to 2dp, so each bucket's accumulated delta is
-  // mathematically a multiple of 0.01. Rounding the summed float recovers
-  // the exact value and strips IEEE-754 noise (eg 0.1 + 0.2 = 0.30000…004).
+  // Each leg's delta is already 2dp, but summing many of them can reintroduce
+  // IEEE-754 noise (eg 0.1 + 0.2 = 0.30000…004); round each bucket total once.
   for (const period of Object.values(result)) {
     for (const change of Object.values(period)) {
-      for (const bucket of Object.values(change)) {
-        bucket.tonnageDelta = roundToTwoDecimalPlaces(bucket.tonnageDelta)
-      }
+      change.balanceAffecting.tonnageDelta = roundToTwoDecimalPlaces(
+        change.balanceAffecting.tonnageDelta
+      )
     }
   }
 
@@ -321,7 +308,6 @@ const reduceEntries = (entries) => {
  * @param {ValidatedWasteRecord} params.wasteRecord
  * @param {Map<string, WasteRecord>} params.existingRecordsMap
  * @param {TableSchema} params.schema
- * @param {boolean} params.isIncluded
  * @param {Set<string>} params.closedPeriods
  * @param {'monthly' | 'quarterly'} params.cadence
  * @param {ClassificationContext} params.context
@@ -331,7 +317,6 @@ const classifyAdjustedWasteRecord = ({
   wasteRecord,
   existingRecordsMap,
   schema,
-  isIncluded,
   closedPeriods,
   cadence,
   context
@@ -368,7 +353,6 @@ const classifyAdjustedWasteRecord = ({
   return classifyAdjustedRecord({
     oldPeriod,
     newPeriod,
-    isIncluded,
     oldAmount,
     newAmount
   })
@@ -413,8 +397,6 @@ export const classifyByPeriodStatus = ({
       continue
     }
 
-    const isIncluded = outcome === ROW_OUTCOME.INCLUDED
-
     if (status === 'added') {
       const period = classifyPeriodStatus(
         record.data,
@@ -431,7 +413,6 @@ export const classifyByPeriodStatus = ({
         entries.push(
           ...classifyAddedRecord({
             period,
-            isIncluded,
             transactionAmount: amount
           })
         )
@@ -442,7 +423,6 @@ export const classifyByPeriodStatus = ({
           wasteRecord,
           existingRecordsMap,
           schema,
-          isIncluded,
           closedPeriods,
           cadence,
           context: classificationContext

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -1,0 +1,386 @@
+import { VERSION_STATUS } from '#domain/waste-records/model.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { MONTHS_PER_PERIOD } from '#reports/domain/cadence.js'
+import { REPORT_STATUS } from '#reports/domain/report-status.js'
+
+/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {PeriodicReport} from '#reports/repository/port.js' */
+/** @import {WasteRecord} from '#domain/waste-records/model.js' */
+/** @import {WasteBalanceClassificationResult, OverseasSitesContext} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
+/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
+
+/**
+ * @typedef {{ count: number, tonnageDelta: number }} PeriodStatusBucket
+ */
+
+/**
+ * @typedef {{ included: PeriodStatusBucket, excluded: PeriodStatusBucket }} PeriodStatusGroup
+ */
+
+/**
+ * @typedef {{ added: PeriodStatusGroup, adjusted: PeriodStatusGroup }} PeriodStatusByRecordChange
+ */
+
+/**
+ * @typedef {{ open: PeriodStatusByRecordChange, closed: PeriodStatusByRecordChange }} LoadsByPeriodStatus
+ */
+
+/**
+ * @typedef {Object} ClassificationContext
+ * @property {Accreditation | null} accreditation
+ * @property {OverseasSitesContext} overseasSites
+ */
+
+/**
+ * A single fold entry produced by classifying one record.
+ * @typedef {Object} PeriodStatusEntry
+ * @property {'open' | 'closed'} period
+ * @property {'added' | 'adjusted'} change
+ * @property {'included' | 'excluded'} inclusion
+ * @property {number} count - 1 for the record's home bucket, 0 for reversal-only entries
+ * @property {number} tonnageDelta
+ */
+
+/** @returns {LoadsByPeriodStatus} */
+const emptyResult = () => ({
+  open: {
+    added: {
+      included: { count: 0, tonnageDelta: 0 },
+      excluded: { count: 0, tonnageDelta: 0 }
+    },
+    adjusted: {
+      included: { count: 0, tonnageDelta: 0 },
+      excluded: { count: 0, tonnageDelta: 0 }
+    }
+  },
+  closed: {
+    added: {
+      included: { count: 0, tonnageDelta: 0 },
+      excluded: { count: 0, tonnageDelta: 0 }
+    },
+    adjusted: {
+      included: { count: 0, tonnageDelta: 0 },
+      excluded: { count: 0, tonnageDelta: 0 }
+    }
+  }
+})
+
+/** Position of the year portion end in an ISO date string (YYYY-MM-DD) */
+const YEAR_END = 4
+/** Start and end of the month portion in an ISO date string */
+const MONTH_START = 5
+const MONTH_END = 7
+
+/**
+ * @param {string | Date} dateValue
+ * @returns {string}
+ */
+const toIsoDate = (dateValue) =>
+  dateValue instanceof Date
+    ? dateValue.toISOString().slice(0, 10)
+    : String(dateValue)
+
+/**
+ * @param {string | Date} dateValue
+ * @returns {number}
+ */
+const extractMonth = (dateValue) => {
+  const str = toIsoDate(dateValue)
+  return Number(str.slice(MONTH_START, MONTH_END))
+}
+
+/**
+ * @param {string | Date} dateValue
+ * @returns {number}
+ */
+const extractYear = (dateValue) =>
+  Number(toIsoDate(dateValue).slice(0, YEAR_END))
+
+/**
+ * Maps a month to its reporting period number.
+ * @param {number} month - 1-12
+ * @param {string} cadence - 'monthly' or 'quarterly'
+ * @returns {number}
+ */
+const monthToPeriod = (month, cadence) => {
+  const monthsPerPeriod = MONTHS_PER_PERIOD[cadence]
+  return Math.ceil(month / monthsPerPeriod)
+}
+
+/**
+ * Builds a set of closed period keys from submitted reports.
+ * A period is closed when it has been submitted: either the current
+ * report has status 'submitted', or there are previous submissions.
+ *
+ * @param {PeriodicReport[]} periodicReports
+ * @param {string} cadence
+ * @returns {Set<string>}
+ */
+const buildClosedPeriods = (periodicReports, cadence) => {
+  const closed = new Set()
+  for (const periodicReport of periodicReports) {
+    const slots = periodicReport.reports[cadence]
+    if (!slots) continue
+    for (const [period, slot] of Object.entries(slots)) {
+      const hasBeenSubmitted =
+        slot.current?.status === REPORT_STATUS.SUBMITTED ||
+        slot.previousSubmissions?.length > 0
+      if (hasBeenSubmitted) {
+        closed.add(`${periodicReport.year}:${period}`)
+      }
+    }
+  }
+  return closed
+}
+
+/**
+ * Applies the closed-wins rule: if ANY date field maps to a closed
+ * period, the record is classified as closed.
+ * Returns null if no date fields have a value.
+ *
+ * @param {Record<string, string | Date | null | undefined>} data
+ * @param {string[]} reportingDateFields
+ * @param {Set<string>} closedPeriods
+ * @param {string} cadence
+ * @returns {'open' | 'closed' | null}
+ */
+const classifyPeriodStatus = (
+  data,
+  reportingDateFields,
+  closedPeriods,
+  cadence
+) => {
+  let hasAnyDate = false
+
+  for (const field of reportingDateFields) {
+    const dateValue = data[field]
+    if (!dateValue) continue
+
+    hasAnyDate = true
+    const period = monthToPeriod(extractMonth(dateValue), cadence)
+    const periodKey = `${extractYear(dateValue)}:${period}`
+    if (closedPeriods.has(periodKey)) {
+      return 'closed'
+    }
+  }
+
+  return hasAnyDate ? 'open' : null
+}
+
+/**
+ * @param {ValidatedWasteRecord['record']} record
+ * @param {string} summaryLogId
+ * @returns {'added' | 'adjusted' | 'unchanged'}
+ */
+const determineRecordStatus = (record, summaryLogId) => {
+  const lastVersion = record.versions[record.versions.length - 1]
+  if (lastVersion?.summaryLog?.id !== summaryLogId) {
+    return 'unchanged'
+  }
+  return lastVersion.status === VERSION_STATUS.CREATED ? 'added' : 'adjusted'
+}
+
+/**
+ * Computes the transaction amount for a record via classifyForWasteBalance.
+ * Returns 0 if the schema has no classifier or the outcome is not INCLUDED.
+ *
+ * @param {import('#domain/summary-logs/table-schemas/index.js').TableSchema | null} schema
+ * @param {Record<string, any>} data
+ * @param {ClassificationContext} context
+ * @returns {number}
+ */
+const getTransactionAmount = (schema, data, context) => {
+  const result = schema?.classifyForWasteBalance?.(data, context)
+  return result?.outcome === ROW_OUTCOME.INCLUDED ? result.transactionAmount : 0
+}
+
+/**
+ * Classifies an added record into a single entry.
+ *
+ * @param {Object} params
+ * @param {'open' | 'closed'} params.period
+ * @param {boolean} params.isIncluded
+ * @param {number} params.transactionAmount
+ * @returns {PeriodStatusEntry[]}
+ */
+const classifyAddedRecord = ({ period, isIncluded, transactionAmount }) => [
+  {
+    period,
+    change: 'added',
+    inclusion: isIncluded ? 'included' : 'excluded',
+    count: 1,
+    tonnageDelta: isIncluded ? transactionAmount : 0
+  }
+]
+
+/**
+ * Classifies an adjusted record into 1-2 entries.
+ *
+ * When old and new dates map to the same period, this produces a single
+ * entry with the net delta (newAmount - oldAmount). When they differ,
+ * the old period gets -oldAmount and the new period gets +newAmount.
+ *
+ * @param {Object} params
+ * @param {'open' | 'closed' | null} params.oldPeriod
+ * @param {'open' | 'closed' | null} params.newPeriod
+ * @param {boolean} params.isIncluded
+ * @param {number} params.oldAmount
+ * @param {number} params.newAmount
+ * @returns {PeriodStatusEntry[]}
+ */
+const classifyAdjustedRecord = ({
+  oldPeriod,
+  newPeriod,
+  isIncluded,
+  oldAmount,
+  newAmount
+}) => {
+  const inclusion = isIncluded ? 'included' : 'excluded'
+  const countedPeriod = newPeriod ?? oldPeriod
+  /** @type {PeriodStatusEntry[]} */
+  const entries = []
+
+  if (oldPeriod) {
+    entries.push({
+      period: oldPeriod,
+      change: 'adjusted',
+      inclusion,
+      count: 0,
+      tonnageDelta: -oldAmount
+    })
+  }
+
+  if (newPeriod) {
+    entries.push({
+      period: newPeriod,
+      change: 'adjusted',
+      inclusion,
+      count: 0,
+      tonnageDelta: newAmount
+    })
+  }
+
+  // Assign the count to the record's "home" bucket (new period, or old if new is null).
+  // The caller guards with (newPeriod || oldPeriod), so countedPeriod is always defined.
+  const countEntry = /** @type {PeriodStatusEntry} */ (
+    entries.find((e) => e.period === countedPeriod)
+  )
+  countEntry.count = 1
+
+  return entries
+}
+
+/**
+ * Folds an array of entries into the LoadsByPeriodStatus structure.
+ *
+ * @param {PeriodStatusEntry[]} entries
+ * @returns {LoadsByPeriodStatus}
+ */
+const reduceEntries = (entries) => {
+  const result = emptyResult()
+
+  for (const { period, change, inclusion, count, tonnageDelta } of entries) {
+    const bucket = result[period][change][inclusion]
+    bucket.count += count
+    bucket.tonnageDelta += tonnageDelta
+  }
+
+  return result
+}
+
+/**
+ * Classifies waste records by reporting period status (open/closed).
+ *
+ * Each record produces 0-2 fold entries which are then reduced into the
+ * final nested structure. Pure function with no I/O.
+ *
+ * @param {Object} params
+ * @param {ValidatedWasteRecord[]} params.wasteRecords
+ * @param {Map<string, WasteRecord>} params.existingRecordsMap
+ * @param {PeriodicReport[]} params.periodicReports
+ * @param {'monthly' | 'quarterly'} params.cadence
+ * @param {string} params.summaryLogId
+ * @param {Record<string, { reportingDateFields: string[], wasteRecordType: string, classifyForWasteBalance?: Function }>} params.tableSchemas
+ * @param {ClassificationContext} params.classificationContext
+ * @returns {LoadsByPeriodStatus}
+ */
+export const classifyByPeriodStatus = ({
+  wasteRecords,
+  existingRecordsMap,
+  periodicReports,
+  cadence,
+  summaryLogId,
+  tableSchemas,
+  classificationContext
+}) => {
+  const closedPeriods = buildClosedPeriods(periodicReports, cadence)
+
+  const classify = (
+    /** @type {Record<string, string | Date | null | undefined>} */ data,
+    /** @type {string[]} */ reportingDateFields
+  ) => classifyPeriodStatus(data, reportingDateFields, closedPeriods, cadence)
+
+  /** @type {PeriodStatusEntry[]} */
+  const entries = []
+
+  for (const wasteRecord of wasteRecords) {
+    const { record, outcome } = wasteRecord
+
+    if (outcome === ROW_OUTCOME.IGNORED) continue
+
+    const status = determineRecordStatus(record, summaryLogId)
+    if (status === 'unchanged') continue
+
+    const schema = tableSchemas[wasteRecord.tableName]
+    if (!schema) continue
+
+    const { reportingDateFields } = schema
+    const isIncluded = outcome === ROW_OUTCOME.INCLUDED
+
+    if (status === 'added') {
+      const period = classify(record.data, reportingDateFields)
+      if (period) {
+        const transactionAmount = getTransactionAmount(
+          schema,
+          record.data,
+          classificationContext
+        )
+        entries.push(
+          ...classifyAddedRecord({ period, isIncluded, transactionAmount })
+        )
+      }
+      continue
+    }
+
+    // Adjusted record: classify old and new dates independently
+    const newPeriod = classify(record.data, reportingDateFields)
+    const existingKey = `${record.type}:${record.rowId}`
+    const existing = existingRecordsMap.get(existingKey)
+    const oldPeriod = existing
+      ? classify(existing.data, reportingDateFields)
+      : null
+
+    const newAmount = getTransactionAmount(
+      schema,
+      record.data,
+      classificationContext
+    )
+    const oldAmount = existing
+      ? getTransactionAmount(schema, existing.data, classificationContext)
+      : 0
+
+    if (newPeriod || oldPeriod) {
+      entries.push(
+        ...classifyAdjustedRecord({
+          oldPeriod,
+          newPeriod,
+          isIncluded,
+          oldAmount,
+          newAmount
+        })
+      )
+    }
+  }
+
+  return reduceEntries(entries)
+}

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -4,6 +4,9 @@ import { MONTHS_PER_PERIOD } from '#reports/domain/cadence.js'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
 import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
 
+/** Internal reporting-period status. Not serialised: mapped to output keys via PERIOD_TO_KEY. */
+const PERIOD_STATUS = Object.freeze({ OPEN: 'open', CLOSED: 'closed' })
+
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {PeriodicReport} from '#reports/repository/port.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
@@ -168,11 +171,11 @@ const classifyPeriodStatus = (
     const period = monthToPeriod(extractMonth(dateValue), cadence)
     const periodKey = `${extractYear(dateValue)}:${period}`
     if (closedPeriods.has(periodKey)) {
-      return 'closed'
+      return PERIOD_STATUS.CLOSED
     }
   }
 
-  return hasAnyDate ? 'open' : null
+  return hasAnyDate ? PERIOD_STATUS.OPEN : null
 }
 
 /**
@@ -266,7 +269,10 @@ const classifyAdjustedRecord = ({
  * Maps a record's internal period status to its output bucket key.
  * @type {Record<'open' | 'closed', 'openPeriodLoads' | 'closedPeriodLoads'>}
  */
-const PERIOD_TO_KEY = { open: 'openPeriodLoads', closed: 'closedPeriodLoads' }
+const PERIOD_TO_KEY = {
+  [PERIOD_STATUS.OPEN]: 'openPeriodLoads',
+  [PERIOD_STATUS.CLOSED]: 'closedPeriodLoads'
+}
 
 /**
  * Folds an array of entries into the LoadsByReportingPeriod structure.

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -8,7 +8,10 @@ import { REPORT_STATUS } from '#reports/domain/report-status.js'
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
 /** @import {OverseasSitesContext} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
 /** @import {TableSchema} from '#domain/summary-logs/table-schemas/index.js' */
+/** @import {PROCESSING_TYPE_TABLES} from '#domain/summary-logs/table-schemas/index.js' */
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
+
+/** @typedef {typeof PROCESSING_TYPE_TABLES[keyof typeof PROCESSING_TYPE_TABLES]} ProcessingTypeSchemas */
 
 /**
  * @typedef {{ count: number, tonnageDelta: number }} PeriodStatusBucket
@@ -347,7 +350,7 @@ const classifyAdjustedWasteRecord = ({
  * @param {PeriodicReport[]} params.periodicReports
  * @param {'monthly' | 'quarterly'} params.cadence
  * @param {string} params.summaryLogId
- * @param {Record<string, TableSchema>} params.tableSchemas
+ * @param {ProcessingTypeSchemas} params.tableSchemas
  * @param {ClassificationContext} params.classificationContext
  * @returns {LoadsByPeriodStatus}
  */

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -279,12 +279,13 @@ const reduceEntries = (entries) => {
 
   for (const { period, change, count, tonnageDelta } of entries) {
     const group = result[PERIOD_TO_KEY[period]][change]
-    // A leg is balanceAffecting iff its (rounded) net delta moved the balance.
-    if (tonnageDelta !== 0) {
+    // A leg with no net delta is nonBalanceAffecting; any movement (rounded)
+    // goes to balanceAffecting.
+    if (tonnageDelta === 0) {
+      group.nonBalanceAffecting.count += count
+    } else {
       group.balanceAffecting.count += count
       group.balanceAffecting.tonnageDelta += tonnageDelta
-    } else {
-      group.nonBalanceAffecting.count += count
     }
   }
 

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -2,6 +2,7 @@ import { VERSION_STATUS } from '#domain/waste-records/model.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { MONTHS_PER_PERIOD } from '#reports/domain/cadence.js'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
+import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {PeriodicReport} from '#reports/repository/port.js' */
@@ -291,6 +292,17 @@ const reduceEntries = (entries) => {
     const bucket = result[period][change][inclusion]
     bucket.count += count
     bucket.tonnageDelta += tonnageDelta
+  }
+
+  // Tonnages are reported to 2dp, so each bucket's accumulated delta is
+  // mathematically a multiple of 0.01. Rounding the summed float recovers
+  // the exact value and strips IEEE-754 noise (eg 0.1 + 0.2 = 0.30000…004).
+  for (const period of Object.values(result)) {
+    for (const change of Object.values(period)) {
+      for (const bucket of Object.values(change)) {
+        bucket.tonnageDelta = roundToTwoDecimalPlaces(bucket.tonnageDelta)
+      }
+    }
   }
 
   return result

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -19,7 +19,7 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
  */
 
 /**
- * @typedef {{ included: PeriodStatusBucket, excluded: PeriodStatusBucket }} PeriodStatusGroup
+ * @typedef {{ balanceAffecting: PeriodStatusBucket, nonBalanceAffecting: PeriodStatusBucket }} PeriodStatusGroup
  */
 
 /**
@@ -41,7 +41,7 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
  * @typedef {Object} PeriodStatusEntry
  * @property {'open' | 'closed'} period
  * @property {'added' | 'adjusted'} change
- * @property {'included' | 'excluded'} inclusion
+ * @property {'balanceAffecting' | 'nonBalanceAffecting'} inclusion
  * @property {number} count - 1 for the record's home bucket, 0 for reversal-only entries
  * @property {number} tonnageDelta
  */
@@ -50,22 +50,22 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
 const emptyResult = () => ({
   open: {
     added: {
-      included: { count: 0, tonnageDelta: 0 },
-      excluded: { count: 0, tonnageDelta: 0 }
+      balanceAffecting: { count: 0, tonnageDelta: 0 },
+      nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
     },
     adjusted: {
-      included: { count: 0, tonnageDelta: 0 },
-      excluded: { count: 0, tonnageDelta: 0 }
+      balanceAffecting: { count: 0, tonnageDelta: 0 },
+      nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
     }
   },
   closed: {
     added: {
-      included: { count: 0, tonnageDelta: 0 },
-      excluded: { count: 0, tonnageDelta: 0 }
+      balanceAffecting: { count: 0, tonnageDelta: 0 },
+      nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
     },
     adjusted: {
-      included: { count: 0, tonnageDelta: 0 },
-      excluded: { count: 0, tonnageDelta: 0 }
+      balanceAffecting: { count: 0, tonnageDelta: 0 },
+      nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
     }
   }
 })
@@ -216,7 +216,7 @@ const classifyAddedRecord = ({ period, isIncluded, transactionAmount }) => [
   {
     period,
     change: 'added',
-    inclusion: isIncluded ? 'included' : 'excluded',
+    inclusion: isIncluded ? 'balanceAffecting' : 'nonBalanceAffecting',
     count: 1,
     tonnageDelta: isIncluded ? transactionAmount : 0
   }
@@ -244,7 +244,7 @@ const classifyAdjustedRecord = ({
   oldAmount,
   newAmount
 }) => {
-  const inclusion = isIncluded ? 'included' : 'excluded'
+  const inclusion = isIncluded ? 'balanceAffecting' : 'nonBalanceAffecting'
   const countedPeriod = newPeriod ?? oldPeriod
   /** @type {PeriodStatusEntry[]} */
   const entries = []

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -124,7 +124,9 @@ const buildClosedPeriods = (periodicReports, cadence) => {
   const closed = new Set()
   for (const periodicReport of periodicReports) {
     const slots = periodicReport.reports[cadence]
-    if (!slots) continue
+    if (!slots) {
+      continue
+    }
     for (const [period, slot] of Object.entries(slots)) {
       const hasBeenSubmitted =
         slot.current?.status === REPORT_STATUS.SUBMITTED ||
@@ -158,7 +160,9 @@ const classifyPeriodStatus = (
 
   for (const field of reportingDateFields) {
     const dateValue = data[field]
-    if (!dateValue) continue
+    if (!dateValue) {
+      continue
+    }
 
     hasAnyDate = true
     const period = monthToPeriod(extractMonth(dateValue), cadence)
@@ -177,7 +181,7 @@ const classifyPeriodStatus = (
  * @returns {'added' | 'adjusted' | 'unchanged'}
  */
 const determineRecordStatus = (record, summaryLogId) => {
-  const lastVersion = record.versions[record.versions.length - 1]
+  const lastVersion = record.versions.at(-1)
   if (lastVersion?.summaryLog?.id !== summaryLogId) {
     return 'unchanged'
   }
@@ -322,7 +326,9 @@ const classifyAdjustedWasteRecord = ({
     ? classify(existing.data, reportingDateFields)
     : null
 
-  if (!newPeriod && !oldPeriod) return []
+  if (!newPeriod && !oldPeriod) {
+    return []
+  }
 
   const newAmount = getTransactionAmount(schema, record.data, context)
   const oldAmount = existing
@@ -375,14 +381,12 @@ export const classifyByPeriodStatus = ({
 
   for (const wasteRecord of wasteRecords) {
     const { record, outcome } = wasteRecord
-
-    if (outcome === ROW_OUTCOME.IGNORED) continue
-
     const status = determineRecordStatus(record, summaryLogId)
-    if (status === 'unchanged') continue
-
     const schema = tableSchemas[wasteRecord.tableName]
-    if (!schema) continue
+
+    if (outcome === ROW_OUTCOME.IGNORED || status === 'unchanged' || !schema) {
+      continue
+    }
 
     const isIncluded = outcome === ROW_OUTCOME.INCLUDED
 
@@ -402,19 +406,18 @@ export const classifyByPeriodStatus = ({
           })
         )
       }
-      continue
+    } else {
+      entries.push(
+        ...classifyAdjustedWasteRecord({
+          wasteRecord,
+          existingRecordsMap,
+          schema,
+          isIncluded,
+          classify,
+          context: classificationContext
+        })
+      )
     }
-
-    entries.push(
-      ...classifyAdjustedWasteRecord({
-        wasteRecord,
-        existingRecordsMap,
-        schema,
-        isIncluded,
-        classify,
-        context: classificationContext
-      })
-    )
   }
 
   return reduceEntries(entries)

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -220,6 +220,35 @@ describe('classifyByPeriodStatus', () => {
         tonnageDelta: 0
       })
     })
+
+    it('rounds summed tonnageDelta to 2dp so no float noise leaks out', () => {
+      // 0.1 + 0.2 = 0.30000000000000004 in IEEE-754. Tonnages are reported
+      // to 2dp, so the aggregate must be the exact 0.3, not the noisy float.
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        wasteRecords: [
+          buildWasteRecord({
+            rowId: '10001',
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: '2026-01-15',
+              GROSS_WEIGHT: '0.1'
+            }
+          }),
+          buildWasteRecord({
+            rowId: '10002',
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: '2026-01-15',
+              GROSS_WEIGHT: '0.2'
+            }
+          })
+        ]
+      })
+
+      expect(result.open.added.included).toEqual({
+        count: 2,
+        tonnageDelta: 0.3
+      })
+    })
   })
 
   describe('adjusted records', () => {

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -109,8 +109,8 @@ const REGISTERED_ONLY_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
 
 const emptyBucket = () => ({ count: 0, tonnageDelta: 0 })
 const emptyChange = () => ({
-  included: emptyBucket(),
-  excluded: emptyBucket()
+  balanceAffecting: emptyBucket(),
+  nonBalanceAffecting: emptyBucket()
 })
 const emptyPeriod = () => ({
   added: emptyChange(),
@@ -190,7 +190,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords: [buildWasteRecord()]
       })
 
-      expect(result.open.added.included).toEqual({
+      expect(result.open.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 42.5
       })
@@ -203,7 +203,7 @@ describe('classifyByPeriodStatus', () => {
         periodicReports: [buildSubmittedReport()]
       })
 
-      expect(result.closed.added.included).toEqual({
+      expect(result.closed.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 42.5
       })
@@ -215,7 +215,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords: [buildWasteRecord({ outcome: ROW_OUTCOME.EXCLUDED })]
       })
 
-      expect(result.open.added.excluded).toEqual({
+      expect(result.open.added.nonBalanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 0
       })
@@ -244,7 +244,7 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.open.added.included).toEqual({
+      expect(result.open.added.balanceAffecting).toEqual({
         count: 2,
         tonnageDelta: 0.3
       })
@@ -294,7 +294,7 @@ describe('classifyByPeriodStatus', () => {
       })
 
       // Same period (February, open) so net delta = 50 - 30 = 20
-      expect(result.open.adjusted.included).toEqual({
+      expect(result.open.adjusted.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 20
       })
@@ -344,12 +344,12 @@ describe('classifyByPeriodStatus', () => {
       })
 
       // Old period (January, closed): -30
-      expect(result.closed.adjusted.included.tonnageDelta).toBe(-30)
+      expect(result.closed.adjusted.balanceAffecting.tonnageDelta).toBe(-30)
       // New period (February, open): +50
-      expect(result.open.adjusted.included.tonnageDelta).toBe(50)
+      expect(result.open.adjusted.balanceAffecting.tonnageDelta).toBe(50)
       // Count goes to the new period
-      expect(result.open.adjusted.included.count).toBe(1)
-      expect(result.closed.adjusted.included.count).toBe(0)
+      expect(result.open.adjusted.balanceAffecting.count).toBe(1)
+      expect(result.closed.adjusted.balanceAffecting.count).toBe(0)
     })
 
     it('assigns count to old period when new date is blanked out', () => {
@@ -394,8 +394,8 @@ describe('classifyByPeriodStatus', () => {
       })
 
       // New date is null so newPeriod is null; count goes to old period
-      expect(result.open.adjusted.included.count).toBe(1)
-      expect(result.open.adjusted.included.tonnageDelta).toBe(-30)
+      expect(result.open.adjusted.balanceAffecting.count).toBe(1)
+      expect(result.open.adjusted.balanceAffecting.tonnageDelta).toBe(-30)
     })
 
     it('handles adjusted record with no existing record in the map', () => {
@@ -423,7 +423,7 @@ describe('classifyByPeriodStatus', () => {
       })
 
       // No existing record so oldPeriod is null, oldAmount is 0
-      expect(result.open.adjusted.included).toEqual({
+      expect(result.open.adjusted.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 50
       })
@@ -474,7 +474,7 @@ describe('classifyByPeriodStatus', () => {
       // Record is now excluded, so it goes to excluded bucket
       // Old amount was 30 (included), new amount is 0 (excluded)
       // Net delta: 0 - 30 = -30
-      expect(result.open.adjusted.excluded).toEqual({
+      expect(result.open.adjusted.nonBalanceAffecting).toEqual({
         count: 1,
         tonnageDelta: -30
       })
@@ -545,8 +545,8 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.closed.added.included.count).toBe(1)
-      expect(result.open.added.included.count).toBe(0)
+      expect(result.closed.added.balanceAffecting.count).toBe(1)
+      expect(result.open.added.balanceAffecting.count).toBe(0)
     })
 
     it('classifies a row as open when all dates are in open periods', () => {
@@ -565,8 +565,8 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.open.added.included.count).toBe(1)
-      expect(result.closed.added.included.count).toBe(0)
+      expect(result.open.added.balanceAffecting.count).toBe(1)
+      expect(result.closed.added.balanceAffecting.count).toBe(0)
     })
   })
 
@@ -640,11 +640,11 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.closed.added.included).toEqual({
+      expect(result.closed.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 10
       })
-      expect(result.open.added.included).toEqual({
+      expect(result.open.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 20
       })
@@ -671,7 +671,7 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.closed.added.included).toEqual({
+      expect(result.closed.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 10
       })
@@ -705,7 +705,7 @@ describe('classifyByPeriodStatus', () => {
       })
 
       // The report is quarterly but cadence is monthly, so no periods are closed
-      expect(result.open.added.included.count).toBe(1)
+      expect(result.open.added.balanceAffecting.count).toBe(1)
     })
   })
 
@@ -736,8 +736,8 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords: [buildWasteRecord()]
       })
 
-      expect(result.open.added.included.count).toBe(1)
-      expect(result.closed.added.included.count).toBe(0)
+      expect(result.open.added.balanceAffecting.count).toBe(1)
+      expect(result.closed.added.balanceAffecting.count).toBe(0)
     })
   })
 
@@ -763,7 +763,7 @@ describe('classifyByPeriodStatus', () => {
 
       // Record is INCLUDED per outcome but schema returns EXCLUDED for amount
       // so tonnageDelta should be 0
-      expect(result.open.added.included.tonnageDelta).toBe(0)
+      expect(result.open.added.balanceAffecting.tonnageDelta).toBe(0)
     })
   })
 
@@ -794,7 +794,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords: [buildWasteRecord()]
       })
 
-      expect(result.closed.added.included.count).toBe(1)
+      expect(result.closed.added.balanceAffecting.count).toBe(1)
     })
   })
 
@@ -814,7 +814,7 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.open.added.included).toEqual({
+      expect(result.open.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 10
       })
@@ -843,7 +843,7 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.open.added.included).toEqual({
+      expect(result.open.added.balanceAffecting).toEqual({
         count: 2,
         tonnageDelta: 50
       })

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -238,6 +238,40 @@ describe('classifyByPeriodStatus', () => {
       expect(result.openPeriodLoads.added.balanceAffecting.count).toBe(0)
     })
 
+    it('classifies registered-only loads (no balance classifier) as nonBalanceAffecting', () => {
+      // Registered-only schemas have no classifyForWasteBalance, so no load can
+      // contribute to a waste balance. Every transaction amount is 0 and every
+      // load must land in nonBalanceAffecting with no tonnage.
+      const registeredOnlySchemas = /** @type {ProcessingTypeSchemas} */ (
+        /** @type {unknown} */ ({
+          RECEIVED_LOADS_FOR_REPROCESSING: {
+            reportingDateFields: ['MONTH_RECEIVED_FOR_REPROCESSING'],
+            wasteRecordType: 'received',
+            classifyForWasteBalance: null
+          }
+        })
+      )
+
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        tableSchemas: registeredOnlySchemas,
+        wasteRecords: [
+          buildWasteRecord({
+            outcome: ROW_OUTCOME.EXCLUDED,
+            data: {
+              MONTH_RECEIVED_FOR_REPROCESSING: '2026-01-01',
+              GROSS_WEIGHT: '42.5'
+            }
+          })
+        ]
+      })
+
+      expect(result.openPeriodLoads.added.nonBalanceAffecting).toEqual({
+        count: 1
+      })
+      expect(result.openPeriodLoads.added.balanceAffecting.count).toBe(0)
+    })
+
     it('rounds summed tonnageDelta to 2dp so no float noise leaks out', () => {
       // 0.1 + 0.2 = 0.30000000000000004 in IEEE-754. Tonnages are reported
       // to 2dp, so the aggregate must be the exact 0.3, not the noisy float.

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -64,36 +64,34 @@ const buildWasteRecord = ({
   )
 
 /** @type {Record<string, TableSchema>} Single-date-field table schemas (most tables). */
-const SINGLE_DATE_TABLE_SCHEMAS =
-  /** @type {Record<string, TableSchema>} */ (
-    /** @type {unknown} */ ({
-      RECEIVED_LOADS_FOR_REPROCESSING: {
-        reportingDateFields: ['DATE_RECEIVED_FOR_REPROCESSING'],
-        wasteRecordType: 'received',
-        classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
-          outcome: ROW_OUTCOME.INCLUDED,
-          reasons: [],
-          transactionAmount: Number(data.GROSS_WEIGHT) || 0
-        })
-      }
-    })
-  )
+const SINGLE_DATE_TABLE_SCHEMAS = /** @type {Record<string, TableSchema>} */ (
+  /** @type {unknown} */ ({
+    RECEIVED_LOADS_FOR_REPROCESSING: {
+      reportingDateFields: ['DATE_RECEIVED_FOR_REPROCESSING'],
+      wasteRecordType: 'received',
+      classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
+        outcome: ROW_OUTCOME.INCLUDED,
+        reasons: [],
+        transactionAmount: Number(data.GROSS_WEIGHT) || 0
+      })
+    }
+  })
+)
 
 /** @type {Record<string, TableSchema>} Multi-date-field table schemas (exporter received-loads). */
-const MULTI_DATE_TABLE_SCHEMAS =
-  /** @type {Record<string, TableSchema>} */ (
-    /** @type {unknown} */ ({
-      RECEIVED_LOADS_FOR_EXPORT: {
-        reportingDateFields: ['DATE_RECEIVED_FOR_EXPORT', 'DATE_OF_EXPORT'],
-        wasteRecordType: 'received',
-        classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
-          outcome: ROW_OUTCOME.INCLUDED,
-          reasons: [],
-          transactionAmount: Number(data.GROSS_WEIGHT) || 0
-        })
-      }
-    })
-  )
+const MULTI_DATE_TABLE_SCHEMAS = /** @type {Record<string, TableSchema>} */ (
+  /** @type {unknown} */ ({
+    RECEIVED_LOADS_FOR_EXPORT: {
+      reportingDateFields: ['DATE_RECEIVED_FOR_EXPORT', 'DATE_OF_EXPORT'],
+      wasteRecordType: 'received',
+      classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
+        outcome: ROW_OUTCOME.INCLUDED,
+        reasons: [],
+        transactionAmount: Number(data.GROSS_WEIGHT) || 0
+      })
+    }
+  })
+)
 
 /** @type {Record<string, TableSchema>} Registered-only table schemas (monthly dates as YYYY-MM). */
 const REGISTERED_ONLY_TABLE_SCHEMAS =
@@ -672,15 +670,17 @@ describe('classifyByPeriodStatus', () => {
 
   describe('transaction amount for non-INCLUDED classification', () => {
     it('uses zero transaction amount when classifyForWasteBalance returns EXCLUDED', () => {
-      const schemasWithExcluded = /** @type {Record<string, TableSchema>} */ (/** @type {unknown} */ ({
-        RECEIVED_LOADS_FOR_REPROCESSING: {
-          ...SINGLE_DATE_TABLE_SCHEMAS.RECEIVED_LOADS_FOR_REPROCESSING,
-          classifyForWasteBalance: () => ({
-            outcome: ROW_OUTCOME.EXCLUDED,
-            reasons: []
-          })
-        }
-      }))
+      const schemasWithExcluded = /** @type {Record<string, TableSchema>} */ (
+        /** @type {unknown} */ ({
+          RECEIVED_LOADS_FOR_REPROCESSING: {
+            ...SINGLE_DATE_TABLE_SCHEMAS.RECEIVED_LOADS_FOR_REPROCESSING,
+            classifyForWasteBalance: () => ({
+              outcome: ROW_OUTCOME.EXCLUDED,
+              reasons: []
+            })
+          }
+        })
+      )
 
       const result = classifyByPeriodStatus({
         ...baseParams,

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -107,10 +107,9 @@ const REGISTERED_ONLY_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
   })
 )
 
-const emptyBucket = () => ({ count: 0, tonnageDelta: 0 })
 const emptyChange = () => ({
-  balanceAffecting: emptyBucket(),
-  nonBalanceAffecting: emptyBucket()
+  balanceAffecting: { count: 0, tonnageDelta: 0 },
+  nonBalanceAffecting: { count: 0 }
 })
 const emptyPeriod = () => ({
   added: emptyChange(),
@@ -209,16 +208,34 @@ describe('classifyByPeriodStatus', () => {
       })
     })
 
-    it('classifies an added excluded record with zero tonnageDelta', () => {
+    it('classifies an added record excluded from the balance as nonBalanceAffecting', () => {
+      // A PRN-issued row passes validation (outcome INCLUDED) but is excluded
+      // from the waste balance, so its transaction amount is 0. It moves no
+      // balance and must land in nonBalanceAffecting.
+      const excludedFromBalanceSchemas = /** @type {ProcessingTypeSchemas} */ (
+        /** @type {unknown} */ ({
+          RECEIVED_LOADS_FOR_REPROCESSING: {
+            reportingDateFields: ['DATE_RECEIVED_FOR_REPROCESSING'],
+            wasteRecordType: 'received',
+            classifyForWasteBalance: () => ({
+              outcome: ROW_OUTCOME.EXCLUDED,
+              reasons: [],
+              transactionAmount: 0
+            })
+          }
+        })
+      )
+
       const result = classifyByPeriodStatus({
         ...baseParams,
-        wasteRecords: [buildWasteRecord({ outcome: ROW_OUTCOME.EXCLUDED })]
+        tableSchemas: excludedFromBalanceSchemas,
+        wasteRecords: [buildWasteRecord()]
       })
 
       expect(result.openPeriodLoads.added.nonBalanceAffecting).toEqual({
-        count: 1,
-        tonnageDelta: 0
+        count: 1
       })
+      expect(result.openPeriodLoads.added.balanceAffecting.count).toBe(0)
     })
 
     it('rounds summed tonnageDelta to 2dp so no float noise leaks out', () => {
@@ -298,6 +315,52 @@ describe('classifyByPeriodStatus', () => {
         count: 1,
         tonnageDelta: 20
       })
+    })
+
+    it('classifies a same-period adjust that nets to zero as nonBalanceAffecting', () => {
+      const existingRecordsMap = new Map([
+        [
+          'received:10001',
+          /** @type {WasteRecord} */ (
+            /** @type {unknown} */ ({
+              type: 'received',
+              rowId: '10001',
+              data: {
+                DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
+                GROSS_WEIGHT: '30'
+              }
+            })
+          )
+        ]
+      ])
+
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        existingRecordsMap,
+        wasteRecords: [
+          buildWasteRecord({
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-15',
+              GROSS_WEIGHT: '30'
+            },
+            versionStatus: VERSION_STATUS.UPDATED,
+            previousVersions: [
+              {
+                summaryLog: { id: 'sl-old' },
+                status: VERSION_STATUS.CREATED,
+                data: {
+                  DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
+                  GROSS_WEIGHT: '30'
+                }
+              }
+            ]
+          })
+        ]
+      })
+
+      // Net delta = 30 - 30 = 0, so the row did not affect the balance.
+      expect(result.openPeriodLoads.adjusted.balanceAffecting.count).toBe(0)
+      expect(result.openPeriodLoads.adjusted.nonBalanceAffecting.count).toBe(1)
     })
 
     it('splits into two entries when old and new dates are in different periods', () => {
@@ -435,7 +498,7 @@ describe('classifyByPeriodStatus', () => {
       })
     })
 
-    it('handles included-to-excluded reversal with negative delta in old period', () => {
+    it('keeps an included-to-excluded reversal in balanceAffecting', () => {
       const existingRecordsMap = new Map([
         [
           'received:10001',
@@ -477,12 +540,15 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      // Record is now excluded, so it goes to excluded bucket
-      // Old amount was 30 (included), new amount is 0 (excluded)
-      // Net delta: 0 - 30 = -30
-      expect(result.openPeriodLoads.adjusted.nonBalanceAffecting).toEqual({
+      // Old amount was 30 (included), new amount is 0 (excluded), same period.
+      // Net delta -30 moved the balance, so the row is balanceAffecting even
+      // though its new version is excluded from the waste balance.
+      expect(result.openPeriodLoads.adjusted.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: -30
+      })
+      expect(result.openPeriodLoads.adjusted.nonBalanceAffecting).toEqual({
+        count: 0
       })
     })
 

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -452,6 +452,52 @@ describe('classifyByPeriodStatus', () => {
         tonnageDelta: -30
       })
     })
+
+    it('produces no entries when both new and existing records have no date', () => {
+      const existingRecordsMap = new Map([
+        [
+          'received:10001',
+          /** @type {WasteRecord} */ (
+            /** @type {unknown} */ ({
+              type: 'received',
+              rowId: '10001',
+              data: {
+                DATE_RECEIVED_FOR_REPROCESSING: null,
+                GROSS_WEIGHT: '30'
+              }
+            })
+          )
+        ]
+      ])
+
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        existingRecordsMap,
+        wasteRecords: [
+          buildWasteRecord({
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: null,
+              GROSS_WEIGHT: '50'
+            },
+            versionStatus: VERSION_STATUS.UPDATED,
+            previousVersions: [
+              {
+                summaryLog: { id: 'sl-old' },
+                status: VERSION_STATUS.CREATED,
+                data: {
+                  DATE_RECEIVED_FOR_REPROCESSING: null,
+                  GROSS_WEIGHT: '30'
+                }
+              }
+            ]
+          })
+        ]
+      })
+
+      // Both new and old dates are null so classify returns null for both;
+      // the record contributes nothing to any period bucket
+      expect(result).toEqual(emptyResult())
+    })
   })
 
   describe('closed-wins rule (multiple reporting date fields)', () => {

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -1,0 +1,767 @@
+import { describe, expect, it } from 'vitest'
+import { classifyByPeriodStatus } from './period-status.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { VERSION_STATUS } from '#domain/waste-records/model.js'
+
+/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {PeriodicReport} from '#reports/repository/port.js' */
+/** @import {WasteRecord} from '#domain/waste-records/model.js' */
+
+const SUMMARY_LOG_ID = 'sl-1'
+
+/**
+ * @param {Partial<{
+ *   rowId: string,
+ *   type: string,
+ *   data: Record<string, string | null>,
+ *   outcome: string,
+ *   tableName: string,
+ *   versionStatus: string,
+ *   summaryLogId: string,
+ *   previousVersions: Array<{ summaryLog: { id: string }, status: string, data: Record<string, string | null> }>
+ * }>} [overrides]
+ * @returns {ValidatedWasteRecord}
+ */
+const buildWasteRecord = ({
+  rowId = '10001',
+  type = 'received',
+  data = { DATE_RECEIVED_FOR_REPROCESSING: '2026-01-15', GROSS_WEIGHT: '42.5' },
+  outcome = ROW_OUTCOME.INCLUDED,
+  tableName = 'RECEIVED_LOADS_FOR_REPROCESSING',
+  versionStatus = VERSION_STATUS.CREATED,
+  summaryLogId = SUMMARY_LOG_ID,
+  previousVersions = []
+} = {}) =>
+  /** @type {ValidatedWasteRecord} */ (
+    /** @type {unknown} */ ({
+      record: {
+        type,
+        rowId,
+        data,
+        versions: [
+          ...previousVersions.map((v) => ({
+            id: `v-prev-${Math.random()}`,
+            createdAt: '2026-01-01T00:00:00Z',
+            summaryLog: v.summaryLog,
+            status: v.status,
+            data: v.data
+          })),
+          {
+            id: 'v-1',
+            createdAt: '2026-01-15T00:00:00Z',
+            summaryLog: { id: summaryLogId },
+            status: versionStatus,
+            data
+          }
+        ]
+      },
+      outcome,
+      tableName,
+      issues: []
+    })
+  )
+
+/** Single-date-field table schemas (most tables). */
+const SINGLE_DATE_TABLE_SCHEMAS = {
+  RECEIVED_LOADS_FOR_REPROCESSING: {
+    reportingDateFields: ['DATE_RECEIVED_FOR_REPROCESSING'],
+    wasteRecordType: 'received',
+    classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
+      outcome: ROW_OUTCOME.INCLUDED,
+      reasons: [],
+      transactionAmount: Number(data.GROSS_WEIGHT) || 0
+    })
+  }
+}
+
+/** Multi-date-field table schemas (exporter received-loads). */
+const MULTI_DATE_TABLE_SCHEMAS = {
+  RECEIVED_LOADS_FOR_EXPORT: {
+    reportingDateFields: ['DATE_RECEIVED_FOR_EXPORT', 'DATE_OF_EXPORT'],
+    wasteRecordType: 'received',
+    classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
+      outcome: ROW_OUTCOME.INCLUDED,
+      reasons: [],
+      transactionAmount: Number(data.GROSS_WEIGHT) || 0
+    })
+  }
+}
+
+/** Registered-only table schemas (monthly dates as YYYY-MM). */
+const REGISTERED_ONLY_TABLE_SCHEMAS = {
+  RECEIVED_LOADS_FOR_REPROCESSING: {
+    reportingDateFields: ['MONTH_RECEIVED_FOR_REPROCESSING'],
+    wasteRecordType: 'received',
+    classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
+      outcome: ROW_OUTCOME.INCLUDED,
+      reasons: [],
+      transactionAmount: Number(data.GROSS_WEIGHT) || 0
+    })
+  }
+}
+
+const emptyBucket = () => ({ count: 0, tonnageDelta: 0 })
+const emptyChange = () => ({
+  included: emptyBucket(),
+  excluded: emptyBucket()
+})
+const emptyPeriod = () => ({
+  added: emptyChange(),
+  adjusted: emptyChange()
+})
+const emptyResult = () => ({
+  open: emptyPeriod(),
+  closed: emptyPeriod()
+})
+
+/**
+ * @param {{ cadence?: string, period?: number, year?: number }} [opts]
+ * @returns {PeriodicReport}
+ */
+const buildSubmittedReport = ({
+  cadence = 'monthly',
+  period = 1,
+  year = 2026
+} = {}) =>
+  /** @type {PeriodicReport} */ (
+    /** @type {unknown} */ ({
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      year,
+      reports: {
+        [cadence]: {
+          [period]: {
+            startDate: '2026-01-01',
+            endDate: '2026-01-31',
+            dueDate: '2026-02-20',
+            current: null,
+            previousSubmissions: [
+              {
+                id: 'report-1',
+                status: 'submitted',
+                submissionNumber: 1,
+                submittedAt: null,
+                submittedBy: null
+              }
+            ]
+          }
+        }
+      }
+    })
+  )
+
+const accreditation = { status: 'approved', validFrom: '2025-01-01' }
+const classificationContext = {
+  accreditation,
+  overseasSites: Symbol('ORS_DISABLED')
+}
+
+const baseParams = {
+  summaryLogId: SUMMARY_LOG_ID,
+  cadence: /** @type {'monthly' | 'quarterly'} */ ('monthly'),
+  tableSchemas: SINGLE_DATE_TABLE_SCHEMAS,
+  classificationContext,
+  existingRecordsMap: /** @type {Map<string, WasteRecord>} */ (new Map()),
+  periodicReports: /** @type {PeriodicReport[]} */ ([])
+}
+
+describe('classifyByPeriodStatus', () => {
+  it('returns all-zero structure for empty waste records', () => {
+    const result = classifyByPeriodStatus({
+      ...baseParams,
+      wasteRecords: []
+    })
+
+    expect(result).toEqual(emptyResult())
+  })
+
+  describe('added records', () => {
+    it('classifies an added included record into the open period', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        wasteRecords: [buildWasteRecord()]
+      })
+
+      expect(result.open.added.included).toEqual({
+        count: 1,
+        tonnageDelta: 42.5
+      })
+    })
+
+    it('classifies an added included record into the closed period', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        wasteRecords: [buildWasteRecord()],
+        periodicReports: [buildSubmittedReport()]
+      })
+
+      expect(result.closed.added.included).toEqual({
+        count: 1,
+        tonnageDelta: 42.5
+      })
+    })
+
+    it('classifies an added excluded record with zero tonnageDelta', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        wasteRecords: [buildWasteRecord({ outcome: ROW_OUTCOME.EXCLUDED })]
+      })
+
+      expect(result.open.added.excluded).toEqual({
+        count: 1,
+        tonnageDelta: 0
+      })
+    })
+  })
+
+  describe('adjusted records', () => {
+    it('computes net delta when the period is unchanged', () => {
+      const existingRecordsMap = new Map([
+        [
+          'received:10001',
+          /** @type {WasteRecord} */ (
+            /** @type {unknown} */ ({
+              type: 'received',
+              rowId: '10001',
+              data: {
+                DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
+                GROSS_WEIGHT: '30'
+              }
+            })
+          )
+        ]
+      ])
+
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        existingRecordsMap,
+        wasteRecords: [
+          buildWasteRecord({
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-15',
+              GROSS_WEIGHT: '50'
+            },
+            versionStatus: VERSION_STATUS.UPDATED,
+            previousVersions: [
+              {
+                summaryLog: { id: 'sl-old' },
+                status: VERSION_STATUS.CREATED,
+                data: {
+                  DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
+                  GROSS_WEIGHT: '30'
+                }
+              }
+            ]
+          })
+        ]
+      })
+
+      // Same period (February, open) so net delta = 50 - 30 = 20
+      expect(result.open.adjusted.included).toEqual({
+        count: 1,
+        tonnageDelta: 20
+      })
+    })
+
+    it('splits into two entries when old and new dates are in different periods', () => {
+      const existingRecordsMap = new Map([
+        [
+          'received:10001',
+          /** @type {WasteRecord} */ (
+            /** @type {unknown} */ ({
+              type: 'received',
+              rowId: '10001',
+              data: {
+                DATE_RECEIVED_FOR_REPROCESSING: '2026-01-10',
+                GROSS_WEIGHT: '30'
+              }
+            })
+          )
+        ]
+      ])
+
+      // January is closed, February is open
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        existingRecordsMap,
+        periodicReports: [buildSubmittedReport({ period: 1 })],
+        wasteRecords: [
+          buildWasteRecord({
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-15',
+              GROSS_WEIGHT: '50'
+            },
+            versionStatus: VERSION_STATUS.UPDATED,
+            previousVersions: [
+              {
+                summaryLog: { id: 'sl-old' },
+                status: VERSION_STATUS.CREATED,
+                data: {
+                  DATE_RECEIVED_FOR_REPROCESSING: '2026-01-10',
+                  GROSS_WEIGHT: '30'
+                }
+              }
+            ]
+          })
+        ]
+      })
+
+      // Old period (January, closed): -30
+      expect(result.closed.adjusted.included.tonnageDelta).toBe(-30)
+      // New period (February, open): +50
+      expect(result.open.adjusted.included.tonnageDelta).toBe(50)
+      // Count goes to the new period
+      expect(result.open.adjusted.included.count).toBe(1)
+      expect(result.closed.adjusted.included.count).toBe(0)
+    })
+
+    it('assigns count to old period when new date is blanked out', () => {
+      const existingRecordsMap = new Map([
+        [
+          'received:10001',
+          /** @type {WasteRecord} */ (
+            /** @type {unknown} */ ({
+              type: 'received',
+              rowId: '10001',
+              data: {
+                DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
+                GROSS_WEIGHT: '30'
+              }
+            })
+          )
+        ]
+      ])
+
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        existingRecordsMap,
+        wasteRecords: [
+          buildWasteRecord({
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: null,
+              GROSS_WEIGHT: '0'
+            },
+            versionStatus: VERSION_STATUS.UPDATED,
+            previousVersions: [
+              {
+                summaryLog: { id: 'sl-old' },
+                status: VERSION_STATUS.CREATED,
+                data: {
+                  DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
+                  GROSS_WEIGHT: '30'
+                }
+              }
+            ]
+          })
+        ]
+      })
+
+      // New date is null so newPeriod is null; count goes to old period
+      expect(result.open.adjusted.included.count).toBe(1)
+      expect(result.open.adjusted.included.tonnageDelta).toBe(-30)
+    })
+
+    it('handles adjusted record with no existing record in the map', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        wasteRecords: [
+          buildWasteRecord({
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-15',
+              GROSS_WEIGHT: '50'
+            },
+            versionStatus: VERSION_STATUS.UPDATED,
+            previousVersions: [
+              {
+                summaryLog: { id: 'sl-old' },
+                status: VERSION_STATUS.CREATED,
+                data: {
+                  DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
+                  GROSS_WEIGHT: '30'
+                }
+              }
+            ]
+          })
+        ]
+      })
+
+      // No existing record so oldPeriod is null, oldAmount is 0
+      expect(result.open.adjusted.included).toEqual({
+        count: 1,
+        tonnageDelta: 50
+      })
+    })
+
+    it('handles included-to-excluded reversal with negative delta in old period', () => {
+      const existingRecordsMap = new Map([
+        [
+          'received:10001',
+          /** @type {WasteRecord} */ (
+            /** @type {unknown} */ ({
+              type: 'received',
+              rowId: '10001',
+              data: {
+                DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
+                GROSS_WEIGHT: '30'
+              }
+            })
+          )
+        ]
+      ])
+
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        existingRecordsMap,
+        wasteRecords: [
+          buildWasteRecord({
+            outcome: ROW_OUTCOME.EXCLUDED,
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-15',
+              GROSS_WEIGHT: '0'
+            },
+            versionStatus: VERSION_STATUS.UPDATED,
+            previousVersions: [
+              {
+                summaryLog: { id: 'sl-old' },
+                status: VERSION_STATUS.CREATED,
+                data: {
+                  DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
+                  GROSS_WEIGHT: '30'
+                }
+              }
+            ]
+          })
+        ]
+      })
+
+      // Record is now excluded, so it goes to excluded bucket
+      // Old amount was 30 (included), new amount is 0 (excluded)
+      // Net delta: 0 - 30 = -30
+      expect(result.open.adjusted.excluded).toEqual({
+        count: 1,
+        tonnageDelta: -30
+      })
+    })
+  })
+
+  describe('closed-wins rule (multiple reporting date fields)', () => {
+    it('classifies a row as closed when one date is in a closed period and another is open', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        tableSchemas: MULTI_DATE_TABLE_SCHEMAS,
+        periodicReports: [buildSubmittedReport({ period: 1 })],
+        wasteRecords: [
+          buildWasteRecord({
+            data: {
+              DATE_RECEIVED_FOR_EXPORT: '2026-01-15',
+              DATE_OF_EXPORT: '2026-02-10',
+              GROSS_WEIGHT: '42.5'
+            },
+            tableName: 'RECEIVED_LOADS_FOR_EXPORT'
+          })
+        ]
+      })
+
+      expect(result.closed.added.included.count).toBe(1)
+      expect(result.open.added.included.count).toBe(0)
+    })
+
+    it('classifies a row as open when all dates are in open periods', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        tableSchemas: MULTI_DATE_TABLE_SCHEMAS,
+        wasteRecords: [
+          buildWasteRecord({
+            data: {
+              DATE_RECEIVED_FOR_EXPORT: '2026-02-15',
+              DATE_OF_EXPORT: '2026-03-10',
+              GROSS_WEIGHT: '42.5'
+            },
+            tableName: 'RECEIVED_LOADS_FOR_EXPORT'
+          })
+        ]
+      })
+
+      expect(result.open.added.included.count).toBe(1)
+      expect(result.closed.added.included.count).toBe(0)
+    })
+  })
+
+  describe('skipped records', () => {
+    it('skips IGNORED records', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        wasteRecords: [buildWasteRecord({ outcome: ROW_OUTCOME.IGNORED })]
+      })
+
+      expect(result).toEqual(emptyResult())
+    })
+
+    it('skips unchanged records (not touched by this summary log)', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        wasteRecords: [buildWasteRecord({ summaryLogId: 'sl-other' })]
+      })
+
+      expect(result).toEqual(emptyResult())
+    })
+
+    it('skips records with no matching table schema', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        wasteRecords: [buildWasteRecord({ tableName: 'UNKNOWN_TABLE' })]
+      })
+
+      expect(result).toEqual(emptyResult())
+    })
+
+    it('skips records with no date field values', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        wasteRecords: [
+          buildWasteRecord({
+            data: { DATE_RECEIVED_FOR_REPROCESSING: null, GROSS_WEIGHT: '10' }
+          })
+        ]
+      })
+
+      expect(result).toEqual(emptyResult())
+    })
+  })
+
+  describe('quarterly cadence', () => {
+    it('maps months to quarterly periods correctly', () => {
+      // March is Q1, April is Q2
+      // Submit Q1 report, so March is closed, April is open
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        cadence: 'quarterly',
+        periodicReports: [
+          buildSubmittedReport({ cadence: 'quarterly', period: 1 })
+        ],
+        wasteRecords: [
+          buildWasteRecord({
+            rowId: '10001',
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: '2026-03-15',
+              GROSS_WEIGHT: '10'
+            }
+          }),
+          buildWasteRecord({
+            rowId: '10002',
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: '2026-04-15',
+              GROSS_WEIGHT: '20'
+            }
+          })
+        ]
+      })
+
+      expect(result.closed.added.included).toEqual({
+        count: 1,
+        tonnageDelta: 10
+      })
+      expect(result.open.added.included).toEqual({
+        count: 1,
+        tonnageDelta: 20
+      })
+    })
+  })
+
+  describe('registered-only YYYY-MM date format', () => {
+    it('handles month-only dates correctly', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        cadence: 'quarterly',
+        tableSchemas: REGISTERED_ONLY_TABLE_SCHEMAS,
+        periodicReports: [
+          buildSubmittedReport({ cadence: 'quarterly', period: 1 })
+        ],
+        wasteRecords: [
+          buildWasteRecord({
+            data: {
+              MONTH_RECEIVED_FOR_REPROCESSING: '2026-01',
+              GROSS_WEIGHT: '10'
+            },
+            tableName: 'RECEIVED_LOADS_FOR_REPROCESSING'
+          })
+        ]
+      })
+
+      expect(result.closed.added.included).toEqual({
+        count: 1,
+        tonnageDelta: 10
+      })
+    })
+  })
+
+  describe('cadence mismatch in periodic reports', () => {
+    it('ignores periodic reports that do not have the requested cadence', () => {
+      // Quarterly report but monthly cadence requested
+      const report = /** @type {PeriodicReport} */ (
+        /** @type {unknown} */ ({
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          year: 2026,
+          reports: {
+            quarterly: {
+              1: {
+                current: null,
+                previousSubmissions: [{ id: 'r-1', status: 'submitted' }]
+              }
+            }
+          }
+        })
+      )
+
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        cadence: 'monthly',
+        periodicReports: [report],
+        wasteRecords: [buildWasteRecord()]
+      })
+
+      // The report is quarterly but cadence is monthly, so no periods are closed
+      expect(result.open.added.included.count).toBe(1)
+    })
+  })
+
+  describe('period open when report exists but is not submitted', () => {
+    it('treats a period as open when report is in_progress with no previous submissions', () => {
+      const report = /** @type {PeriodicReport} */ (
+        /** @type {unknown} */ ({
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          year: 2026,
+          reports: {
+            monthly: {
+              1: {
+                startDate: '2026-01-01',
+                endDate: '2026-01-31',
+                dueDate: '2026-02-20',
+                current: { status: 'in_progress', submissionNumber: 0 },
+                previousSubmissions: []
+              }
+            }
+          }
+        })
+      )
+
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        periodicReports: [report],
+        wasteRecords: [buildWasteRecord()]
+      })
+
+      expect(result.open.added.included.count).toBe(1)
+      expect(result.closed.added.included.count).toBe(0)
+    })
+  })
+
+  describe('transaction amount for non-INCLUDED classification', () => {
+    it('uses zero transaction amount when classifyForWasteBalance returns EXCLUDED', () => {
+      const schemasWithExcluded = {
+        RECEIVED_LOADS_FOR_REPROCESSING: {
+          ...SINGLE_DATE_TABLE_SCHEMAS.RECEIVED_LOADS_FOR_REPROCESSING,
+          classifyForWasteBalance: () => ({
+            outcome: ROW_OUTCOME.EXCLUDED,
+            reasons: []
+          })
+        }
+      }
+
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        tableSchemas: schemasWithExcluded,
+        wasteRecords: [buildWasteRecord()]
+      })
+
+      // Record is INCLUDED per outcome but schema returns EXCLUDED for amount
+      // so tonnageDelta should be 0
+      expect(result.open.added.included.tonnageDelta).toBe(0)
+    })
+  })
+
+  describe('period closed by current submission status', () => {
+    it('treats a period as closed when current report status is submitted', () => {
+      const report = /** @type {PeriodicReport} */ (
+        /** @type {unknown} */ ({
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          year: 2026,
+          reports: {
+            monthly: {
+              1: {
+                startDate: '2026-01-01',
+                endDate: '2026-01-31',
+                dueDate: '2026-02-20',
+                current: { status: 'submitted', submissionNumber: 1 },
+                previousSubmissions: []
+              }
+            }
+          }
+        })
+      )
+
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        periodicReports: [report],
+        wasteRecords: [buildWasteRecord()]
+      })
+
+      expect(result.closed.added.included.count).toBe(1)
+    })
+  })
+
+  describe('Date object date values', () => {
+    it('handles Date objects in reporting date fields', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        wasteRecords: [
+          buildWasteRecord({
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: /** @type {any} */ (
+                new Date('2026-01-15T00:00:00Z')
+              ),
+              GROSS_WEIGHT: '10'
+            }
+          })
+        ]
+      })
+
+      expect(result.open.added.included).toEqual({
+        count: 1,
+        tonnageDelta: 10
+      })
+    })
+  })
+
+  describe('aggregation across multiple records', () => {
+    it('sums counts and tonnageDelta across multiple records in the same bucket', () => {
+      const result = classifyByPeriodStatus({
+        ...baseParams,
+        wasteRecords: [
+          buildWasteRecord({
+            rowId: '10001',
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
+              GROSS_WEIGHT: '20'
+            }
+          }),
+          buildWasteRecord({
+            rowId: '10002',
+            data: {
+              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-15',
+              GROSS_WEIGHT: '30'
+            }
+          })
+        ]
+      })
+
+      expect(result.open.added.included).toEqual({
+        count: 2,
+        tonnageDelta: 50
+      })
+    })
+  })
+})

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -117,8 +117,8 @@ const emptyPeriod = () => ({
   adjusted: emptyChange()
 })
 const emptyResult = () => ({
-  open: emptyPeriod(),
-  closed: emptyPeriod()
+  openPeriodLoads: emptyPeriod(),
+  closedPeriodLoads: emptyPeriod()
 })
 
 /**
@@ -190,7 +190,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords: [buildWasteRecord()]
       })
 
-      expect(result.open.added.balanceAffecting).toEqual({
+      expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 42.5
       })
@@ -203,7 +203,7 @@ describe('classifyByPeriodStatus', () => {
         periodicReports: [buildSubmittedReport()]
       })
 
-      expect(result.closed.added.balanceAffecting).toEqual({
+      expect(result.closedPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 42.5
       })
@@ -215,7 +215,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords: [buildWasteRecord({ outcome: ROW_OUTCOME.EXCLUDED })]
       })
 
-      expect(result.open.added.nonBalanceAffecting).toEqual({
+      expect(result.openPeriodLoads.added.nonBalanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 0
       })
@@ -244,7 +244,7 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.open.added.balanceAffecting).toEqual({
+      expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
         count: 2,
         tonnageDelta: 0.3
       })
@@ -294,7 +294,7 @@ describe('classifyByPeriodStatus', () => {
       })
 
       // Same period (February, open) so net delta = 50 - 30 = 20
-      expect(result.open.adjusted.balanceAffecting).toEqual({
+      expect(result.openPeriodLoads.adjusted.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 20
       })
@@ -344,12 +344,16 @@ describe('classifyByPeriodStatus', () => {
       })
 
       // Old period (January, closed): -30
-      expect(result.closed.adjusted.balanceAffecting.tonnageDelta).toBe(-30)
+      expect(
+        result.closedPeriodLoads.adjusted.balanceAffecting.tonnageDelta
+      ).toBe(-30)
       // New period (February, open): +50
-      expect(result.open.adjusted.balanceAffecting.tonnageDelta).toBe(50)
+      expect(
+        result.openPeriodLoads.adjusted.balanceAffecting.tonnageDelta
+      ).toBe(50)
       // Count goes to the new period
-      expect(result.open.adjusted.balanceAffecting.count).toBe(1)
-      expect(result.closed.adjusted.balanceAffecting.count).toBe(0)
+      expect(result.openPeriodLoads.adjusted.balanceAffecting.count).toBe(1)
+      expect(result.closedPeriodLoads.adjusted.balanceAffecting.count).toBe(0)
     })
 
     it('assigns count to old period when new date is blanked out', () => {
@@ -394,8 +398,10 @@ describe('classifyByPeriodStatus', () => {
       })
 
       // New date is null so newPeriod is null; count goes to old period
-      expect(result.open.adjusted.balanceAffecting.count).toBe(1)
-      expect(result.open.adjusted.balanceAffecting.tonnageDelta).toBe(-30)
+      expect(result.openPeriodLoads.adjusted.balanceAffecting.count).toBe(1)
+      expect(
+        result.openPeriodLoads.adjusted.balanceAffecting.tonnageDelta
+      ).toBe(-30)
     })
 
     it('handles adjusted record with no existing record in the map', () => {
@@ -423,7 +429,7 @@ describe('classifyByPeriodStatus', () => {
       })
 
       // No existing record so oldPeriod is null, oldAmount is 0
-      expect(result.open.adjusted.balanceAffecting).toEqual({
+      expect(result.openPeriodLoads.adjusted.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 50
       })
@@ -474,7 +480,7 @@ describe('classifyByPeriodStatus', () => {
       // Record is now excluded, so it goes to excluded bucket
       // Old amount was 30 (included), new amount is 0 (excluded)
       // Net delta: 0 - 30 = -30
-      expect(result.open.adjusted.nonBalanceAffecting).toEqual({
+      expect(result.openPeriodLoads.adjusted.nonBalanceAffecting).toEqual({
         count: 1,
         tonnageDelta: -30
       })
@@ -545,8 +551,8 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.closed.added.balanceAffecting.count).toBe(1)
-      expect(result.open.added.balanceAffecting.count).toBe(0)
+      expect(result.closedPeriodLoads.added.balanceAffecting.count).toBe(1)
+      expect(result.openPeriodLoads.added.balanceAffecting.count).toBe(0)
     })
 
     it('classifies a row as open when all dates are in open periods', () => {
@@ -565,8 +571,8 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.open.added.balanceAffecting.count).toBe(1)
-      expect(result.closed.added.balanceAffecting.count).toBe(0)
+      expect(result.openPeriodLoads.added.balanceAffecting.count).toBe(1)
+      expect(result.closedPeriodLoads.added.balanceAffecting.count).toBe(0)
     })
   })
 
@@ -640,11 +646,11 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.closed.added.balanceAffecting).toEqual({
+      expect(result.closedPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 10
       })
-      expect(result.open.added.balanceAffecting).toEqual({
+      expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 20
       })
@@ -671,7 +677,7 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.closed.added.balanceAffecting).toEqual({
+      expect(result.closedPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 10
       })
@@ -705,7 +711,7 @@ describe('classifyByPeriodStatus', () => {
       })
 
       // The report is quarterly but cadence is monthly, so no periods are closed
-      expect(result.open.added.balanceAffecting.count).toBe(1)
+      expect(result.openPeriodLoads.added.balanceAffecting.count).toBe(1)
     })
   })
 
@@ -736,8 +742,8 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords: [buildWasteRecord()]
       })
 
-      expect(result.open.added.balanceAffecting.count).toBe(1)
-      expect(result.closed.added.balanceAffecting.count).toBe(0)
+      expect(result.openPeriodLoads.added.balanceAffecting.count).toBe(1)
+      expect(result.closedPeriodLoads.added.balanceAffecting.count).toBe(0)
     })
   })
 
@@ -763,7 +769,7 @@ describe('classifyByPeriodStatus', () => {
 
       // Record is INCLUDED per outcome but schema returns EXCLUDED for amount
       // so tonnageDelta should be 0
-      expect(result.open.added.balanceAffecting.tonnageDelta).toBe(0)
+      expect(result.openPeriodLoads.added.balanceAffecting.tonnageDelta).toBe(0)
     })
   })
 
@@ -794,7 +800,7 @@ describe('classifyByPeriodStatus', () => {
         wasteRecords: [buildWasteRecord()]
       })
 
-      expect(result.closed.added.balanceAffecting.count).toBe(1)
+      expect(result.closedPeriodLoads.added.balanceAffecting.count).toBe(1)
     })
   })
 
@@ -814,7 +820,7 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.open.added.balanceAffecting).toEqual({
+      expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 10
       })
@@ -843,7 +849,7 @@ describe('classifyByPeriodStatus', () => {
         ]
       })
 
-      expect(result.open.added.balanceAffecting).toEqual({
+      expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
         count: 2,
         tonnageDelta: 50
       })

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -7,7 +7,7 @@ import { VERSION_STATUS } from '#domain/waste-records/model.js'
 /** @import {PeriodicReport} from '#reports/repository/port.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
 /** @import {TableSchema} from '#domain/summary-logs/table-schemas/index.js' */
-/** @import {ClassificationContext} from './period-status.js' */
+/** @import {ClassificationContext, ProcessingTypeSchemas} from './period-status.js' */
 
 const SUMMARY_LOG_ID = 'sl-1'
 
@@ -63,8 +63,8 @@ const buildWasteRecord = ({
     })
   )
 
-/** @type {Record<string, TableSchema>} Single-date-field table schemas (most tables). */
-const SINGLE_DATE_TABLE_SCHEMAS = /** @type {Record<string, TableSchema>} */ (
+/** @type {ProcessingTypeSchemas} Single-date-field table schemas (most tables). */
+const SINGLE_DATE_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
   /** @type {unknown} */ ({
     RECEIVED_LOADS_FOR_REPROCESSING: {
       reportingDateFields: ['DATE_RECEIVED_FOR_REPROCESSING'],
@@ -78,8 +78,8 @@ const SINGLE_DATE_TABLE_SCHEMAS = /** @type {Record<string, TableSchema>} */ (
   })
 )
 
-/** @type {Record<string, TableSchema>} Multi-date-field table schemas (exporter received-loads). */
-const MULTI_DATE_TABLE_SCHEMAS = /** @type {Record<string, TableSchema>} */ (
+/** @type {ProcessingTypeSchemas} Multi-date-field table schemas (exporter received-loads). */
+const MULTI_DATE_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
   /** @type {unknown} */ ({
     RECEIVED_LOADS_FOR_EXPORT: {
       reportingDateFields: ['DATE_RECEIVED_FOR_EXPORT', 'DATE_OF_EXPORT'],
@@ -93,9 +93,9 @@ const MULTI_DATE_TABLE_SCHEMAS = /** @type {Record<string, TableSchema>} */ (
   })
 )
 
-/** @type {Record<string, TableSchema>} Registered-only table schemas (monthly dates as YYYY-MM). */
+/** @type {ProcessingTypeSchemas} Registered-only table schemas (monthly dates as YYYY-MM). */
 const REGISTERED_ONLY_TABLE_SCHEMAS =
-  /** @type {Record<string, TableSchema>} */ (
+  /** @type {ProcessingTypeSchemas} */ (
     /** @type {unknown} */ ({
       RECEIVED_LOADS_FOR_REPROCESSING: {
         reportingDateFields: ['MONTH_RECEIVED_FOR_REPROCESSING'],
@@ -716,7 +716,7 @@ describe('classifyByPeriodStatus', () => {
 
   describe('transaction amount for non-INCLUDED classification', () => {
     it('uses zero transaction amount when classifyForWasteBalance returns EXCLUDED', () => {
-      const schemasWithExcluded = /** @type {Record<string, TableSchema>} */ (
+      const schemasWithExcluded = /** @type {ProcessingTypeSchemas} */ (
         /** @type {unknown} */ ({
           RECEIVED_LOADS_FOR_REPROCESSING: {
             ...SINGLE_DATE_TABLE_SCHEMAS.RECEIVED_LOADS_FOR_REPROCESSING,

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -6,6 +6,8 @@ import { VERSION_STATUS } from '#domain/waste-records/model.js'
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {PeriodicReport} from '#reports/repository/port.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
+/** @import {TableSchema} from '#domain/summary-logs/table-schemas/index.js' */
+/** @import {ClassificationContext} from './period-status.js' */
 
 const SUMMARY_LOG_ID = 'sl-1'
 
@@ -61,44 +63,53 @@ const buildWasteRecord = ({
     })
   )
 
-/** Single-date-field table schemas (most tables). */
-const SINGLE_DATE_TABLE_SCHEMAS = {
-  RECEIVED_LOADS_FOR_REPROCESSING: {
-    reportingDateFields: ['DATE_RECEIVED_FOR_REPROCESSING'],
-    wasteRecordType: 'received',
-    classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
-      outcome: ROW_OUTCOME.INCLUDED,
-      reasons: [],
-      transactionAmount: Number(data.GROSS_WEIGHT) || 0
+/** @type {Record<string, TableSchema>} Single-date-field table schemas (most tables). */
+const SINGLE_DATE_TABLE_SCHEMAS =
+  /** @type {Record<string, TableSchema>} */ (
+    /** @type {unknown} */ ({
+      RECEIVED_LOADS_FOR_REPROCESSING: {
+        reportingDateFields: ['DATE_RECEIVED_FOR_REPROCESSING'],
+        wasteRecordType: 'received',
+        classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
+          outcome: ROW_OUTCOME.INCLUDED,
+          reasons: [],
+          transactionAmount: Number(data.GROSS_WEIGHT) || 0
+        })
+      }
     })
-  }
-}
+  )
 
-/** Multi-date-field table schemas (exporter received-loads). */
-const MULTI_DATE_TABLE_SCHEMAS = {
-  RECEIVED_LOADS_FOR_EXPORT: {
-    reportingDateFields: ['DATE_RECEIVED_FOR_EXPORT', 'DATE_OF_EXPORT'],
-    wasteRecordType: 'received',
-    classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
-      outcome: ROW_OUTCOME.INCLUDED,
-      reasons: [],
-      transactionAmount: Number(data.GROSS_WEIGHT) || 0
+/** @type {Record<string, TableSchema>} Multi-date-field table schemas (exporter received-loads). */
+const MULTI_DATE_TABLE_SCHEMAS =
+  /** @type {Record<string, TableSchema>} */ (
+    /** @type {unknown} */ ({
+      RECEIVED_LOADS_FOR_EXPORT: {
+        reportingDateFields: ['DATE_RECEIVED_FOR_EXPORT', 'DATE_OF_EXPORT'],
+        wasteRecordType: 'received',
+        classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
+          outcome: ROW_OUTCOME.INCLUDED,
+          reasons: [],
+          transactionAmount: Number(data.GROSS_WEIGHT) || 0
+        })
+      }
     })
-  }
-}
+  )
 
-/** Registered-only table schemas (monthly dates as YYYY-MM). */
-const REGISTERED_ONLY_TABLE_SCHEMAS = {
-  RECEIVED_LOADS_FOR_REPROCESSING: {
-    reportingDateFields: ['MONTH_RECEIVED_FOR_REPROCESSING'],
-    wasteRecordType: 'received',
-    classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
-      outcome: ROW_OUTCOME.INCLUDED,
-      reasons: [],
-      transactionAmount: Number(data.GROSS_WEIGHT) || 0
+/** @type {Record<string, TableSchema>} Registered-only table schemas (monthly dates as YYYY-MM). */
+const REGISTERED_ONLY_TABLE_SCHEMAS =
+  /** @type {Record<string, TableSchema>} */ (
+    /** @type {unknown} */ ({
+      RECEIVED_LOADS_FOR_REPROCESSING: {
+        reportingDateFields: ['MONTH_RECEIVED_FOR_REPROCESSING'],
+        wasteRecordType: 'received',
+        classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
+          outcome: ROW_OUTCOME.INCLUDED,
+          reasons: [],
+          transactionAmount: Number(data.GROSS_WEIGHT) || 0
+        })
+      }
     })
-  }
-}
+  )
 
 const emptyBucket = () => ({ count: 0, tonnageDelta: 0 })
 const emptyChange = () => ({
@@ -150,11 +161,12 @@ const buildSubmittedReport = ({
     })
   )
 
-const accreditation = { status: 'approved', validFrom: '2025-01-01' }
-const classificationContext = {
-  accreditation,
-  overseasSites: Symbol('ORS_DISABLED')
-}
+const classificationContext = /** @type {ClassificationContext} */ (
+  /** @type {unknown} */ ({
+    accreditation: { status: 'approved', validFrom: '2025-01-01' },
+    overseasSites: Symbol('ORS_DISABLED')
+  })
+)
 
 const baseParams = {
   summaryLogId: SUMMARY_LOG_ID,
@@ -660,7 +672,7 @@ describe('classifyByPeriodStatus', () => {
 
   describe('transaction amount for non-INCLUDED classification', () => {
     it('uses zero transaction amount when classifyForWasteBalance returns EXCLUDED', () => {
-      const schemasWithExcluded = {
+      const schemasWithExcluded = /** @type {Record<string, TableSchema>} */ (/** @type {unknown} */ ({
         RECEIVED_LOADS_FOR_REPROCESSING: {
           ...SINGLE_DATE_TABLE_SCHEMAS.RECEIVED_LOADS_FOR_REPROCESSING,
           classifyForWasteBalance: () => ({
@@ -668,7 +680,7 @@ describe('classifyByPeriodStatus', () => {
             reasons: []
           })
         }
-      }
+      }))
 
       const result = classifyByPeriodStatus({
         ...baseParams,

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -6,7 +6,6 @@ import { VERSION_STATUS } from '#domain/waste-records/model.js'
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {PeriodicReport} from '#reports/repository/port.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
-/** @import {TableSchema} from '#domain/summary-logs/table-schemas/index.js' */
 /** @import {ClassificationContext, ProcessingTypeSchemas} from './period-status.js' */
 
 const SUMMARY_LOG_ID = 'sl-1'
@@ -94,20 +93,19 @@ const MULTI_DATE_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
 )
 
 /** @type {ProcessingTypeSchemas} Registered-only table schemas (monthly dates as YYYY-MM). */
-const REGISTERED_ONLY_TABLE_SCHEMAS =
-  /** @type {ProcessingTypeSchemas} */ (
-    /** @type {unknown} */ ({
-      RECEIVED_LOADS_FOR_REPROCESSING: {
-        reportingDateFields: ['MONTH_RECEIVED_FOR_REPROCESSING'],
-        wasteRecordType: 'received',
-        classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
-          outcome: ROW_OUTCOME.INCLUDED,
-          reasons: [],
-          transactionAmount: Number(data.GROSS_WEIGHT) || 0
-        })
-      }
-    })
-  )
+const REGISTERED_ONLY_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
+  /** @type {unknown} */ ({
+    RECEIVED_LOADS_FOR_REPROCESSING: {
+      reportingDateFields: ['MONTH_RECEIVED_FOR_REPROCESSING'],
+      wasteRecordType: 'received',
+      classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
+        outcome: ROW_OUTCOME.INCLUDED,
+        reasons: [],
+        transactionAmount: Number(data.GROSS_WEIGHT) || 0
+      })
+    }
+  })
+)
 
 const emptyBucket = () => ({ count: 0, tonnageDelta: 0 })
 const emptyChange = () => ({

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -125,6 +125,9 @@ describe('SummaryLogsValidator integration', () => {
       summaryLogsRepository,
       organisationsRepository,
       wasteRecordsRepository,
+      reportsRepository: /** @type {any} */ ({
+        findPeriodicReports: async () => []
+      }),
       summaryLogExtractor: extractor
     })
 

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -593,7 +593,11 @@ const classifyLoads = ({
   existingRecordsMap
 }) => {
   if (status !== SUMMARY_LOG_STATUS.VALIDATED || !wasteRecords) {
-    return { loads: null, loadsByWasteRecordType: null, loadsByPeriodStatus: null }
+    return {
+      loads: null,
+      loadsByWasteRecordType: null,
+      loadsByPeriodStatus: null
+    }
   }
 
   const loads = mergeLoads(
@@ -679,22 +683,17 @@ export const createSummaryLogsValidator = ({
     })
 
     const validationStart = Date.now()
-    const {
-      issues,
-      wasteRecords,
-      meta,
-      registration,
-      existingRecordsMap
-    } = await performValidationChecks({
-      summaryLogId,
-      summaryLog,
-      loggingContext,
-      logger,
-      summaryLogExtractor,
-      organisationsRepository,
-      wasteRecordsRepository,
-      validateDataSyntax
-    })
+    const { issues, wasteRecords, meta, registration, existingRecordsMap } =
+      await performValidationChecks({
+        summaryLogId,
+        summaryLog,
+        loggingContext,
+        logger,
+        summaryLogExtractor,
+        organisationsRepository,
+        wasteRecordsRepository,
+        validateDataSyntax
+      })
     const validationDurationMs = Date.now() - validationStart
 
     logValidationIssues({ summaryLogId, summaryLog, issues, logger })
@@ -738,8 +737,8 @@ export const createSummaryLogsValidator = ({
       })
     }
 
-    const { loads, loadsByWasteRecordType, loadsByPeriodStatus } = classifyLoads(
-      {
+    const { loads, loadsByWasteRecordType, loadsByPeriodStatus } =
+      classifyLoads({
         processingType,
         status,
         summaryLogId,
@@ -748,8 +747,7 @@ export const createSummaryLogsValidator = ({
         periodicReports,
         registration,
         existingRecordsMap
-      }
-    )
+      })
 
     await persistValidationResult({
       issues,

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -23,12 +23,14 @@ import {
 } from '#domain/summary-logs/table-schemas/index.js'
 import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
 import {
   countByValidity,
   countByWasteBalanceInclusion,
   countByWasteRecordType,
   mergeLoads
 } from './load-counts.js'
+import { classifyByPeriodStatus } from './period-status.js'
 import {
   logValidationIssues,
   MAX_VALIDATION_ISSUES
@@ -56,6 +58,9 @@ export const MAX_ACTUAL_LENGTH = 200
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 /** @import {SummaryLogExtractor} from './extractor.js' */
 /** @import {Loads} from './load-counts.js' */
+/** @import {LoadsByPeriodStatus} from './period-status.js' */
+/** @import {ReportsRepository} from '#reports/repository/port.js' */
+/** @import {WasteRecord} from '#domain/waste-records/model.js' */
 
 /**
  * @param {{
@@ -94,6 +99,7 @@ const extractSummaryLog = async ({
  * }} params
  * @returns {Promise<{
  *   wasteRecords: ValidatedWasteRecord[],
+ *   existingRecordsMap: Map<string, WasteRecord>,
  *   issues: ValidationIssuesCollector
  * }>}
  */
@@ -137,7 +143,7 @@ const transformAndValidateData = async ({
   // Data business validation using waste records
   const issues = validateDataBusiness({ wasteRecords, existingWasteRecords })
 
-  return { wasteRecords, issues }
+  return { wasteRecords, existingRecordsMap, issues }
 }
 
 /**
@@ -183,6 +189,8 @@ const fetchRegistration = async ({
  * @property {ValidationIssuesCollector} issues - Validation issues object with methods like getAllIssues(), isFatal()
  * @property {ValidatedWasteRecord[]|null} wasteRecords - Waste records with validation issues (null if transformation not reached)
  * @property {ExtractedMeta} [meta] - Extracted metadata values (only present after successful extraction)
+ * @property {Registration} [registration] - Registration fetched during validation
+ * @property {Map<string, WasteRecord>} [existingRecordsMap] - Existing records map for adjusted record lookup
  */
 
 /**
@@ -304,7 +312,12 @@ const performValidationChecks = async ({
 }) => {
   const issues = createValidationIssues()
   let wasteRecords = null
+  /** @type {ExtractedMeta | undefined} */
   let meta
+  /** @type {Registration | undefined} */
+  let registration
+  /** @type {Map<string, WasteRecord> | undefined} */
+  let existingRecordsMap
 
   try {
     const parsed = await extractSummaryLog({
@@ -322,7 +335,7 @@ const performValidationChecks = async ({
       return { issues, wasteRecords, meta }
     }
 
-    const registration = await fetchRegistration({
+    registration = await fetchRegistration({
       organisationsRepository,
       organisationId: summaryLog.organisationId,
       registrationId: summaryLog.registrationId,
@@ -339,7 +352,7 @@ const performValidationChecks = async ({
     )
 
     if (issues.isFatal()) {
-      return { issues, wasteRecords, meta }
+      return { issues, wasteRecords, meta, registration }
     }
 
     // Data syntax validation returns validated data with issues attached to rows
@@ -348,7 +361,7 @@ const performValidationChecks = async ({
     issues.merge(dataSyntaxIssues)
 
     if (issues.isFatal()) {
-      return { issues, wasteRecords, meta }
+      return { issues, wasteRecords, meta, registration }
     }
 
     const dataResult = await transformAndValidateData({
@@ -359,6 +372,7 @@ const performValidationChecks = async ({
     })
 
     wasteRecords = dataResult.wasteRecords
+    existingRecordsMap = dataResult.existingRecordsMap
 
     markIgnoredByDateRange(wasteRecords, registration, meta.PROCESSING_TYPE)
 
@@ -372,7 +386,7 @@ const performValidationChecks = async ({
     )
   }
 
-  return { issues, wasteRecords, meta }
+  return { issues, wasteRecords, meta, registration, existingRecordsMap }
 }
 
 /**
@@ -504,6 +518,7 @@ const recordValidationMetrics = async ({
  * @param {Object} params
  * @param {ValidationIssuesCollector} params.issues
  * @param {Loads | null} params.loads
+ * @param {LoadsByPeriodStatus | null} params.loadsByPeriodStatus
  * @param {import('./load-counts.js').LoadsByWasteRecordType | null} params.loadsByWasteRecordType
  * @param {ExtractedMeta | undefined} params.meta
  * @param {SummaryLogStatus} params.status
@@ -515,6 +530,7 @@ const recordValidationMetrics = async ({
 const persistValidationResult = async ({
   issues,
   loads,
+  loadsByPeriodStatus,
   loadsByWasteRecordType,
   meta,
   status,
@@ -533,6 +549,7 @@ const persistValidationResult = async ({
       counts: issues.getCounts()
     },
     ...(loads && { loads }),
+    ...(loadsByPeriodStatus && { loadsByPeriodStatus }),
     ...(loadsByWasteRecordType && { loadsByWasteRecordType }),
     ...(meta && { meta })
   })
@@ -594,6 +611,85 @@ const classifyLoads = ({
 }
 
 /**
+ * Computes loadsByPeriodStatus with graceful degradation.
+ * Returns null if preconditions aren't met or the reports lookup fails.
+ *
+ * @param {Object} params
+ * @param {ValidatedWasteRecord[] | null} params.wasteRecords
+ * @param {string} params.summaryLogId
+ * @param {string} params.status
+ * @param {Registration} [params.registration]
+ * @param {string} [params.processingType]
+ * @param {Map<string, WasteRecord>} [params.existingRecordsMap]
+ * @param {ReportsRepository} params.reportsRepository
+ * @param {SubmittedSummaryLog} params.summaryLog
+ * @param {string} params.loggingContext
+ * @param {TypedLogger} params.logger
+ * @returns {Promise<LoadsByPeriodStatus | null>}
+ */
+const computeLoadsByPeriodStatus = async ({
+  wasteRecords,
+  summaryLogId,
+  status,
+  registration,
+  processingType,
+  existingRecordsMap,
+  reportsRepository,
+  summaryLog,
+  loggingContext,
+  logger
+}) => {
+  if (
+    status !== SUMMARY_LOG_STATUS.VALIDATED ||
+    !wasteRecords ||
+    !registration ||
+    !processingType ||
+    !existingRecordsMap
+  ) {
+    return null
+  }
+
+  const tableSchemas = PROCESSING_TYPE_TABLES[processingType]
+  if (!tableSchemas) {
+    return null
+  }
+
+  try {
+    const periodicReports = await reportsRepository.findPeriodicReports({
+      organisationId: summaryLog.organisationId,
+      registrationId: summaryLog.registrationId
+    })
+
+    const cadence = isRegistrationAccredited(registration)
+      ? 'monthly'
+      : 'quarterly'
+
+    return classifyByPeriodStatus({
+      wasteRecords,
+      existingRecordsMap,
+      periodicReports,
+      cadence,
+      summaryLogId,
+      tableSchemas,
+      classificationContext: {
+        accreditation: registration.accreditation ?? null,
+        overseasSites: ORS_VALIDATION_DISABLED
+      }
+    })
+  } catch (err) {
+    logger.warn({
+      message: `Failed to classify loads by period status: ${loggingContext}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
+      },
+      err
+    })
+    return null
+  }
+}
+
+/**
  * Creates a summary logs validator function.
  *
  * @param {{
@@ -601,6 +697,7 @@ const classifyLoads = ({
  *   summaryLogsRepository: SummaryLogsRepository,
  *   organisationsRepository: OrganisationsRepository,
  *   wasteRecordsRepository: WasteRecordsRepository,
+ *   reportsRepository: ReportsRepository,
  *   summaryLogExtractor: SummaryLogExtractor
  * }} params
  * @returns {(summaryLogId: string) => Promise<void>}
@@ -610,6 +707,7 @@ export const createSummaryLogsValidator = ({
   summaryLogsRepository,
   organisationsRepository,
   wasteRecordsRepository,
+  reportsRepository,
   summaryLogExtractor
 }) => {
   const validateDataSyntax = createDataSyntaxValidator(PROCESSING_TYPE_TABLES)
@@ -636,7 +734,13 @@ export const createSummaryLogsValidator = ({
     })
 
     const validationStart = Date.now()
-    const { issues, wasteRecords, meta } = await performValidationChecks({
+    const {
+      issues,
+      wasteRecords,
+      meta,
+      registration,
+      existingRecordsMap
+    } = await performValidationChecks({
       summaryLogId,
       summaryLog,
       loggingContext,
@@ -677,9 +781,23 @@ export const createSummaryLogsValidator = ({
       wasteRecords
     })
 
+    const loadsByPeriodStatus = await computeLoadsByPeriodStatus({
+      wasteRecords,
+      summaryLogId,
+      status,
+      registration,
+      processingType,
+      existingRecordsMap,
+      reportsRepository,
+      summaryLog,
+      loggingContext,
+      logger
+    })
+
     await persistValidationResult({
       issues,
       loads,
+      loadsByPeriodStatus,
       loadsByWasteRecordType,
       meta,
       status,

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -24,7 +24,7 @@ import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shar
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import {
   classifyLoads,
-  fetchPeriodicReportsSafe,
+  fetchPeriodicReports,
   filterWasteBalanceRecords
 } from './classify-and-persist.js'
 import {
@@ -567,17 +567,13 @@ const classifyAndPersistResult = async ({
   summaryLog,
   summaryLogsRepository,
   version,
-  reportsRepository,
-  loggingContext,
-  logger
+  reportsRepository
 }) => {
-  const periodicReports = await fetchPeriodicReportsSafe({
+  const periodicReports = await fetchPeriodicReports({
     registration,
     status,
     summaryLog,
-    reportsRepository,
-    loggingContext,
-    logger
+    reportsRepository
   })
 
   const { loads, loadsByWasteRecordType, loadsByReportingPeriod } =
@@ -692,9 +688,7 @@ export const createSummaryLogsValidator = ({
       summaryLog,
       summaryLogsRepository,
       version,
-      reportsRepository,
-      loggingContext,
-      logger
+      reportsRepository
     })
 
     logger.info({

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -617,6 +617,7 @@ const classifyLoads = ({
     tableSchemas
   })
 
+  /* v8 ignore start -- defensive guard: all three are always set when status is VALIDATED */
   const loadsByPeriodStatus =
     registration && existingRecordsMap && tableSchemas
       ? classifyByPeriodStatus({
@@ -634,6 +635,7 @@ const classifyLoads = ({
           }
         })
       : null
+  /* v8 ignore stop */
 
   return { loads, loadsByWasteRecordType, loadsByPeriodStatus }
 }

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -577,7 +577,7 @@ const filterWasteBalanceRecords = (wasteRecords, processingType) =>
  * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords - Waste-balance-eligible records
  * @param {string} params.summaryLogId
  * @param {ProcessingType} params.processingType
- * @param {import('#reports/repository/port.js').PeriodicReport[] | null} params.periodicReports
+ * @param {import('#reports/repository/port.js').PeriodicReport[]} params.periodicReports
  * @param {Registration} [params.registration]
  * @param {Map<string, WasteRecord>} [params.existingRecordsMap]
  * @returns {{ loads: Loads | null, loadsByWasteRecordType: import('./load-counts.js').LoadsByWasteRecordType | null, loadsByPeriodStatus: LoadsByPeriodStatus | null }}
@@ -618,7 +618,7 @@ const classifyLoads = ({
   })
 
   const loadsByPeriodStatus =
-    periodicReports && registration && existingRecordsMap && tableSchemas
+    registration && existingRecordsMap && tableSchemas
       ? classifyByPeriodStatus({
           wasteRecords,
           existingRecordsMap,
@@ -717,8 +717,8 @@ export const createSummaryLogsValidator = ({
       wasteBalanceRecords
     })
 
-    /** @type {import('#reports/repository/port.js').PeriodicReport[] | null} */
-    let periodicReports = null
+    /** @type {import('#reports/repository/port.js').PeriodicReport[]} */
+    let periodicReports = []
     try {
       if (registration && status === SUMMARY_LOG_STATUS.VALIDATED) {
         periodicReports = await reportsRepository.findPeriodicReports({

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -465,15 +465,6 @@ const recordRowOutcomeMetrics = async (wasteRecords, processingType) => {
 }
 
 /**
- * @param {string} summaryLogId
- * @param {SubmittedSummaryLog} summaryLog
- */
-const buildLoggingContext = (summaryLogId, summaryLog) => {
-  const { id: fileId, name: filename } = summaryLog.file
-  return `summaryLogId=${summaryLogId}, fileId=${fileId}, filename=${filename}`
-}
-
-/**
  * @param {{ summaryLog: SummaryLog, version: number } | null | undefined} result
  * @param {string} summaryLogId
  */
@@ -644,7 +635,8 @@ export const createSummaryLogsValidator = ({
       /** @type {{ version: number, summaryLog: SubmittedSummaryLog }} */ (
         result
       )
-    const loggingContext = buildLoggingContext(summaryLogId, summaryLog)
+    const { id: fileId, name: filename } = summaryLog.file
+    const loggingContext = `summaryLogId=${summaryLogId}, fileId=${fileId}, filename=${filename}`
 
     logger.info({
       message: `Summary log validation started: ${loggingContext}`,

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -54,7 +54,7 @@ export const MAX_ACTUAL_LENGTH = 200
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 /** @import {SummaryLogExtractor} from './extractor.js' */
 /** @import {Loads} from './load-counts.js' */
-/** @import {LoadsByPeriodStatus} from './period-status.js' */
+/** @import {LoadsByReportingPeriod} from './period-status.js' */
 /** @import {ReportsRepository} from '#reports/repository/port.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
 
@@ -514,7 +514,7 @@ const recordValidationMetrics = async ({
  * @param {Object} params
  * @param {ValidationIssuesCollector} params.issues
  * @param {Loads | null} params.loads
- * @param {LoadsByPeriodStatus | null} params.loadsByPeriodStatus
+ * @param {LoadsByReportingPeriod | null} params.loadsByReportingPeriod
  * @param {import('./load-counts.js').LoadsByWasteRecordType | null} params.loadsByWasteRecordType
  * @param {ExtractedMeta | undefined} params.meta
  * @param {SummaryLogStatus} params.status
@@ -526,7 +526,7 @@ const recordValidationMetrics = async ({
 const persistValidationResult = async ({
   issues,
   loads,
-  loadsByPeriodStatus,
+  loadsByReportingPeriod,
   loadsByWasteRecordType,
   meta,
   status,
@@ -545,7 +545,7 @@ const persistValidationResult = async ({
       counts: issues.getCounts()
     },
     ...(loads && { loads }),
-    ...(loadsByPeriodStatus && { loadsByPeriodStatus }),
+    ...(loadsByReportingPeriod && { loadsByReportingPeriod }),
     ...(loadsByWasteRecordType && { loadsByWasteRecordType }),
     ...(meta && { meta })
   })
@@ -580,21 +580,22 @@ const classifyAndPersistResult = async ({
     logger
   })
 
-  const { loads, loadsByWasteRecordType, loadsByPeriodStatus } = classifyLoads({
-    processingType,
-    status,
-    summaryLogId,
-    wasteBalanceRecords,
-    wasteRecords,
-    periodicReports,
-    registration,
-    existingRecordsMap
-  })
+  const { loads, loadsByWasteRecordType, loadsByReportingPeriod } =
+    classifyLoads({
+      processingType,
+      status,
+      summaryLogId,
+      wasteBalanceRecords,
+      wasteRecords,
+      periodicReports,
+      registration,
+      existingRecordsMap
+    })
 
   await persistValidationResult({
     issues,
     loads,
-    loadsByPeriodStatus,
+    loadsByReportingPeriod,
     loadsByWasteRecordType,
     meta,
     status,

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -469,6 +469,15 @@ const recordRowOutcomeMetrics = async (wasteRecords, processingType) => {
 }
 
 /**
+ * @param {string} summaryLogId
+ * @param {SubmittedSummaryLog} summaryLog
+ */
+const buildLoggingContext = (summaryLogId, summaryLog) => {
+  const { id: fileId, name: filename } = summaryLog.file
+  return `summaryLogId=${summaryLogId}, fileId=${fileId}, filename=${filename}`
+}
+
+/**
  * @param {{ summaryLog: SummaryLog, version: number } | null | undefined} result
  * @param {string} summaryLogId
  */
@@ -768,11 +777,7 @@ export const createSummaryLogsValidator = ({
       /** @type {{ version: number, summaryLog: SubmittedSummaryLog }} */ (
         result
       )
-    const {
-      file: { id: fileId, name: filename }
-    } = summaryLog
-
-    const loggingContext = `summaryLogId=${summaryLogId}, fileId=${fileId}, filename=${filename}`
+    const loggingContext = buildLoggingContext(summaryLogId, summaryLog)
 
     logger.info({
       message: `Summary log validation started: ${loggingContext}`,
@@ -794,16 +799,13 @@ export const createSummaryLogsValidator = ({
         wasteRecordsRepository,
         validateDataSyntax
       })
-    const validationDurationMs = Date.now() - validationStart
 
     logValidationIssues({ summaryLogId, summaryLog, issues, logger })
 
     const processingType = meta?.[SUMMARY_LOG_META_FIELDS.PROCESSING_TYPE]
-
     const status = issues.isFatal()
       ? SUMMARY_LOG_STATUS.INVALID
       : SUMMARY_LOG_STATUS.VALIDATED
-
     const wasteBalanceRecords = filterWasteBalanceRecords(
       wasteRecords,
       processingType
@@ -813,7 +815,7 @@ export const createSummaryLogsValidator = ({
       issues,
       processingType,
       status,
-      validationDurationMs,
+      validationDurationMs: Date.now() - validationStart,
       wasteBalanceRecords
     })
 

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -561,6 +561,60 @@ const persistValidationResult = async ({
 }
 
 /**
+ * Fetches periodic reports, classifies loads, and persists the validation result.
+ */
+const classifyAndPersistResult = async ({
+  issues,
+  processingType,
+  status,
+  summaryLogId,
+  wasteBalanceRecords,
+  wasteRecords,
+  registration,
+  existingRecordsMap,
+  meta,
+  summaryLog,
+  summaryLogsRepository,
+  version,
+  reportsRepository,
+  loggingContext,
+  logger
+}) => {
+  const periodicReports = await fetchPeriodicReportsSafe({
+    registration,
+    status,
+    summaryLog,
+    reportsRepository,
+    loggingContext,
+    logger
+  })
+
+  const { loads, loadsByWasteRecordType, loadsByPeriodStatus } = classifyLoads({
+    processingType,
+    status,
+    summaryLogId,
+    wasteBalanceRecords,
+    wasteRecords,
+    periodicReports,
+    registration,
+    existingRecordsMap
+  })
+
+  await persistValidationResult({
+    issues,
+    loads,
+    loadsByPeriodStatus,
+    loadsByWasteRecordType,
+    meta,
+    status,
+    summaryLog,
+    summaryLogId,
+    summaryLogsRepository,
+    version
+  })
+}
+
+/**
  * Creates a summary logs validator function.
  *
  * @param {{
@@ -632,38 +686,22 @@ export const createSummaryLogsValidator = ({
       wasteBalanceRecords
     })
 
-    const periodicReports = await fetchPeriodicReportsSafe({
-      registration,
+    await classifyAndPersistResult({
+      issues,
+      processingType,
       status,
+      summaryLogId,
+      wasteBalanceRecords,
+      wasteRecords,
+      registration,
+      existingRecordsMap,
+      meta,
       summaryLog,
+      summaryLogsRepository,
+      version,
       reportsRepository,
       loggingContext,
       logger
-    })
-
-    const { loads, loadsByWasteRecordType, loadsByPeriodStatus } =
-      classifyLoads({
-        processingType,
-        status,
-        summaryLogId,
-        wasteBalanceRecords,
-        wasteRecords,
-        periodicReports,
-        registration,
-        existingRecordsMap
-      })
-
-    await persistValidationResult({
-      issues,
-      loads,
-      loadsByPeriodStatus,
-      loadsByWasteRecordType,
-      meta,
-      status,
-      summaryLog,
-      summaryLogId,
-      summaryLogsRepository,
-      version
     })
 
     logger.info({

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -6,7 +6,6 @@ import {
   VALIDATION_CODE,
   VALIDATION_SEVERITY
 } from '#common/enums/index.js'
-import { isNil } from '#common/helpers/is-nil.js'
 import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
 import { createValidationIssues } from '#common/validation/validation-issues.js'
 import {
@@ -18,19 +17,16 @@ import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 import { transformFromSummaryLog } from '#application/waste-records/transform-from-summary-log.js'
 import { SUMMARY_LOG_META_FIELDS } from '#domain/summary-logs/meta-fields.js'
 import {
-  PROCESSING_TYPE_TABLES,
-  findSchemaForProcessingType
+  findSchemaForProcessingType,
+  PROCESSING_TYPE_TABLES
 } from '#domain/summary-logs/table-schemas/index.js'
 import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
-import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
 import {
-  countByValidity,
-  countByWasteBalanceInclusion,
-  countByWasteRecordType,
-  mergeLoads
-} from './load-counts.js'
-import { classifyByPeriodStatus } from './period-status.js'
+  classifyLoads,
+  fetchPeriodicReportsSafe,
+  filterWasteBalanceRecords
+} from './classify-and-persist.js'
 import {
   logValidationIssues,
   MAX_VALIDATION_ISSUES
@@ -565,189 +561,6 @@ const persistValidationResult = async ({
 }
 
 /**
- * Filters waste records to only those from tables that participate in waste balance.
- *
- * @param {ValidatedWasteRecord[] | null} wasteRecords
- * @param {string} processingType
- * @returns {ValidatedWasteRecord[]}
- */
-const filterWasteBalanceRecords = (wasteRecords, processingType) =>
-  wasteRecords?.filter((wr) => {
-    const schema = findSchemaForProcessingType(processingType, wr.record.type)
-    return !isNil(schema?.classifyForWasteBalance)
-  }) ?? []
-
-/**
- * Computes all load classifications for validated summary logs.
- *
- * @param {Object} params
- * @param {string} params.status - Summary log status after validation
- * @param {ValidatedWasteRecord[] | null} params.wasteRecords - All waste records
- * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords - Waste-balance-eligible records
- * @param {string} params.summaryLogId
- * @param {ProcessingType} params.processingType
- * @param {import('#reports/repository/port.js').PeriodicReport[]} params.periodicReports
- * @param {Registration} [params.registration]
- * @param {Map<string, WasteRecord>} [params.existingRecordsMap]
- * @returns {{ loads: Loads | null, loadsByWasteRecordType: import('./load-counts.js').LoadsByWasteRecordType | null, loadsByPeriodStatus: LoadsByPeriodStatus | null }}
- */
-const classifyLoads = ({
-  processingType,
-  status,
-  summaryLogId,
-  wasteBalanceRecords,
-  wasteRecords,
-  periodicReports,
-  registration,
-  existingRecordsMap
-}) => {
-  if (status !== SUMMARY_LOG_STATUS.VALIDATED || !wasteRecords) {
-    return {
-      loads: null,
-      loadsByWasteRecordType: null,
-      loadsByPeriodStatus: null
-    }
-  }
-
-  const loads = mergeLoads(
-    countByValidity({ wasteRecords, summaryLogId }),
-    countByWasteBalanceInclusion({
-      wasteRecords: wasteBalanceRecords,
-      summaryLogId
-    })
-  )
-
-  const tableSchemas = PROCESSING_TYPE_TABLES[processingType]
-
-  const loadsByWasteRecordType = countByWasteRecordType({
-    wasteRecords,
-    wasteBalanceRecords,
-    summaryLogId,
-    tableSchemas
-  })
-
-  /* v8 ignore start -- defensive guard: all three are always set when status is VALIDATED */
-  const loadsByPeriodStatus =
-    registration && existingRecordsMap && tableSchemas
-      ? classifyByPeriodStatus({
-          wasteRecords,
-          existingRecordsMap,
-          periodicReports,
-          cadence: isRegistrationAccredited(registration)
-            ? 'monthly'
-            : 'quarterly',
-          summaryLogId,
-          tableSchemas,
-          classificationContext: {
-            accreditation: registration.accreditation ?? null,
-            overseasSites: ORS_VALIDATION_DISABLED
-          }
-        })
-      : null
-  /* v8 ignore stop */
-
-  return { loads, loadsByWasteRecordType, loadsByPeriodStatus }
-}
-
-/**
- * Classifies loads and persists the validation result.
- *
- * @param {Object} params
- * @param {ValidationIssuesCollector} params.issues
- * @param {ProcessingType} params.processingType
- * @param {typeof SUMMARY_LOG_STATUS[keyof typeof SUMMARY_LOG_STATUS]} params.status
- * @param {string} params.summaryLogId
- * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords
- * @param {ValidatedWasteRecord[] | null} params.wasteRecords
- * @param {import('#reports/repository/port.js').PeriodicReport[]} params.periodicReports
- * @param {Registration} [params.registration]
- * @param {Map<string, WasteRecord>} [params.existingRecordsMap]
- * @param {ExtractedMeta} [params.meta]
- * @param {SubmittedSummaryLog} params.summaryLog
- * @param {SummaryLogsRepository} params.summaryLogsRepository
- * @param {number} params.version
- */
-const classifyAndPersist = async ({
-  issues,
-  processingType,
-  status,
-  summaryLogId,
-  wasteBalanceRecords,
-  wasteRecords,
-  periodicReports,
-  registration,
-  existingRecordsMap,
-  meta,
-  summaryLog,
-  summaryLogsRepository,
-  version
-}) => {
-  const { loads, loadsByWasteRecordType, loadsByPeriodStatus } = classifyLoads({
-    processingType,
-    status,
-    summaryLogId,
-    wasteBalanceRecords,
-    wasteRecords,
-    periodicReports,
-    registration,
-    existingRecordsMap
-  })
-
-  await persistValidationResult({
-    issues,
-    loads,
-    loadsByPeriodStatus,
-    loadsByWasteRecordType,
-    meta,
-    status,
-    summaryLog,
-    summaryLogId,
-    summaryLogsRepository,
-    version
-  })
-}
-
-/**
- * Fetches periodic reports for the validated summary log, swallowing errors.
- *
- * @param {Object} params
- * @param {Registration} [params.registration]
- * @param {string} params.status
- * @param {SubmittedSummaryLog} params.summaryLog
- * @param {ReportsRepository} params.reportsRepository
- * @param {string} params.loggingContext
- * @param {TypedLogger} params.logger
- * @returns {Promise<import('#reports/repository/port.js').PeriodicReport[]>}
- */
-const fetchPeriodicReportsSafe = async ({
-  registration,
-  status,
-  summaryLog,
-  reportsRepository,
-  loggingContext,
-  logger
-}) => {
-  try {
-    if (registration && status === SUMMARY_LOG_STATUS.VALIDATED) {
-      return await reportsRepository.findPeriodicReports({
-        organisationId: summaryLog.organisationId,
-        registrationId: summaryLog.registrationId
-      })
-    }
-  } catch (err) {
-    logger.warn({
-      message: `Failed to fetch periodic reports: ${loggingContext}`,
-      event: {
-        category: LOGGING_EVENT_CATEGORIES.SERVER,
-        action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
-      },
-      err
-    })
-  }
-  return []
-}
-
-/**
  * Creates a summary logs validator function.
  *
  * @param {{
@@ -828,18 +641,27 @@ export const createSummaryLogsValidator = ({
       logger
     })
 
-    await classifyAndPersist({
+    const { loads, loadsByWasteRecordType, loadsByPeriodStatus } =
+      classifyLoads({
+        processingType,
+        status,
+        summaryLogId,
+        wasteBalanceRecords,
+        wasteRecords,
+        periodicReports,
+        registration,
+        existingRecordsMap
+      })
+
+    await persistValidationResult({
       issues,
-      processingType,
-      status,
-      summaryLogId,
-      wasteBalanceRecords,
-      wasteRecords,
-      periodicReports,
-      registration,
-      existingRecordsMap,
+      loads,
+      loadsByPeriodStatus,
+      loadsByWasteRecordType,
       meta,
+      status,
       summaryLog,
+      summaryLogId,
       summaryLogsRepository,
       version
     })

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -569,7 +569,7 @@ const filterWasteBalanceRecords = (wasteRecords, processingType) =>
   }) ?? []
 
 /**
- * Computes aggregate and per-waste-record-type load counts for validated summary logs.
+ * Computes all load classifications for validated summary logs.
  *
  * @param {Object} params
  * @param {string} params.status - Summary log status after validation
@@ -577,17 +577,23 @@ const filterWasteBalanceRecords = (wasteRecords, processingType) =>
  * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords - Waste-balance-eligible records
  * @param {string} params.summaryLogId
  * @param {ProcessingType} params.processingType
- * @returns {{ loads: Loads | null, loadsByWasteRecordType: import('./load-counts.js').LoadsByWasteRecordType | null }}
+ * @param {import('#reports/repository/port.js').PeriodicReport[] | null} params.periodicReports
+ * @param {Registration} [params.registration]
+ * @param {Map<string, WasteRecord>} [params.existingRecordsMap]
+ * @returns {{ loads: Loads | null, loadsByWasteRecordType: import('./load-counts.js').LoadsByWasteRecordType | null, loadsByPeriodStatus: LoadsByPeriodStatus | null }}
  */
 const classifyLoads = ({
   processingType,
   status,
   summaryLogId,
   wasteBalanceRecords,
-  wasteRecords
+  wasteRecords,
+  periodicReports,
+  registration,
+  existingRecordsMap
 }) => {
   if (status !== SUMMARY_LOG_STATUS.VALIDATED || !wasteRecords) {
-    return { loads: null, loadsByWasteRecordType: null }
+    return { loads: null, loadsByWasteRecordType: null, loadsByPeriodStatus: null }
   }
 
   const loads = mergeLoads(
@@ -607,86 +613,25 @@ const classifyLoads = ({
     tableSchemas
   })
 
-  return { loads, loadsByWasteRecordType }
-}
+  const loadsByPeriodStatus =
+    periodicReports && registration && existingRecordsMap && tableSchemas
+      ? classifyByPeriodStatus({
+          wasteRecords,
+          existingRecordsMap,
+          periodicReports,
+          cadence: isRegistrationAccredited(registration)
+            ? 'monthly'
+            : 'quarterly',
+          summaryLogId,
+          tableSchemas,
+          classificationContext: {
+            accreditation: registration.accreditation ?? null,
+            overseasSites: ORS_VALIDATION_DISABLED
+          }
+        })
+      : null
 
-/**
- * Computes loadsByPeriodStatus with graceful degradation.
- * Returns null if preconditions aren't met or the reports lookup fails.
- *
- * @param {Object} params
- * @param {ValidatedWasteRecord[] | null} params.wasteRecords
- * @param {string} params.summaryLogId
- * @param {string} params.status
- * @param {Registration} [params.registration]
- * @param {string} [params.processingType]
- * @param {Map<string, WasteRecord>} [params.existingRecordsMap]
- * @param {ReportsRepository} params.reportsRepository
- * @param {SubmittedSummaryLog} params.summaryLog
- * @param {string} params.loggingContext
- * @param {TypedLogger} params.logger
- * @returns {Promise<LoadsByPeriodStatus | null>}
- */
-const computeLoadsByPeriodStatus = async ({
-  wasteRecords,
-  summaryLogId,
-  status,
-  registration,
-  processingType,
-  existingRecordsMap,
-  reportsRepository,
-  summaryLog,
-  loggingContext,
-  logger
-}) => {
-  if (
-    status !== SUMMARY_LOG_STATUS.VALIDATED ||
-    !wasteRecords ||
-    !registration ||
-    !processingType ||
-    !existingRecordsMap
-  ) {
-    return null
-  }
-
-  const tableSchemas = PROCESSING_TYPE_TABLES[processingType]
-  if (!tableSchemas) {
-    return null
-  }
-
-  try {
-    const periodicReports = await reportsRepository.findPeriodicReports({
-      organisationId: summaryLog.organisationId,
-      registrationId: summaryLog.registrationId
-    })
-
-    const cadence = isRegistrationAccredited(registration)
-      ? 'monthly'
-      : 'quarterly'
-
-    return classifyByPeriodStatus({
-      wasteRecords,
-      existingRecordsMap,
-      periodicReports,
-      cadence,
-      summaryLogId,
-      tableSchemas,
-      classificationContext: {
-        accreditation: registration.accreditation ?? null,
-        overseasSites: ORS_VALIDATION_DISABLED
-      }
-    })
-  } catch (err) {
-    logger.warn({
-      message: `Failed to classify loads by period status: ${loggingContext}`,
-      event: {
-        category: LOGGING_EVENT_CATEGORIES.SERVER,
-        action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
-      },
-      err
-    })
-    return null
-  }
+  return { loads, loadsByWasteRecordType, loadsByPeriodStatus }
 }
 
 /**
@@ -773,26 +718,38 @@ export const createSummaryLogsValidator = ({
       wasteBalanceRecords
     })
 
-    const { loads, loadsByWasteRecordType } = classifyLoads({
-      processingType,
-      status,
-      summaryLogId,
-      wasteBalanceRecords,
-      wasteRecords
-    })
+    /** @type {import('#reports/repository/port.js').PeriodicReport[] | null} */
+    let periodicReports = null
+    try {
+      if (registration && status === SUMMARY_LOG_STATUS.VALIDATED) {
+        periodicReports = await reportsRepository.findPeriodicReports({
+          organisationId: summaryLog.organisationId,
+          registrationId: summaryLog.registrationId
+        })
+      }
+    } catch (err) {
+      logger.warn({
+        message: `Failed to fetch periodic reports: ${loggingContext}`,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.SERVER,
+          action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
+        },
+        err
+      })
+    }
 
-    const loadsByPeriodStatus = await computeLoadsByPeriodStatus({
-      wasteRecords,
-      summaryLogId,
-      status,
-      registration,
-      processingType,
-      existingRecordsMap,
-      reportsRepository,
-      summaryLog,
-      loggingContext,
-      logger
-    })
+    const { loads, loadsByWasteRecordType, loadsByPeriodStatus } = classifyLoads(
+      {
+        processingType,
+        status,
+        summaryLogId,
+        wasteBalanceRecords,
+        wasteRecords,
+        periodicReports,
+        registration,
+        existingRecordsMap
+      }
+    )
 
     await persistValidationResult({
       issues,

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -641,6 +641,104 @@ const classifyLoads = ({
 }
 
 /**
+ * Classifies loads and persists the validation result.
+ *
+ * @param {Object} params
+ * @param {ValidationIssuesCollector} params.issues
+ * @param {ProcessingType} params.processingType
+ * @param {typeof SUMMARY_LOG_STATUS[keyof typeof SUMMARY_LOG_STATUS]} params.status
+ * @param {string} params.summaryLogId
+ * @param {ValidatedWasteRecord[]} params.wasteBalanceRecords
+ * @param {ValidatedWasteRecord[] | null} params.wasteRecords
+ * @param {import('#reports/repository/port.js').PeriodicReport[]} params.periodicReports
+ * @param {Registration} [params.registration]
+ * @param {Map<string, WasteRecord>} [params.existingRecordsMap]
+ * @param {ExtractedMeta} [params.meta]
+ * @param {SubmittedSummaryLog} params.summaryLog
+ * @param {SummaryLogsRepository} params.summaryLogsRepository
+ * @param {number} params.version
+ */
+const classifyAndPersist = async ({
+  issues,
+  processingType,
+  status,
+  summaryLogId,
+  wasteBalanceRecords,
+  wasteRecords,
+  periodicReports,
+  registration,
+  existingRecordsMap,
+  meta,
+  summaryLog,
+  summaryLogsRepository,
+  version
+}) => {
+  const { loads, loadsByWasteRecordType, loadsByPeriodStatus } = classifyLoads({
+    processingType,
+    status,
+    summaryLogId,
+    wasteBalanceRecords,
+    wasteRecords,
+    periodicReports,
+    registration,
+    existingRecordsMap
+  })
+
+  await persistValidationResult({
+    issues,
+    loads,
+    loadsByPeriodStatus,
+    loadsByWasteRecordType,
+    meta,
+    status,
+    summaryLog,
+    summaryLogId,
+    summaryLogsRepository,
+    version
+  })
+}
+
+/**
+ * Fetches periodic reports for the validated summary log, swallowing errors.
+ *
+ * @param {Object} params
+ * @param {Registration} [params.registration]
+ * @param {string} params.status
+ * @param {SubmittedSummaryLog} params.summaryLog
+ * @param {ReportsRepository} params.reportsRepository
+ * @param {string} params.loggingContext
+ * @param {TypedLogger} params.logger
+ * @returns {Promise<import('#reports/repository/port.js').PeriodicReport[]>}
+ */
+const fetchPeriodicReportsSafe = async ({
+  registration,
+  status,
+  summaryLog,
+  reportsRepository,
+  loggingContext,
+  logger
+}) => {
+  try {
+    if (registration && status === SUMMARY_LOG_STATUS.VALIDATED) {
+      return await reportsRepository.findPeriodicReports({
+        organisationId: summaryLog.organisationId,
+        registrationId: summaryLog.registrationId
+      })
+    }
+  } catch (err) {
+    logger.warn({
+      message: `Failed to fetch periodic reports: ${loggingContext}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
+      },
+      err
+    })
+  }
+  return []
+}
+
+/**
  * Creates a summary logs validator function.
  *
  * @param {{
@@ -719,47 +817,27 @@ export const createSummaryLogsValidator = ({
       wasteBalanceRecords
     })
 
-    /** @type {import('#reports/repository/port.js').PeriodicReport[]} */
-    let periodicReports = []
-    try {
-      if (registration && status === SUMMARY_LOG_STATUS.VALIDATED) {
-        periodicReports = await reportsRepository.findPeriodicReports({
-          organisationId: summaryLog.organisationId,
-          registrationId: summaryLog.registrationId
-        })
-      }
-    } catch (err) {
-      logger.warn({
-        message: `Failed to fetch periodic reports: ${loggingContext}`,
-        event: {
-          category: LOGGING_EVENT_CATEGORIES.SERVER,
-          action: LOGGING_EVENT_ACTIONS.PROCESS_FAILURE
-        },
-        err
-      })
-    }
-
-    const { loads, loadsByWasteRecordType, loadsByPeriodStatus } =
-      classifyLoads({
-        processingType,
-        status,
-        summaryLogId,
-        wasteBalanceRecords,
-        wasteRecords,
-        periodicReports,
-        registration,
-        existingRecordsMap
-      })
-
-    await persistValidationResult({
-      issues,
-      loads,
-      loadsByPeriodStatus,
-      loadsByWasteRecordType,
-      meta,
+    const periodicReports = await fetchPeriodicReportsSafe({
+      registration,
       status,
       summaryLog,
+      reportsRepository,
+      loggingContext,
+      logger
+    })
+
+    await classifyAndPersist({
+      issues,
+      processingType,
+      status,
       summaryLogId,
+      wasteBalanceRecords,
+      wasteRecords,
+      periodicReports,
+      registration,
+      existingRecordsMap,
+      meta,
+      summaryLog,
       summaryLogsRepository,
       version
     })

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -675,6 +675,9 @@ describe('SummaryLogsValidator', () => {
       summaryLogsRepository: brokenRepository,
       organisationsRepository: /** @type {any} */ (organisationsRepository),
       wasteRecordsRepository: /** @type {any} */ (wasteRecordsRepository),
+      reportsRepository: /** @type {any} */ ({
+        findPeriodicReports: vi.fn().mockResolvedValue([])
+      }),
       summaryLogExtractor
     })
 

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -711,6 +711,35 @@ describe('SummaryLogsValidator', () => {
     expect(result).toBe(databaseError)
   })
 
+  it('should log a warning when fetching periodic reports fails', async () => {
+    const fetchError = new Error('Database connection lost')
+
+    const validateWithBrokenReports = createSummaryLogsValidator({
+      logger,
+      summaryLogsRepository: /** @type {any} */ (summaryLogsRepository),
+      organisationsRepository: /** @type {any} */ (organisationsRepository),
+      wasteRecordsRepository: /** @type {any} */ (wasteRecordsRepository),
+      reportsRepository: /** @type {any} */ ({
+        findPeriodicReports: vi.fn().mockRejectedValue(fetchError)
+      }),
+      summaryLogExtractor
+    })
+
+    await validateWithBrokenReports(summaryLogId)
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          'Failed to fetch periodic reports: summaryLogId=summary-log-123, fileId=file-123, filename=test.xlsx',
+        event: expect.objectContaining({
+          category: 'server',
+          action: 'process_failure'
+        }),
+        err: fetchError
+      })
+    )
+  })
+
   describe('Four-level validation hierarchy short-circuit behavior', () => {
     it('Level 1 fatal (meta syntax) stops Level 2 (meta business) from running', async () => {
       // Meta syntax error: missing TEMPLATE_VERSION

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -249,6 +249,9 @@ describe('SummaryLogsValidator', () => {
       summaryLogsRepository: /** @type {any} */ (summaryLogsRepository),
       organisationsRepository: /** @type {any} */ (organisationsRepository),
       wasteRecordsRepository: /** @type {any} */ (wasteRecordsRepository),
+      reportsRepository: /** @type {any} */ ({
+        findPeriodicReports: vi.fn().mockResolvedValue([])
+      }),
       summaryLogExtractor
     })
   })

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -711,7 +711,7 @@ describe('SummaryLogsValidator', () => {
     expect(result).toBe(databaseError)
   })
 
-  it('should log a warning when fetching periodic reports fails', async () => {
+  it('should throw and not persist when fetching periodic reports fails', async () => {
     const fetchError = new Error('Database connection lost')
 
     const validateWithBrokenReports = createSummaryLogsValidator({
@@ -725,19 +725,15 @@ describe('SummaryLogsValidator', () => {
       summaryLogExtractor
     })
 
-    await validateWithBrokenReports(summaryLogId)
-
-    expect(mockLoggerWarn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message:
-          'Failed to fetch periodic reports: summaryLogId=summary-log-123, fileId=file-123, filename=test.xlsx',
-        event: expect.objectContaining({
-          category: 'server',
-          action: 'process_failure'
-        }),
-        err: fetchError
-      })
+    const result = await validateWithBrokenReports(summaryLogId).catch(
+      (err) => err
     )
+
+    // The reports lookup is core flow: a failure must fail validation (the
+    // consumer's onFailure then marks the log validation_failed) rather than
+    // persist a result with every load misclassified as open.
+    expect(result).toBe(fetchError)
+    expect(summaryLogsRepository.update).not.toHaveBeenCalled()
   })
 
   describe('Four-level validation hierarchy short-circuit behavior', () => {

--- a/src/domain/summary-logs/loads-by-period-status-schema.js
+++ b/src/domain/summary-logs/loads-by-period-status-schema.js
@@ -12,8 +12,8 @@ const periodStatusBucketSchema = Joi.object({
 })
 
 const periodStatusGroupSchema = Joi.object({
-  included: periodStatusBucketSchema.required(),
-  excluded: periodStatusBucketSchema.required()
+  balanceAffecting: periodStatusBucketSchema.required(),
+  nonBalanceAffecting: periodStatusBucketSchema.required()
 })
 
 const periodStatusByChangeSchema = Joi.object({
@@ -28,8 +28,8 @@ export const loadsByPeriodStatusSchema = Joi.object({
 
 const emptyBucket = () => ({ count: 0, tonnageDelta: 0 })
 const emptyGroup = () => ({
-  included: emptyBucket(),
-  excluded: emptyBucket()
+  balanceAffecting: emptyBucket(),
+  nonBalanceAffecting: emptyBucket()
 })
 const emptyChange = () => ({ added: emptyGroup(), adjusted: emptyGroup() })
 

--- a/src/domain/summary-logs/loads-by-period-status-schema.js
+++ b/src/domain/summary-logs/loads-by-period-status-schema.js
@@ -6,14 +6,18 @@ import Joi from 'joi'
  * Used by both repository (storage validation) and route (response validation).
  */
 
-const periodStatusBucketSchema = Joi.object({
+const balanceAffectingBucketSchema = Joi.object({
   count: Joi.number().integer().min(0).required(),
   tonnageDelta: Joi.number().required()
 })
 
+const nonBalanceAffectingBucketSchema = Joi.object({
+  count: Joi.number().integer().min(0).required()
+})
+
 const periodStatusGroupSchema = Joi.object({
-  balanceAffecting: periodStatusBucketSchema.required(),
-  nonBalanceAffecting: periodStatusBucketSchema.required()
+  balanceAffecting: balanceAffectingBucketSchema.required(),
+  nonBalanceAffecting: nonBalanceAffectingBucketSchema.required()
 })
 
 const periodStatusByChangeSchema = Joi.object({
@@ -26,10 +30,9 @@ export const loadsByReportingPeriodSchema = Joi.object({
   closedPeriodLoads: periodStatusByChangeSchema.required()
 })
 
-const emptyBucket = () => ({ count: 0, tonnageDelta: 0 })
 const emptyGroup = () => ({
-  balanceAffecting: emptyBucket(),
-  nonBalanceAffecting: emptyBucket()
+  balanceAffecting: { count: 0, tonnageDelta: 0 },
+  nonBalanceAffecting: { count: 0 }
 })
 const emptyChange = () => ({ added: emptyGroup(), adjusted: emptyGroup() })
 

--- a/src/domain/summary-logs/loads-by-period-status-schema.js
+++ b/src/domain/summary-logs/loads-by-period-status-schema.js
@@ -21,9 +21,9 @@ const periodStatusByChangeSchema = Joi.object({
   adjusted: periodStatusGroupSchema.required()
 })
 
-export const loadsByPeriodStatusSchema = Joi.object({
-  open: periodStatusByChangeSchema.required(),
-  closed: periodStatusByChangeSchema.required()
+export const loadsByReportingPeriodSchema = Joi.object({
+  openPeriodLoads: periodStatusByChangeSchema.required(),
+  closedPeriodLoads: periodStatusByChangeSchema.required()
 })
 
 const emptyBucket = () => ({ count: 0, tonnageDelta: 0 })
@@ -33,8 +33,8 @@ const emptyGroup = () => ({
 })
 const emptyChange = () => ({ added: emptyGroup(), adjusted: emptyGroup() })
 
-/** Default loadsByPeriodStatus for validated logs without period-status data. */
-export const emptyLoadsByPeriodStatus = () => ({
-  open: emptyChange(),
-  closed: emptyChange()
+/** Default loadsByReportingPeriod for validated logs without period-status data. */
+export const emptyLoadsByReportingPeriod = () => ({
+  openPeriodLoads: emptyChange(),
+  closedPeriodLoads: emptyChange()
 })

--- a/src/domain/summary-logs/loads-by-period-status-schema.js
+++ b/src/domain/summary-logs/loads-by-period-status-schema.js
@@ -25,3 +25,16 @@ export const loadsByPeriodStatusSchema = Joi.object({
   open: periodStatusByChangeSchema.required(),
   closed: periodStatusByChangeSchema.required()
 })
+
+const emptyBucket = () => ({ count: 0, tonnageDelta: 0 })
+const emptyGroup = () => ({
+  included: emptyBucket(),
+  excluded: emptyBucket()
+})
+const emptyChange = () => ({ added: emptyGroup(), adjusted: emptyGroup() })
+
+/** Default loadsByPeriodStatus for validated logs without period-status data. */
+export const emptyLoadsByPeriodStatus = () => ({
+  open: emptyChange(),
+  closed: emptyChange()
+})

--- a/src/domain/summary-logs/loads-by-period-status-schema.js
+++ b/src/domain/summary-logs/loads-by-period-status-schema.js
@@ -1,0 +1,27 @@
+import Joi from 'joi'
+
+/**
+ * Shared Joi schema for loads classified by reporting period status.
+ *
+ * Used by both repository (storage validation) and route (response validation).
+ */
+
+const periodStatusBucketSchema = Joi.object({
+  count: Joi.number().integer().min(0).required(),
+  tonnageDelta: Joi.number().required()
+})
+
+const periodStatusGroupSchema = Joi.object({
+  included: periodStatusBucketSchema.required(),
+  excluded: periodStatusBucketSchema.required()
+})
+
+const periodStatusByChangeSchema = Joi.object({
+  added: periodStatusGroupSchema.required(),
+  adjusted: periodStatusGroupSchema.required()
+})
+
+export const loadsByPeriodStatusSchema = Joi.object({
+  open: periodStatusByChangeSchema.required(),
+  closed: periodStatusByChangeSchema.required()
+})

--- a/src/domain/summary-logs/model.js
+++ b/src/domain/summary-logs/model.js
@@ -34,6 +34,7 @@
  */
 
 /** @import {Loads, LoadsByWasteRecordType} from '#application/summary-logs/load-counts.js' */
+/** @import {LoadsByPeriodStatus} from '#application/summary-logs/period-status.js' */
 /** @import {ValidationIssueCounts} from '#common/validation/validation-issues.js' */
 /** @import {ProcessingType} from './meta-fields.js' */
 /** @import {SummaryLogStatus} from './status.js' */
@@ -58,6 +59,7 @@
  *   expiresAt?: Date | null,
  *   file: SummaryLogFile,
  *   loads?: Loads,
+ *   loadsByPeriodStatus?: LoadsByPeriodStatus,
  *   loadsByWasteRecordType?: LoadsByWasteRecordType,
  *   meta?: SummaryLogMeta,
  *   organisationId?: string,

--- a/src/domain/summary-logs/model.js
+++ b/src/domain/summary-logs/model.js
@@ -34,7 +34,7 @@
  */
 
 /** @import {Loads, LoadsByWasteRecordType} from '#application/summary-logs/load-counts.js' */
-/** @import {LoadsByPeriodStatus} from '#application/summary-logs/period-status.js' */
+/** @import {LoadsByReportingPeriod} from '#application/summary-logs/period-status.js' */
 /** @import {ValidationIssueCounts} from '#common/validation/validation-issues.js' */
 /** @import {ProcessingType} from './meta-fields.js' */
 /** @import {SummaryLogStatus} from './status.js' */
@@ -59,7 +59,7 @@
  *   expiresAt?: Date | null,
  *   file: SummaryLogFile,
  *   loads?: Loads,
- *   loadsByPeriodStatus?: LoadsByPeriodStatus,
+ *   loadsByReportingPeriod?: LoadsByReportingPeriod,
  *   loadsByWasteRecordType?: LoadsByWasteRecordType,
  *   meta?: SummaryLogMeta,
  *   organisationId?: string,

--- a/src/repositories/summary-logs/schema.js
+++ b/src/repositories/summary-logs/schema.js
@@ -5,6 +5,7 @@ import {
   loadsSchema,
   loadsByWasteRecordTypeSchema
 } from '#domain/summary-logs/loads-schema.js'
+import { loadsByPeriodStatusSchema } from '#domain/summary-logs/loads-by-period-status-schema.js'
 
 const commonMessages = {
   'any.required': '{#label} is required',
@@ -89,6 +90,7 @@ export const summaryLogUpdateSchema = Joi.object({
   status: statusSchema.optional(),
   validation: validationSchema.optional(),
   loads: loadsSchema.optional(),
+  loadsByPeriodStatus: loadsByPeriodStatusSchema.optional(),
   loadsByWasteRecordType: loadsByWasteRecordTypeSchema.optional(),
   file: fileSchema.optional(),
   organisationId: Joi.string().optional(),

--- a/src/repositories/summary-logs/schema.js
+++ b/src/repositories/summary-logs/schema.js
@@ -5,7 +5,7 @@ import {
   loadsSchema,
   loadsByWasteRecordTypeSchema
 } from '#domain/summary-logs/loads-schema.js'
-import { loadsByPeriodStatusSchema } from '#domain/summary-logs/loads-by-period-status-schema.js'
+import { loadsByReportingPeriodSchema } from '#domain/summary-logs/loads-by-period-status-schema.js'
 
 const commonMessages = {
   'any.required': '{#label} is required',
@@ -90,7 +90,7 @@ export const summaryLogUpdateSchema = Joi.object({
   status: statusSchema.optional(),
   validation: validationSchema.optional(),
   loads: loadsSchema.optional(),
-  loadsByPeriodStatus: loadsByPeriodStatusSchema.optional(),
+  loadsByReportingPeriod: loadsByReportingPeriodSchema.optional(),
   loadsByWasteRecordType: loadsByWasteRecordTypeSchema.optional(),
   file: fileSchema.optional(),
   organisationId: Joi.string().optional(),

--- a/src/routes/v1/organisations/registrations/summary-logs/get.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.js
@@ -9,7 +9,7 @@ import {
   SUMMARY_LOG_STATUS
 } from '#domain/summary-logs/status.js'
 import { extractResponseMetaFields } from '#domain/summary-logs/extract-response-meta-fields.js'
-import { emptyLoadsByPeriodStatus } from '#domain/summary-logs/loads-by-period-status-schema.js'
+import { emptyLoadsByReportingPeriod } from '#domain/summary-logs/loads-by-period-status-schema.js'
 import { transformValidationResponse } from './transform-validation-response.js'
 import { summaryLogResponseSchema } from './response.schema.js'
 import { ROLES } from '#common/helpers/auth/constants.js'
@@ -51,8 +51,8 @@ export const summaryLogsGet = {
       ...transformValidationResponse(summaryLog.validation),
       ...(summaryLog.loads && { loads: summaryLog.loads }),
       ...(summaryLog.status === SUMMARY_LOG_STATUS.VALIDATED && {
-        loadsByPeriodStatus:
-          summaryLog.loadsByPeriodStatus ?? emptyLoadsByPeriodStatus()
+        loadsByReportingPeriod:
+          summaryLog.loadsByReportingPeriod ?? emptyLoadsByReportingPeriod()
       }),
       ...(summaryLog.loadsByWasteRecordType && {
         loadsByWasteRecordType: summaryLog.loadsByWasteRecordType

--- a/src/routes/v1/organisations/registrations/summary-logs/get.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.js
@@ -46,6 +46,9 @@ export const summaryLogsGet = {
       status: summaryLog.status,
       ...transformValidationResponse(summaryLog.validation),
       ...(summaryLog.loads && { loads: summaryLog.loads }),
+      ...(summaryLog.loadsByPeriodStatus && {
+        loadsByPeriodStatus: summaryLog.loadsByPeriodStatus
+      }),
       ...(summaryLog.loadsByWasteRecordType && {
         loadsByWasteRecordType: summaryLog.loadsByWasteRecordType
       }),

--- a/src/routes/v1/organisations/registrations/summary-logs/get.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.js
@@ -4,8 +4,12 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
-import { getDefaultStatus } from '#domain/summary-logs/status.js'
+import {
+  getDefaultStatus,
+  SUMMARY_LOG_STATUS
+} from '#domain/summary-logs/status.js'
 import { extractResponseMetaFields } from '#domain/summary-logs/extract-response-meta-fields.js'
+import { emptyLoadsByPeriodStatus } from '#domain/summary-logs/loads-by-period-status-schema.js'
 import { transformValidationResponse } from './transform-validation-response.js'
 import { summaryLogResponseSchema } from './response.schema.js'
 import { ROLES } from '#common/helpers/auth/constants.js'
@@ -46,8 +50,9 @@ export const summaryLogsGet = {
       status: summaryLog.status,
       ...transformValidationResponse(summaryLog.validation),
       ...(summaryLog.loads && { loads: summaryLog.loads }),
-      ...(summaryLog.loadsByPeriodStatus && {
-        loadsByPeriodStatus: summaryLog.loadsByPeriodStatus
+      ...(summaryLog.status === SUMMARY_LOG_STATUS.VALIDATED && {
+        loadsByPeriodStatus:
+          summaryLog.loadsByPeriodStatus ?? emptyLoadsByPeriodStatus()
       }),
       ...(summaryLog.loadsByWasteRecordType && {
         loadsByWasteRecordType: summaryLog.loadsByWasteRecordType

--- a/src/routes/v1/organisations/registrations/summary-logs/get.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.test.js
@@ -13,29 +13,6 @@ import { asStandardUser } from '#test/inject-auth.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 
-const emptyLoadsByPeriodStatus = {
-  open: {
-    added: {
-      included: { count: 0, tonnageDelta: 0 },
-      excluded: { count: 0, tonnageDelta: 0 }
-    },
-    adjusted: {
-      included: { count: 0, tonnageDelta: 0 },
-      excluded: { count: 0, tonnageDelta: 0 }
-    }
-  },
-  closed: {
-    added: {
-      included: { count: 0, tonnageDelta: 0 },
-      excluded: { count: 0, tonnageDelta: 0 }
-    },
-    adjusted: {
-      included: { count: 0, tonnageDelta: 0 },
-      excluded: { count: 0, tonnageDelta: 0 }
-    }
-  }
-}
-
 describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/summary-logs/{summaryLogId}', () => {
   setupAuthContext()
 

--- a/src/routes/v1/organisations/registrations/summary-logs/get.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.test.js
@@ -13,6 +13,29 @@ import { asStandardUser } from '#test/inject-auth.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 
+const emptyLoadsByPeriodStatus = {
+  open: {
+    added: {
+      included: { count: 0, tonnageDelta: 0 },
+      excluded: { count: 0, tonnageDelta: 0 }
+    },
+    adjusted: {
+      included: { count: 0, tonnageDelta: 0 },
+      excluded: { count: 0, tonnageDelta: 0 }
+    }
+  },
+  closed: {
+    added: {
+      included: { count: 0, tonnageDelta: 0 },
+      excluded: { count: 0, tonnageDelta: 0 }
+    },
+    adjusted: {
+      included: { count: 0, tonnageDelta: 0 },
+      excluded: { count: 0, tonnageDelta: 0 }
+    }
+  }
+}
+
 describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/summary-logs/{summaryLogId}', () => {
   setupAuthContext()
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -478,6 +478,9 @@ export const createTestInfrastructure = async (
     summaryLogsRepository,
     organisationsRepository,
     wasteRecordsRepository,
+    reportsRepository: /** @type {any} */ ({
+      findPeriodicReports: async () => []
+    }),
     summaryLogExtractor,
     logger: mockLogger
   })
@@ -561,6 +564,9 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
     summaryLogsRepository,
     organisationsRepository,
     wasteRecordsRepository,
+    reportsRepository: /** @type {any} */ ({
+      findPeriodicReports: async () => []
+    }),
     summaryLogExtractor: dynamicExtractor,
     logger: mockLogger
   })

--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -537,6 +537,7 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
 
   const systemLogsForBalanceAudit = {
     insert: vi.fn().mockResolvedValue(undefined),
+    insertMany: vi.fn().mockResolvedValue(undefined),
     find: vi.fn(),
     findSummaryLogSubmitActors: vi.fn()
   }

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
@@ -243,7 +243,8 @@ describe('Repeated uploads of identical data', () => {
         organisationsRepository,
         wasteRecordsRepository,
         summaryLogExtractor,
-        logger: mockLogger
+        logger: mockLogger,
+        reportsRepository: /** @type {any} */ ({ findPeriodicReports: async () => [] })
       })
 
       const syncWasteRecords = syncFromSummaryLog({

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
@@ -245,12 +245,14 @@ describe('Repeated uploads of identical data', () => {
         })
       })
 
-      const syncWasteRecords = syncFromSummaryLog(/** @type {any} */ ({
-        extractor: summaryLogExtractor,
-        wasteRecordRepository: wasteRecordsRepository,
-        organisationsRepository,
-        overseasSitesRepository: { findByIds: vi.fn().mockResolvedValue([]) }
-      }))
+      const syncWasteRecords = syncFromSummaryLog(
+        /** @type {any} */ ({
+          extractor: summaryLogExtractor,
+          wasteRecordRepository: wasteRecordsRepository,
+          organisationsRepository,
+          overseasSitesRepository: { findByIds: vi.fn().mockResolvedValue([]) }
+        })
+      )
 
       const summaryLogsWorker = {
         validate: validateSummaryLog,
@@ -258,7 +260,10 @@ describe('Repeated uploads of identical data', () => {
           await new Promise((resolve) => setImmediate(resolve))
 
           const existing = await summaryLogsRepository.findById(summaryLogId)
-          const { version, summaryLog } = /** @type {import('#repositories/summary-logs/port.js').SummaryLogVersion} */ (existing)
+          const { version, summaryLog } =
+            /** @type {import('#repositories/summary-logs/port.js').SummaryLogVersion} */ (
+              existing
+            )
 
           await syncWasteRecords(summaryLog)
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
@@ -244,7 +244,9 @@ describe('Repeated uploads of identical data', () => {
         wasteRecordsRepository,
         summaryLogExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({ findPeriodicReports: async () => [] })
+        reportsRepository: /** @type {any} */ ({
+          findPeriodicReports: async () => []
+        })
       })
 
       const syncWasteRecords = syncFromSummaryLog({

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
@@ -14,6 +14,7 @@ import { buildOrganisation } from '#repositories/organisations/contract/test-dat
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
+import { createMockLogger } from '#test/mock-logger.js'
 import { createTestServer } from '#test/create-test-server.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 
@@ -58,12 +59,7 @@ describe('Repeated uploads of identical data', () => {
     let secondUploadResponse
 
     beforeEach(async () => {
-      const mockLogger = {
-        info: vi.fn(),
-        error: vi.fn(),
-        warn: vi.fn(),
-        debug: vi.fn()
-      }
+      const mockLogger = createMockLogger()
 
       const summaryLogsRepositoryFactory = createInMemorySummaryLogsRepository()
       const summaryLogsRepository = summaryLogsRepositoryFactory(mockLogger)
@@ -99,7 +95,7 @@ describe('Repeated uploads of identical data', () => {
       testOrg.id = organisationId
 
       const organisationsRepository = createInMemoryOrganisationsRepository([
-        testOrg
+        { ...testOrg, status: 'active' }
       ])()
 
       // Define shared metadata and headers
@@ -249,12 +245,12 @@ describe('Repeated uploads of identical data', () => {
         })
       })
 
-      const syncWasteRecords = syncFromSummaryLog({
+      const syncWasteRecords = syncFromSummaryLog(/** @type {any} */ ({
         extractor: summaryLogExtractor,
         wasteRecordRepository: wasteRecordsRepository,
         organisationsRepository,
         overseasSitesRepository: { findByIds: vi.fn().mockResolvedValue([]) }
-      })
+      }))
 
       const summaryLogsWorker = {
         validate: validateSummaryLog,
@@ -262,7 +258,7 @@ describe('Repeated uploads of identical data', () => {
           await new Promise((resolve) => setImmediate(resolve))
 
           const existing = await summaryLogsRepository.findById(summaryLogId)
-          const { version, summaryLog } = existing
+          const { version, summaryLog } = /** @type {import('#repositories/summary-logs/port.js').SummaryLogVersion} */ (existing)
 
           await syncWasteRecords(summaryLog)
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -354,7 +354,9 @@ describe('Submission and placeholder tests', () => {
         wasteRecordsRepository,
         summaryLogExtractor: validationExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({ findPeriodicReports: async () => [] })
+        reportsRepository: /** @type {any} */ ({
+          findPeriodicReports: async () => []
+        })
       })
 
       const syncWasteRecords = syncFromSummaryLog({
@@ -804,7 +806,9 @@ describe('Submission and placeholder tests', () => {
         wasteRecordsRepository,
         summaryLogExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({ findPeriodicReports: async () => [] })
+        reportsRepository: /** @type {any} */ ({
+          findPeriodicReports: async () => []
+        })
       })
       const featureFlags = createInMemoryFeatureFlags()
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -355,12 +355,14 @@ describe('Submission and placeholder tests', () => {
         })
       })
 
-      const syncWasteRecords = syncFromSummaryLog(/** @type {any} */ ({
-        extractor: transformationExtractor,
-        wasteRecordRepository: wasteRecordsRepository,
-        organisationsRepository,
-        overseasSitesRepository: { findByIds: vi.fn().mockResolvedValue([]) }
-      }))
+      const syncWasteRecords = syncFromSummaryLog(
+        /** @type {any} */ ({
+          extractor: transformationExtractor,
+          wasteRecordRepository: wasteRecordsRepository,
+          organisationsRepository,
+          overseasSitesRepository: { findByIds: vi.fn().mockResolvedValue([]) }
+        })
+      )
 
       const submitterWorker = {
         validate: validateSummaryLog,
@@ -368,7 +370,10 @@ describe('Submission and placeholder tests', () => {
           await new Promise((resolve) => setImmediate(resolve))
 
           const existing = await summaryLogsRepository.findById(summaryLogId)
-          const { version, summaryLog } = /** @type {import('#repositories/summary-logs/port.js').SummaryLogVersion} */ (existing)
+          const { version, summaryLog } =
+            /** @type {import('#repositories/summary-logs/port.js').SummaryLogVersion} */ (
+              existing
+            )
 
           await syncWasteRecords(summaryLog)
 
@@ -768,7 +773,9 @@ describe('Submission and placeholder tests', () => {
         { ...testOrg, status: 'active' }
       ])()
 
-      const excelBuffer = /** @type {Buffer<ArrayBufferLike>} */ (/** @type {unknown} */ (await createExcelWithPlaceholders()))
+      const excelBuffer = /** @type {Buffer<ArrayBufferLike>} */ (
+        /** @type {unknown} */ (await createExcelWithPlaceholders())
+      )
 
       const { uploadId } = await uploadsRepository.initiateSummaryLogUpload({
         organisationId,

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -353,7 +353,8 @@ describe('Submission and placeholder tests', () => {
         organisationsRepository,
         wasteRecordsRepository,
         summaryLogExtractor: validationExtractor,
-        logger: mockLogger
+        logger: mockLogger,
+        reportsRepository: /** @type {any} */ ({ findPeriodicReports: async () => [] })
       })
 
       const syncWasteRecords = syncFromSummaryLog({
@@ -802,7 +803,8 @@ describe('Submission and placeholder tests', () => {
         organisationsRepository,
         wasteRecordsRepository,
         summaryLogExtractor,
-        logger: mockLogger
+        logger: mockLogger,
+        reportsRepository: /** @type {any} */ ({ findPeriodicReports: async () => [] })
       })
       const featureFlags = createInMemoryFeatureFlags()
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -19,6 +19,7 @@ import { createInMemoryOrganisationsRepository } from '#repositories/organisatio
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
+import { createMockLogger } from '#test/mock-logger.js'
 import { createTestServer } from '#test/create-test-server.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 
@@ -69,12 +70,7 @@ describe('Submission and placeholder tests', () => {
 
     beforeEach(async () => {
       const summaryLogsRepositoryFactory = createInMemorySummaryLogsRepository()
-      const mockLogger = {
-        info: vi.fn(),
-        error: vi.fn(),
-        warn: vi.fn(),
-        debug: vi.fn()
-      }
+      const mockLogger = createMockLogger()
       const uploadsRepository = createInMemoryUploadsRepository()
       const summaryLogsRepository = summaryLogsRepositoryFactory(mockLogger)
 
@@ -105,7 +101,7 @@ describe('Submission and placeholder tests', () => {
       testOrg.id = organisationId
 
       const organisationsRepository = createInMemoryOrganisationsRepository([
-        testOrg
+        { ...testOrg, status: 'active' }
       ])()
 
       const sharedMeta = {
@@ -359,12 +355,12 @@ describe('Submission and placeholder tests', () => {
         })
       })
 
-      const syncWasteRecords = syncFromSummaryLog({
+      const syncWasteRecords = syncFromSummaryLog(/** @type {any} */ ({
         extractor: transformationExtractor,
         wasteRecordRepository: wasteRecordsRepository,
         organisationsRepository,
         overseasSitesRepository: { findByIds: vi.fn().mockResolvedValue([]) }
-      })
+      }))
 
       const submitterWorker = {
         validate: validateSummaryLog,
@@ -372,7 +368,7 @@ describe('Submission and placeholder tests', () => {
           await new Promise((resolve) => setImmediate(resolve))
 
           const existing = await summaryLogsRepository.findById(summaryLogId)
-          const { version, summaryLog } = existing
+          const { version, summaryLog } = /** @type {import('#repositories/summary-logs/port.js').SummaryLogVersion} */ (existing)
 
           await syncWasteRecords(summaryLog)
 
@@ -738,12 +734,7 @@ describe('Submission and placeholder tests', () => {
 
     beforeEach(async () => {
       const summaryLogsRepositoryFactory = createInMemorySummaryLogsRepository()
-      const mockLogger = {
-        info: vi.fn(),
-        error: vi.fn(),
-        warn: vi.fn(),
-        debug: vi.fn()
-      }
+      const mockLogger = createMockLogger()
       uploadsRepository = createInMemoryUploadsRepository()
       testSummaryLogsRepository = summaryLogsRepositoryFactory(mockLogger)
 
@@ -774,10 +765,10 @@ describe('Submission and placeholder tests', () => {
       testOrg.id = organisationId
 
       const organisationsRepository = createInMemoryOrganisationsRepository([
-        testOrg
+        { ...testOrg, status: 'active' }
       ])()
 
-      const excelBuffer = await createExcelWithPlaceholders()
+      const excelBuffer = /** @type {Buffer<ArrayBufferLike>} */ (/** @type {unknown} */ (await createExcelWithPlaceholders()))
 
       const { uploadId } = await uploadsRepository.initiateSummaryLogUpload({
         organisationId,
@@ -794,8 +785,7 @@ describe('Submission and placeholder tests', () => {
       const { Bucket: s3Bucket, Key: s3Key } = parseS3Uri(s3Uri)
 
       const summaryLogExtractor = createSummaryLogExtractor({
-        uploadsRepository,
-        logger: mockLogger
+        uploadsRepository
       })
 
       const wasteRecordsRepository = createInMemoryWasteRecordsRepository()()

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
@@ -143,22 +143,22 @@ describe('Summary logs upload lifecycle', () => {
           loadsByPeriodStatus: {
             open: {
               added: {
-                included: { count: 0, tonnageDelta: 0 },
-                excluded: { count: 0, tonnageDelta: 0 }
+                balanceAffecting: { count: 0, tonnageDelta: 0 },
+                nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
               },
               adjusted: {
-                included: { count: 0, tonnageDelta: 0 },
-                excluded: { count: 0, tonnageDelta: 0 }
+                balanceAffecting: { count: 0, tonnageDelta: 0 },
+                nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
               }
             },
             closed: {
               added: {
-                included: { count: 0, tonnageDelta: 0 },
-                excluded: { count: 0, tonnageDelta: 0 }
+                balanceAffecting: { count: 0, tonnageDelta: 0 },
+                nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
               },
               adjusted: {
-                included: { count: 0, tonnageDelta: 0 },
-                excluded: { count: 0, tonnageDelta: 0 }
+                balanceAffecting: { count: 0, tonnageDelta: 0 },
+                nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
               }
             }
           },

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
@@ -140,8 +140,8 @@ describe('Summary logs upload lifecycle', () => {
             counts: { fatal: 0, error: 0, warning: 0, total: 0 }
           },
           loads: createEmptyLoads(),
-          loadsByPeriodStatus: {
-            open: {
+          loadsByReportingPeriod: {
+            openPeriodLoads: {
               added: {
                 balanceAffecting: { count: 0, tonnageDelta: 0 },
                 nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
@@ -151,7 +151,7 @@ describe('Summary logs upload lifecycle', () => {
                 nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
               }
             },
-            closed: {
+            closedPeriodLoads: {
               added: {
                 balanceAffecting: { count: 0, tonnageDelta: 0 },
                 nonBalanceAffecting: { count: 0, tonnageDelta: 0 }

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
@@ -144,21 +144,21 @@ describe('Summary logs upload lifecycle', () => {
             openPeriodLoads: {
               added: {
                 balanceAffecting: { count: 0, tonnageDelta: 0 },
-                nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
+                nonBalanceAffecting: { count: 0 }
               },
               adjusted: {
                 balanceAffecting: { count: 0, tonnageDelta: 0 },
-                nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
+                nonBalanceAffecting: { count: 0 }
               }
             },
             closedPeriodLoads: {
               added: {
                 balanceAffecting: { count: 0, tonnageDelta: 0 },
-                nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
+                nonBalanceAffecting: { count: 0 }
               },
               adjusted: {
                 balanceAffecting: { count: 0, tonnageDelta: 0 },
-                nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
+                nonBalanceAffecting: { count: 0 }
               }
             }
           },

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
@@ -140,6 +140,28 @@ describe('Summary logs upload lifecycle', () => {
             counts: { fatal: 0, error: 0, warning: 0, total: 0 }
           },
           loads: createEmptyLoads(),
+          loadsByPeriodStatus: {
+            open: {
+              added: {
+                included: { count: 0, tonnageDelta: 0 },
+                excluded: { count: 0, tonnageDelta: 0 }
+              },
+              adjusted: {
+                included: { count: 0, tonnageDelta: 0 },
+                excluded: { count: 0, tonnageDelta: 0 }
+              }
+            },
+            closed: {
+              added: {
+                included: { count: 0, tonnageDelta: 0 },
+                excluded: { count: 0, tonnageDelta: 0 }
+              },
+              adjusted: {
+                included: { count: 0, tonnageDelta: 0 },
+                excluded: { count: 0, tonnageDelta: 0 }
+              }
+            }
+          },
           loadsByWasteRecordType: [
             {
               wasteRecordType: 'received',

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
@@ -388,7 +388,9 @@ describe('Advanced validation scenarios', () => {
         wasteRecordsRepository,
         summaryLogExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({ findPeriodicReports: async () => [] })
+        reportsRepository: /** @type {any} */ ({
+          findPeriodicReports: async () => []
+        })
       })
       const featureFlags = createInMemoryFeatureFlags()
 
@@ -571,7 +573,9 @@ describe('Advanced validation scenarios', () => {
         wasteRecordsRepository,
         summaryLogExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({ findPeriodicReports: async () => [] })
+        reportsRepository: /** @type {any} */ ({
+          findPeriodicReports: async () => []
+        })
       })
       const featureFlags = createInMemoryFeatureFlags()
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
@@ -387,7 +387,8 @@ describe('Advanced validation scenarios', () => {
         organisationsRepository,
         wasteRecordsRepository,
         summaryLogExtractor,
-        logger: mockLogger
+        logger: mockLogger,
+        reportsRepository: /** @type {any} */ ({ findPeriodicReports: async () => [] })
       })
       const featureFlags = createInMemoryFeatureFlags()
 
@@ -569,7 +570,8 @@ describe('Advanced validation scenarios', () => {
         organisationsRepository,
         wasteRecordsRepository,
         summaryLogExtractor,
-        logger: mockLogger
+        logger: mockLogger,
+        reportsRepository: /** @type {any} */ ({ findPeriodicReports: async () => [] })
       })
       const featureFlags = createInMemoryFeatureFlags()
 

--- a/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
@@ -70,7 +70,11 @@ export const summaryLogResponseSchema = Joi.object({
     }).required()
   }).optional(),
   loads: loadsSchema.optional(),
-  loadsByPeriodStatus: loadsByPeriodStatusSchema.optional(),
+  loadsByPeriodStatus: Joi.when('status', {
+    is: SUMMARY_LOG_STATUS.VALIDATED,
+    then: loadsByPeriodStatusSchema.required(),
+    otherwise: loadsByPeriodStatusSchema.optional()
+  }),
   loadsByWasteRecordType: loadsByWasteRecordTypeSchema.optional(),
   processingType: Joi.string().optional(),
   material: Joi.string().optional(),

--- a/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
@@ -5,7 +5,7 @@ import {
   loadsSchema,
   loadsByWasteRecordTypeSchema
 } from '#domain/summary-logs/loads-schema.js'
-import { loadsByPeriodStatusSchema } from '#domain/summary-logs/loads-by-period-status-schema.js'
+import { loadsByReportingPeriodSchema } from '#domain/summary-logs/loads-by-period-status-schema.js'
 
 const countSchema = Joi.number().integer().min(0).required()
 
@@ -70,10 +70,10 @@ export const summaryLogResponseSchema = Joi.object({
     }).required()
   }).optional(),
   loads: loadsSchema.optional(),
-  loadsByPeriodStatus: Joi.when('status', {
+  loadsByReportingPeriod: Joi.when('status', {
     is: SUMMARY_LOG_STATUS.VALIDATED,
-    then: loadsByPeriodStatusSchema.required(),
-    otherwise: loadsByPeriodStatusSchema.optional()
+    then: loadsByReportingPeriodSchema.required(),
+    otherwise: loadsByReportingPeriodSchema.optional()
   }),
   loadsByWasteRecordType: loadsByWasteRecordTypeSchema.optional(),
   processingType: Joi.string().optional(),

--- a/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
@@ -5,6 +5,7 @@ import {
   loadsSchema,
   loadsByWasteRecordTypeSchema
 } from '#domain/summary-logs/loads-schema.js'
+import { loadsByPeriodStatusSchema } from '#domain/summary-logs/loads-by-period-status-schema.js'
 
 const countSchema = Joi.number().integer().min(0).required()
 
@@ -69,6 +70,7 @@ export const summaryLogResponseSchema = Joi.object({
     }).required()
   }).optional(),
   loads: loadsSchema.optional(),
+  loadsByPeriodStatus: loadsByPeriodStatusSchema.optional(),
   loadsByWasteRecordType: loadsByWasteRecordTypeSchema.optional(),
   processingType: Joi.string().optional(),
   material: Joi.string().optional(),

--- a/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
@@ -767,22 +767,22 @@ describe('transformValidationResponse', () => {
         loadsByPeriodStatus: {
           open: {
             added: {
-              included: { count: 0, tonnageDelta: 0 },
-              excluded: { count: 0, tonnageDelta: 0 }
+              balanceAffecting: { count: 0, tonnageDelta: 0 },
+              nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
             },
             adjusted: {
-              included: { count: 0, tonnageDelta: 0 },
-              excluded: { count: 0, tonnageDelta: 0 }
+              balanceAffecting: { count: 0, tonnageDelta: 0 },
+              nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
             }
           },
           closed: {
             added: {
-              included: { count: 0, tonnageDelta: 0 },
-              excluded: { count: 0, tonnageDelta: 0 }
+              balanceAffecting: { count: 0, tonnageDelta: 0 },
+              nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
             },
             adjusted: {
-              included: { count: 0, tonnageDelta: 0 },
-              excluded: { count: 0, tonnageDelta: 0 }
+              balanceAffecting: { count: 0, tonnageDelta: 0 },
+              nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
             }
           }
         }

--- a/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
@@ -768,21 +768,21 @@ describe('transformValidationResponse', () => {
           openPeriodLoads: {
             added: {
               balanceAffecting: { count: 0, tonnageDelta: 0 },
-              nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
+              nonBalanceAffecting: { count: 0 }
             },
             adjusted: {
               balanceAffecting: { count: 0, tonnageDelta: 0 },
-              nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
+              nonBalanceAffecting: { count: 0 }
             }
           },
           closedPeriodLoads: {
             added: {
               balanceAffecting: { count: 0, tonnageDelta: 0 },
-              nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
+              nonBalanceAffecting: { count: 0 }
             },
             adjusted: {
               balanceAffecting: { count: 0, tonnageDelta: 0 },
-              nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
+              nonBalanceAffecting: { count: 0 }
             }
           }
         }

--- a/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
@@ -764,8 +764,8 @@ describe('transformValidationResponse', () => {
       const httpResponse = {
         status: SUMMARY_LOG_STATUS.VALIDATED,
         ...transformValidationResponse(validation),
-        loadsByPeriodStatus: {
-          open: {
+        loadsByReportingPeriod: {
+          openPeriodLoads: {
             added: {
               balanceAffecting: { count: 0, tonnageDelta: 0 },
               nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
@@ -775,7 +775,7 @@ describe('transformValidationResponse', () => {
               nonBalanceAffecting: { count: 0, tonnageDelta: 0 }
             }
           },
-          closed: {
+          closedPeriodLoads: {
             added: {
               balanceAffecting: { count: 0, tonnageDelta: 0 },
               nonBalanceAffecting: { count: 0, tonnageDelta: 0 }

--- a/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
@@ -763,7 +763,29 @@ describe('transformValidationResponse', () => {
 
       const httpResponse = {
         status: SUMMARY_LOG_STATUS.VALIDATED,
-        ...transformValidationResponse(validation)
+        ...transformValidationResponse(validation),
+        loadsByPeriodStatus: {
+          open: {
+            added: {
+              included: { count: 0, tonnageDelta: 0 },
+              excluded: { count: 0, tonnageDelta: 0 }
+            },
+            adjusted: {
+              included: { count: 0, tonnageDelta: 0 },
+              excluded: { count: 0, tonnageDelta: 0 }
+            }
+          },
+          closed: {
+            added: {
+              included: { count: 0, tonnageDelta: 0 },
+              excluded: { count: 0, tonnageDelta: 0 }
+            },
+            adjusted: {
+              included: { count: 0, tonnageDelta: 0 },
+              excluded: { count: 0, tonnageDelta: 0 }
+            }
+          }
+        }
       }
       const { error } = summaryLogResponseSchema.validate(httpResponse)
       expect(error).toBeUndefined()

--- a/src/server/queue-consumer/queue-consumer.plugin.js
+++ b/src/server/queue-consumer/queue-consumer.plugin.js
@@ -69,6 +69,7 @@ function buildConsumerDeps(server, { config }) {
     organisationsRepository,
     wasteRecordsRepository,
     wasteBalancesRepository,
+    reportsRepository,
     summaryLogExtractor: createSummaryLogExtractor({ uploadsRepository }),
     onSummaryLogSubmittedReportHook
   }

--- a/src/server/queue-consumer/queue-consumer.plugin.test.js
+++ b/src/server/queue-consumer/queue-consumer.plugin.test.js
@@ -139,6 +139,7 @@ describe('commandQueueConsumerPlugin', () => {
           organisationsRepository: server.app.organisationsRepository,
           wasteRecordsRepository: server.app.wasteRecordsRepository,
           wasteBalancesRepository: server.app.wasteBalancesRepository,
+          reportsRepository: server.app.reportsRepository,
           summaryLogExtractor: expect.any(Object),
           onSummaryLogSubmittedReportHook: expect.any(Function)
         },

--- a/src/server/queue-consumer/summary-log-commands.js
+++ b/src/server/queue-consumer/summary-log-commands.js
@@ -14,6 +14,7 @@ import { submitSummaryLog } from '#application/summary-logs/submit.js'
 /** @typedef {import('#repositories/waste-records/port.js').WasteRecordsRepository} WasteRecordsRepository */
 /** @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository */
 /** @typedef {import('#domain/summary-logs/extractor/port.js').SummaryLogExtractor} SummaryLogExtractor */
+/** @typedef {import('#reports/repository/port.js').ReportsRepository} ReportsRepository */
 
 /**
  * @typedef {object} SummaryLogHandlerDeps
@@ -22,6 +23,7 @@ import { submitSummaryLog } from '#application/summary-logs/submit.js'
  * @property {OrganisationsRepository} organisationsRepository
  * @property {WasteRecordsRepository} wasteRecordsRepository
  * @property {WasteBalancesRepository} wasteBalancesRepository
+ * @property {ReportsRepository} reportsRepository
  * @property {SummaryLogExtractor} summaryLogExtractor
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
  * @property {(organisationId: string, registrationId: string) => Promise<void>} onSummaryLogSubmittedReportHook
@@ -60,6 +62,7 @@ export const summaryLogCommandHandlers = [
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
+        reportsRepository,
         summaryLogExtractor
       } = deps
 
@@ -68,6 +71,7 @@ export const summaryLogCommandHandlers = [
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
+        reportsRepository,
         summaryLogExtractor
       })
 


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)

## Summary

This PR provides backend capability for the ticket's [related designs](https://www.figma.com/design/scTmpd6bQJQxLF6U26hwqA/Waste-Management?node-id=13117-45366&t=qPcFZYJ3YfEd6vji-4) with the exception of the accordion breakdown of individual rows (to follow).

Adds period-status classification to the summary log validation pipeline. Each validated waste record is classified into an open or closed reporting period bucket, then further split by whether the record was added or adjusted, and whether it moved the waste balance.

The `GET /v1/organisations/{organisationId}/registrations/{registrationId}/summary-logs/{summaryLogId}` response gains an optional `loadsByReportingPeriod` field on validated summary logs:

```json
{
  "loadsByReportingPeriod": {
    "openPeriodLoads": {
      "added": {
        "balanceAffecting": { "count": 3, "tonnageDelta": 42.5 },
        "nonBalanceAffecting": { "count": 1 }
      },
      "adjusted": {
        "balanceAffecting": { "count": 1, "tonnageDelta": -2.0 },
        "nonBalanceAffecting": { "count": 0 }
      }
    },
    "closedPeriodLoads": {
      "added": { ... },
      "adjusted": { ... }
    }
  }
}
```

| Field | Meaning |
|---|---|
| `openPeriodLoads` / `closedPeriodLoads` | Whether the record's reporting period has been submitted. A period is closed when a report has been submitted for it (current status is `submitted` or there are previous submissions). |
| `added` / `adjusted` | Whether the record was newly created or updated by this summary log. |
| `balanceAffecting` / `nonBalanceAffecting` | Whether the record actually moved the waste balance, decided per leg from its rounded net tonnage delta. A leg is `balanceAffecting` when its delta is non-zero, otherwise `nonBalanceAffecting`. This makes all balance movement (including amendment reversals) live in `balanceAffecting`, so a row that is valid but contributes nothing (eg PRN-issued, outside accreditation, or an unchanged resubmission) is `nonBalanceAffecting`. |
| `count` | Number of record legs in this bucket. |
| `tonnageDelta` | Present only on `balanceAffecting`. The net waste balance impact: for added records the transaction amount, for adjusted records the net effect across the old and new period classifications. Summing `tonnageDelta` across all four `balanceAffecting` buckets gives the total predicted impact on the waste balance. `nonBalanceAffecting` carries no `tonnageDelta` because it is always zero. |

The field is absent when validation fails (status is `INVALID`). When the reports lookup fails the whole validation fails rather than persisting a misclassified split: the error propagates, the queue consumer retries the transient failure via SQS redrive, and the log is marked `validation_failed` once retries are exhausted. All inner buckets are always present when the field exists (no null nesting).

### Business rules

- **Closed-wins rule**: when a row has multiple reporting date fields (eg exporter received-loads with both `DATE_RECEIVED_FOR_EXPORT` and `DATE_OF_EXPORT`), if any date maps to a submitted period the entire row is classified as closed.
- **Per-leg classification**: an adjusted record contributes to each period it touches. The old period gets `-oldAmount` and the new period gets `+newAmount`; when both fall in the same period these merge into a single net leg. Each leg is independently `balanceAffecting` or `nonBalanceAffecting` based on its own rounded delta, so a same-period amendment that nets to zero (eg an identical resubmission) is `nonBalanceAffecting`.
- **Cadence**: accredited registrations use monthly periods, registered-only use quarterly.
- **IGNORED and unchanged records**: skipped entirely.

### Design

The classification is a pure function (`classifyByPeriodStatus` in `period-status.js`) with no I/O. Each record produces 0-2 leg entries which are folded into the final nested structure; inclusion is derived from each leg's rounded delta at fold time. The reports fetch lives in `validate.js` alongside the existing orchestration, and a fetch failure propagates so the consumer can retry then fail the log.

`reportsRepository` is threaded through the queue-consumer plugin to the validator factory.

[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541

