### PR TITLE
PAE-1558: Add detail columns to waste-records CSV export

### DIFF
--- a/src/domain/organisations/registration-utils.js
+++ b/src/domain/organisations/registration-utils.js
@@ -1,8 +1,8 @@
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
 
-/** @import { Organisation, RegAccStatus } from '#domain/organisations/model.js' */
-/** @import { RegistrationApproved } from '#domain/organisations/registration.js' */
+/** @import { GlassRecyclingProcess, Material, Organisation, RegAccStatus } from '#domain/organisations/model.js' */
+/** @import { Registration, RegistrationApproved } from '#domain/organisations/registration.js' */
 /** @import { Accreditation } from '#domain/organisations/accreditation.js' */
 
 const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
@@ -70,6 +70,28 @@ export function resolveAccreditationNumber(registration, org) {
 export function isRegistrationAccredited(registration) {
   const status = registration.accreditation?.status
   return ACTIVE_ACCREDITATION_STATUSES.has(/** @type {RegAccStatus} */ (status))
+}
+
+/**
+ * Returns the registration's material at its finest granularity. Glass is the
+ * only material that sub-divides: each glass registration carries a single
+ * recycling process (submissions are split per process upstream), so the
+ * process value (glass_re_melt / glass_other) is returned in place of 'glass'.
+ * All other materials are returned unchanged.
+ *
+ * @param {Pick<Registration, 'material' | 'glassRecyclingProcess'>} registration
+ * @returns {Material | GlassRecyclingProcess}
+ */
+export function resolveDetailedMaterial(registration) {
+  const glassProcess = registration.glassRecyclingProcess
+  if (
+    registration.material === 'glass' &&
+    glassProcess &&
+    glassProcess.length > 0
+  ) {
+    return glassProcess[0]
+  }
+  return registration.material
 }
 
 /**

--- a/src/domain/organisations/registration-utils.test.js
+++ b/src/domain/organisations/registration-utils.test.js
@@ -3,7 +3,8 @@ import {
   getReportableRegistrations,
   isRegistrationAccredited,
   resolveAccreditationNumber,
-  resolveAccreditation
+  resolveAccreditation,
+  resolveDetailedMaterial
 } from './registration-utils.js'
 
 /** @import { Organisation } from '#domain/organisations/model.js' */
@@ -279,5 +280,47 @@ describe('resolveAccreditation', () => {
     const reg = buildReg({ accreditationId: 'acc-1' })
 
     expect(resolveAccreditation(reg, org)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveDetailedMaterial
+// ---------------------------------------------------------------------------
+
+describe('resolveDetailedMaterial', () => {
+  it('returns the glass recycling process for a glass registration', () => {
+    const reg = buildReg({
+      material: 'glass',
+      glassRecyclingProcess: ['glass_re_melt']
+    })
+
+    expect(resolveDetailedMaterial(reg)).toBe('glass_re_melt')
+  })
+
+  it('returns glass_other for a glass-other registration', () => {
+    const reg = buildReg({
+      material: 'glass',
+      glassRecyclingProcess: ['glass_other']
+    })
+
+    expect(resolveDetailedMaterial(reg)).toBe('glass_other')
+  })
+
+  it('returns glass when a glass registration has no recycling process', () => {
+    const reg = buildReg({ material: 'glass' })
+
+    expect(resolveDetailedMaterial(reg)).toBe('glass')
+  })
+
+  it('returns glass when the recycling process array is empty', () => {
+    const reg = buildReg({ material: 'glass', glassRecyclingProcess: [] })
+
+    expect(resolveDetailedMaterial(reg)).toBe('glass')
+  })
+
+  it('returns the material unchanged for non-glass registrations', () => {
+    const reg = buildReg({ material: 'plastic' })
+
+    expect(resolveDetailedMaterial(reg)).toBe('plastic')
   })
 })

--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -1,4 +1,5 @@
 import { badRequest, conflict } from '#common/helpers/logging/cdp-boom.js'
+import { resolveDetailedMaterial } from '#domain/organisations/registration-utils.js'
 import { getOrsDetailsMap } from '#overseas-sites/application/get-ors-details-map.js'
 import { getIssuedTonnage } from '#packaging-recycling-notes/application/get-issued-tonnage.js'
 import { aggregateReportDetail } from '#reports/domain/aggregation/aggregate-report-detail.js'
@@ -60,22 +61,6 @@ export async function fetchCurrentReport(
   }
 
   return reportsRepository.findReportById(currentReportId)
-}
-
-/**
- * Resolves the tonnage-monitoring material from a registration.
- * Glass registrations use glassRecyclingProcess[0] (e.g. 'glass_re_melt').
- * @param {object} registration
- * @returns {string}
- */
-function resolveTonnageMaterial(registration) {
-  if (
-    registration.material === 'glass' &&
-    registration.glassRecyclingProcess?.length > 0
-  ) {
-    return registration.glassRecyclingProcess[0]
-  }
-  return registration.material
 }
 
 /**
@@ -211,7 +196,7 @@ function buildReportData(aggregated, registration) {
   const { recyclingActivity, exportActivity, wasteSent, prn, source } =
     aggregated
   return {
-    material: resolveTonnageMaterial(registration),
+    material: resolveDetailedMaterial(registration),
     wasteProcessingType: registration.wasteProcessingType,
     siteAddress: formatSiteAddress(registration.site?.address),
     source,

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -406,6 +406,36 @@ describe('streamCsvExport', () => {
     expect(cells[9]).toBe('"false"')
   })
 
+  it('reads Accredited "Yes" with the number for a suspended accreditation', async () => {
+    const suspendedAccreditation = {
+      id: 'acc-1',
+      status: 'suspended',
+      accreditationNumber: 'ACC-SUS-1',
+      validFrom: '2026-01-01',
+      validTo: '2026-12-31',
+      statusHistory: []
+    }
+    const org = baseOrg({
+      accreditations: [suspendedAccreditation],
+      registrations: [
+        baseRegistration({ accreditation: null, accreditationId: 'acc-1' })
+      ]
+    })
+    const deps = baseDeps({
+      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
+      wasteRecordsRepository: {
+        findByRegistration: vi
+          .fn()
+          .mockResolvedValue([reprocessorReceivedRecord()])
+      }
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const cells = out[1].trim().split(',')
+    expect(cells[5]).toBe('"Yes"') // Accredited
+    expect(cells[6]).toBe('"ACC-SUS-1"') // Accreditation Number
+  })
+
   it('iterates organisations and registrations sorted by id for deterministic output', async () => {
     const orgB = baseOrg({
       id: 'org-b',

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -130,6 +130,44 @@ describe('streamCsvExport', () => {
     )
   })
 
+  it('emits registration and accreditation numbers and the detailed glass material', async () => {
+    const accreditation = {
+      id: 'acc-1',
+      status: 'approved',
+      accreditationNumber: 'ACC-777',
+      validFrom: '2026-01-01',
+      validTo: '2026-12-31',
+      statusHistory: []
+    }
+    const org = baseOrg({
+      accreditations: [accreditation],
+      registrations: [
+        baseRegistration({
+          accreditation: null,
+          accreditationId: 'acc-1',
+          registrationNumber: 'REG-555',
+          material: 'glass',
+          glassRecyclingProcess: ['glass_re_melt']
+        })
+      ]
+    })
+    const record = reprocessorReceivedRecord()
+    const deps = baseDeps({
+      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
+      wasteRecordsRepository: {
+        findByRegistration: vi.fn().mockResolvedValue([record])
+      }
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    expect(out).toHaveLength(2)
+    const cells = out[1].trim().split(',')
+    expect(cells[2]).toBe('"REG-555"') // Registration Number
+    expect(cells[3]).toBe('"glass_re_melt"') // Material (detailed)
+    expect(cells[5]).toBe('"Yes"') // Accredited
+    expect(cells[6]).toBe('"ACC-777"') // Accreditation Number
+  })
+
   it('emits empty Submitted At when the record references a missing summary log', async () => {
     const org = baseOrg({ registrations: [baseRegistration()] })
     const record = reprocessorReceivedRecord({
@@ -147,9 +185,9 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(2)
-    // The Submitted At column (index 6) should be an empty quoted cell
+    // The Submitted At column (index 8) should be an empty quoted cell
     const cells = out[1].trim().split(',')
-    expect(cells[6]).toBe('""')
+    expect(cells[8]).toBe('""')
   })
 
   it('processes received, processed, sentOn and exported records on the same registration', async () => {
@@ -254,9 +292,9 @@ describe('streamCsvExport', () => {
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(2)
     expect(deps.overseasSitesRepository.findAll).toHaveBeenCalledTimes(1)
-    // "Included in Waste Balance" is the 8th metadata column (index 7) → "true"
+    // "Included in Waste Balance" is the 10th metadata column (index 9) → "true"
     const cells = out[1].trim().split(',')
-    expect(cells[7]).toBe('"true"')
+    expect(cells[9]).toBe('"true"')
   })
 
   const exporterAccreditation = {
@@ -329,8 +367,8 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     const cells = out[1].trim().split(',')
-    expect(cells[4]).toBe('"Yes"') // Accredited column
-    expect(cells[7]).toBe('"true"')
+    expect(cells[5]).toBe('"Yes"') // Accredited column
+    expect(cells[9]).toBe('"true"')
   })
 
   it('marks accredited exporter row as not included when DATE_OF_EXPORT is outside accreditation period', async () => {
@@ -364,8 +402,8 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     const cells = out[1].trim().split(',')
-    expect(cells[4]).toBe('"Yes"') // Accredited column
-    expect(cells[7]).toBe('"false"')
+    expect(cells[5]).toBe('"Yes"') // Accredited column
+    expect(cells[9]).toBe('"false"')
   })
 
   it('iterates organisations and registrations sorted by id for deterministic output', async () => {
@@ -449,7 +487,7 @@ describe('streamCsvExport', () => {
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(2)
     const cells = out[1].trim().split(',')
-    expect(cells[4]).toBe('"No"') // Accredited column
+    expect(cells[5]).toBe('"No"') // Accredited column
   })
 
   it('skips organisations that have no registrations array', async () => {

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -1,4 +1,5 @@
 import { uppercaseString } from '#common/helpers/formatters.js'
+import { resolveDetailedMaterial } from '#domain/organisations/registration-utils.js'
 
 import * as exporter from '#domain/summary-logs/table-schemas/exporter/fields.js'
 import * as exporterRegisteredOnly from '#domain/summary-logs/table-schemas/exporter-registered-only/fields.js'
@@ -15,9 +16,11 @@ import * as shared from '#domain/summary-logs/table-schemas/shared/fields.js'
 export const METADATA_COLUMNS = Object.freeze([
   'Regulator',
   'Organisation Name',
+  'Registration Number',
   'Material',
   'Operator Processing Type',
   'Accredited',
+  'Accreditation Number',
   'Waste Record Type',
   'Submitted At',
   'Included in Waste Balance',
@@ -124,9 +127,11 @@ export const buildDataRow = ({
   const metadata = [
     uppercaseString(registration.submittedToRegulator),
     org.companyDetails.name,
-    registration.material,
+    registration.registrationNumber ?? '',
+    resolveDetailedMaterial(registration),
     data.processingType,
     accredited,
+    accreditation?.accreditationNumber ?? '',
     record.type,
     summaryLogEntry?.submittedAt ?? '',
     includedInWasteBalance ? 'true' : 'false',

--- a/src/waste-records-export/domain/csv-columns.test.js
+++ b/src/waste-records-export/domain/csv-columns.test.js
@@ -8,15 +8,22 @@ import {
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 
+/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
+/** @import {Organisation} from '#domain/organisations/model.js' */
+/** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {WasteRecord} from '#domain/waste-records/model.js' */
+
 describe('csv-columns', () => {
   describe('METADATA_COLUMNS', () => {
     it('starts with the fixed metadata prefix in the documented order', () => {
       expect(METADATA_COLUMNS).toEqual([
         'Regulator',
         'Organisation Name',
+        'Registration Number',
         'Material',
         'Operator Processing Type',
         'Accredited',
+        'Accreditation Number',
         'Waste Record Type',
         'Submitted At',
         'Included in Waste Balance',
@@ -94,24 +101,105 @@ describe('csv-columns', () => {
   describe('buildDataRow', () => {
     const dataFieldColumns = buildDataFieldColumns([])
 
+    const userFixture = {
+      fullName: 'Test User',
+      email: 'test@example.com',
+      phone: '01234567890'
+    }
+
+    /** @type {Organisation} */
+    const orgFixture = {
+      id: 'org-1',
+      orgId: 500001,
+      accreditations: [],
+      registrations: [],
+      companyDetails: { name: 'Acme Ltd' },
+      formSubmission: { id: 'fs-1', time: new Date('2026-01-01') },
+      schemaVersion: 1,
+      status: 'active',
+      statusHistory: [
+        { status: 'approved', updatedAt: new Date('2026-01-01') }
+      ],
+      submittedToRegulator: 'ea',
+      submitterContactDetails: userFixture,
+      users: [],
+      version: 1,
+      wasteProcessingTypes: []
+    }
+
+    /** @type {Registration} */
+    const regFixture = {
+      id: 'reg-1',
+      accreditation: null,
+      applicationContactDetails: userFixture,
+      approvedPersons: [],
+      formSubmission: { id: 'fs-1', time: new Date('2026-01-01') },
+      material: 'plastic',
+      orgName: 'Acme Ltd',
+      site: { address: {}, gridReference: 'TQ123456', siteCapacity: [] },
+      submittedToRegulator: 'ea',
+      submitterContactDetails: userFixture,
+      wasteProcessingType: 'reprocessor',
+      registrationNumber: 'REG-001',
+      status: 'approved',
+      validFrom: '2026-01-01',
+      validTo: '2026-12-31'
+    }
+
+    /** @type {Accreditation} */
+    const accreditationFixture = {
+      id: 'acc-1',
+      statusHistory: [],
+      formSubmission: { id: 'fs-1', time: new Date('2026-01-01') },
+      material: 'plastic',
+      prnIssuance: {
+        incomeBusinessPlan: [],
+        signatories: [],
+        tonnageBand: '500'
+      },
+      submittedToRegulator: 'ea',
+      submitterContactDetails: userFixture,
+      wasteProcessingType: 'reprocessor',
+      accreditationNumber: 'ACC-001',
+      status: 'approved',
+      validFrom: '2026-01-01',
+      validTo: '2026-12-31'
+    }
+
+    /** @type {WasteRecord} */
+    const recordFixture = {
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      type: WASTE_RECORD_TYPE.RECEIVED,
+      rowId: '1001',
+      data: {
+        processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+        DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01',
+        GROSS_WEIGHT: 10,
+        TONNAGE_RECEIVED_FOR_RECYCLING: 9
+      },
+      versions: [
+        {
+          id: 'v1',
+          createdAt: '2026-02-01T00:00:00Z',
+          status: 'created',
+          summaryLog: { id: 'sl-1', uri: 's3://bucket/sl-1' },
+          data: {}
+        }
+      ]
+    }
+
+    /** @returns {Registration} */
+    const buildReg = (overrides = {}) => ({ ...regFixture, ...overrides })
+
+    /** @returns {WasteRecord} */
+    const buildRecord = (overrides = {}) => ({ ...recordFixture, ...overrides })
+
     const baseInput = {
-      org: { companyDetails: { name: 'Acme Ltd' } },
-      registration: {
-        material: 'plastic',
-        submittedToRegulator: 'ea'
-      },
-      accreditation: { status: 'approved' },
-      record: {
-        type: WASTE_RECORD_TYPE.RECEIVED,
-        rowId: '1001',
-        data: {
-          processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
-          DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01',
-          GROSS_WEIGHT: 10,
-          TONNAGE_RECEIVED_FOR_RECYCLING: 9
-        },
-        versions: [{ summaryLog: { id: 'sl-1' } }]
-      },
+      org: orgFixture,
+      registration: regFixture,
+      accreditation: accreditationFixture,
+      record: recordFixture,
       summaryLogEntry: {
         submittedAt: '2026-04-15T09:00:00Z'
       },
@@ -128,13 +216,40 @@ describe('csv-columns', () => {
       const row = buildDataRow(baseInput)
       expect(row[0]).toBe('EA') // Regulator
       expect(row[1]).toBe('Acme Ltd') // Organisation Name
-      expect(row[2]).toBe('plastic') // Material
-      expect(row[3]).toBe('REPROCESSOR_INPUT') // Operator Processing Type
-      expect(row[4]).toBe('Yes') // Accredited
-      expect(row[5]).toBe('received') // Waste Record Type
-      expect(row[6]).toBe('2026-04-15T09:00:00Z') // Submitted At
-      expect(row[7]).toBe('true') // Included in Waste Balance
-      expect(row[8]).toBe('1001') // Row ID
+      expect(row[2]).toBe('REG-001') // Registration Number
+      expect(row[3]).toBe('plastic') // Material
+      expect(row[4]).toBe('REPROCESSOR_INPUT') // Operator Processing Type
+      expect(row[5]).toBe('Yes') // Accredited
+      expect(row[6]).toBe('ACC-001') // Accreditation Number
+      expect(row[7]).toBe('received') // Waste Record Type
+      expect(row[8]).toBe('2026-04-15T09:00:00Z') // Submitted At
+      expect(row[9]).toBe('true') // Included in Waste Balance
+      expect(row[10]).toBe('1001') // Row ID
+    })
+
+    it('emits the glass recycling process in place of "glass" for the Material column', () => {
+      const row = buildDataRow({
+        ...baseInput,
+        registration: buildReg({
+          material: 'glass',
+          glassRecyclingProcess: ['glass_re_melt']
+        })
+      })
+      expect(row[3]).toBe('glass_re_melt') // Material
+    })
+
+    it('emits an empty Registration Number when the registration has none', () => {
+      const row = buildDataRow({
+        ...baseInput,
+        registration: buildReg({ registrationNumber: undefined })
+      })
+      expect(row[2]).toBe('')
+    })
+
+    it('emits an empty Accreditation Number when the row has no accreditation', () => {
+      const row = buildDataRow({ ...baseInput, accreditation: null })
+      expect(row[5]).toBe('No') // Accredited
+      expect(row[6]).toBe('') // Accreditation Number
     })
 
     it('emits empty string when a data field is absent on the record', () => {
@@ -156,13 +271,12 @@ describe('csv-columns', () => {
       const cols = buildDataFieldColumns(observedKeys)
       const row = buildDataRow({
         ...baseInput,
-        record: {
-          ...baseInput.record,
+        record: buildRecord({
           data: {
-            ...baseInput.record.data,
+            ...recordFixture.data,
             BILL_OF_LANDING_REFERENCE_NUMBER: 'BL-99'
           }
-        },
+        }),
         dataFieldColumns: cols
       })
       const idx =
@@ -176,17 +290,17 @@ describe('csv-columns', () => {
         ...baseInput,
         accreditation: null
       })
-      expect(row[4]).toBe('No')
+      expect(row[5]).toBe('No')
     })
 
     it('emits empty Submitted At when no summary log entry is found', () => {
       const row = buildDataRow({ ...baseInput, summaryLogEntry: null })
-      expect(row[6]).toBe('')
+      expect(row[8]).toBe('')
     })
 
     it('emits "false" for Included in Waste Balance when input is false', () => {
       const row = buildDataRow({ ...baseInput, includedInWasteBalance: false })
-      expect(row[7]).toBe('false')
+      expect(row[9]).toBe('false')
     })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1558](https://eaflood.atlassian.net/browse/PAE-1558)
## What

Extends the waste-records CSV export with the detail an FOI/EIR data request needs:

- **New `Registration Number` column** — populated for approved and suspended registrations, empty otherwise. Sits after `Organisation Name`.
- **New `Accreditation Number` column** — taken from the row's resolved active accreditation, empty for registered-only rows. Sits after the existing `Accredited` flag. The Yes/No `Accredited` flag is kept: a suspended accreditation still has a number and still reads `Yes`, so the two columns are not redundant.
- **`Material` column now carries the detailed material** — glass reports its recycling process (`glass_re_melt` / `glass_other`) in place of the generic `glass`; every other material is unchanged. Raw enum values are retained to match the export's existing style.

The glass-detail resolution previously lived as a private helper in the periodic report service. It is now a shared `resolveDetailedMaterial` in `registration-utils`, typed against the `Registration` domain union and returning the `Material | GlassRecyclingProcess` union, and consumed by both the export and the periodic report. The report's output is unchanged.

## Why

Regulators must answer Freedom of Information and Environmental Information Regulations requests on the underlying Summary Log data. Those responses need the accreditation number, the registration number, and a material value that distinguishes the two glass recycling processes — none of which the export surfaced before.


[PAE-1558]: https://eaflood.atlassian.net/browse/PAE-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ