### PR TITLE
PAE-1541: Extract reports-side period helpers

### DIFF
--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -1,7 +1,9 @@
 import { VERSION_STATUS } from '#domain/waste-records/model.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
-import { MONTHS_PER_PERIOD } from '#reports/domain/cadence.js'
-import { REPORT_STATUS } from '#reports/domain/report-status.js'
+import {
+  buildSubmittedPeriods,
+  isDateInSubmittedPeriod
+} from '#reports/domain/submitted-periods.js'
 import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
 
 /** Internal reporting-period status. Not serialised: mapped to output keys via PERIOD_TO_KEY. */
@@ -72,91 +74,21 @@ const emptyResult = () => ({
   closedPeriodLoads: emptyChange()
 })
 
-/** Position of the year portion end in an ISO date string (YYYY-MM-DD) */
-const YEAR_END = 4
-/** Start and end of the month portion in an ISO date string */
-const MONTH_START = 5
-const MONTH_END = 7
-
 /**
- * @param {string | Date} dateValue
- * @returns {string}
- */
-const toIsoDate = (dateValue) =>
-  dateValue instanceof Date
-    ? dateValue.toISOString().slice(0, 10)
-    : String(dateValue)
-
-/**
- * @param {string | Date} dateValue
- * @returns {number}
- */
-const extractMonth = (dateValue) => {
-  const str = toIsoDate(dateValue)
-  return Number(str.slice(MONTH_START, MONTH_END))
-}
-
-/**
- * @param {string | Date} dateValue
- * @returns {number}
- */
-const extractYear = (dateValue) =>
-  Number(toIsoDate(dateValue).slice(0, YEAR_END))
-
-/**
- * Maps a month to its reporting period number.
- * @param {number} month - 1-12
- * @param {string} cadence - 'monthly' or 'quarterly'
- * @returns {number}
- */
-const monthToPeriod = (month, cadence) => {
-  const monthsPerPeriod = MONTHS_PER_PERIOD[cadence]
-  return Math.ceil(month / monthsPerPeriod)
-}
-
-/**
- * Builds a set of closed period keys from submitted reports.
- * A period is closed when it has been submitted: either the current
- * report has status 'submitted', or there are previous submissions.
- *
- * @param {PeriodicReport[]} periodicReports
- * @param {string} cadence
- * @returns {Set<string>}
- */
-const buildClosedPeriods = (periodicReports, cadence) => {
-  const closed = new Set()
-  for (const periodicReport of periodicReports) {
-    const slots = periodicReport.reports[cadence]
-    if (!slots) {
-      continue
-    }
-    for (const [period, slot] of Object.entries(slots)) {
-      const hasBeenSubmitted =
-        slot.current?.status === REPORT_STATUS.SUBMITTED ||
-        slot.previousSubmissions?.length > 0
-      if (hasBeenSubmitted) {
-        closed.add(`${periodicReport.year}:${period}`)
-      }
-    }
-  }
-  return closed
-}
-
-/**
- * Applies the closed-wins rule: if ANY date field maps to a closed
- * period, the record is classified as closed.
+ * Applies the closed-wins rule: if ANY date field falls in a submitted
+ * (closed) period, the record is classified as closed.
  * Returns null if no date fields have a value.
  *
  * @param {Record<string, string | Date | null | undefined>} data
  * @param {string[]} reportingDateFields
- * @param {Set<string>} closedPeriods
+ * @param {Set<string>} submittedPeriods
  * @param {string} cadence
  * @returns {'open' | 'closed' | null}
  */
 const classifyPeriodStatus = (
   data,
   reportingDateFields,
-  closedPeriods,
+  submittedPeriods,
   cadence
 ) => {
   let hasAnyDate = false
@@ -168,9 +100,7 @@ const classifyPeriodStatus = (
     }
 
     hasAnyDate = true
-    const period = monthToPeriod(extractMonth(dateValue), cadence)
-    const periodKey = `${extractYear(dateValue)}:${period}`
-    if (closedPeriods.has(periodKey)) {
+    if (isDateInSubmittedPeriod(submittedPeriods, dateValue, cadence)) {
       return PERIOD_STATUS.CLOSED
     }
   }
@@ -315,7 +245,7 @@ const reduceEntries = (entries) => {
  * @param {ValidatedWasteRecord} params.wasteRecord
  * @param {Map<string, WasteRecord>} params.existingRecordsMap
  * @param {TableSchema} params.schema
- * @param {Set<string>} params.closedPeriods
+ * @param {Set<string>} params.submittedPeriods
  * @param {'monthly' | 'quarterly'} params.cadence
  * @param {ClassificationContext} params.context
  * @returns {PeriodStatusEntry[]}
@@ -324,7 +254,7 @@ const classifyAdjustedWasteRecord = ({
   wasteRecord,
   existingRecordsMap,
   schema,
-  closedPeriods,
+  submittedPeriods,
   cadence,
   context
 }) => {
@@ -334,7 +264,7 @@ const classifyAdjustedWasteRecord = ({
   const newPeriod = classifyPeriodStatus(
     record.data,
     reportingDateFields,
-    closedPeriods,
+    submittedPeriods,
     cadence
   )
   const existingKey = `${record.type}:${record.rowId}`
@@ -343,7 +273,7 @@ const classifyAdjustedWasteRecord = ({
     ? classifyPeriodStatus(
         existing.data,
         reportingDateFields,
-        closedPeriods,
+        submittedPeriods,
         cadence
       )
     : null
@@ -390,7 +320,7 @@ export const classifyByPeriodStatus = ({
   tableSchemas,
   classificationContext
 }) => {
-  const closedPeriods = buildClosedPeriods(periodicReports, cadence)
+  const submittedPeriods = buildSubmittedPeriods(periodicReports, cadence)
 
   /** @type {PeriodStatusEntry[]} */
   const entries = []
@@ -408,7 +338,7 @@ export const classifyByPeriodStatus = ({
       const period = classifyPeriodStatus(
         record.data,
         schema.reportingDateFields,
-        closedPeriods,
+        submittedPeriods,
         cadence
       )
       if (period) {
@@ -430,7 +360,7 @@ export const classifyByPeriodStatus = ({
           wasteRecord,
           existingRecordsMap,
           schema,
-          closedPeriods,
+          submittedPeriods,
           cadence,
           context: classificationContext
         })

--- a/src/reports/domain/period-for-date.js
+++ b/src/reports/domain/period-for-date.js
@@ -1,0 +1,32 @@
+import { MONTHS_PER_PERIOD } from './cadence.js'
+
+/** Position of the year portion end in an ISO date string (YYYY-MM-DD) */
+const YEAR_END = 4
+/** Start and end of the month portion in an ISO date string */
+const MONTH_START = 5
+const MONTH_END = 7
+
+/**
+ * @param {string | Date} dateValue
+ * @returns {string}
+ */
+const toIsoDate = (dateValue) =>
+  dateValue instanceof Date
+    ? dateValue.toISOString().slice(0, 10)
+    : String(dateValue)
+
+/**
+ * Maps a date to the reporting period it falls in for the given cadence.
+ * Monthly periods are 1-12, quarterly periods are 1-4.
+ *
+ * @param {string | Date} dateValue - ISO date string (YYYY-MM-DD) or Date
+ * @param {string} cadence - 'monthly' or 'quarterly'
+ * @returns {{ year: number, period: number }}
+ */
+export const periodForDate = (dateValue, cadence) => {
+  const str = toIsoDate(dateValue)
+  const year = Number(str.slice(0, YEAR_END))
+  const month = Number(str.slice(MONTH_START, MONTH_END))
+  const period = Math.ceil(month / MONTHS_PER_PERIOD[cadence])
+  return { year, period }
+}

--- a/src/reports/domain/period-for-date.test.js
+++ b/src/reports/domain/period-for-date.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { CADENCE } from './cadence.js'
+import { periodForDate } from './period-for-date.js'
+
+describe('periodForDate', () => {
+  it('maps each month to its own period under a monthly cadence', () => {
+    expect(periodForDate('2026-01-15', CADENCE.monthly)).toEqual({
+      year: 2026,
+      period: 1
+    })
+    expect(periodForDate('2026-12-31', CADENCE.monthly)).toEqual({
+      year: 2026,
+      period: 12
+    })
+  })
+
+  it('groups months into quarters under a quarterly cadence', () => {
+    expect(periodForDate('2026-03-31', CADENCE.quarterly)).toEqual({
+      year: 2026,
+      period: 1
+    })
+    expect(periodForDate('2026-04-01', CADENCE.quarterly)).toEqual({
+      year: 2026,
+      period: 2
+    })
+    expect(periodForDate('2026-12-01', CADENCE.quarterly)).toEqual({
+      year: 2026,
+      period: 4
+    })
+  })
+
+  it('accepts a Date as well as an ISO string', () => {
+    expect(
+      periodForDate(new Date('2025-07-09T12:00:00Z'), CADENCE.quarterly)
+    ).toEqual({ year: 2025, period: 3 })
+  })
+})

--- a/src/reports/domain/submitted-periods.js
+++ b/src/reports/domain/submitted-periods.js
@@ -1,0 +1,59 @@
+import { periodForDate } from './period-for-date.js'
+import { REPORT_STATUS } from './report-status.js'
+
+/** @import {PeriodicReport} from '#reports/repository/port.js' */
+
+/**
+ * @param {number} year
+ * @param {number | string} period
+ * @returns {string}
+ */
+const periodKey = (year, period) => `${year}:${period}`
+
+/**
+ * Builds the set of reporting periods that have been submitted for the given
+ * cadence. A period counts as submitted when its current report has status
+ * 'submitted' or it has any previous submissions.
+ *
+ * Keys are opaque to callers: use {@link isDateInSubmittedPeriod} to test a date
+ * against the result.
+ *
+ * @param {PeriodicReport[]} periodicReports
+ * @param {string} cadence - 'monthly' or 'quarterly'
+ * @returns {Set<string>}
+ */
+export const buildSubmittedPeriods = (periodicReports, cadence) => {
+  const submitted = new Set()
+  for (const periodicReport of periodicReports) {
+    const slots = periodicReport.reports[cadence]
+    if (!slots) {
+      continue
+    }
+    for (const [period, slot] of Object.entries(slots)) {
+      const hasBeenSubmitted =
+        slot.current?.status === REPORT_STATUS.SUBMITTED ||
+        slot.previousSubmissions?.length > 0
+      if (hasBeenSubmitted) {
+        submitted.add(periodKey(periodicReport.year, period))
+      }
+    }
+  }
+  return submitted
+}
+
+/**
+ * Tests whether a date falls in one of the submitted periods.
+ *
+ * @param {Set<string>} submittedPeriods - result of {@link buildSubmittedPeriods}
+ * @param {string | Date} dateValue
+ * @param {string} cadence - 'monthly' or 'quarterly'
+ * @returns {boolean}
+ */
+export const isDateInSubmittedPeriod = (
+  submittedPeriods,
+  dateValue,
+  cadence
+) => {
+  const { year, period } = periodForDate(dateValue, cadence)
+  return submittedPeriods.has(periodKey(year, period))
+}

--- a/src/reports/domain/submitted-periods.test.js
+++ b/src/reports/domain/submitted-periods.test.js
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import { CADENCE } from './cadence.js'
+import { REPORT_STATUS } from './report-status.js'
+import {
+  buildSubmittedPeriods,
+  isDateInSubmittedPeriod
+} from './submitted-periods.js'
+
+/** @import {ReportStatus} from './report-status.js' */
+
+/**
+ * @param {ReportStatus} status
+ * @param {string} id
+ * @returns {import('#reports/repository/port.js').ReportSummary}
+ */
+const reportSummary = (status, id) => ({
+  id,
+  status,
+  submissionNumber: 1,
+  submittedAt:
+    status === REPORT_STATUS.SUBMITTED ? '2026-04-10T00:00:00Z' : null,
+  submittedBy: null
+})
+
+/**
+ * @param {Partial<import('#reports/repository/port.js').ReportPerPeriod>} [overrides]
+ * @returns {import('#reports/repository/port.js').ReportPerPeriod}
+ */
+const slot = (overrides = {}) => ({
+  startDate: '2026-01-01',
+  endDate: '2026-03-31',
+  dueDate: '2026-04-20',
+  current: null,
+  previousSubmissions: [],
+  ...overrides
+})
+
+const submittedSlot = () =>
+  slot({ current: reportSummary(REPORT_STATUS.SUBMITTED, 'r1') })
+
+const inProgressSlot = () =>
+  slot({ current: reportSummary(REPORT_STATUS.IN_PROGRESS, 'r2') })
+
+const resubmittedSlot = () =>
+  slot({
+    current: reportSummary(REPORT_STATUS.IN_PROGRESS, 'r4'),
+    previousSubmissions: [reportSummary(REPORT_STATUS.SUBMITTED, 'r3')]
+  })
+
+/**
+ * @param {number} year
+ * @param {import('#reports/repository/port.js').PeriodicReport['reports']} reports
+ * @returns {import('#reports/repository/port.js').PeriodicReport}
+ */
+const periodicReport = (year, reports) => ({
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  year,
+  reports
+})
+
+describe('buildSubmittedPeriods', () => {
+  it('includes a period whose current report is submitted', () => {
+    const reports = [
+      periodicReport(2026, { quarterly: { 1: submittedSlot() } })
+    ]
+
+    const result = buildSubmittedPeriods(reports, CADENCE.quarterly)
+
+    expect(result.has('2026:1')).toBe(true)
+  })
+
+  it('includes a period with previous submissions even if the current report is not submitted', () => {
+    const reports = [
+      periodicReport(2026, { quarterly: { 2: resubmittedSlot() } })
+    ]
+
+    const result = buildSubmittedPeriods(reports, CADENCE.quarterly)
+
+    expect(result.has('2026:2')).toBe(true)
+  })
+
+  it('excludes a period that has never been submitted', () => {
+    const reports = [
+      periodicReport(2026, { quarterly: { 3: inProgressSlot() } })
+    ]
+
+    const result = buildSubmittedPeriods(reports, CADENCE.quarterly)
+
+    expect(result.has('2026:3')).toBe(false)
+  })
+
+  it('skips a periodic report with no slots for the cadence', () => {
+    const reports = [periodicReport(2026, { monthly: { 1: submittedSlot() } })]
+
+    const result = buildSubmittedPeriods(reports, CADENCE.quarterly)
+
+    expect(result.size).toBe(0)
+  })
+
+  it('keys submitted periods by year across multiple years', () => {
+    const reports = [
+      periodicReport(2025, { quarterly: { 4: submittedSlot() } }),
+      periodicReport(2026, { quarterly: { 1: submittedSlot() } })
+    ]
+
+    const result = buildSubmittedPeriods(reports, CADENCE.quarterly)
+
+    expect(result.has('2025:4')).toBe(true)
+    expect(result.has('2026:1')).toBe(true)
+  })
+})
+
+describe('isDateInSubmittedPeriod', () => {
+  const reports = [periodicReport(2026, { quarterly: { 1: submittedSlot() } })]
+  const submitted = buildSubmittedPeriods(reports, CADENCE.quarterly)
+
+  it('returns true for a date in a submitted period', () => {
+    expect(
+      isDateInSubmittedPeriod(submitted, '2026-02-10', CADENCE.quarterly)
+    ).toBe(true)
+  })
+
+  it('returns false for a date in an open period', () => {
+    expect(
+      isDateInSubmittedPeriod(submitted, '2026-05-10', CADENCE.quarterly)
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)

## Summary

Follow-up from review on #1300. The period-status classifier re-derived two reports-domain facts straight from the raw `PeriodicReport` storage shape, coupling the summary-logs module to the reports module's representation:

1. **Which reporting period a date falls in** (`Math.ceil(month / MONTHS_PER_PERIOD[cadence])`), duplicating the period-numbering convention the reports module owns.
2. **Whether a period has been submitted** (reading `slot.current.status === 'submitted' || slot.previousSubmissions.length > 0`).

This moves both behind the reports module so summary-logs asks "is this date in a submitted period?" through an intentional API rather than reaching into the slot shape.

## Changes

- **`src/reports/domain/period-for-date.js`** (new): `periodForDate(date, cadence)` returns `{ year, period }`. Owns the calendar/period-numbering convention.
- **`src/reports/domain/submitted-periods.js`** (new): `buildSubmittedPeriods(periodicReports, cadence)` and `isDateInSubmittedPeriod(submittedPeriods, date, cadence)`. Owns the "submitted" rule, the slot-reading, and is the only place the period key is constructed.
- **`src/application/summary-logs/period-status.js`**: keeps the summary-log-specific closed-wins classification, but stops importing `MONTHS_PER_PERIOD` and `REPORT_STATUS` and stops reading the slot shape. It now composes the two reports helpers.

## Notes

This is a pure refactor: behaviour is unchanged and the existing `period-status` test suite passes untouched, which is the regression guard. New unit tests cover the two reports helpers directly.

The classifier was already pure (no repository call: the caller fetches the reports and passes them in), so only the data-shape interpretation needed moving.


[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ