### PR TITLE
PAE-1541: Add integration coverage for loads by reporting period

### DIFF
--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -205,113 +205,11 @@ describe('classifyByPeriodStatus', () => {
   })
 
   describe('adjusted records', () => {
-    // The same-period net-delta happy path (re-upload of an existing load) is
-    // exercised at integration level. The cases below cover edges that the
-    // integration submit-then-reupload flow cannot reach directly: net-zero
-    // adjustments, cross-period moves, blanked dates and missing existing
-    // records.
-
-    it('classifies a same-period adjust that nets to zero as nonBalanceAffecting', () => {
-      const existingRecordsMap = new Map([
-        [
-          'received:10001',
-          /** @type {WasteRecord} */ (
-            /** @type {unknown} */ ({
-              type: 'received',
-              rowId: '10001',
-              data: {
-                DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
-                GROSS_WEIGHT: '30'
-              }
-            })
-          )
-        ]
-      ])
-
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        existingRecordsMap,
-        wasteRecords: [
-          buildWasteRecord({
-            data: {
-              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-15',
-              GROSS_WEIGHT: '30'
-            },
-            versionStatus: VERSION_STATUS.UPDATED,
-            previousVersions: [
-              {
-                summaryLog: { id: 'sl-old' },
-                status: VERSION_STATUS.CREATED,
-                data: {
-                  DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
-                  GROSS_WEIGHT: '30'
-                }
-              }
-            ]
-          })
-        ]
-      })
-
-      // Net delta = 30 - 30 = 0, so the row did not affect the balance.
-      expect(result.openPeriodLoads.adjusted.balanceAffecting.count).toBe(0)
-      expect(result.openPeriodLoads.adjusted.nonBalanceAffecting.count).toBe(1)
-    })
-
-    it('splits into two entries when old and new dates are in different periods', () => {
-      const existingRecordsMap = new Map([
-        [
-          'received:10001',
-          /** @type {WasteRecord} */ (
-            /** @type {unknown} */ ({
-              type: 'received',
-              rowId: '10001',
-              data: {
-                DATE_RECEIVED_FOR_REPROCESSING: '2026-01-10',
-                GROSS_WEIGHT: '30'
-              }
-            })
-          )
-        ]
-      ])
-
-      // January is closed, February is open
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        existingRecordsMap,
-        periodicReports: [buildSubmittedReport({ period: 1 })],
-        wasteRecords: [
-          buildWasteRecord({
-            data: {
-              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-15',
-              GROSS_WEIGHT: '50'
-            },
-            versionStatus: VERSION_STATUS.UPDATED,
-            previousVersions: [
-              {
-                summaryLog: { id: 'sl-old' },
-                status: VERSION_STATUS.CREATED,
-                data: {
-                  DATE_RECEIVED_FOR_REPROCESSING: '2026-01-10',
-                  GROSS_WEIGHT: '30'
-                }
-              }
-            ]
-          })
-        ]
-      })
-
-      // Old period (January, closed): -30
-      expect(
-        result.closedPeriodLoads.adjusted.balanceAffecting.tonnageDelta
-      ).toBe(-30)
-      // New period (February, open): +50
-      expect(
-        result.openPeriodLoads.adjusted.balanceAffecting.tonnageDelta
-      ).toBe(50)
-      // Each leg the record touches counts once, so both periods read count:1
-      expect(result.openPeriodLoads.adjusted.balanceAffecting.count).toBe(1)
-      expect(result.closedPeriodLoads.adjusted.balanceAffecting.count).toBe(1)
-    })
+    // The operator-meaningful adjusted outcomes (same-period net delta,
+    // net-zero corrections, cross-period moves and included-to-excluded
+    // reversals) are exercised at integration level via the submit-then-
+    // reupload flow. The cases below cover edges that flow cannot reach
+    // directly: blanked dates, missing existing records and all-null dates.
 
     it('assigns count to old period when new date is blanked out', () => {
       const existingRecordsMap = new Map([
@@ -389,60 +287,6 @@ describe('classifyByPeriodStatus', () => {
       expect(result.openPeriodLoads.adjusted.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 50
-      })
-    })
-
-    it('keeps an included-to-excluded reversal in balanceAffecting', () => {
-      const existingRecordsMap = new Map([
-        [
-          'received:10001',
-          /** @type {WasteRecord} */ (
-            /** @type {unknown} */ ({
-              type: 'received',
-              rowId: '10001',
-              data: {
-                DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
-                GROSS_WEIGHT: '30'
-              }
-            })
-          )
-        ]
-      ])
-
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        existingRecordsMap,
-        wasteRecords: [
-          buildWasteRecord({
-            outcome: ROW_OUTCOME.EXCLUDED,
-            data: {
-              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-15',
-              GROSS_WEIGHT: '0'
-            },
-            versionStatus: VERSION_STATUS.UPDATED,
-            previousVersions: [
-              {
-                summaryLog: { id: 'sl-old' },
-                status: VERSION_STATUS.CREATED,
-                data: {
-                  DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
-                  GROSS_WEIGHT: '30'
-                }
-              }
-            ]
-          })
-        ]
-      })
-
-      // Old amount was 30 (included), new amount is 0 (excluded), same period.
-      // Net delta -30 moved the balance, so the row is balanceAffecting even
-      // though its new version is excluded from the waste balance.
-      expect(result.openPeriodLoads.adjusted.balanceAffecting).toEqual({
-        count: 1,
-        tonnageDelta: -30
-      })
-      expect(result.openPeriodLoads.adjusted.nonBalanceAffecting).toEqual({
-        count: 0
       })
     })
 

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -174,40 +174,6 @@ describe('classifyByPeriodStatus', () => {
     // routes/.../summary-logs/integration.loads-by-period-status.test.js.
     // Only edges unreachable there remain here.
 
-    it('classifies registered-only loads (no balance classifier) as nonBalanceAffecting', () => {
-      // Registered-only schemas have no classifyForWasteBalance, so no load can
-      // contribute to a waste balance. Every transaction amount is 0 and every
-      // load must land in nonBalanceAffecting with no tonnage.
-      const registeredOnlySchemas = /** @type {ProcessingTypeSchemas} */ (
-        /** @type {unknown} */ ({
-          RECEIVED_LOADS_FOR_REPROCESSING: {
-            reportingDateFields: ['MONTH_RECEIVED_FOR_REPROCESSING'],
-            wasteRecordType: 'received',
-            classifyForWasteBalance: null
-          }
-        })
-      )
-
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        tableSchemas: registeredOnlySchemas,
-        wasteRecords: [
-          buildWasteRecord({
-            outcome: ROW_OUTCOME.EXCLUDED,
-            data: {
-              MONTH_RECEIVED_FOR_REPROCESSING: '2026-01-01',
-              GROSS_WEIGHT: '42.5'
-            }
-          })
-        ]
-      })
-
-      expect(result.openPeriodLoads.added.nonBalanceAffecting).toEqual({
-        count: 1
-      })
-      expect(result.openPeriodLoads.added.balanceAffecting.count).toBe(0)
-    })
-
     it('rounds summed tonnageDelta to 2dp so no float noise leaks out', () => {
       // 0.1 + 0.2 = 0.30000000000000004 in IEEE-754. Tonnages are reported
       // to 2dp, so the aggregate must be the exact 0.3, not the noisy float.
@@ -569,45 +535,11 @@ describe('classifyByPeriodStatus', () => {
     })
   })
 
-  describe('quarterly cadence', () => {
-    it('maps months to quarterly periods correctly', () => {
-      // March is Q1, April is Q2
-      // Submit Q1 report, so March is closed, April is open
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        cadence: 'quarterly',
-        periodicReports: [
-          buildSubmittedReport({ cadence: 'quarterly', period: 1 })
-        ],
-        wasteRecords: [
-          buildWasteRecord({
-            rowId: '10001',
-            data: {
-              DATE_RECEIVED_FOR_REPROCESSING: '2026-03-15',
-              GROSS_WEIGHT: '10'
-            }
-          }),
-          buildWasteRecord({
-            rowId: '10002',
-            data: {
-              DATE_RECEIVED_FOR_REPROCESSING: '2026-04-15',
-              GROSS_WEIGHT: '20'
-            }
-          })
-        ]
-      })
-
-      expect(result.closedPeriodLoads.added.balanceAffecting).toEqual({
-        count: 1,
-        tonnageDelta: 10
-      })
-      expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
-        count: 1,
-        tonnageDelta: 20
-      })
-    })
-  })
-
+  // Quarterly-cadence month-to-quarter bucketing (Q1 closed, Q2 open) is
+  // exercised end to end by the registered-only scenario in
+  // routes/.../summary-logs/integration.loads-by-period-status.test.js. This
+  // unit case remains to pin the registered-only YYYY-MM month-only date
+  // string, which the integration data (first-of-month dates) does not cover.
   describe('registered-only YYYY-MM date format', () => {
     it('handles month-only dates correctly', () => {
       const result = classifyByPeriodStatus({

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -77,21 +77,6 @@ const SINGLE_DATE_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
   })
 )
 
-/** @type {ProcessingTypeSchemas} Multi-date-field table schemas (exporter received-loads). */
-const MULTI_DATE_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
-  /** @type {unknown} */ ({
-    RECEIVED_LOADS_FOR_EXPORT: {
-      reportingDateFields: ['DATE_RECEIVED_FOR_EXPORT', 'DATE_OF_EXPORT'],
-      wasteRecordType: 'received',
-      classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
-        outcome: ROW_OUTCOME.INCLUDED,
-        reasons: [],
-        transactionAmount: Number(data.GROSS_WEIGHT) || 0
-      })
-    }
-  })
-)
-
 /** @type {ProcessingTypeSchemas} Registered-only table schemas (monthly dates as YYYY-MM). */
 const REGISTERED_ONLY_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
   /** @type {unknown} */ ({
@@ -183,60 +168,11 @@ describe('classifyByPeriodStatus', () => {
   })
 
   describe('added records', () => {
-    it('classifies an added included record into the open period', () => {
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        wasteRecords: [buildWasteRecord()]
-      })
-
-      expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
-        count: 1,
-        tonnageDelta: 42.5
-      })
-    })
-
-    it('classifies an added included record into the closed period', () => {
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        wasteRecords: [buildWasteRecord()],
-        periodicReports: [buildSubmittedReport()]
-      })
-
-      expect(result.closedPeriodLoads.added.balanceAffecting).toEqual({
-        count: 1,
-        tonnageDelta: 42.5
-      })
-    })
-
-    it('classifies an added record excluded from the balance as nonBalanceAffecting', () => {
-      // A PRN-issued row passes validation (outcome INCLUDED) but is excluded
-      // from the waste balance, so its transaction amount is 0. It moves no
-      // balance and must land in nonBalanceAffecting.
-      const excludedFromBalanceSchemas = /** @type {ProcessingTypeSchemas} */ (
-        /** @type {unknown} */ ({
-          RECEIVED_LOADS_FOR_REPROCESSING: {
-            reportingDateFields: ['DATE_RECEIVED_FOR_REPROCESSING'],
-            wasteRecordType: 'received',
-            classifyForWasteBalance: () => ({
-              outcome: ROW_OUTCOME.EXCLUDED,
-              reasons: [],
-              transactionAmount: 0
-            })
-          }
-        })
-      )
-
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        tableSchemas: excludedFromBalanceSchemas,
-        wasteRecords: [buildWasteRecord()]
-      })
-
-      expect(result.openPeriodLoads.added.nonBalanceAffecting).toEqual({
-        count: 1
-      })
-      expect(result.openPeriodLoads.added.balanceAffecting.count).toBe(0)
-    })
+    // Operator-meaningful added-load behaviour (open period, closed period, and
+    // the balance-excluded -> nonBalanceAffecting split) is exercised at
+    // integration level in
+    // routes/.../summary-logs/integration.loads-by-period-status.test.js.
+    // Only edges unreachable there remain here.
 
     it('classifies registered-only loads (no balance classifier) as nonBalanceAffecting', () => {
       // Registered-only schemas have no classifyForWasteBalance, so no load can
@@ -303,53 +239,11 @@ describe('classifyByPeriodStatus', () => {
   })
 
   describe('adjusted records', () => {
-    it('computes net delta when the period is unchanged', () => {
-      const existingRecordsMap = new Map([
-        [
-          'received:10001',
-          /** @type {WasteRecord} */ (
-            /** @type {unknown} */ ({
-              type: 'received',
-              rowId: '10001',
-              data: {
-                DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
-                GROSS_WEIGHT: '30'
-              }
-            })
-          )
-        ]
-      ])
-
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        existingRecordsMap,
-        wasteRecords: [
-          buildWasteRecord({
-            data: {
-              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-15',
-              GROSS_WEIGHT: '50'
-            },
-            versionStatus: VERSION_STATUS.UPDATED,
-            previousVersions: [
-              {
-                summaryLog: { id: 'sl-old' },
-                status: VERSION_STATUS.CREATED,
-                data: {
-                  DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
-                  GROSS_WEIGHT: '30'
-                }
-              }
-            ]
-          })
-        ]
-      })
-
-      // Same period (February, open) so net delta = 50 - 30 = 20
-      expect(result.openPeriodLoads.adjusted.balanceAffecting).toEqual({
-        count: 1,
-        tonnageDelta: 20
-      })
-    })
+    // The same-period net-delta happy path (re-upload of an existing load) is
+    // exercised at integration level. The cases below cover edges that the
+    // integration submit-then-reupload flow cannot reach directly: net-zero
+    // adjustments, cross-period moves, blanked dates and missing existing
+    // records.
 
     it('classifies a same-period adjust that nets to zero as nonBalanceAffecting', () => {
       const existingRecordsMap = new Map([
@@ -633,49 +527,6 @@ describe('classifyByPeriodStatus', () => {
     })
   })
 
-  describe('closed-wins rule (multiple reporting date fields)', () => {
-    it('classifies a row as closed when one date is in a closed period and another is open', () => {
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        tableSchemas: MULTI_DATE_TABLE_SCHEMAS,
-        periodicReports: [buildSubmittedReport({ period: 1 })],
-        wasteRecords: [
-          buildWasteRecord({
-            data: {
-              DATE_RECEIVED_FOR_EXPORT: '2026-01-15',
-              DATE_OF_EXPORT: '2026-02-10',
-              GROSS_WEIGHT: '42.5'
-            },
-            tableName: 'RECEIVED_LOADS_FOR_EXPORT'
-          })
-        ]
-      })
-
-      expect(result.closedPeriodLoads.added.balanceAffecting.count).toBe(1)
-      expect(result.openPeriodLoads.added.balanceAffecting.count).toBe(0)
-    })
-
-    it('classifies a row as open when all dates are in open periods', () => {
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        tableSchemas: MULTI_DATE_TABLE_SCHEMAS,
-        wasteRecords: [
-          buildWasteRecord({
-            data: {
-              DATE_RECEIVED_FOR_EXPORT: '2026-02-15',
-              DATE_OF_EXPORT: '2026-03-10',
-              GROSS_WEIGHT: '42.5'
-            },
-            tableName: 'RECEIVED_LOADS_FOR_EXPORT'
-          })
-        ]
-      })
-
-      expect(result.openPeriodLoads.added.balanceAffecting.count).toBe(1)
-      expect(result.closedPeriodLoads.added.balanceAffecting.count).toBe(0)
-    })
-  })
-
   describe('skipped records', () => {
     it('skips IGNORED records', () => {
       const result = classifyByPeriodStatus({
@@ -923,35 +774,6 @@ describe('classifyByPeriodStatus', () => {
       expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 10
-      })
-    })
-  })
-
-  describe('aggregation across multiple records', () => {
-    it('sums counts and tonnageDelta across multiple records in the same bucket', () => {
-      const result = classifyByPeriodStatus({
-        ...baseParams,
-        wasteRecords: [
-          buildWasteRecord({
-            rowId: '10001',
-            data: {
-              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
-              GROSS_WEIGHT: '20'
-            }
-          }),
-          buildWasteRecord({
-            rowId: '10002',
-            data: {
-              DATE_RECEIVED_FOR_REPROCESSING: '2026-02-15',
-              GROSS_WEIGHT: '30'
-            }
-          })
-        ]
-      })
-
-      expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
-        count: 2,
-        tonnageDelta: 50
       })
     })
   })

--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -511,7 +511,8 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
   organisationId = new ObjectId().toString(),
   registrationId = new ObjectId().toString(),
   featureFlagOverrides = {},
-  reportsRepository = createInMemoryReportsRepository()()
+  reportsRepository = createInMemoryReportsRepository()(),
+  accredited = true
 } = {}) => {
   const accreditationId = 'ACC-123'
   const summaryLogsRepositoryFactory = createInMemorySummaryLogsRepository()
@@ -524,7 +525,8 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
     accreditationId,
     processingType,
     reprocessingType,
-    material
+    material,
+    accredited
   })
   testOrg.id = organisationId
 
@@ -675,6 +677,7 @@ const createTestSubmitterWorker = ({
  * @param {string} options.processingType
  * @param {string} options.reprocessingType
  * @param {string} options.material
+ * @param {boolean} [options.accredited] - When false, builds a registered-only registration (no accreditation, quarterly cadence)
  * @returns {Object} Test organisation with registrations and accreditations
  */
 const TEST_OVERSEAS_SITE_ID = 'test-overseas-site-100'
@@ -684,7 +687,8 @@ const buildComplexTestOrg = ({
   accreditationId,
   processingType,
   reprocessingType,
-  material
+  material,
+  accredited = true
 }) => {
   const registration = {
     id: registrationId,
@@ -701,37 +705,38 @@ const buildComplexTestOrg = ({
     submittedToRegulator: 'ea',
     validFrom: VALID_FROM,
     validTo: VALID_TO,
-    accreditationId
-  }
-
-  if (processingType === 'exporter') {
-    registration.overseasSites = {
-      100: { overseasSiteId: TEST_OVERSEAS_SITE_ID }
-    }
+    // A registered-only operator has no accreditation, which makes the
+    // registration report on a quarterly cadence rather than monthly.
+    ...(accredited && { accreditationId }),
+    ...(processingType === 'exporter' && {
+      overseasSites: { 100: { overseasSiteId: TEST_OVERSEAS_SITE_ID } }
+    })
   }
 
   return buildOrganisation({
     status: 'active',
     registrations: [registration],
-    accreditations: [
-      {
-        id: accreditationId,
-        accreditationNumber: 'ACC-123',
-        validFrom: VALID_FROM,
-        validTo: VALID_TO,
-        material,
-        submittedToRegulator: 'ea',
-        site: {
-          address: {
-            line1: '123 Test Street',
-            postcode: 'AB1 2CD'
+    accreditations: accredited
+      ? [
+          {
+            id: accreditationId,
+            accreditationNumber: 'ACC-123',
+            validFrom: VALID_FROM,
+            validTo: VALID_TO,
+            material,
+            submittedToRegulator: 'ea',
+            site: {
+              address: {
+                line1: '123 Test Street',
+                postcode: 'AB1 2CD'
+              }
+            },
+            statusHistory: [
+              { status: 'created', updatedAt: '2023-12-01T00:00:00.000Z' },
+              { status: 'approved', updatedAt: '2023-12-15T00:00:00.000Z' }
+            ]
           }
-        },
-        statusHistory: [
-          { status: 'created', updatedAt: '2023-12-01T00:00:00.000Z' },
-          { status: 'approved', updatedAt: '2023-12-15T00:00:00.000Z' }
         ]
-      }
-    ]
+      : []
   })
 }

--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -16,6 +16,7 @@ import { createWasteBalancesRepository } from '#waste-balances/repository/reposi
 import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
 import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
+import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 
 import { createTestServer } from '#test/create-test-server.js'
 import { createMockLogger } from '#test/mock-logger.js'
@@ -509,7 +510,8 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
   material = 'paper',
   organisationId = new ObjectId().toString(),
   registrationId = new ObjectId().toString(),
-  featureFlagOverrides = {}
+  featureFlagOverrides = {},
+  reportsRepository = createInMemoryReportsRepository()()
 } = {}) => {
   const accreditationId = 'ACC-123'
   const summaryLogsRepositoryFactory = createInMemorySummaryLogsRepository()
@@ -582,9 +584,7 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
     summaryLogsRepository,
     organisationsRepository,
     wasteRecordsRepository,
-    reportsRepository: /** @type {any} */ ({
-      findPeriodicReports: async () => []
-    }),
+    reportsRepository,
     overseasSitesRepository,
     summaryLogExtractor: dynamicExtractor,
     logger: mockLogger
@@ -637,7 +637,8 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
     accreditationId,
     fileDataMap,
     streamRepository,
-    systemLogsForBalanceAudit
+    systemLogsForBalanceAudit,
+    reportsRepository
   }
 }
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
@@ -322,6 +322,133 @@ describe('loadsByReportingPeriod population at validate time', () => {
     ).toBe(0)
   })
 
+  it('debits the closed period and credits the open period when a re-upload moves a load across periods', async () => {
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'exporter'
+    })
+    await closeJanuary2025(env)
+
+    // Establish the load wholly within closed January.
+    await upload(
+      env,
+      'sl-move-original',
+      'file-move-original',
+      createUploadData([
+        {
+          rowId: 1001,
+          osrId: 100,
+          exportTonnage: 100,
+          dateReceived: '2025-01-15T00:00:00.000Z',
+          dateReceivedByOsr: '2025-01-18T00:00:00.000Z',
+          exportDate: '2025-01-20T00:00:00.000Z'
+        }
+      ])
+    )
+    await submitAndPoll(env, 'sl-move-original')
+
+    // Re-upload the same row moved wholly into open February.
+    const loadsByReportingPeriod = await uploadAndValidate(
+      env,
+      'sl-move-reupload',
+      'file-move-reupload',
+      createUploadData([
+        {
+          rowId: 1001,
+          osrId: 100,
+          exportTonnage: 100,
+          dateReceived: '2025-02-15T00:00:00.000Z',
+          dateReceivedByOsr: '2025-02-18T00:00:00.000Z',
+          exportDate: '2025-02-20T00:00:00.000Z'
+        }
+      ])
+    )
+
+    // The load leaves closed January (-100) and arrives in open February
+    // (+100); each period it touches counts the load once.
+    expect(
+      loadsByReportingPeriod.closedPeriodLoads.adjusted.balanceAffecting
+    ).toEqual({ count: 1, tonnageDelta: -100 })
+    expect(
+      loadsByReportingPeriod.openPeriodLoads.adjusted.balanceAffecting
+    ).toEqual({ count: 1, tonnageDelta: 100 })
+  })
+
+  it('classifies a re-upload that nets to zero as nonBalanceAffecting', async () => {
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'exporter'
+    })
+
+    await upload(
+      env,
+      'sl-zero-original',
+      'file-zero-original',
+      createUploadData([
+        {
+          rowId: 1001,
+          osrId: 100,
+          exportTonnage: 100,
+          dateReceived: '2025-01-15T00:00:00.000Z'
+        }
+      ])
+    )
+    await submitAndPoll(env, 'sl-zero-original')
+
+    // Re-upload the same row with a corrected received date (still open
+    // January) but unchanged tonnage: a real amendment whose net delta is
+    // zero, so it moves no balance and lands in nonBalanceAffecting.
+    const loadsByReportingPeriod = await uploadAndValidate(
+      env,
+      'sl-zero-reupload',
+      'file-zero-reupload',
+      createUploadData([
+        {
+          rowId: 1001,
+          osrId: 100,
+          exportTonnage: 100,
+          dateReceived: '2025-01-16T00:00:00.000Z'
+        }
+      ])
+    )
+
+    expect(loadsByReportingPeriod.openPeriodLoads.adjusted).toEqual({
+      balanceAffecting: { count: 0, tonnageDelta: 0 },
+      nonBalanceAffecting: { count: 1 }
+    })
+  })
+
+  it('keeps a load amended to PRN-excluded in balanceAffecting as a reversal', async () => {
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'exporter'
+    })
+
+    // Establish an included load contributing 100t to the balance.
+    await upload(
+      env,
+      'sl-reverse-original',
+      'file-reverse-original',
+      createUploadData([{ rowId: 1001, osrId: 100, exportTonnage: 100 }])
+    )
+    await submitAndPoll(env, 'sl-reverse-original')
+
+    // Re-upload the same row PRN-issued, so its new contribution is zero. The
+    // net delta of -100 still moved the balance, so it stays balanceAffecting.
+    const loadsByReportingPeriod = await uploadAndValidate(
+      env,
+      'sl-reverse-reupload',
+      'file-reverse-reupload',
+      createUploadData([
+        { rowId: 1001, osrId: 100, exportTonnage: 100, prnIssued: 'Yes' }
+      ])
+    )
+
+    expect(
+      loadsByReportingPeriod.openPeriodLoads.adjusted.balanceAffecting
+    ).toEqual({ count: 1, tonnageDelta: -100 })
+    expect(
+      loadsByReportingPeriod.openPeriodLoads.adjusted.nonBalanceAffecting.count
+    ).toBe(0)
+  })
+
   // A registered-only operator has no accreditation, so it reports on a
   // quarterly cadence and its loads carry no waste-balance classifier.
   const registeredOnlyMeta = {

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
@@ -22,8 +22,14 @@ import {
   createWasteBalanceMeta,
   EXPORTER_HEADERS,
   pollForValidation,
+  pollWhileStatus,
   setupWasteBalanceIntegrationEnvironment
 } from './integration-test-helpers.js'
+
+// Data tables start with their header at row 7, so data rows begin at row 8.
+const TABLE_HEADER_ROW = 7
+const FIRST_DATA_ROW = TABLE_HEADER_ROW + 1
+const SUBMIT_MAX_POLL_ATTEMPTS = 10
 
 describe('loadsByReportingPeriod population at validate time', () => {
   const { getServer } = setupAuthContext()
@@ -41,10 +47,10 @@ describe('loadsByReportingPeriod population at validate time', () => {
 
   const createUploadData = (rows) => ({
     RECEIVED_LOADS_FOR_EXPORT: {
-      location: { sheet: 'Received', row: 7, column: 'A' },
+      location: { sheet: 'Received', row: TABLE_HEADER_ROW, column: 'A' },
       headers: EXPORTER_HEADERS,
       rows: rows.map((row, index) => ({
-        rowNumber: 8 + index,
+        rowNumber: FIRST_DATA_ROW + index,
         values: createExporterRowValues(row)
       }))
     }
@@ -113,18 +119,16 @@ describe('loadsByReportingPeriod population at validate time', () => {
       ...asStandardUser({ linkedOrgId: organisationId })
     })
 
-    let attempts = 0
-    let status = SUMMARY_LOG_STATUS.SUBMITTING
-    while (status === SUMMARY_LOG_STATUS.SUBMITTING && attempts < 10) {
-      await new Promise((resolve) => setTimeout(resolve, 50))
-      const response = await env.server.inject({
-        method: 'GET',
-        url: buildGetUrl(organisationId, registrationId, summaryLogId),
-        ...asStandardUser({ linkedOrgId: organisationId })
-      })
-      status = JSON.parse(response.payload).status
-      attempts++
-    }
+    await pollWhileStatus(
+      server,
+      organisationId,
+      registrationId,
+      summaryLogId,
+      {
+        waitWhile: SUMMARY_LOG_STATUS.SUBMITTING,
+        maxAttempts: SUBMIT_MAX_POLL_ATTEMPTS
+      }
+    )
   }
 
   // Submits a January 2025 monthly report so loads dated in January fall into a
@@ -487,10 +491,10 @@ describe('loadsByReportingPeriod population at validate time', () => {
 
   const createRegisteredOnlyUploadData = (rows) => ({
     RECEIVED_LOADS_FOR_REPROCESSING: {
-      location: { sheet: 'Received', row: 7, column: 'A' },
+      location: { sheet: 'Received', row: TABLE_HEADER_ROW, column: 'A' },
       headers: REGISTERED_ONLY_RECEIVED_HEADERS,
       rows: rows.map(({ rowId, month }, index) => ({
-        rowNumber: 8 + index,
+        rowNumber: FIRST_DATA_ROW + index,
         values: [
           rowId,
           month,

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
@@ -5,7 +5,10 @@ import {
   SUMMARY_LOG_STATUS,
   UPLOAD_STATUS
 } from '#domain/summary-logs/status.js'
-import { MONTHLY_PERIODS } from '#reports/domain/period-labels.js'
+import {
+  MONTHLY_PERIODS,
+  QUARTERLY_PERIODS
+} from '#reports/domain/period-labels.js'
 import { createAndSubmitReport } from '#reports/repository/contract/test-data.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 
@@ -47,10 +50,16 @@ describe('loadsByReportingPeriod population at validate time', () => {
     }
   })
 
-  const upload = async (env, summaryLogId, fileId, uploadData) => {
+  const upload = async (
+    env,
+    summaryLogId,
+    fileId,
+    uploadData,
+    meta = sharedMeta
+  ) => {
     const { server, fileDataMap, organisationId, registrationId } = env
 
-    fileDataMap[fileId] = { meta: sharedMeta, data: uploadData }
+    fileDataMap[fileId] = { meta, data: uploadData }
 
     await server.inject({
       method: 'POST',
@@ -84,8 +93,14 @@ describe('loadsByReportingPeriod population at validate time', () => {
     return JSON.parse(response.payload).loadsByReportingPeriod
   }
 
-  const uploadAndValidate = async (env, summaryLogId, fileId, uploadData) => {
-    await upload(env, summaryLogId, fileId, uploadData)
+  const uploadAndValidate = async (
+    env,
+    summaryLogId,
+    fileId,
+    uploadData,
+    meta
+  ) => {
+    await upload(env, summaryLogId, fileId, uploadData, meta)
     return getLoadsByReportingPeriod(env, summaryLogId)
   }
 
@@ -302,6 +317,116 @@ describe('loadsByReportingPeriod population at validate time', () => {
     expect(
       loadsByReportingPeriod.openPeriodLoads.adjusted.balanceAffecting
     ).toEqual({ count: 1, tonnageDelta: 50 })
+    expect(
+      loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
+    ).toBe(0)
+  })
+
+  // A registered-only operator has no accreditation, so it reports on a
+  // quarterly cadence and its loads carry no waste-balance classifier.
+  const registeredOnlyMeta = {
+    REGISTRATION_NUMBER: {
+      value: 'REG-123',
+      location: { sheet: 'Cover', row: 1, column: 'B' }
+    },
+    PROCESSING_TYPE: {
+      value: 'REPROCESSOR_REGISTERED_ONLY',
+      location: { sheet: 'Cover', row: 2, column: 'B' }
+    },
+    MATERIAL: {
+      value: 'Paper_and_board',
+      location: { sheet: 'Cover', row: 3, column: 'B' }
+    },
+    TEMPLATE_VERSION: {
+      value: 2.1,
+      location: { sheet: 'Cover', row: 4, column: 'B' }
+    }
+  }
+
+  const REGISTERED_ONLY_RECEIVED_HEADERS = [
+    'ROW_ID',
+    'MONTH_RECEIVED_FOR_REPROCESSING',
+    'NET_WEIGHT',
+    'HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION',
+    'RECYCLABLE_PROPORTION_PERCENTAGE',
+    'TONNAGE_RECEIVED_FOR_RECYCLING',
+    'SUPPLIER_NAME',
+    'SUPPLIER_ADDRESS',
+    'SUPPLIER_POSTCODE',
+    'SUPPLIER_EMAIL',
+    'SUPPLIER_PHONE_NUMBER',
+    'ACTIVITIES_CARRIED_OUT_BY_SUPPLIER'
+  ]
+
+  const createRegisteredOnlyUploadData = (rows) => ({
+    RECEIVED_LOADS_FOR_REPROCESSING: {
+      location: { sheet: 'Received', row: 7, column: 'A' },
+      headers: REGISTERED_ONLY_RECEIVED_HEADERS,
+      rows: rows.map(({ rowId, month }, index) => ({
+        rowNumber: 8 + index,
+        values: [
+          rowId,
+          month,
+          10.5,
+          'Actual weight (100%)',
+          0.95,
+          9.975,
+          'Supplier Co',
+          '1 High St',
+          'SW1A 1AA',
+          'supplier@example.com',
+          '01234567',
+          'Sorting'
+        ]
+      }))
+    }
+  })
+
+  it('classifies registered-only loads by quarter, closing a submitted quarter', async () => {
+    const organisationId = new ObjectId().toString()
+    const registrationId = new ObjectId().toString()
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'reprocessor',
+      accredited: false,
+      organisationId,
+      registrationId
+    })
+
+    // Submit Q1 2025 so a load received in January is closed, while a load
+    // received in April (Q2) stays open.
+    await createAndSubmitReport(env.reportsRepository, {
+      organisationId,
+      registrationId,
+      year: 2025,
+      cadence: 'quarterly',
+      period: QUARTERLY_PERIODS.Q1,
+      startDate: '2025-01-01T00:00:00.000Z',
+      endDate: '2025-03-31T00:00:00.000Z',
+      dueDate: '2025-05-20T00:00:00.000Z'
+    })
+
+    const loadsByReportingPeriod = await uploadAndValidate(
+      env,
+      'sl-quarterly',
+      'file-quarterly',
+      createRegisteredOnlyUploadData([
+        { rowId: 1001, month: '2025-01-01' },
+        { rowId: 1002, month: '2025-04-01' }
+      ]),
+      registeredOnlyMeta
+    )
+
+    // Registered-only loads have no balance classifier, so both are
+    // nonBalanceAffecting; the quarterly split puts Q1 closed and Q2 open.
+    expect(
+      loadsByReportingPeriod.closedPeriodLoads.added.nonBalanceAffecting.count
+    ).toBe(1)
+    expect(
+      loadsByReportingPeriod.openPeriodLoads.added.nonBalanceAffecting.count
+    ).toBe(1)
+    expect(
+      loadsByReportingPeriod.closedPeriodLoads.added.balanceAffecting.count
+    ).toBe(0)
     expect(
       loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
     ).toBe(0)

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
@@ -1,12 +1,19 @@
 import { http, HttpResponse } from 'msw'
+import { ObjectId } from 'mongodb'
 
-import { UPLOAD_STATUS } from '#domain/summary-logs/status.js'
+import {
+  SUMMARY_LOG_STATUS,
+  UPLOAD_STATUS
+} from '#domain/summary-logs/status.js'
+import { MONTHLY_PERIODS } from '#reports/domain/period-labels.js'
+import { createAndSubmitReport } from '#reports/repository/contract/test-data.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 
 import {
   asStandardUser,
   buildGetUrl,
   buildPostUrl,
+  buildSubmitUrl,
   createExporterRowValues,
   createUploadPayload,
   createWasteBalanceMeta,
@@ -40,7 +47,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
     }
   })
 
-  const uploadAndValidate = async (env, summaryLogId, fileId, uploadData) => {
+  const upload = async (env, summaryLogId, fileId, uploadData) => {
     const { server, fileDataMap, organisationId, registrationId } = env
 
     fileDataMap[fileId] = { meta: sharedMeta, data: uploadData }
@@ -63,6 +70,10 @@ describe('loadsByReportingPeriod population at validate time', () => {
       registrationId,
       summaryLogId
     )
+  }
+
+  const getLoadsByReportingPeriod = async (env, summaryLogId) => {
+    const { server, organisationId, registrationId } = env
 
     const response = await server.inject({
       method: 'GET',
@@ -70,8 +81,55 @@ describe('loadsByReportingPeriod population at validate time', () => {
       ...asStandardUser({ linkedOrgId: organisationId })
     })
 
-    return JSON.parse(response.payload)
+    return JSON.parse(response.payload).loadsByReportingPeriod
   }
+
+  const uploadAndValidate = async (env, summaryLogId, fileId, uploadData) => {
+    await upload(env, summaryLogId, fileId, uploadData)
+    return getLoadsByReportingPeriod(env, summaryLogId)
+  }
+
+  const submitAndPoll = async (env, summaryLogId) => {
+    const { server, organisationId, registrationId } = env
+
+    await server.inject({
+      method: 'POST',
+      url: buildSubmitUrl(organisationId, registrationId, summaryLogId),
+      ...asStandardUser({ linkedOrgId: organisationId })
+    })
+
+    let attempts = 0
+    let status = SUMMARY_LOG_STATUS.SUBMITTING
+    while (status === SUMMARY_LOG_STATUS.SUBMITTING && attempts < 10) {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      const response = await env.server.inject({
+        method: 'GET',
+        url: buildGetUrl(organisationId, registrationId, summaryLogId),
+        ...asStandardUser({ linkedOrgId: organisationId })
+      })
+      status = JSON.parse(response.payload).status
+      attempts++
+    }
+  }
+
+  // Submits a January 2025 monthly report so loads dated in January fall into a
+  // closed reporting period. The org is accredited, so its cadence is monthly.
+  const closeJanuary2025 = (env) =>
+    createAndSubmitReport(env.reportsRepository, {
+      organisationId: env.organisationId,
+      registrationId: env.registrationId,
+      year: 2025,
+      cadence: 'monthly',
+      period: MONTHLY_PERIODS.January,
+      startDate: '2025-01-01T00:00:00.000Z',
+      endDate: '2025-01-31T00:00:00.000Z',
+      dueDate: '2025-02-20T00:00:00.000Z'
+    })
+
+  const emptyChange = () => ({
+    balanceAffecting: { count: 0, tonnageDelta: 0 },
+    nonBalanceAffecting: { count: 0 }
+  })
 
   it('splits added loads into balanceAffecting and nonBalanceAffecting by ORS approval', async () => {
     const env = await setupWasteBalanceIntegrationEnvironment({
@@ -83,39 +141,169 @@ describe('loadsByReportingPeriod population at validate time', () => {
     // so it counts toward the predicted waste-balance delta. Row 200t uses
     // OSR_ID 999, which has no approved overseas site, so it must be excluded
     // from the delta exactly as it is at submit time.
-    const uploadData = createUploadData([
-      { rowId: 1001, osrId: 100, exportTonnage: 100 },
-      { rowId: 2001, osrId: 999, exportTonnage: 200 }
-    ])
-
-    const payload = await uploadAndValidate(
+    const loadsByReportingPeriod = await uploadAndValidate(
       env,
       'sl-period-status',
       'file-period-status',
-      uploadData
+      createUploadData([
+        { rowId: 1001, osrId: 100, exportTonnage: 100 },
+        { rowId: 2001, osrId: 999, exportTonnage: 200 }
+      ])
     )
 
-    expect(payload.loadsByReportingPeriod).toEqual({
+    expect(loadsByReportingPeriod).toEqual({
       openPeriodLoads: {
         added: {
           balanceAffecting: { count: 1, tonnageDelta: 100 },
           nonBalanceAffecting: { count: 1 }
         },
-        adjusted: {
-          balanceAffecting: { count: 0, tonnageDelta: 0 },
-          nonBalanceAffecting: { count: 0 }
-        }
+        adjusted: emptyChange()
       },
       closedPeriodLoads: {
-        added: {
-          balanceAffecting: { count: 0, tonnageDelta: 0 },
-          nonBalanceAffecting: { count: 0 }
-        },
-        adjusted: {
-          balanceAffecting: { count: 0, tonnageDelta: 0 },
-          nonBalanceAffecting: { count: 0 }
-        }
+        added: emptyChange(),
+        adjusted: emptyChange()
       }
     })
+  })
+
+  it('classifies a PRN-issued added load as nonBalanceAffecting in the open period', async () => {
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'exporter'
+    })
+
+    // A PRN/PERN-issued load passes validation but is excluded from the waste
+    // balance, so it moves no tonnage and lands in nonBalanceAffecting.
+    const loadsByReportingPeriod = await uploadAndValidate(
+      env,
+      'sl-prn',
+      'file-prn',
+      createUploadData([
+        { rowId: 1001, osrId: 100, exportTonnage: 100, prnIssued: 'Yes' }
+      ])
+    )
+
+    expect(loadsByReportingPeriod.openPeriodLoads.added).toEqual({
+      balanceAffecting: { count: 0, tonnageDelta: 0 },
+      nonBalanceAffecting: { count: 1 }
+    })
+  })
+
+  it('classifies an added load dated in a closed period as a closed-period load', async () => {
+    const organisationId = new ObjectId().toString()
+    const registrationId = new ObjectId().toString()
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'exporter',
+      organisationId,
+      registrationId
+    })
+    await closeJanuary2025(env)
+
+    // The load's export dates are all in January 2025, which is now closed.
+    const loadsByReportingPeriod = await uploadAndValidate(
+      env,
+      'sl-closed',
+      'file-closed',
+      createUploadData([{ rowId: 1001, osrId: 100, exportTonnage: 100 }])
+    )
+
+    expect(
+      loadsByReportingPeriod.closedPeriodLoads.added.balanceAffecting
+    ).toEqual({ count: 1, tonnageDelta: 100 })
+    expect(
+      loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
+    ).toBe(0)
+  })
+
+  it('applies closed-wins when one date field is closed and another is open', async () => {
+    const organisationId = new ObjectId().toString()
+    const registrationId = new ObjectId().toString()
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'exporter',
+      organisationId,
+      registrationId
+    })
+    await closeJanuary2025(env)
+
+    // DATE_RECEIVED_FOR_EXPORT is in closed January; DATE_OF_EXPORT is in open
+    // February. Either date in a closed period forces the load closed.
+    const loadsByReportingPeriod = await uploadAndValidate(
+      env,
+      'sl-closed-wins',
+      'file-closed-wins',
+      createUploadData([
+        {
+          rowId: 1001,
+          osrId: 100,
+          exportTonnage: 100,
+          dateReceived: '2025-01-15T00:00:00.000Z',
+          dateReceivedByOsr: '2025-02-08T00:00:00.000Z',
+          exportDate: '2025-02-10T00:00:00.000Z'
+        }
+      ])
+    )
+
+    expect(
+      loadsByReportingPeriod.closedPeriodLoads.added.balanceAffecting.count
+    ).toBe(1)
+    expect(
+      loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
+    ).toBe(0)
+  })
+
+  it('aggregates count and tonnageDelta across multiple loads in the same period', async () => {
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'exporter'
+    })
+
+    const loadsByReportingPeriod = await uploadAndValidate(
+      env,
+      'sl-aggregate',
+      'file-aggregate',
+      createUploadData([
+        { rowId: 1001, osrId: 100, exportTonnage: 100 },
+        { rowId: 1002, osrId: 100, exportTonnage: 200 }
+      ])
+    )
+
+    expect(
+      loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting
+    ).toEqual({
+      count: 2,
+      tonnageDelta: 300
+    })
+  })
+
+  it('classifies a re-uploaded load as an adjusted net delta in the open period', async () => {
+    const organisationId = new ObjectId().toString()
+    const registrationId = new ObjectId().toString()
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'exporter',
+      organisationId,
+      registrationId
+    })
+
+    // First submission establishes the load at 100t.
+    await upload(
+      env,
+      'sl-original',
+      'file-original',
+      createUploadData([{ rowId: 1001, osrId: 100, exportTonnage: 100 }])
+    )
+    await submitAndPoll(env, 'sl-original')
+
+    // Re-upload the same row at 150t (same open period): net delta +50.
+    const loadsByReportingPeriod = await uploadAndValidate(
+      env,
+      'sl-reupload',
+      'file-reupload',
+      createUploadData([{ rowId: 1001, osrId: 100, exportTonnage: 150 }])
+    )
+
+    expect(
+      loadsByReportingPeriod.openPeriodLoads.adjusted.balanceAffecting
+    ).toEqual({ count: 1, tonnageDelta: 50 })
+    expect(
+      loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
+    ).toBe(0)
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)
## What

Lifts the operator-meaningful `loadsByReportingPeriod` classification scenarios from the `period-status` unit suite up to integration level, exercising the real validate path (`createSummaryLogsValidator`) through the HTTP harness rather than calling the classifier in isolation.

Integration scenarios now covered against the real upload-then-validate flow:

- Added loads split into balance-affecting and non-balance-affecting by overseas-site approval
- A PRN/PERN-issued load excluded from the waste balance landing in non-balance-affecting
- An added load dated in a closed reporting period
- The closed-wins rule when one reporting date field is closed and another is open
- Aggregation of count and tonnage across multiple loads in the same period
- A re-uploaded load adjusted within the same open period (net tonnage delta)
- A re-uploaded load moved across periods, debiting the closed period and crediting the open one
- A re-upload that nets to zero landing in non-balance-affecting
- A load amended to PRN-excluded staying balance-affecting as a reversal
- A registered-only operator on a quarterly cadence, with one quarter closed by a submitted report and the next still open

## Why

These behaviours drive the predicted waste-balance figures shown on the check page, so they are best guarded at the layer an operator actually hits: a real upload, validation and read-back. Unit-only coverage of the pure classifier could drift from the wiring that feeds it.

## Changes

- The integration test harness (`integration-test-helpers.js`) now wires a real in-memory reports repository into the validator instead of a stub, and returns it, so tests can submit periodic reports and exercise closed periods. Adjusted-load scenarios use the submit-then-re-upload flow.
- The harness can build a registered-only (non-accredited) organisation, which reports on a quarterly cadence, so quarterly month-to-quarter bucketing is exercised end to end.
- The `period-status` unit suite is pruned to the genuine edge cases that cannot be reached, or are awkward to force, at integration level: float rounding, null and blanked dates, Date-object dates, missing existing records, unknown table schemas, cadence-mismatch and report-status branches, the registered-only month-only date string, and skipped IGNORED/unchanged rows.


[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ