### PR TITLE
PAE-1541: Apply ORS validation to validate-time loads classification

### DIFF
--- a/src/application/summary-logs/cap-issues-for-storage.js
+++ b/src/application/summary-logs/cap-issues-for-storage.js
@@ -1,0 +1,58 @@
+import { VALIDATION_SEVERITY } from '#common/enums/index.js'
+import { MAX_VALIDATION_ISSUES } from './validate-issue-logging.js'
+
+/** @import {ValidationIssue} from '#common/validation/validation-issues.js' */
+
+export const MAX_ACTUAL_LENGTH = 200
+
+/** @param {ValidationIssue[]} issues */
+const truncateActualValues = (issues) => {
+  for (const issue of issues) {
+    if (
+      typeof issue.context?.actual === 'string' &&
+      issue.context.actual.length > MAX_ACTUAL_LENGTH
+    ) {
+      issue.context.actual =
+        issue.context.actual.slice(0, MAX_ACTUAL_LENGTH) + '…'
+    }
+  }
+}
+
+/**
+ * Caps the issues array and truncates long actual values for MongoDB storage.
+ *
+ * Both the issue count and per-issue actual values are bounded to prevent
+ * the summary log document exceeding MongoDB's 16 MiB BSON limit.
+ * @see https://eaflood.atlassian.net/browse/PAE-1244
+ *
+ * Fatal issues are always preserved — they determine the summary log status
+ * and are required by the frontend to render specific error messages.
+ * Non-fatal issues fill the remaining capacity.
+ *
+ * @param {ValidationIssue[]} allIssues - All validation issues
+ * @returns {ValidationIssue[]} The capped, actual-value-truncated issues
+ */
+export const capIssuesForStorage = (allIssues) => {
+  let cappedIssues
+
+  if (allIssues.length <= MAX_VALIDATION_ISSUES) {
+    cappedIssues = allIssues
+  } else {
+    const fatal = allIssues.filter(
+      (issue) => issue.severity === VALIDATION_SEVERITY.FATAL
+    )
+    const nonFatal = allIssues.filter(
+      (issue) => issue.severity !== VALIDATION_SEVERITY.FATAL
+    )
+    const cappedFatal = fatal.slice(0, MAX_VALIDATION_ISSUES)
+    const nonFatalSlots = Math.max(
+      0,
+      MAX_VALIDATION_ISSUES - cappedFatal.length
+    )
+    cappedIssues = [...cappedFatal, ...nonFatal.slice(0, nonFatalSlots)]
+  }
+
+  truncateActualValues(cappedIssues)
+
+  return cappedIssues
+}

--- a/src/application/summary-logs/classify-and-persist.js
+++ b/src/application/summary-logs/classify-and-persist.js
@@ -5,7 +5,6 @@ import {
   PROCESSING_TYPE_TABLES
 } from '#domain/summary-logs/table-schemas/index.js'
 import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
-import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 import { CADENCE } from '#reports/domain/cadence.js'
 import { classifyByPeriodStatus } from './period-status.js'
 import {
@@ -47,6 +46,7 @@ export const filterWasteBalanceRecords = (wasteRecords, processingType) =>
  * @param {string} params.summaryLogId
  * @param {ProcessingType} params.processingType
  * @param {import('#reports/repository/port.js').PeriodicReport[]} params.periodicReports
+ * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} params.overseasSites
  * @param {Registration} [params.registration]
  * @param {Map<string, WasteRecord>} [params.existingRecordsMap]
  * @returns {{ loads: Loads | null, loadsByWasteRecordType: import('./load-counts.js').LoadsByWasteRecordType | null, loadsByReportingPeriod: LoadsByReportingPeriod | null }}
@@ -58,6 +58,7 @@ export const classifyLoads = ({
   wasteBalanceRecords,
   wasteRecords,
   periodicReports,
+  overseasSites,
   registration,
   existingRecordsMap
 }) => {
@@ -100,7 +101,7 @@ export const classifyLoads = ({
           tableSchemas,
           classificationContext: {
             accreditation: registration.accreditation ?? null,
-            overseasSites: ORS_VALIDATION_DISABLED
+            overseasSites
           }
         })
       : null

--- a/src/application/summary-logs/classify-and-persist.js
+++ b/src/application/summary-logs/classify-and-persist.js
@@ -5,6 +5,9 @@ import {
   PROCESSING_TYPE_TABLES
 } from '#domain/summary-logs/table-schemas/index.js'
 import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
+import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
 import { CADENCE } from '#reports/domain/cadence.js'
 import { classifyByPeriodStatus } from './period-status.js'
 import {
@@ -17,6 +20,8 @@ import {
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
+/** @import {OverseasSitesRepository} from '#overseas-sites/repository/port.js' */
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 /** @typedef {import('./load-counts.js').Loads} Loads */
 /** @typedef {import('./period-status.js').LoadsByReportingPeriod} LoadsByReportingPeriod */
@@ -139,3 +144,33 @@ export const fetchPeriodicReports = async ({
   }
   return []
 }
+
+/**
+ * Resolves the overseas-sites context for ORS validation (VAL014). Only
+ * exporters carry overseas sites, so other processing types skip the lookup
+ * and disable the check, mirroring the submit-time path in
+ * sync-from-summary-log.js. Without this, loads requiring ORS approval would
+ * be misclassified in the predicted waste-balance delta shown on the check
+ * page.
+ *
+ * @param {Object} params
+ * @param {ProcessingType} params.processingType
+ * @param {SubmittedSummaryLog} params.summaryLog
+ * @param {OrganisationsRepository} params.organisationsRepository
+ * @param {OverseasSitesRepository} params.overseasSitesRepository
+ * @returns {Promise<import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext>}
+ */
+export const resolveOverseasSitesContext = async ({
+  processingType,
+  summaryLog,
+  organisationsRepository,
+  overseasSitesRepository
+}) =>
+  processingType === PROCESSING_TYPES.EXPORTER
+    ? resolveOverseasSites(
+        organisationsRepository,
+        overseasSitesRepository,
+        summaryLog.organisationId,
+        summaryLog.registrationId
+      )
+    : ORS_VALIDATION_DISABLED

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -10,6 +10,7 @@ import {
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import { TABLE_SCHEMAS as EXPORTER_TABLE_SCHEMAS } from '#domain/summary-logs/table-schemas/exporter/index.js'
 import { buildOrganisation } from '#repositories/organisations/contract/test-data.js'
+import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
 import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
@@ -128,6 +129,7 @@ describe('SummaryLogsValidator integration', () => {
       reportsRepository: /** @type {any} */ ({
         findPeriodicReports: async () => []
       }),
+      overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
       summaryLogExtractor: extractor
     })
 

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -27,20 +27,15 @@ import {
   filterWasteBalanceRecords,
   resolveOverseasSitesContext
 } from './classify-and-persist.js'
-import {
-  logValidationIssues,
-  MAX_VALIDATION_ISSUES
-} from './validate-issue-logging.js'
+import { logValidationIssues } from './validate-issue-logging.js'
 import { validateDataBusiness } from './validations/data-business.js'
 import { createDataSyntaxValidator } from './validations/data-syntax.js'
 import { validateMetaBusiness } from './validations/meta-business.js'
 import { validateMetaSyntax } from './validations/meta-syntax.js'
-import {
-  capIssuesForStorage,
-  MAX_ACTUAL_LENGTH
-} from './cap-issues-for-storage.js'
+import { capIssuesForStorage } from './cap-issues-for-storage.js'
 
-export { MAX_VALIDATION_ISSUES, MAX_ACTUAL_LENGTH }
+export { MAX_VALIDATION_ISSUES } from './validate-issue-logging.js'
+export { MAX_ACTUAL_LENGTH } from './cap-issues-for-storage.js'
 
 /** @import {ValidatedSummaryLog, ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -15,7 +15,11 @@ import {
 import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 
 import { transformFromSummaryLog } from '#application/waste-records/transform-from-summary-log.js'
-import { SUMMARY_LOG_META_FIELDS } from '#domain/summary-logs/meta-fields.js'
+import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
+import {
+  PROCESSING_TYPES,
+  SUMMARY_LOG_META_FIELDS
+} from '#domain/summary-logs/meta-fields.js'
 import {
   findSchemaForProcessingType,
   PROCESSING_TYPE_TABLES
@@ -49,6 +53,7 @@ export const MAX_ACTUAL_LENGTH = 200
 /** @import {SummaryLog} from '#domain/summary-logs/model.js' */
 /** @import {SummaryLogStatus} from '#domain/summary-logs/status.js' */
 /** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
+/** @import {OverseasSitesRepository} from '#overseas-sites/repository/port.js' */
 /** @import {SummaryLogsRepository} from '#repositories/summary-logs/port.js' */
 /** @import {WasteRecordsRepository} from '#repositories/waste-records/port.js' */
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
@@ -552,6 +557,36 @@ const persistValidationResult = async ({
 }
 
 /**
+ * Resolves the overseas-sites context for ORS validation (VAL014). Only
+ * exporters carry overseas sites, so other processing types skip the lookup
+ * and disable the check, mirroring the submit-time path in
+ * sync-from-summary-log.js. Without this, loads requiring ORS approval would
+ * be misclassified in the predicted waste-balance delta shown on the check
+ * page.
+ *
+ * @param {Object} params
+ * @param {ProcessingType} params.processingType
+ * @param {SubmittedSummaryLog} params.summaryLog
+ * @param {OrganisationsRepository} params.organisationsRepository
+ * @param {OverseasSitesRepository} params.overseasSitesRepository
+ * @returns {Promise<import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext>}
+ */
+const resolveOverseasSitesContext = async ({
+  processingType,
+  summaryLog,
+  organisationsRepository,
+  overseasSitesRepository
+}) =>
+  processingType === PROCESSING_TYPES.EXPORTER
+    ? resolveOverseasSites(
+        organisationsRepository,
+        overseasSitesRepository,
+        summaryLog.organisationId,
+        summaryLog.registrationId
+      )
+    : ORS_VALIDATION_DISABLED
+
+/**
  * Fetches periodic reports, classifies loads, and persists the validation result.
  */
 const classifyAndPersistResult = async ({
@@ -567,13 +602,22 @@ const classifyAndPersistResult = async ({
   summaryLog,
   summaryLogsRepository,
   version,
-  reportsRepository
+  reportsRepository,
+  organisationsRepository,
+  overseasSitesRepository
 }) => {
   const periodicReports = await fetchPeriodicReports({
     registration,
     status,
     summaryLog,
     reportsRepository
+  })
+
+  const overseasSites = await resolveOverseasSitesContext({
+    processingType,
+    summaryLog,
+    organisationsRepository,
+    overseasSitesRepository
   })
 
   const { loads, loadsByWasteRecordType, loadsByReportingPeriod } =
@@ -584,6 +628,7 @@ const classifyAndPersistResult = async ({
       wasteBalanceRecords,
       wasteRecords,
       periodicReports,
+      overseasSites,
       registration,
       existingRecordsMap
     })
@@ -611,6 +656,7 @@ const classifyAndPersistResult = async ({
  *   organisationsRepository: OrganisationsRepository,
  *   wasteRecordsRepository: WasteRecordsRepository,
  *   reportsRepository: ReportsRepository,
+ *   overseasSitesRepository: OverseasSitesRepository,
  *   summaryLogExtractor: SummaryLogExtractor
  * }} params
  * @returns {(summaryLogId: string) => Promise<void>}
@@ -621,6 +667,7 @@ export const createSummaryLogsValidator = ({
   organisationsRepository,
   wasteRecordsRepository,
   reportsRepository,
+  overseasSitesRepository,
   summaryLogExtractor
 }) => {
   const validateDataSyntax = createDataSyntaxValidator(PROCESSING_TYPE_TABLES)
@@ -688,7 +735,9 @@ export const createSummaryLogsValidator = ({
       summaryLog,
       summaryLogsRepository,
       version,
-      reportsRepository
+      reportsRepository,
+      organisationsRepository,
+      overseasSitesRepository
     })
 
     logger.info({

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -3,8 +3,7 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES,
   VALIDATION_CATEGORY,
-  VALIDATION_CODE,
-  VALIDATION_SEVERITY
+  VALIDATION_CODE
 } from '#common/enums/index.js'
 import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
 import { createValidationIssues } from '#common/validation/validation-issues.js'
@@ -15,11 +14,7 @@ import {
 import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 
 import { transformFromSummaryLog } from '#application/waste-records/transform-from-summary-log.js'
-import { resolveOverseasSites } from '#application/waste-records/resolve-overseas-sites.js'
-import {
-  PROCESSING_TYPES,
-  SUMMARY_LOG_META_FIELDS
-} from '#domain/summary-logs/meta-fields.js'
+import { SUMMARY_LOG_META_FIELDS } from '#domain/summary-logs/meta-fields.js'
 import {
   findSchemaForProcessingType,
   PROCESSING_TYPE_TABLES
@@ -29,7 +24,8 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
 import {
   classifyLoads,
   fetchPeriodicReports,
-  filterWasteBalanceRecords
+  filterWasteBalanceRecords,
+  resolveOverseasSitesContext
 } from './classify-and-persist.js'
 import {
   logValidationIssues,
@@ -39,14 +35,16 @@ import { validateDataBusiness } from './validations/data-business.js'
 import { createDataSyntaxValidator } from './validations/data-syntax.js'
 import { validateMetaBusiness } from './validations/meta-business.js'
 import { validateMetaSyntax } from './validations/meta-syntax.js'
+import {
+  capIssuesForStorage,
+  MAX_ACTUAL_LENGTH
+} from './cap-issues-for-storage.js'
 
-export { MAX_VALIDATION_ISSUES }
-
-export const MAX_ACTUAL_LENGTH = 200
+export { MAX_VALIDATION_ISSUES, MAX_ACTUAL_LENGTH }
 
 /** @import {ValidatedSummaryLog, ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
-/** @import {ValidationIssue, ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
+/** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {ParsedSummaryLog} from '#domain/summary-logs/extractor/port.js' */
 /** @import {ProcessingType} from '#domain/summary-logs/meta-fields.js' */
@@ -557,36 +555,6 @@ const persistValidationResult = async ({
 }
 
 /**
- * Resolves the overseas-sites context for ORS validation (VAL014). Only
- * exporters carry overseas sites, so other processing types skip the lookup
- * and disable the check, mirroring the submit-time path in
- * sync-from-summary-log.js. Without this, loads requiring ORS approval would
- * be misclassified in the predicted waste-balance delta shown on the check
- * page.
- *
- * @param {Object} params
- * @param {ProcessingType} params.processingType
- * @param {SubmittedSummaryLog} params.summaryLog
- * @param {OrganisationsRepository} params.organisationsRepository
- * @param {OverseasSitesRepository} params.overseasSitesRepository
- * @returns {Promise<import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext>}
- */
-const resolveOverseasSitesContext = async ({
-  processingType,
-  summaryLog,
-  organisationsRepository,
-  overseasSitesRepository
-}) =>
-  processingType === PROCESSING_TYPES.EXPORTER
-    ? resolveOverseasSites(
-        organisationsRepository,
-        overseasSitesRepository,
-        summaryLog.organisationId,
-        summaryLog.registrationId
-      )
-    : ORS_VALIDATION_DISABLED
-
-/**
  * Fetches periodic reports, classifies loads, and persists the validation result.
  */
 const classifyAndPersistResult = async ({
@@ -748,56 +716,4 @@ export const createSummaryLogsValidator = ({
       }
     })
   }
-}
-
-/** @param {ValidationIssue[]} issues */
-const truncateActualValues = (issues) => {
-  for (const issue of issues) {
-    if (
-      typeof issue.context?.actual === 'string' &&
-      issue.context.actual.length > MAX_ACTUAL_LENGTH
-    ) {
-      issue.context.actual =
-        issue.context.actual.slice(0, MAX_ACTUAL_LENGTH) + '…'
-    }
-  }
-}
-
-/**
- * Caps the issues array and truncates long actual values for MongoDB storage.
- *
- * Both the issue count and per-issue actual values are bounded to prevent
- * the summary log document exceeding MongoDB's 16 MiB BSON limit.
- * @see https://eaflood.atlassian.net/browse/PAE-1244
- *
- * Fatal issues are always preserved — they determine the summary log status
- * and are required by the frontend to render specific error messages.
- * Non-fatal issues fill the remaining capacity.
- *
- * @param {ValidationIssue[]} allIssues - All validation issues
- * @returns {ValidationIssue[]} The capped, actual-value-truncated issues
- */
-const capIssuesForStorage = (allIssues) => {
-  let cappedIssues
-
-  if (allIssues.length <= MAX_VALIDATION_ISSUES) {
-    cappedIssues = allIssues
-  } else {
-    const fatal = allIssues.filter(
-      (issue) => issue.severity === VALIDATION_SEVERITY.FATAL
-    )
-    const nonFatal = allIssues.filter(
-      (issue) => issue.severity !== VALIDATION_SEVERITY.FATAL
-    )
-    const cappedFatal = fatal.slice(0, MAX_VALIDATION_ISSUES)
-    const nonFatalSlots = Math.max(
-      0,
-      MAX_VALIDATION_ISSUES - cappedFatal.length
-    )
-    cappedIssues = [...cappedFatal, ...nonFatal.slice(0, nonFatalSlots)]
-  }
-
-  truncateActualValues(cappedIssues)
-
-  return cappedIssues
 }

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -14,6 +14,7 @@ import {
   createEmptyLoadCategory,
   createEmptyLoadValidity
 } from './load-counts.js'
+import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
 
@@ -252,6 +253,7 @@ describe('SummaryLogsValidator', () => {
       reportsRepository: /** @type {any} */ ({
         findPeriodicReports: vi.fn().mockResolvedValue([])
       }),
+      overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
       summaryLogExtractor
     })
   })
@@ -678,6 +680,7 @@ describe('SummaryLogsValidator', () => {
       reportsRepository: /** @type {any} */ ({
         findPeriodicReports: vi.fn().mockResolvedValue([])
       }),
+      overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
       summaryLogExtractor
     })
 
@@ -722,6 +725,7 @@ describe('SummaryLogsValidator', () => {
       reportsRepository: /** @type {any} */ ({
         findPeriodicReports: vi.fn().mockRejectedValue(fetchError)
       }),
+      overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
       summaryLogExtractor
     })
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -473,6 +473,7 @@ export const createTestInfrastructure = async (
   ])()
   const summaryLogExtractor = createInMemorySummaryLogExtractor(extractorData)
   const wasteRecordsRepository = createInMemoryWasteRecordsRepository()()
+  const overseasSitesRepository = createInMemoryOverseasSitesRepository([])()
 
   const validateSummaryLog = createSummaryLogsValidator({
     summaryLogsRepository,
@@ -481,6 +482,7 @@ export const createTestInfrastructure = async (
     reportsRepository: /** @type {any} */ ({
       findPeriodicReports: async () => []
     }),
+    overseasSitesRepository,
     summaryLogExtractor,
     logger: mockLogger
   })
@@ -561,17 +563,6 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
     }
   }
 
-  const validateSummaryLog = createSummaryLogsValidator({
-    summaryLogsRepository,
-    organisationsRepository,
-    wasteRecordsRepository,
-    reportsRepository: /** @type {any} */ ({
-      findPeriodicReports: async () => []
-    }),
-    summaryLogExtractor: dynamicExtractor,
-    logger: mockLogger
-  })
-
   const overseasSitesRepository = createInMemoryOverseasSitesRepository([
     {
       id: TEST_OVERSEAS_SITE_ID,
@@ -586,6 +577,18 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
       updatedAt: new Date()
     }
   ])()
+
+  const validateSummaryLog = createSummaryLogsValidator({
+    summaryLogsRepository,
+    organisationsRepository,
+    wasteRecordsRepository,
+    reportsRepository: /** @type {any} */ ({
+      findPeriodicReports: async () => []
+    }),
+    overseasSitesRepository,
+    summaryLogExtractor: dynamicExtractor,
+    logger: mockLogger
+  })
 
   const syncWasteRecords = syncFromSummaryLog({
     extractor: dynamicExtractor,

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
@@ -1,0 +1,121 @@
+import { http, HttpResponse } from 'msw'
+
+import { UPLOAD_STATUS } from '#domain/summary-logs/status.js'
+import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+
+import {
+  asStandardUser,
+  buildGetUrl,
+  buildPostUrl,
+  createExporterRowValues,
+  createUploadPayload,
+  createWasteBalanceMeta,
+  EXPORTER_HEADERS,
+  pollForValidation,
+  setupWasteBalanceIntegrationEnvironment
+} from './integration-test-helpers.js'
+
+describe('loadsByReportingPeriod population at validate time', () => {
+  const { getServer } = setupAuthContext()
+
+  beforeEach(() => {
+    getServer().use(
+      http.post(
+        'http://localhost:3001/v1/organisations/:orgId/registrations/:regId/summary-logs/:summaryLogId/upload-completed',
+        () => HttpResponse.json({ success: true }, { status: 200 })
+      )
+    )
+  })
+
+  const sharedMeta = createWasteBalanceMeta('EXPORTER')
+
+  const createUploadData = (rows) => ({
+    RECEIVED_LOADS_FOR_EXPORT: {
+      location: { sheet: 'Received', row: 7, column: 'A' },
+      headers: EXPORTER_HEADERS,
+      rows: rows.map((row, index) => ({
+        rowNumber: 8 + index,
+        values: createExporterRowValues(row)
+      }))
+    }
+  })
+
+  const uploadAndValidate = async (env, summaryLogId, fileId, uploadData) => {
+    const { server, fileDataMap, organisationId, registrationId } = env
+
+    fileDataMap[fileId] = { meta: sharedMeta, data: uploadData }
+
+    await server.inject({
+      method: 'POST',
+      url: buildPostUrl(organisationId, registrationId, summaryLogId),
+      payload: createUploadPayload(
+        organisationId,
+        registrationId,
+        UPLOAD_STATUS.COMPLETE,
+        fileId,
+        'waste-data.xlsx'
+      )
+    })
+
+    await pollForValidation(
+      server,
+      organisationId,
+      registrationId,
+      summaryLogId
+    )
+
+    const response = await server.inject({
+      method: 'GET',
+      url: buildGetUrl(organisationId, registrationId, summaryLogId),
+      ...asStandardUser({ linkedOrgId: organisationId })
+    })
+
+    return JSON.parse(response.payload)
+  }
+
+  it('splits added loads into balanceAffecting and nonBalanceAffecting by ORS approval', async () => {
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'exporter'
+    })
+
+    // Both loads export on 2025-01-20 (an open period, since no reports are
+    // submitted). Row 100t uses OSR_ID 100, which is approved from 2025-01-01,
+    // so it counts toward the predicted waste-balance delta. Row 200t uses
+    // OSR_ID 999, which has no approved overseas site, so it must be excluded
+    // from the delta exactly as it is at submit time.
+    const uploadData = createUploadData([
+      { rowId: 1001, osrId: 100, exportTonnage: 100 },
+      { rowId: 2001, osrId: 999, exportTonnage: 200 }
+    ])
+
+    const payload = await uploadAndValidate(
+      env,
+      'sl-period-status',
+      'file-period-status',
+      uploadData
+    )
+
+    expect(payload.loadsByReportingPeriod).toEqual({
+      openPeriodLoads: {
+        added: {
+          balanceAffecting: { count: 1, tonnageDelta: 100 },
+          nonBalanceAffecting: { count: 1 }
+        },
+        adjusted: {
+          balanceAffecting: { count: 0, tonnageDelta: 0 },
+          nonBalanceAffecting: { count: 0 }
+        }
+      },
+      closedPeriodLoads: {
+        added: {
+          balanceAffecting: { count: 0, tonnageDelta: 0 },
+          nonBalanceAffecting: { count: 0 }
+        },
+        adjusted: {
+          balanceAffecting: { count: 0, tonnageDelta: 0 },
+          nonBalanceAffecting: { count: 0 }
+        }
+      }
+    })
+  })
+})

--- a/src/server/queue-consumer/summary-log-commands.js
+++ b/src/server/queue-consumer/summary-log-commands.js
@@ -63,6 +63,7 @@ export const summaryLogCommandHandlers = [
         organisationsRepository,
         wasteRecordsRepository,
         reportsRepository,
+        overseasSitesRepository,
         summaryLogExtractor
       } = deps
 
@@ -72,6 +73,7 @@ export const summaryLogCommandHandlers = [
         organisationsRepository,
         wasteRecordsRepository,
         reportsRepository,
+        overseasSitesRepository,
         summaryLogExtractor
       })
 


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)
## What

At validate time, `classifyLoads` passed `ORS_VALIDATION_DISABLED` into the classification context used by `classifyByPeriodStatus`. Now the validate path resolves a real overseas-sites context (gated on the EXPORTER processing type) and threads it through `createSummaryLogsValidator` and `classifyAndPersistResult` into `classifyLoads`, so loads that depend on ORS approval are classified the same way they are at submit time.

## Why

`loadsByReportingPeriod` now drives the predicted waste-balance delta and the open/closed period split shown to the operator on the CMA check page. With ORS validation disabled at validate time, an exporter load whose overseas site is not approved at the export date was counted toward the predicted delta, even though the same load is correctly excluded when the report is submitted. The check page therefore reported an inaccurate predicted balance. Resolving the real ORS context closes that gap, so the preview matches the eventual submitted result.

The resolution mirrors the existing submit-time path in `sync-from-summary-log.js`: only exporters carry overseas sites, so other processing types continue to skip the lookup.

## Changes

- `classify-and-persist.js`: `classifyLoads` takes an `overseasSites` parameter and uses it in the classification context instead of the hardcoded disabled sentinel.
- `validate.js`: adds `resolveOverseasSitesContext`, threads `organisationsRepository` and `overseasSitesRepository` through `classifyAndPersistResult`, and accepts `overseasSitesRepository` on `createSummaryLogsValidator`.
- `summary-log-commands.js`: the validate handler passes the `overseasSitesRepository` from its dependencies into the validator.
- Test harnesses now supply an overseas-sites repository to the validator.
- Adds an integration test asserting that an exporter load with an unapproved overseas site is excluded from the validate-time `loadsByReportingPeriod` balance, while an approved load contributes to it.

[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ