### PR TITLE
PAE-1556: Record user role on system log entries

### DIFF
--- a/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
@@ -100,7 +100,8 @@ describe('SQS command executor integration', () => {
         credentials: {
           id: 'user-123',
           email: 'test@example.com',
-          scope: ['admin']
+          scope: ['admin'],
+          role: 'standard_user'
         }
       }
     }
@@ -138,7 +139,8 @@ describe('SQS command executor integration', () => {
           user: {
             id: 'user-123',
             email: 'test@example.com',
-            scope: ['admin']
+            scope: ['admin'],
+            role: 'standard_user'
           }
         })
       }
@@ -248,7 +250,8 @@ describe('SQS command executor integration', () => {
         const user = {
           id: 'user-123',
           email: 'maintainer@defra.gov.uk',
-          scope: ['serviceMaintainer']
+          scope: ['serviceMaintainer'],
+          role: 'service_maintainer'
         }
         await executor.orsImportsWorker.importOverseasSites(importId, user)
 

--- a/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.integration.test.js
@@ -12,6 +12,18 @@ vi.mock(import('@defra/hapi-tracing'), () => ({
 const TEST_TIMEOUT = 30000
 
 /**
+ * @param {{ Messages?: Array<{ Body?: string }> }} response
+ * @returns {unknown}
+ */
+const parseSingleMessageBody = (response) => {
+  const [message] = response.Messages ?? []
+  if (!message?.Body) {
+    throw new Error('Expected a single SQS message carrying a body')
+  }
+  return JSON.parse(message.Body)
+}
+
+/**
  * Integration tests for SQS command executor.
  *
  * These tests verify that the executor correctly sends messages to an SQS queue
@@ -62,7 +74,7 @@ describe('SQS command executor integration', () => {
 
         expect(response.Messages).toHaveLength(1)
 
-        const message = JSON.parse(response.Messages[0].Body)
+        const message = parseSingleMessageBody(response)
         expect(message).toEqual({
           command: 'validate',
           summaryLogId
@@ -95,13 +107,15 @@ describe('SQS command executor integration', () => {
   })
 
   describe('submit', () => {
+    /** @type {import('#common/hapi-types.js').AuthenticatedRequest} */
     const mockRequest = {
       auth: {
         credentials: {
           id: 'user-123',
           email: 'test@example.com',
           scope: ['admin'],
-          role: 'standard_user'
+          role: 'standard_user',
+          issuer: 'https://defra-id.example.com'
         }
       }
     }
@@ -132,7 +146,7 @@ describe('SQS command executor integration', () => {
 
         expect(response.Messages).toHaveLength(1)
 
-        const message = JSON.parse(response.Messages[0].Body)
+        const message = parseSingleMessageBody(response)
         expect(message).toEqual({
           command: 'submit',
           summaryLogId,
@@ -156,6 +170,7 @@ describe('SQS command executor integration', () => {
           logger
         })
 
+        /** @type {import('#common/hapi-types.js').AuthenticatedRequest} */
         const machineRequest = {
           auth: {
             credentials: {
@@ -228,7 +243,7 @@ describe('SQS command executor integration', () => {
 
         expect(response.Messages).toHaveLength(1)
 
-        const message = JSON.parse(response.Messages[0].Body)
+        const message = parseSingleMessageBody(response)
         expect(message).toEqual({
           command: 'import-overseas-sites',
           importId
@@ -268,7 +283,7 @@ describe('SQS command executor integration', () => {
 
         expect(response.Messages).toHaveLength(1)
 
-        const message = JSON.parse(response.Messages[0].Body)
+        const message = parseSingleMessageBody(response)
         expect(message).toEqual({
           command: 'import-overseas-sites',
           importId,
@@ -341,7 +356,7 @@ describe('SQS command executor integration', () => {
 
         expect(response.Messages).toHaveLength(1)
 
-        const message = JSON.parse(response.Messages[0].Body)
+        const message = parseSingleMessageBody(response)
         expect(message).toEqual({
           command: 'validate',
           summaryLogId,
@@ -380,7 +395,7 @@ describe('SQS command executor integration', () => {
 
         expect(response.Messages).toHaveLength(1)
 
-        const message = JSON.parse(response.Messages[0].Body)
+        const message = parseSingleMessageBody(response)
         expect(message).toEqual({
           command: 'validate',
           summaryLogId

--- a/src/adapters/sqs-command-executor/sqs-command-executor.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.js
@@ -42,7 +42,8 @@ export const extractUser = (request) => {
     id: credentials.id,
     ...(credentials.name && { name: credentials.name }),
     email: credentials.email,
-    scope: credentials.scope
+    scope: credentials.scope,
+    role: credentials.role
   }
 }
 

--- a/src/adapters/sqs-command-executor/sqs-command-executor.test.js
+++ b/src/adapters/sqs-command-executor/sqs-command-executor.test.js
@@ -11,6 +11,7 @@ describe('extractUser', () => {
           name: 'Ada Lovelace',
           email: 'ada@example.com',
           scope: ['admin'],
+          role: 'standard_user',
           issuer: 'defra-id'
         }
       }
@@ -20,7 +21,8 @@ describe('extractUser', () => {
       id: 'user-123',
       name: 'Ada Lovelace',
       email: 'ada@example.com',
-      scope: ['admin']
+      scope: ['admin'],
+      role: 'standard_user'
     })
   })
 
@@ -32,6 +34,7 @@ describe('extractUser', () => {
           id: 'user-456',
           email: 'noname@example.com',
           scope: ['admin'],
+          role: null,
           issuer: 'defra-id'
         }
       }
@@ -42,7 +45,8 @@ describe('extractUser', () => {
     expect(user).toEqual({
       id: 'user-456',
       email: 'noname@example.com',
-      scope: ['admin']
+      scope: ['admin'],
+      role: null
     })
     expect('name' in user).toBe(false)
   })

--- a/src/auditing/duplicate-accreditation-link-migration.js
+++ b/src/auditing/duplicate-accreditation-link-migration.js
@@ -4,7 +4,7 @@ import { isPayloadSmallEnoughToAudit, safeAudit } from './helpers.js'
  * @import {SystemLogsRepository} from '#repositories/system-logs/port.js'
  */
 
-const SYSTEM_USER = { id: 'system', email: 'system', scope: [] }
+const SYSTEM_USER = { id: 'system', email: 'system', scope: [], role: null }
 
 /**
  * Audit a duplicate accreditation link fix for an organisation.

--- a/src/auditing/duplicate-accreditation-link-migration.test.js
+++ b/src/auditing/duplicate-accreditation-link-migration.test.js
@@ -44,7 +44,7 @@ describe('auditDuplicateAccreditationLinkMigration', () => {
   })
 
   const organisationId = new ObjectId().toString()
-  const systemUser = { id: 'system', email: 'system', scope: [] }
+  const systemUser = { id: 'system', email: 'system', scope: [], role: null }
 
   const findStoredLog = async () => {
     const { systemLogs } = await systemLogsRepository.find({ limit: 10 })

--- a/src/auditing/form-submission-lineage-migration.js
+++ b/src/auditing/form-submission-lineage-migration.js
@@ -4,7 +4,7 @@ import { isPayloadSmallEnoughToAudit, safeAudit } from './helpers.js'
  * @import {SystemLogsRepository} from '#repositories/system-logs/port.js'
  */
 
-const SYSTEM_USER = { id: 'system', email: 'system', scope: [] }
+const SYSTEM_USER = { id: 'system', email: 'system', scope: [], role: null }
 
 const EVENT = {
   category: 'entity',

--- a/src/auditing/form-submission-lineage-migration.test.js
+++ b/src/auditing/form-submission-lineage-migration.test.js
@@ -44,7 +44,7 @@ describe('auditFormSubmissionLineageMigration', () => {
   })
 
   const organisationId = new ObjectId().toString()
-  const systemUser = { id: 'system', email: 'system', scope: [] }
+  const systemUser = { id: 'system', email: 'system', scope: [], role: null }
 
   const findStoredLog = async () => {
     const { systemLogs } = await systemLogsRepository.find({ limit: 10 })

--- a/src/auditing/helpers.js
+++ b/src/auditing/helpers.js
@@ -18,7 +18,8 @@ function extractUserDetails(request) {
     : {
         id: request.auth?.credentials?.id,
         email: request.auth?.credentials?.email,
-        scope: request.auth?.credentials?.scope
+        scope: request.auth?.credentials?.scope,
+        role: request.auth?.credentials?.role
       }
 }
 

--- a/src/auditing/helpers.test.js
+++ b/src/auditing/helpers.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { audit } from '@defra/cdp-auditing'
 import { logger } from '#common/helpers/logging/logger.js'
-import { safeAudit, recordSystemLogs } from './helpers.js'
+import { extractUserDetails, safeAudit, recordSystemLogs } from './helpers.js'
 
 vi.mock('@defra/cdp-auditing', () => ({
   audit: vi.fn()
@@ -104,6 +104,65 @@ describe('safeAudit', () => {
 
     expect(audit).toHaveBeenCalledWith({
       event: payload.event
+    })
+  })
+})
+
+describe('extractUserDetails', () => {
+  it('records the role alongside id, email and scope for a human actor', () => {
+    const request = {
+      auth: {
+        credentials: {
+          id: 'contact-123',
+          email: 'maintainer@example.com',
+          scope: ['admin.read', 'admin.dlq.purge'],
+          role: 'service_maintainer'
+        }
+      }
+    }
+
+    expect(extractUserDetails(request)).toEqual({
+      id: 'contact-123',
+      email: 'maintainer@example.com',
+      scope: ['admin.read', 'admin.dlq.purge'],
+      role: 'service_maintainer'
+    })
+  })
+
+  it('records a null role for a human actor with no resolved role', () => {
+    const request = {
+      auth: {
+        credentials: {
+          id: 'contact-456',
+          email: 'operator@example.com',
+          scope: ['inquirer'],
+          role: null
+        }
+      }
+    }
+
+    expect(extractUserDetails(request)).toEqual({
+      id: 'contact-456',
+      email: 'operator@example.com',
+      scope: ['inquirer'],
+      role: null
+    })
+  })
+
+  it('does not record a role for a machine actor', () => {
+    const request = {
+      auth: {
+        credentials: {
+          id: 'machine-1',
+          isMachine: true,
+          name: 'batch-job'
+        }
+      }
+    }
+
+    expect(extractUserDetails(request)).toEqual({
+      id: 'machine-1',
+      name: 'batch-job'
     })
   })
 })

--- a/src/auditing/helpers.test.js
+++ b/src/auditing/helpers.test.js
@@ -110,16 +110,17 @@ describe('safeAudit', () => {
 
 describe('extractUserDetails', () => {
   it('records the role alongside id, email and scope for a human actor', () => {
-    const request = {
-      auth: {
-        credentials: {
-          id: 'contact-123',
-          email: 'maintainer@example.com',
-          scope: ['admin.read', 'admin.dlq.purge'],
-          role: 'service_maintainer'
+    const request =
+      /** @type {import('#common/hapi-types.js').HapiRequest} */ ({
+        auth: {
+          credentials: {
+            id: 'contact-123',
+            email: 'maintainer@example.com',
+            scope: ['admin.read', 'admin.dlq.purge'],
+            role: 'service_maintainer'
+          }
         }
-      }
-    }
+      })
 
     expect(extractUserDetails(request)).toEqual({
       id: 'contact-123',
@@ -130,16 +131,17 @@ describe('extractUserDetails', () => {
   })
 
   it('records a null role for a human actor with no resolved role', () => {
-    const request = {
-      auth: {
-        credentials: {
-          id: 'contact-456',
-          email: 'operator@example.com',
-          scope: ['inquirer'],
-          role: null
+    const request =
+      /** @type {import('#common/hapi-types.js').HapiRequest} */ ({
+        auth: {
+          credentials: {
+            id: 'contact-456',
+            email: 'operator@example.com',
+            scope: ['inquirer'],
+            role: null
+          }
         }
-      }
-    }
+      })
 
     expect(extractUserDetails(request)).toEqual({
       id: 'contact-456',
@@ -150,15 +152,16 @@ describe('extractUserDetails', () => {
   })
 
   it('does not record a role for a machine actor', () => {
-    const request = {
-      auth: {
-        credentials: {
-          id: 'machine-1',
-          isMachine: true,
-          name: 'batch-job'
+    const request =
+      /** @type {import('#common/hapi-types.js').HapiRequest} */ ({
+        auth: {
+          credentials: {
+            id: 'machine-1',
+            isMachine: true,
+            name: 'batch-job'
+          }
         }
-      }
-    }
+      })
 
     expect(extractUserDetails(request)).toEqual({
       id: 'machine-1',

--- a/src/auditing/incremental-form-migration.js
+++ b/src/auditing/incremental-form-migration.js
@@ -4,7 +4,7 @@ import { isPayloadSmallEnoughToAudit, safeAudit } from './helpers.js'
  * @import {SystemLogsRepository} from '#repositories/system-logs/port.js'
  */
 
-const SYSTEM_USER = { id: 'system', email: 'system', scope: [] }
+const SYSTEM_USER = { id: 'system', email: 'system', scope: [], role: null }
 
 /**
  * Audit an incremental form migration for an organisation.

--- a/src/auditing/incremental-form-migration.test.js
+++ b/src/auditing/incremental-form-migration.test.js
@@ -44,7 +44,7 @@ describe('auditIncrementalFormMigration', () => {
   })
 
   const organisationId = new ObjectId().toString()
-  const systemUser = { id: 'system', email: 'system', scope: [] }
+  const systemUser = { id: 'system', email: 'system', scope: [], role: null }
 
   const findStoredLog = async () => {
     const { systemLogs } = await systemLogsRepository.find({ limit: 10 })

--- a/src/common/hapi-types.js
+++ b/src/common/hapi-types.js
@@ -17,6 +17,7 @@
  *   id: string,
  *   email: string,
  *   scope: string[],
+ *   role: string | null,
  *   issuer: string,
  *   name?: string,
  *   currentRelationshipId?: string,

--- a/src/common/helpers/auth/get-jwt-strategy-config.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.js
@@ -48,7 +48,7 @@ export function getJwtStrategyConfig(oidcConfigs) {
 
         const email = tokenPayload.preferred_username
 
-        const { scopes } = await getEntraUserRoles(email)
+        const { role, scopes } = await getEntraUserRoles(email)
 
         return {
           isValid: true,
@@ -56,6 +56,7 @@ export function getJwtStrategyConfig(oidcConfigs) {
             id: tokenPayload.oid,
             email,
             issuer,
+            role,
             scope: scopes
           }
         }
@@ -72,7 +73,7 @@ export function getJwtStrategyConfig(oidcConfigs) {
           .filter(Boolean)
           .map((s) => s.trim())
           .join(' ')
-        const { scopes } = await getDefraUserRoles(tokenPayload, request)
+        const { role, scopes } = await getDefraUserRoles(tokenPayload, request)
 
         return {
           isValid: true,
@@ -81,6 +82,7 @@ export function getJwtStrategyConfig(oidcConfigs) {
             email,
             name,
             issuer,
+            role,
             scope: scopes,
             currentRelationshipId: tokenPayload?.currentRelationshipId
           }

--- a/src/common/helpers/auth/get-jwt-strategy-config.test.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.test.js
@@ -172,27 +172,6 @@ describe('#getJwtStrategyConfig', () => {
       expect(result.credentials.role).toBe('service_maintainer')
     })
 
-    test('credential role is null when user matches no admin tier', async () => {
-      mockGetEntraUserRoles.mockResolvedValue({ role: null, scopes: [] })
-
-      const config = getJwtStrategyConfig(mockOidcConfigs)
-
-      const artifacts = {
-        decoded: {
-          payload: {
-            iss: entraIdMockOidcWellKnownResponse.issuer,
-            aud: mockEntraClientId,
-            oid: 'contact-456',
-            preferred_username: 'regular-user@example.com'
-          }
-        }
-      }
-
-      const result = await config.validate(artifacts)
-
-      expect(result.credentials.role).toBeNull()
-    })
-
     test('calls getEntraUserRoles with email address from token payload', async () => {
       const config = getJwtStrategyConfig(mockOidcConfigs)
 

--- a/src/common/helpers/auth/get-jwt-strategy-config.test.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.test.js
@@ -147,9 +147,50 @@ describe('#getJwtStrategyConfig', () => {
           id: 'contact-123',
           email: 'user@example.com',
           issuer: entraIdMockOidcWellKnownResponse.issuer,
+          role: 'service_maintainer',
           scope: expectedMaintainerScope
         }
       })
+    })
+
+    test('credential carries the resolved admin role', async () => {
+      const config = getJwtStrategyConfig(mockOidcConfigs)
+
+      const artifacts = {
+        decoded: {
+          payload: {
+            iss: entraIdMockOidcWellKnownResponse.issuer,
+            aud: mockEntraClientId,
+            oid: 'contact-123',
+            preferred_username: 'user@example.com'
+          }
+        }
+      }
+
+      const result = await config.validate(artifacts)
+
+      expect(result.credentials.role).toBe('service_maintainer')
+    })
+
+    test('credential role is null when user matches no admin tier', async () => {
+      mockGetEntraUserRoles.mockResolvedValue({ role: null, scopes: [] })
+
+      const config = getJwtStrategyConfig(mockOidcConfigs)
+
+      const artifacts = {
+        decoded: {
+          payload: {
+            iss: entraIdMockOidcWellKnownResponse.issuer,
+            aud: mockEntraClientId,
+            oid: 'contact-456',
+            preferred_username: 'regular-user@example.com'
+          }
+        }
+      }
+
+      const result = await config.validate(artifacts)
+
+      expect(result.credentials.role).toBeNull()
     })
 
     test('calls getEntraUserRoles with email address from token payload', async () => {
@@ -525,6 +566,30 @@ describe('#getJwtStrategyConfig', () => {
         const result = await config.validate(artifacts, stubRequest())
 
         expect(result.credentials.scope).toEqual([ROLES.inquirer])
+      })
+
+      test('Defra ID credential carries a null role', async () => {
+        const config = getJwtStrategyConfig(mockOidcConfigs)
+
+        const artifacts = {
+          decoded: {
+            payload: {
+              aud: mockDefraClientId,
+              contactId: 'defra-contact-123',
+              email: 'defra-user@example.com',
+              iss: defraIdMockOidcWellKnownResponse.issuer
+            }
+          }
+        }
+        const request = {
+          organisationsRepository: {},
+          path: '/v1/me/organisations',
+          method: 'get'
+        }
+
+        const result = await config.validate(artifacts, request)
+
+        expect(result.credentials.role).toBeNull()
       })
 
       test('includes name from firstName and lastName in credentials', async () => {

--- a/src/common/helpers/auth/get-jwt-strategy-config.test.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.test.js
@@ -560,13 +560,7 @@ describe('#getJwtStrategyConfig', () => {
             }
           }
         }
-        const request = {
-          organisationsRepository: {},
-          path: '/v1/me/organisations',
-          method: 'get'
-        }
-
-        const result = await config.validate(artifacts, request)
+        const result = await config.validate(artifacts, stubRequest())
 
         expect(result.credentials.role).toBeNull()
       })

--- a/src/domain/summary-logs/worker/port.js
+++ b/src/domain/summary-logs/worker/port.js
@@ -4,6 +4,7 @@
  * @property {string} [name]
  * @property {string} email
  * @property {string[]} scope
+ * @property {string | null} role
  */
 
 /**

--- a/src/overseas-sites/application/process-import-file.js
+++ b/src/overseas-sites/application/process-import-file.js
@@ -3,7 +3,7 @@ import { SpreadsheetValidationError } from '#adapters/parsers/summary-logs/excel
 import { ORS_FILE_RESULT_STATUS } from '#overseas-sites/domain/import-status.js'
 
 /**
- * @import { SystemLogsRepository } from '#repositories/system-logs/port.js'
+ * @import { SystemLogsRepository, SystemLogHumanActor } from '#repositories/system-logs/port.js'
  * @import { TypedLogger } from '#common/hapi-types.js'
  */
 
@@ -17,7 +17,7 @@ import { ORS_FILE_RESULT_STATUS } from '#overseas-sites/domain/import-status.js'
  * @param {object} deps.organisationsRepository
  * @param {SystemLogsRepository} deps.systemLogsRepository
  * @param {TypedLogger} deps.logger
- * @param {{ id: string, email: string, scope: string[], role?: string | null }} deps.user
+ * @param {SystemLogHumanActor} deps.user
  * @returns {Promise<{status: string, sitesCreated: number, mappingsUpdated: number, registrationNumber: string|null, errors: Array}>}
  */
 export const processImportFile = async (

--- a/src/overseas-sites/application/process-import-file.js
+++ b/src/overseas-sites/application/process-import-file.js
@@ -17,7 +17,7 @@ import { ORS_FILE_RESULT_STATUS } from '#overseas-sites/domain/import-status.js'
  * @param {object} deps.organisationsRepository
  * @param {SystemLogsRepository} deps.systemLogsRepository
  * @param {TypedLogger} deps.logger
- * @param {{ id: string, email: string, scope: string[] }} deps.user
+ * @param {{ id: string, email: string, scope: string[], role?: string | null }} deps.user
  * @returns {Promise<{status: string, sitesCreated: number, mappingsUpdated: number, registrationNumber: string|null, errors: Array}>}
  */
 export const processImportFile = async (

--- a/src/overseas-sites/application/process-import.js
+++ b/src/overseas-sites/application/process-import.js
@@ -33,7 +33,7 @@ import { processImportFile } from './process-import-file.js'
  * @param {SystemLogsRepository} deps.systemLogsRepository
  * @param {TypedLogger} deps.logger
  * @param {OrsImportMetrics} deps.orsImportMetrics
- * @param {{ id: string, email: string, scope: string[] }} deps.user
+ * @param {{ id: string, email: string, scope: string[], role?: string | null }} deps.user
  */
 export const processOrsImport = async (importId, deps) => {
   const {

--- a/src/overseas-sites/application/process-import.js
+++ b/src/overseas-sites/application/process-import.js
@@ -13,7 +13,7 @@ import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 import { processImportFile } from './process-import-file.js'
 
 /**
- * @import { SystemLogsRepository } from '#repositories/system-logs/port.js'
+ * @import { SystemLogsRepository, SystemLogHumanActor } from '#repositories/system-logs/port.js'
  * @import { TypedLogger } from '#common/hapi-types.js'
  * @import { OrsImportMetrics } from '#overseas-sites/metrics/ors-imports.js'
  */
@@ -33,7 +33,7 @@ import { processImportFile } from './process-import-file.js'
  * @param {SystemLogsRepository} deps.systemLogsRepository
  * @param {TypedLogger} deps.logger
  * @param {OrsImportMetrics} deps.orsImportMetrics
- * @param {{ id: string, email: string, scope: string[], role?: string | null }} deps.user
+ * @param {SystemLogHumanActor} deps.user
  */
 export const processOrsImport = async (importId, deps) => {
   const {

--- a/src/overseas-sites/imports/repository/port.js
+++ b/src/overseas-sites/imports/repository/port.js
@@ -11,7 +11,7 @@
  * @property {string} _id
  * @property {string} status - 'preprocessing' | 'processing' | 'completed' | 'failed'
  * @property {OrsImportFile[]} files
- * @property {{ id: string, email: string, scope: string[] }} [createdBy] - User who initiated the import
+ * @property {{ id: string, email: string, scope: string[], role?: string | null }} [createdBy] - User who initiated the import
  * @property {string} createdAt - ISO 8601 date string
  * @property {string} updatedAt - ISO 8601 date string
  * @property {Date|null} expiresAt - TTL expiry date, null for completed imports

--- a/src/overseas-sites/imports/repository/port.js
+++ b/src/overseas-sites/imports/repository/port.js
@@ -11,7 +11,7 @@
  * @property {string} _id
  * @property {string} status - 'preprocessing' | 'processing' | 'completed' | 'failed'
  * @property {OrsImportFile[]} files
- * @property {{ id: string, email: string, scope: string[], role?: string | null }} [createdBy] - User who initiated the import
+ * @property {{ id: string, email: string, scope: string[], role: string | null }} [createdBy] - User who initiated the import
  * @property {string} createdAt - ISO 8601 date string
  * @property {string} updatedAt - ISO 8601 date string
  * @property {Date|null} expiresAt - TTL expiry date, null for completed imports

--- a/src/overseas-sites/imports/worker/port.js
+++ b/src/overseas-sites/imports/worker/port.js
@@ -1,6 +1,8 @@
 /**
+ * @import { SystemLogHumanActor } from '#repositories/system-logs/port.js'
+ *
  * @typedef {Object} OrsImportsCommandExecutor
- * @property {(importId: string, user?: { id: string, email: string, scope: string[], role?: string | null }) => Promise<void>} importOverseasSites
+ * @property {(importId: string, user?: SystemLogHumanActor) => Promise<void>} importOverseasSites
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/overseas-sites/imports/worker/port.js
+++ b/src/overseas-sites/imports/worker/port.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {Object} OrsImportsCommandExecutor
- * @property {(importId: string, user?: { id: string, email: string, scope: string[] }) => Promise<void>} importOverseasSites
+ * @property {(importId: string, user?: { id: string, email: string, scope: string[], role?: string | null }) => Promise<void>} importOverseasSites
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/reports/application/audit.js
+++ b/src/reports/application/audit.js
@@ -7,7 +7,12 @@ import {
 } from '#auditing/helpers.js'
 
 /** @type {import('#repositories/system-logs/port.js').SystemLog['createdBy']} */
-const SYSTEM_ACTOR = Object.freeze({ id: 'system', email: 'system', scope: [] })
+const SYSTEM_ACTOR = Object.freeze({
+  id: 'system',
+  email: 'system',
+  scope: [],
+  role: null
+})
 
 const AUDIT_CATEGORY = 'waste-reporting'
 const AUDIT_SUB_CATEGORY = 'reports'

--- a/src/reports/application/audit.test.js
+++ b/src/reports/application/audit.test.js
@@ -259,7 +259,7 @@ describe('auditReportDelete', () => {
 })
 
 describe('auditMarkReportsStale', () => {
-  const systemActor = { id: 'system', email: 'system', scope: [] }
+  const systemActor = { id: 'system', email: 'system', scope: [], role: null }
   const mockInsertMany = vi.fn()
 
   /** @type {import('#reports/repository/port.js').ReportStale} */

--- a/src/repositories/system-logs/contract/test-data.js
+++ b/src/repositories/system-logs/contract/test-data.js
@@ -4,6 +4,7 @@
  * @param {Date} [overrides.createdAt]
  * @param {string} [overrides.userId]
  * @param {string} [overrides.email]
+ * @param {string | null} [overrides.role]
  * @param {string} [overrides.subCategory]
  * @param {string} [overrides.action]
  * @param {*} [overrides.id]
@@ -14,13 +15,14 @@ export const buildSystemLog = ({
   createdAt = new Date(),
   userId = 'user-001',
   email = 'user@email.com',
+  role = null,
   subCategory = 'test-sub-category',
   action = 'test-action',
   id,
   summaryLogId
 } = {}) => ({
   createdAt,
-  createdBy: { id: userId, email, scope: [] },
+  createdBy: { id: userId, email, scope: [], role },
   event: {
     category: 'test-category',
     subCategory,

--- a/src/repositories/system-logs/mongodb.js
+++ b/src/repositories/system-logs/mongodb.js
@@ -8,6 +8,19 @@ import { buildPage } from './pagination.js'
 export const SYSTEM_LOGS_COLLECTION_NAME = 'system-logs'
 
 /**
+ * Normalise a stored actor so a human session always reads back with an explicit
+ * role: a stored human actor with no role field surfaces as null rather than
+ * absent. A machine actor is returned untouched.
+ *
+ * @param {any} createdBy
+ * @returns {import('./port.js').SystemLogActor}
+ */
+const normaliseActorRole = (createdBy) =>
+  'email' in createdBy && !('role' in createdBy)
+    ? { ...createdBy, role: null }
+    : createdBy
+
+/**
  * Ensures the collection exists with required indexes.
  * Safe to call multiple times - MongoDB createIndex is idempotent.
  *
@@ -96,7 +109,7 @@ const performFind =
         event: doc.event,
         context: doc.context,
         createdAt: doc.createdAt,
-        createdBy: doc.createdBy
+        createdBy: normaliseActorRole(doc.createdBy)
       })),
       hasNext,
       hasPrev,

--- a/src/repositories/system-logs/mongodb.test.js
+++ b/src/repositories/system-logs/mongodb.test.js
@@ -62,6 +62,63 @@ describe('Mongo DB system logs repository', () => {
     testSystemLogsRepositoryContract(it)
   })
 
+  it('surfaces a null role for a human log written before role capture', async ({
+    mongoClient,
+    systemLogsRepository
+  }) => {
+    const client = /** @type {MongoClient} */ (
+      /** @type {unknown} */ (mongoClient)
+    )
+    const organisationId = randomUUID()
+    await client
+      .db('epr-backend')
+      .collection('system-logs')
+      .insertOne({
+        createdAt: new Date(),
+        createdBy: { id: 'user-001', email: 'user@email.com', scope: [] },
+        event: { category: 'c', subCategory: 's', action: 'a' },
+        context: { organisationId }
+      })
+
+    const { systemLogs } = await systemLogsRepository().find({
+      organisationId,
+      limit: 10
+    })
+
+    expect(systemLogs[0].createdBy).toEqual({
+      id: 'user-001',
+      email: 'user@email.com',
+      scope: [],
+      role: null
+    })
+  })
+
+  it('leaves a machine actor untouched on read', async ({
+    mongoClient,
+    systemLogsRepository
+  }) => {
+    const client = /** @type {MongoClient} */ (
+      /** @type {unknown} */ (mongoClient)
+    )
+    const organisationId = randomUUID()
+    await client
+      .db('epr-backend')
+      .collection('system-logs')
+      .insertOne({
+        createdAt: new Date(),
+        createdBy: { id: 'machine-1', name: 'RPD' },
+        event: { category: 'c', subCategory: 's', action: 'a' },
+        context: { organisationId }
+      })
+
+    const { systemLogs } = await systemLogsRepository().find({
+      organisationId,
+      limit: 10
+    })
+
+    expect(systemLogs[0].createdBy).toEqual({ id: 'machine-1', name: 'RPD' })
+  })
+
   it('fails gracefully and logs an error when DB write fails', async () => {
     const mockLogger = buildMockLogger()
     const mockDb = buildMockDb()

--- a/src/repositories/system-logs/mongodb.test.js
+++ b/src/repositories/system-logs/mongodb.test.js
@@ -7,25 +7,30 @@ import { randomUUID } from 'crypto'
 
 /** @import { Db } from 'mongodb' */
 /** @import { TypedLogger } from '#common/helpers/logging/logger.js' */
-/** @import { SystemLog } from './port.js' */
+/** @import { SystemLog, SystemLogsRepositoryFactory } from './port.js' */
 
-const it = mongoIt.extend({
-  mongoClient: async ({ db }, use) => {
-    const client = await MongoClient.connect(
-      /** @type {string} */ (/** @type {unknown} */ (db))
-    )
-    await use(client)
-    await client.close()
-  },
+/**
+ * @typedef {object} SystemLogsRepoFixtures
+ * @property {MongoClient} mongoClient
+ * @property {SystemLogsRepositoryFactory} systemLogsRepository
+ */
 
-  systemLogsRepository: async ({ mongoClient }, use) => {
-    const client = /** @type {MongoClient} */ (
-      /** @type {unknown} */ (mongoClient)
-    )
-    const factory = await createSystemLogsRepository(client.db('epr-backend'))
-    await use(factory)
-  }
-})
+const it = /** @type {import('vitest').TestAPI<SystemLogsRepoFixtures>} */ (
+  mongoIt.extend({
+    mongoClient: async ({ db }, use) => {
+      const client = await MongoClient.connect(db)
+      await use(client)
+      await client.close()
+    },
+
+    systemLogsRepository: async ({ mongoClient }, use) => {
+      const factory = await createSystemLogsRepository(
+        mongoClient.db('epr-backend')
+      )
+      await use(factory)
+    }
+  })
+)
 
 const buildMockDb = () => {
   let callCount = 0
@@ -66,11 +71,8 @@ describe('Mongo DB system logs repository', () => {
     mongoClient,
     systemLogsRepository
   }) => {
-    const client = /** @type {MongoClient} */ (
-      /** @type {unknown} */ (mongoClient)
-    )
     const organisationId = randomUUID()
-    await client
+    await mongoClient
       .db('epr-backend')
       .collection('system-logs')
       .insertOne({
@@ -80,7 +82,7 @@ describe('Mongo DB system logs repository', () => {
         context: { organisationId }
       })
 
-    const { systemLogs } = await systemLogsRepository().find({
+    const { systemLogs } = await systemLogsRepository(buildMockLogger()).find({
       organisationId,
       limit: 10
     })
@@ -97,11 +99,8 @@ describe('Mongo DB system logs repository', () => {
     mongoClient,
     systemLogsRepository
   }) => {
-    const client = /** @type {MongoClient} */ (
-      /** @type {unknown} */ (mongoClient)
-    )
     const organisationId = randomUUID()
-    await client
+    await mongoClient
       .db('epr-backend')
       .collection('system-logs')
       .insertOne({
@@ -111,7 +110,7 @@ describe('Mongo DB system logs repository', () => {
         context: { organisationId }
       })
 
-    const { systemLogs } = await systemLogsRepository().find({
+    const { systemLogs } = await systemLogsRepository(buildMockLogger()).find({
       organisationId,
       limit: 10
     })

--- a/src/repositories/system-logs/port.contract.js
+++ b/src/repositories/system-logs/port.contract.js
@@ -478,7 +478,12 @@ export const testSystemLogsRepositoryContract = (it) => {
       expect(actors).toEqual([
         {
           summaryLogId: 'doc-1',
-          createdBy: { id: 'user-1', email: 'alice@example.com', scope: [] }
+          createdBy: {
+            id: 'user-1',
+            email: 'alice@example.com',
+            scope: [],
+            role: null
+          }
         }
       ])
     })

--- a/src/repositories/system-logs/port.js
+++ b/src/repositories/system-logs/port.js
@@ -1,11 +1,10 @@
 /**
  * The actor on a system log. A human session carries an email, scope and the
  * role it resolved to (null when none); a machine credential carries a name
- * instead. Both always carry an id. Role is optional because logs predating
- * role capture carry only email and scope.
+ * instead. Both always carry an id.
  *
  * @typedef {(
- *   | { id: string, email: string, scope: string[], role?: string | null }
+ *   | { id: string, email: string, scope: string[], role: string | null }
  *   | { id: string, name: string }
  * )} SystemLogActor
  */

--- a/src/repositories/system-logs/port.js
+++ b/src/repositories/system-logs/port.js
@@ -1,9 +1,11 @@
 /**
- * The actor on a system log. A human session carries an email and scope; a
- * machine credential carries a name instead. Both always carry an id.
+ * The actor on a system log. A human session carries an email, scope and the
+ * role it resolved to (null when none); a machine credential carries a name
+ * instead. Both always carry an id. Role is optional because logs predating
+ * role capture carry only email and scope.
  *
  * @typedef {(
- *   | { id: string, email: string, scope: string[] }
+ *   | { id: string, email: string, scope: string[], role?: string | null }
  *   | { id: string, name: string }
  * )} SystemLogActor
  */

--- a/src/repositories/system-logs/port.js
+++ b/src/repositories/system-logs/port.js
@@ -3,8 +3,9 @@
  * role it resolved to (null when none); a machine credential carries a name
  * instead. Both always carry an id.
  *
+ * @typedef {{ id: string, email: string, scope: string[], role: string | null }} SystemLogHumanActor
  * @typedef {(
- *   | { id: string, email: string, scope: string[], role: string | null }
+ *   | SystemLogHumanActor
  *   | { id: string, name: string }
  * )} SystemLogActor
  */

--- a/src/routes/v1/organisations/link.test.js
+++ b/src/routes/v1/organisations/link.test.js
@@ -464,7 +464,8 @@ describe('POST /v1/organisations/{organisationId}/link', () => {
           expect(systemLogPayload.createdBy).toEqual({
             id: defraIdContactId,
             email: userEmail,
-            scope: ['inquirer']
+            scope: ['inquirer'],
+            role: null
           })
 
           expect(
@@ -496,7 +497,8 @@ describe('POST /v1/organisations/{organisationId}/link', () => {
           expect(auditPayload.user).toEqual({
             id: defraIdContactId,
             email: userEmail,
-            scope: ['inquirer']
+            scope: ['inquirer'],
+            role: null
           })
 
           expect(auditPayload.event).toEqual({

--- a/src/routes/v1/organisations/user/put.test.js
+++ b/src/routes/v1/organisations/user/put.test.js
@@ -177,7 +177,8 @@ describe('PUT /v1/organisations/{organisationId}/user', () => {
         expect(auditPayload.user).toEqual({
           id: newUser.contactId,
           email: newUser.email,
-          scope: ['inquirer', 'standard_user']
+          scope: ['inquirer', 'standard_user'],
+          role: null
         })
 
         expect(auditPayload.context).toEqual({
@@ -230,7 +231,8 @@ describe('PUT /v1/organisations/{organisationId}/user', () => {
         expect(log.createdBy).toEqual({
           id: newUser.contactId,
           email: newUser.email,
-          scope: ['inquirer', 'standard_user']
+          scope: ['inquirer', 'standard_user'],
+          role: null
         })
 
         expect(new Date(log.createdAt).getTime()).toBeGreaterThanOrEqual(
@@ -288,7 +290,8 @@ describe('PUT /v1/organisations/{organisationId}/user', () => {
         expect(auditPayload.user).toEqual({
           id: updatedUser().contactId,
           email: updatedUser().email,
-          scope: ['inquirer', 'standard_user']
+          scope: ['inquirer', 'standard_user'],
+          role: null
         })
 
         expect(auditPayload.context).toEqual({
@@ -349,7 +352,8 @@ describe('PUT /v1/organisations/{organisationId}/user', () => {
         expect(log.createdBy).toEqual({
           id: updatedUser().contactId,
           email: updatedUser().email,
-          scope: ['inquirer', 'standard_user']
+          scope: ['inquirer', 'standard_user'],
+          role: null
         })
 
         expect(new Date(log.createdAt).getTime()).toBeGreaterThanOrEqual(

--- a/src/routes/v1/system-logs/get-search.test.js
+++ b/src/routes/v1/system-logs/get-search.test.js
@@ -33,7 +33,7 @@ describe('GET /v1/system-logs/search', () => {
    *   userId?: string,
    *   email?: string,
    *   subCategory?: string,
-   *   role?: string,
+   *   role?: string | null,
    *   id?: number
    * }} [overrides]
    */

--- a/src/routes/v1/system-logs/get-search.test.js
+++ b/src/routes/v1/system-logs/get-search.test.js
@@ -33,6 +33,7 @@ describe('GET /v1/system-logs/search', () => {
    *   userId?: string,
    *   email?: string,
    *   subCategory?: string,
+   *   role?: string,
    *   id?: number
    * }} [overrides]
    */
@@ -42,6 +43,7 @@ describe('GET /v1/system-logs/search', () => {
     userId = 'user-id',
     email = 'user@email.com',
     subCategory = 'test',
+    role,
     id
   } = {}) => {
     await systemLogsRepository.insert({
@@ -51,7 +53,12 @@ describe('GET /v1/system-logs/search', () => {
         ...(id !== undefined && { id })
       },
       createdAt,
-      createdBy: { id: userId, email, scope: [] }
+      createdBy: {
+        id: userId,
+        email,
+        scope: [],
+        ...(role !== undefined && { role })
+      }
     })
   }
 
@@ -81,6 +88,16 @@ describe('GET /v1/system-logs/search', () => {
       const result = JSON.parse(response.payload)
       expect(result.systemLogs).toHaveLength(1)
       expect(result.systemLogs[0].createdBy.id).toBe('alice')
+    })
+
+    it('returns the user role recorded on the log', async () => {
+      await addSystemLog({ userId: 'alice', role: 'service_maintainer', id: 1 })
+
+      const response = await makeRequest({ userId: 'alice' })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const result = JSON.parse(response.payload)
+      expect(result.systemLogs[0].createdBy.role).toBe('service_maintainer')
     })
 
     it('returns logs filtered by sub-category', async () => {

--- a/src/routes/v1/system-logs/get-search.test.js
+++ b/src/routes/v1/system-logs/get-search.test.js
@@ -57,7 +57,7 @@ describe('GET /v1/system-logs/search', () => {
         id: userId,
         email,
         scope: [],
-        ...(role !== undefined && { role })
+        role: role ?? null
       }
     })
   }

--- a/src/server/queue-consumer/consumer.integration.test.js
+++ b/src/server/queue-consumer/consumer.integration.test.js
@@ -200,7 +200,8 @@ describe('SQS command queue consumer integration', () => {
         const user = {
           id: 'user-123',
           email: 'test@example.com',
-          scope: ['operator']
+          scope: ['operator'],
+          role: null
         }
         const request = {
           auth: { credentials: { ...user, issuer: 'test-issuer' } }

--- a/src/server/queue-consumer/consumer.test.js
+++ b/src/server/queue-consumer/consumer.test.js
@@ -29,7 +29,8 @@ vi.mock('#common/helpers/metrics/summary-logs.js')
 const TEST_USER = {
   id: 'test-user',
   email: 'test-user@example.com',
-  scope: ['standard_user']
+  scope: ['standard_user'],
+  role: null
 }
 
 const { createSummaryLogsValidator } =

--- a/src/server/queue-consumer/ors-import-commands.js
+++ b/src/server/queue-consumer/ors-import-commands.js
@@ -19,7 +19,7 @@ const userSchema = Joi.object({
   id: Joi.string().required(),
   email: Joi.string().required(),
   scope: Joi.array().items(Joi.string()).required(),
-  role: Joi.string().allow(null)
+  role: Joi.string().allow(null).required()
 })
 
 /**

--- a/src/server/queue-consumer/ors-import-commands.js
+++ b/src/server/queue-consumer/ors-import-commands.js
@@ -18,7 +18,8 @@ import { orsImportMetrics } from '#overseas-sites/metrics/ors-imports.js'
 const userSchema = Joi.object({
   id: Joi.string().required(),
   email: Joi.string().required(),
-  scope: Joi.array().items(Joi.string()).required()
+  scope: Joi.array().items(Joi.string()).required(),
+  role: Joi.string().allow(null)
 })
 
 /**

--- a/src/server/queue-consumer/ors-import-commands.test.js
+++ b/src/server/queue-consumer/ors-import-commands.test.js
@@ -97,6 +97,19 @@ describe('orsImportCommandHandlers', () => {
 
         expect(error).toBeUndefined()
       })
+
+      it('rejects a user without a role', () => {
+        const { error } = handler.payloadSchema.validate({
+          importId: 'import-123',
+          user: {
+            id: 'user-1',
+            email: 'operator@example.com',
+            scope: ['operator']
+          }
+        })
+
+        expect(error?.message).toBe('"user.role" is required')
+      })
     })
 
     describe('execute', () => {

--- a/src/server/queue-consumer/ors-import-commands.test.js
+++ b/src/server/queue-consumer/ors-import-commands.test.js
@@ -69,6 +69,34 @@ describe('orsImportCommandHandlers', () => {
 
         expect(error?.message).toContain('"extra" is not allowed')
       })
+
+      it('accepts a user carrying a resolved role', () => {
+        const { error } = handler.payloadSchema.validate({
+          importId: 'import-123',
+          user: {
+            id: 'user-1',
+            email: 'maintainer@example.com',
+            scope: ['admin.read'],
+            role: 'service_maintainer'
+          }
+        })
+
+        expect(error).toBeUndefined()
+      })
+
+      it('accepts a user with a null role', () => {
+        const { error } = handler.payloadSchema.validate({
+          importId: 'import-123',
+          user: {
+            id: 'user-1',
+            email: 'operator@example.com',
+            scope: ['operator'],
+            role: null
+          }
+        })
+
+        expect(error).toBeUndefined()
+      })
     })
 
     describe('execute', () => {

--- a/src/server/queue-consumer/summary-log-commands.js
+++ b/src/server/queue-consumer/summary-log-commands.js
@@ -34,7 +34,7 @@ const userSchema = Joi.object({
   name: Joi.string(),
   email: Joi.string().required(),
   scope: Joi.array().items(Joi.string()).required(),
-  role: Joi.string().allow(null)
+  role: Joi.string().allow(null).required()
 })
 
 /**

--- a/src/server/queue-consumer/summary-log-commands.js
+++ b/src/server/queue-consumer/summary-log-commands.js
@@ -33,7 +33,8 @@ const userSchema = Joi.object({
   id: Joi.string().required(),
   name: Joi.string(),
   email: Joi.string().required(),
-  scope: Joi.array().items(Joi.string()).required()
+  scope: Joi.array().items(Joi.string()).required(),
+  role: Joi.string().allow(null)
 })
 
 /**

--- a/src/server/queue-consumer/summary-log-commands.test.js
+++ b/src/server/queue-consumer/summary-log-commands.test.js
@@ -191,6 +191,34 @@ describe('summaryLogCommandHandlers', () => {
         expect(error.message).toContain('"user.email" is required')
       })
 
+      it('accepts a user carrying a resolved role', () => {
+        const { error } = handler.payloadSchema.validate({
+          summaryLogId: 'log-123',
+          user: {
+            id: 'user-1',
+            email: 'maintainer@example.com',
+            scope: ['admin.read'],
+            role: 'service_maintainer'
+          }
+        })
+
+        expect(error).toBeUndefined()
+      })
+
+      it('accepts a user with a null role', () => {
+        const { error } = handler.payloadSchema.validate({
+          summaryLogId: 'log-123',
+          user: {
+            id: 'user-1',
+            email: 'operator@example.com',
+            scope: ['operator'],
+            role: null
+          }
+        })
+
+        expect(error).toBeUndefined()
+      })
+
       it('rejects unknown fields', () => {
         const error = validationErrorFrom(
           handler.payloadSchema.validate({

--- a/src/server/queue-consumer/summary-log-commands.test.js
+++ b/src/server/queue-consumer/summary-log-commands.test.js
@@ -153,7 +153,8 @@ describe('summaryLogCommandHandlers', () => {
           user: {
             id: 'user-1',
             email: 'test@example.com',
-            scope: ['operator']
+            scope: ['operator'],
+            role: null
           }
         })
 
@@ -167,11 +168,27 @@ describe('summaryLogCommandHandlers', () => {
             id: 'user-1',
             name: 'Test User',
             email: 'test@example.com',
-            scope: ['operator']
+            scope: ['operator'],
+            role: null
           }
         })
 
         expect(error).toBeUndefined()
+      })
+
+      it('rejects a user without a role', () => {
+        const error = validationErrorFrom(
+          handler.payloadSchema.validate({
+            summaryLogId: 'log-123',
+            user: {
+              id: 'user-1',
+              email: 'test@example.com',
+              scope: ['operator']
+            }
+          })
+        )
+
+        expect(error.message).toBe('"user.role" is required')
       })
 
       it('requires summaryLogId', () => {
@@ -226,7 +243,8 @@ describe('summaryLogCommandHandlers', () => {
             user: {
               id: 'user-1',
               email: 'test@example.com',
-              scope: ['operator']
+              scope: ['operator'],
+              role: null
             },
             extra: true
           })
@@ -243,7 +261,8 @@ describe('summaryLogCommandHandlers', () => {
           user: {
             id: 'user-1',
             email: 'test@example.com',
-            scope: ['operator']
+            scope: ['operator'],
+            role: null
           }
         }
 

--- a/src/waste-balances/application/audit.js
+++ b/src/waste-balances/application/audit.js
@@ -41,7 +41,7 @@ export const recordWasteBalanceUpdateAudit = async ({
   if (systemLogsRepository) {
     await systemLogsRepository.insert({
       createdAt: new Date(),
-      createdBy: user,
+      createdBy: { ...user, role: null },
       event: payload.event,
       context: payload.context
     })

--- a/src/waste-balances/application/update-via-stream.test.js
+++ b/src/waste-balances/application/update-via-stream.test.js
@@ -59,7 +59,8 @@ const user = {
   id: 'user-1',
   name: 'Test User',
   email: 'user@example.test',
-  scope: ['standard_user']
+  scope: ['standard_user'],
+  role: 'standard_user'
 }
 
 const buildExporterRecord = ({
@@ -369,7 +370,12 @@ describe('performUpdateViaStream', () => {
         streamRepository,
         rowStateRepository,
         dependencies: { systemLogsRepository },
-        user: { id: 'user-2', email: 'noname@example.test', scope: [] },
+        user: {
+          id: 'user-2',
+          email: 'noname@example.test',
+          scope: [],
+          role: null
+        },
         overseasSites,
         summaryLogId: 'log-A'
       })

--- a/src/waste-balances/application/update-via-stream.test.js
+++ b/src/waste-balances/application/update-via-stream.test.js
@@ -290,7 +290,7 @@ describe('performUpdateViaStream', () => {
       const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
       expect(systemLogs).toHaveLength(1)
       const [entry] = systemLogs
-      expect(entry.createdBy).toEqual(user)
+      expect(entry.createdBy).toEqual({ ...user, role: null })
       expect(entry.createdAt).toBeInstanceOf(Date)
       expect(entry.event).toEqual({
         category: 'waste-reporting',


### PR DESCRIPTION
Ticket: [PAE-1556](https://eaflood.atlassian.net/browse/PAE-1556)
System logs display a user's scopes under a "role" label, and the user's actual role is not recorded at all. This threads the authenticated user's role through to the system log so it can be displayed correctly (PAE-1556).

When a request authenticates, the JWT strategy now carries the resolved `role` on the credentials alongside `scope`, for both identity providers. For Entra ID (admins) the role is resolved from `ADMIN_ROLES`; for Defra ID (operators) it is currently `null` — operators have scopes but no role mapping yet. Mapping operator scopes to a role is a domain decision that needs a separate conversation, so this change deliberately plumbs it through as nullable rather than inventing a mapping.

The audit helper that builds the `createdBy` actor for a human session now records `role` next to `id`, `email` and `scope`, so the role lands on every system log entry. The system-logs search endpoint and repositories are pure pass-through, so the role surfaces on read with no further change there — covered by a round-trip test.

Some system logs are written asynchronously: ORS imports and summary log submissions hand the actor to an SQS command that a queue consumer processes and records. The consumer command schemas validate the actor, so they now accept the nullable `role` field, letting it survive the round-trip to where the async log is written.

Types: `HumanCredentials` gains a required `role: string | null` (freshly minted on every authenticated request, so always present). `SystemLogActor` gains an optional `role?: string | null`, because logs written before this change carry only `id`, `email` and `scope`.

Note: this touches `src/common/helpers/auth/get-jwt-strategy-config.js`, which is part of the in-flight role/scopes refactor series — worth checking for conflicts before merge.

The frontend change to split the "role" label from the scopes and show both is tracked separately and will follow in an admin-frontend PR.


[PAE-1556]: https://eaflood.atlassian.net/browse/PAE-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ