### PR TITLE
PAE-1541: Count cross-period adjustments in both periods

### DIFF
--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -52,7 +52,7 @@ const PERIOD_STATUS = Object.freeze({ OPEN: 'open', CLOSED: 'closed' })
  * @typedef {Object} PeriodStatusEntry
  * @property {'open' | 'closed'} period
  * @property {'added' | 'adjusted'} change
- * @property {number} count - 1 for the record's home leg, 0 for reversal-only legs
+ * @property {number} count - 1 per leg, so a record counts once per period it touches
  * @property {number} tonnageDelta - rounded to 2dp; non-zero means balanceAffecting
  */
 
@@ -183,14 +183,13 @@ const classifyAdjustedRecord = ({
     legs.set(newPeriod, (legs.get(newPeriod) ?? 0) + newAmount)
   }
 
-  // The record's count lives on its "home" leg (new period, or old if new is
-  // null). The caller guards with (newPeriod || oldPeriod), so it is defined.
-  const homePeriod = newPeriod ?? oldPeriod
-
+  // Every period a record touches counts once. A cross-period amendment thus
+  // reads count:1 in both periods with signed deltas (outflow from the old,
+  // inflow into the new), so the period it left does not look empty.
   return [...legs].map(([period, tonnageDelta]) => ({
     period,
     change: 'adjusted',
-    count: period === homePeriod ? 1 : 0,
+    count: 1,
     tonnageDelta: roundToTwoDecimalPlaces(tonnageDelta)
   }))
 }

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -448,9 +448,9 @@ describe('classifyByPeriodStatus', () => {
       expect(
         result.openPeriodLoads.adjusted.balanceAffecting.tonnageDelta
       ).toBe(50)
-      // Count goes to the new period
+      // Each leg the record touches counts once, so both periods read count:1
       expect(result.openPeriodLoads.adjusted.balanceAffecting.count).toBe(1)
-      expect(result.closedPeriodLoads.adjusted.balanceAffecting.count).toBe(0)
+      expect(result.closedPeriodLoads.adjusted.balanceAffecting.count).toBe(1)
     })
 
     it('assigns count to old period when new date is blanked out', () => {


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)
## What

In `loadsByPeriodStatus`, a cross-period amendment (a row whose reporting date moves it from one period to another) now reads `count: 1` in **both** the period it left and the period it joined, rather than placing the count only on the record's home (new) period.

Previously `classifyAdjustedRecord` set `count: 1` solely on the record's home leg and `count: 0` on the reversal-only leg. That made the period the row left read `count: 0` alongside a non-zero `tonnageDelta` (e.g. `closedPeriodLoads.adjusted.balanceAffecting = { count: 0, tonnageDelta: -30 }`). A closed period that will soon need a resubmission prompt therefore looked empty.

Now every period a record touches counts once, with signed deltas as before: a cross-period move reads `count: 1, tonnageDelta: -30` on the closed (outflow) leg and `count: 1, tonnageDelta: +50` on the open (inflow) leg. The deltas already summed to the accurate net impact, so no balance information changes, only the count.

## Why

`count` now means "loads affecting this period" rather than "rows in the upload", so a cross-period row is counted once per period it touches. This is the per-period semantics the check page needs: the period a load left no longer appears empty when it still carries a balance impact awaiting resubmission. It also avoids introducing a separate cross-period sub-structure to carry the same signal.

Follow-up from review on PR #1300.

[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ