### PR TITLE
PAE-1554: Add submissionNumber to report period routes

### DIFF
--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -32,8 +32,9 @@ function findReportIdBySubmissionNumber(
     cadence
   ]?.[period]
   if (!slot) return null
-  if (slot.current?.submissionNumber === submissionNumber)
-    {return slot.current.id}
+  if (slot.current?.submissionNumber === submissionNumber) {
+    return slot.current.id
+  }
   const previous = slot.previousSubmissions?.find(
     (s) => s.submissionNumber === submissionNumber
   )

--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -31,7 +31,9 @@ function findReportIdBySubmissionNumber(
   const slot = periodicReports.find((pr) => pr.year === year)?.reports?.[
     cadence
   ]?.[period]
-  if (!slot) return null
+  if (!slot) {
+    return null
+  }
   if (slot.current?.submissionNumber === submissionNumber) {
     return slot.current.id
   }

--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -12,48 +12,65 @@ import { errorCodes } from '#reports/enums/error-codes.js'
  */
 
 /**
- * Finds the current report ID for a specific period slot within periodic reports.
- * @param {import('#reports/repository/port.js').PeriodicReport[]} periodicReports
+ * Finds the report ID for a specific submission number within periodic reports,
+ * checking both the current slot and previous submissions.
+ * @param {PeriodicReport[]} periodicReports
  * @param {number} year
  * @param {string} cadence
  * @param {number} period
+ * @param {number} submissionNumber
  * @returns {string|null}
  */
-function findCurrentReportId(periodicReports, year, cadence, period) {
+function findReportIdBySubmissionNumber(
+  periodicReports,
+  year,
+  cadence,
+  period,
+  submissionNumber
+) {
   const slot = periodicReports.find((pr) => pr.year === year)?.reports?.[
     cadence
   ]?.[period]
-  return slot?.current?.id ?? slot?.previousSubmissions?.[0]?.id ?? null
+  if (!slot) return null
+  if (slot.current?.submissionNumber === submissionNumber)
+    {return slot.current.id}
+  const previous = slot.previousSubmissions?.find(
+    (s) => s.submissionNumber === submissionNumber
+  )
+  return previous?.id ?? null
 }
 
 /**
- * Looks up the stored report for a period, if one exists.
+ * Looks up a stored report for a specific period and submission number.
  * @param {import('#reports/repository/port.js').ReportsRepository} reportsRepository
  * @param {string} organisationId
  * @param {string} registrationId
  * @param {number} year
  * @param {string} cadence
  * @param {number} period
+ * @param {number} submissionNumber
  * @returns {Promise<import('#reports/repository/port.js').Report | null>}
  */
-export async function fetchCurrentReport(
+export async function fetchReportBySubmissionNumber(
   reportsRepository,
   organisationId,
   registrationId,
   year,
   cadence,
-  period
+  period,
+  submissionNumber
 ) {
   const periodicReports = await reportsRepository.findPeriodicReports({
     organisationId,
     registrationId
   })
 
-  const currentReportId = findCurrentReportId(
+  const currentReportId = findReportIdBySubmissionNumber(
     periodicReports,
     year,
     cadence,
-    period
+    period,
+    submissionNumber
   )
 
   if (!currentReportId) {
@@ -154,8 +171,20 @@ const assertPeriodEnded = (periodInfo, period, cadence) => {
  * @param {number} period
  * @returns {void}
  */
-const assertNoExistingReport = (periodicReports, year, cadence, period) => {
-  const id = findCurrentReportId(periodicReports, year, cadence, period)
+const assertNoExistingReport = (
+  periodicReports,
+  year,
+  cadence,
+  period,
+  submissionNumber
+) => {
+  const id = findReportIdBySubmissionNumber(
+    periodicReports,
+    year,
+    cadence,
+    period,
+    submissionNumber
+  )
   if (id) {
     throw conflict(
       `Report already exists for ${cadence} period ${period} of ${year}`,
@@ -222,6 +251,7 @@ function buildReportData(aggregated, registration) {
  * @param {number} params.year
  * @param {string} params.cadence
  * @param {number} params.period
+ * @param {number} params.submissionNumber
  * @returns {Promise<import('#reports/repository/port.js').Report | import('#reports/domain/aggregation/aggregate-report-detail.js').AggregatedReportDetail>}
  */
 export async function fetchOrGenerateReportForPeriod({
@@ -234,15 +264,17 @@ export async function fetchOrGenerateReportForPeriod({
   registration,
   year,
   cadence,
-  period
+  period,
+  submissionNumber
 }) {
-  const storedReport = await fetchCurrentReport(
+  const storedReport = await fetchReportBySubmissionNumber(
     reportsRepository,
     organisationId,
     registrationId,
     year,
     cadence,
-    period
+    period,
+    submissionNumber
   )
 
   if (storedReport) {
@@ -327,6 +359,7 @@ async function getAggregatedReportDetail({
  * @param {number} params.year
  * @param {string} params.cadence
  * @param {number} params.period
+ * @param {number} params.submissionNumber
  * @param {import('#reports/repository/port.js').UserSummary} params.changedBy
  * @returns {Promise<import('#reports/repository/port.js').Report>}
  */
@@ -341,6 +374,7 @@ export async function createReportForPeriod({
   year,
   cadence,
   period,
+  submissionNumber,
   changedBy
 }) {
   const { startDate, endDate, dueDate } = getValidatedPeriodInfo(
@@ -354,7 +388,13 @@ export async function createReportForPeriod({
     registrationId
   })
 
-  assertNoExistingReport(periodicReports, year, cadence, period)
+  assertNoExistingReport(
+    periodicReports,
+    year,
+    cadence,
+    period,
+    submissionNumber
+  )
 
   const operatorCategory = getOperatorCategory(registration)
   const wasteRecords = await wasteRecordsRepository.findByRegistration(
@@ -382,6 +422,7 @@ export async function createReportForPeriod({
     startDate,
     endDate,
     dueDate,
+    submissionNumber,
     changedBy,
     ...buildReportData(aggregatedReportData, registration)
   })

--- a/src/reports/application/report-service.test.js
+++ b/src/reports/application/report-service.test.js
@@ -1,13 +1,18 @@
 import { ObjectId } from 'mongodb'
-import { REPORT_STATUS } from '#reports/domain/report-status.js'
+import {
+  REPORT_STATUS,
+  REPORT_STATUS_SLOT
+} from '#reports/domain/report-status.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { buildAwaitingAcceptancePrn } from '#packaging-recycling-notes/repository/contract/test-data.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
+import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import {
   fetchOrGenerateReportForPeriod,
-  createReportForPeriod
+  createReportForPeriod,
+  fetchReportBySubmissionNumber
 } from './report-service.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
@@ -69,6 +74,11 @@ const buildWasteRecordsRepository = (params) =>
     }
   ])()
 
+const createPrnRepo = (initialData = []) =>
+  createInMemoryPackagingRecyclingNotesRepository(initialData)(
+    /** @type {any} */ (null)
+  )
+
 const defaultParams = () => {
   const organisationId = new ObjectId().toString()
   const registration = buildRegistration()
@@ -78,7 +88,9 @@ const defaultParams = () => {
     registration,
     year: 2024,
     cadence: 'monthly',
-    period: 1
+    period: 1,
+    submissionNumber: 1,
+    overseasSitesRepository: createInMemoryOverseasSitesRepository()()
   }
 }
 
@@ -87,8 +99,7 @@ describe('report-service', () => {
     it('returns computed report when no stored report exists', async () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const wasteRecordsRepository = createInMemoryWasteRecordsRepository([])()
-      const packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository()()
+      const packagingRecyclingNotesRepository = createPrnRepo()
       const params = defaultParams()
 
       const report = await fetchOrGenerateReportForPeriod({
@@ -100,14 +111,13 @@ describe('report-service', () => {
 
       expect(report.recyclingActivity).toBeDefined()
       expect(report.wasteSent).toBeDefined()
-      expect(report.id).toBeUndefined()
+      expect(report).not.toHaveProperty('id')
     })
 
     it('returns stored report when one exists', async () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const wasteRecordsRepository = createInMemoryWasteRecordsRepository([])()
-      const packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository()()
+      const packagingRecyclingNotesRepository = createPrnRepo()
       const params = defaultParams()
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
 
@@ -117,6 +127,7 @@ describe('report-service', () => {
         year: 2024,
         cadence: 'monthly',
         period: 1,
+        submissionNumber: 1,
         startDate: '2024-01-01',
         endDate: '2024-01-31',
         dueDate: '2024-02-15',
@@ -149,8 +160,74 @@ describe('report-service', () => {
         ...params
       })
 
-      expect(report.id).toBeDefined()
-      expect(report.status.currentStatus).toBe(REPORT_STATUS.IN_PROGRESS)
+      const storedReport =
+        /** @type {import('#reports/repository/port.js').Report} */ (report)
+      expect(storedReport.id).toBeDefined()
+      expect(storedReport.status.currentStatus).toBe(REPORT_STATUS.IN_PROGRESS)
+    })
+
+    it('returns stored report when submissionNumber matches a previous submission', async () => {
+      const reportsRepository = createInMemoryReportsRepository()()
+      const wasteRecordsRepository = createInMemoryWasteRecordsRepository([])()
+      const packagingRecyclingNotesRepository = createPrnRepo()
+      const params = defaultParams()
+      const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
+
+      const baseReport = {
+        organisationId: params.organisationId,
+        registrationId: params.registrationId,
+        year: 2024,
+        cadence: 'monthly',
+        period: 1,
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+        dueDate: '2024-02-15',
+        changedBy,
+        material: 'plastic',
+        wasteProcessingType: 'reprocessor',
+        source: { summaryLogId: 'sl-1', lastUploadedAt: null },
+        prn: null,
+        recyclingActivity: {
+          suppliers: [],
+          totalTonnageReceived: 0,
+          tonnageRecycled: null,
+          tonnageNotRecycled: null
+        },
+        wasteSent: {
+          tonnageSentToReprocessor: 0,
+          tonnageSentToExporter: 0,
+          tonnageSentToAnotherSite: 0,
+          finalDestinations: []
+        }
+      }
+
+      const report1 = await reportsRepository.createReport({
+        ...baseReport,
+        submissionNumber: 1
+      })
+      await reportsRepository.updateReportStatus({
+        reportId: report1.id,
+        version: 1,
+        status: 'submitted',
+        slot: REPORT_STATUS_SLOT.SUBMITTED,
+        changedBy
+      })
+      await reportsRepository.createReport({
+        ...baseReport,
+        submissionNumber: 2
+      })
+
+      const report = await fetchOrGenerateReportForPeriod({
+        reportsRepository,
+        wasteRecordsRepository,
+        packagingRecyclingNotesRepository,
+        ...params,
+        submissionNumber: 1
+      })
+
+      const storedReport =
+        /** @type {import('#reports/repository/port.js').Report} */ (report)
+      expect(storedReport.id).toBe(report1.id)
     })
 
     it('returns computed report with aggregated waste data', async () => {
@@ -164,8 +241,7 @@ describe('report-service', () => {
         }
       ])()
       const reportsRepository = createInMemoryReportsRepository()()
-      const packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository()()
+      const packagingRecyclingNotesRepository = createPrnRepo()
 
       const report = await fetchOrGenerateReportForPeriod({
         reportsRepository,
@@ -174,10 +250,63 @@ describe('report-service', () => {
         ...params
       })
 
-      expect(report.recyclingActivity.suppliers).toHaveLength(1)
-      expect(report.recyclingActivity.suppliers[0].supplierName).toBe(
+      expect(report.recyclingActivity?.suppliers).toHaveLength(1)
+      expect(report.recyclingActivity?.suppliers[0]?.supplierName).toBe(
         'Supplier A'
       )
+    })
+  })
+
+  describe('fetchReportBySubmissionNumber', () => {
+    const baseReportFields = (params, changedBy) => ({
+      organisationId: params.organisationId,
+      registrationId: params.registrationId,
+      year: 2024,
+      cadence: 'monthly',
+      period: 1,
+      startDate: '2024-01-01',
+      endDate: '2024-01-31',
+      dueDate: '2024-02-15',
+      changedBy,
+      material: 'plastic',
+      wasteProcessingType: 'reprocessor',
+      source: { summaryLogId: 'sl-1', lastUploadedAt: null },
+      prn: null,
+      recyclingActivity: {
+        suppliers: [],
+        totalTonnageReceived: 0,
+        tonnageRecycled: null,
+        tonnageNotRecycled: null
+      },
+      wasteSent: {
+        tonnageSentToReprocessor: 0,
+        tonnageSentToExporter: 0,
+        tonnageSentToAnotherSite: 0,
+        finalDestinations: []
+      }
+    })
+
+    it('returns null when submissionNumber does not match current or any previous submission', async () => {
+      const reportsRepository = createInMemoryReportsRepository()()
+      const params = defaultParams()
+      const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
+
+      await reportsRepository.createReport({
+        ...baseReportFields(params, changedBy),
+        submissionNumber: 1
+      })
+
+      const result = await fetchReportBySubmissionNumber(
+        reportsRepository,
+        params.organisationId,
+        params.registrationId,
+        2024,
+        'monthly',
+        1,
+        99
+      )
+
+      expect(result).toBeNull()
     })
   })
 
@@ -186,8 +315,7 @@ describe('report-service', () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const params = defaultParams()
       const wasteRecordsRepository = buildWasteRecordsRepository(params)
-      const packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository()()
+      const packagingRecyclingNotesRepository = createPrnRepo()
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
 
       const report = await createReportForPeriod({
@@ -209,8 +337,7 @@ describe('report-service', () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const params = defaultParams()
       const wasteRecordsRepository = buildWasteRecordsRepository(params)
-      const packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository()()
+      const packagingRecyclingNotesRepository = createPrnRepo()
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
 
       await createReportForPeriod({
@@ -235,8 +362,7 @@ describe('report-service', () => {
     it('throws badRequest for period that has not yet ended', async () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const wasteRecordsRepository = createInMemoryWasteRecordsRepository([])()
-      const packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository()()
+      const packagingRecyclingNotesRepository = createPrnRepo()
       const params = defaultParams()
       params.year = 2099
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
@@ -260,8 +386,7 @@ describe('report-service', () => {
         glassRecyclingProcess: ['glass_re_melt']
       })
       const wasteRecordsRepository = buildWasteRecordsRepository(params)
-      const packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository()()
+      const packagingRecyclingNotesRepository = createPrnRepo()
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
 
       const report = await createReportForPeriod({
@@ -279,8 +404,7 @@ describe('report-service', () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const params = defaultParams()
       const wasteRecordsRepository = buildWasteRecordsRepository(params)
-      const packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository()()
+      const packagingRecyclingNotesRepository = createPrnRepo()
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
 
       const report = await createReportForPeriod({
@@ -312,7 +436,14 @@ describe('report-service', () => {
           status: {
             currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
             currentStatusAt: IN_PERIOD,
-            issued: { at: IN_PERIOD, by: { id: 'test', name: 'test' } }
+            issued: { at: IN_PERIOD, by: { id: 'test', name: 'test' } },
+            history: [
+              {
+                status: PRN_STATUS.AWAITING_ACCEPTANCE,
+                at: IN_PERIOD,
+                by: { id: 'test', name: 'test' }
+              }
+            ]
           }
         })
 
@@ -321,7 +452,7 @@ describe('report-service', () => {
         const params = defaultParams()
         params.registration = buildRegistration({ accreditationId: undefined })
         const wasteRecordsRepository = buildWasteRecordsRepository(params)
-        const prnRepo = createInMemoryPackagingRecyclingNotesRepository()()
+        const prnRepo = createPrnRepo()
 
         const report = await createReportForPeriod({
           reportsRepository,
@@ -338,7 +469,7 @@ describe('report-service', () => {
         const reportsRepository = createInMemoryReportsRepository()()
         const params = defaultParams()
         const wasteRecordsRepository = buildWasteRecordsRepository(params)
-        const prnRepo = createInMemoryPackagingRecyclingNotesRepository()()
+        const prnRepo = createPrnRepo()
 
         const report = await createReportForPeriod({
           reportsRepository,
@@ -348,14 +479,14 @@ describe('report-service', () => {
           changedBy
         })
 
-        expect(report.prn.issuedTonnage).toBe(0)
+        expect(report.prn?.issuedTonnage).toBe(0)
       })
 
       it('persists prn with summed issuedTonnage from PRNs in period', async () => {
         const reportsRepository = createInMemoryReportsRepository()()
         const params = defaultParams()
         const wasteRecordsRepository = buildWasteRecordsRepository(params)
-        const prnRepo = createInMemoryPackagingRecyclingNotesRepository()()
+        const prnRepo = createPrnRepo()
 
         await prnRepo.create(
           buildIssuedPrn(params.registration.accreditationId, 30)
@@ -372,7 +503,7 @@ describe('report-service', () => {
           changedBy
         })
 
-        expect(report.prn.issuedTonnage).toBe(50)
+        expect(report.prn?.issuedTonnage).toBe(50)
       })
     })
   })

--- a/src/reports/domain/merge-reporting-periods.js
+++ b/src/reports/domain/merge-reporting-periods.js
@@ -36,6 +36,7 @@ function indexPersistedSlots(periodicReports, cadence) {
  *   startDate: string;
  *   endDate: string;
  *   dueDate: string;
+ *   submissionNumber: number;
  *   report: ReportSummary | null;
  * }} MergedPeriod
  */
@@ -71,6 +72,7 @@ export function mergeReportingPeriods(
       startDate: cp.startDate,
       endDate: cp.endDate,
       dueDate: cp.dueDate,
+      submissionNumber: slot?.current?.submissionNumber ?? 1,
       report: slot?.current ?? null
     })
   }
@@ -86,6 +88,7 @@ export function mergeReportingPeriods(
       startDate: slot.startDate,
       endDate: slot.endDate,
       dueDate: slot.dueDate,
+      submissionNumber: slot.current.submissionNumber,
       report: slot.current
     })
   }

--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -148,7 +148,7 @@
 /**
  * Curated subset of ReportSummary used for list-style responses
  * (e.g. the reports calendar). Excludes heavy activity payloads.
- * @typedef {Pick<ReportSummary, 'id' | 'status' | 'submittedAt' | 'submittedBy'>} ReportListItem
+ * @typedef {Pick<ReportSummary, 'id' | 'status' | 'submissionNumber' | 'submittedAt' | 'submittedBy'>} ReportListItem
  */
 
 /**

--- a/src/reports/routes/delete.js
+++ b/src/reports/routes/delete.js
@@ -11,7 +11,7 @@ import {
 } from './shared.js'
 
 export const reportsDeletePath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/submissions/{submissionNumber}'
 
 export const reportsDelete = {
   method: 'DELETE',

--- a/src/reports/routes/delete.js
+++ b/src/reports/routes/delete.js
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import Boom from '@hapi/boom'
 import { auditReportDelete } from '#reports/application/audit.js'
-import { fetchCurrentReport } from '#reports/application/report-service.js'
+import { fetchReportBySubmissionNumber } from '#reports/application/report-service.js'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
 import {
   periodParamsSchema,
@@ -11,7 +11,7 @@ import {
 } from './shared.js'
 
 export const reportsDeletePath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}'
 
 export const reportsDelete = {
   method: 'DELETE',
@@ -32,14 +32,16 @@ export const reportsDelete = {
     const { organisationId, registrationId, cadence } = params
     const year = Number(params.year)
     const period = Number(params.period)
+    const submissionNumber = Number(params.submissionNumber)
 
-    const report = await fetchCurrentReport(
+    const report = await fetchReportBySubmissionNumber(
       reportsRepository,
       organisationId,
       registrationId,
       year,
       cadence,
-      period
+      period,
+      submissionNumber
     )
 
     if (!report) {

--- a/src/reports/routes/delete.test.js
+++ b/src/reports/routes/delete.test.js
@@ -24,7 +24,7 @@ describe(`DELETE ${reportsDeletePath}`, () => {
   setupAuthContext()
 
   const makeUrl = (orgId, regId, year, cadence, period, submissionNumber = 1) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
 
   describe('when feature flag is enabled', () => {
     const createServerWithReport = async (registrationOverrides = {}) => {

--- a/src/reports/routes/delete.test.js
+++ b/src/reports/routes/delete.test.js
@@ -23,8 +23,8 @@ vi.mock('#reports/application/audit.js', () => ({
 describe(`DELETE ${reportsDeletePath}`, () => {
   setupAuthContext()
 
-  const makeUrl = (orgId, regId, year, cadence, period) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}`
+  const makeUrl = (orgId, regId, year, cadence, period, submissionNumber = 1) =>
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
 
   describe('when feature flag is enabled', () => {
     const createServerWithReport = async (registrationOverrides = {}) => {
@@ -58,7 +58,7 @@ describe(`DELETE ${reportsDeletePath}`, () => {
           wasteRecordsRepository: createInMemoryWasteRecordsRepository([]),
           reportsRepository: reportsRepositoryFactory
         },
-        featureFlags: createInMemoryFeatureFlags({ reports: true })
+        featureFlags: createInMemoryFeatureFlags()
       })
 
       return {
@@ -85,7 +85,7 @@ describe(`DELETE ${reportsDeletePath}`, () => {
           wasteRecordsRepository: createInMemoryWasteRecordsRepository([]),
           reportsRepository: createInMemoryReportsRepository()
         },
-        featureFlags: createInMemoryFeatureFlags({ reports: true })
+        featureFlags: createInMemoryFeatureFlags()
       })
 
       return {
@@ -293,7 +293,7 @@ describe(`DELETE ${reportsDeletePath}`, () => {
 
       const server = await createTestServer({
         repositories: {},
-        featureFlags: createInMemoryFeatureFlags({ reports: false })
+        featureFlags: createInMemoryFeatureFlags()
       })
 
       const response = await server.inject({

--- a/src/reports/routes/get-detail.js
+++ b/src/reports/routes/get-detail.js
@@ -12,11 +12,11 @@ import { ROLES, SCOPES } from '#common/helpers/auth/constants.js'
  * @import { WasteRecordsRepository } from '#repositories/waste-records/port.js'
  * @import { PackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/port.js'
  * @import { OverseasSitesRepository } from '#overseas-sites/repository/port.js'
- * @import { PeriodPathParams } from './shared.js'
+ * @import { PeriodWithSubmissionPathParams } from './shared.js'
  */
 
 export const reportsGetDetailPath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}'
 
 export const reportsGetDetail = {
   method: 'GET',
@@ -30,7 +30,7 @@ export const reportsGetDetail = {
   },
   /**
    * @param {HapiRequest & {
-   *   params: PeriodPathParams,
+   *   params: PeriodWithSubmissionPathParams,
    *   organisationsRepository: OrganisationsRepository,
    *   wasteRecordsRepository: WasteRecordsRepository,
    *   packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository,
@@ -48,7 +48,14 @@ export const reportsGetDetail = {
       overseasSitesRepository,
       params
     } = request
-    const { organisationId, registrationId, year, cadence, period } = params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = params
 
     const registration = await organisationsRepository.findRegistrationById(
       organisationId,
@@ -65,7 +72,8 @@ export const reportsGetDetail = {
       registration,
       year,
       cadence,
-      period
+      period,
+      submissionNumber
     })
 
     // The 'diagnostics' in report check acts as a type discriminator:

--- a/src/reports/routes/get-detail.js
+++ b/src/reports/routes/get-detail.js
@@ -16,7 +16,7 @@ import { ROLES, SCOPES } from '#common/helpers/auth/constants.js'
  */
 
 export const reportsGetDetailPath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/submissions/{submissionNumber}'
 
 export const reportsGetDetail = {
   method: 'GET',

--- a/src/reports/routes/get-detail.test.js
+++ b/src/reports/routes/get-detail.test.js
@@ -19,8 +19,8 @@ import { reportsGetDetailPath } from './get-detail.js'
 describe(`GET ${reportsGetDetailPath}`, () => {
   setupAuthContext()
 
-  const makeUrl = (orgId, regId, year, cadence, period) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}`
+  const makeUrl = (orgId, regId, year, cadence, period, submissionNumber = 1) =>
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
 
   describe('when feature flag is enabled', () => {
     const createServer = async (

--- a/src/reports/routes/get-detail.test.js
+++ b/src/reports/routes/get-detail.test.js
@@ -20,7 +20,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
   setupAuthContext()
 
   const makeUrl = (orgId, regId, year, cadence, period, submissionNumber = 1) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
 
   describe('when feature flag is enabled', () => {
     const createServer = async (

--- a/src/reports/routes/get.js
+++ b/src/reports/routes/get.js
@@ -31,8 +31,8 @@ const toReportListItem = (current) => {
   if (!current) {
     return null
   }
-  const { id, status, submittedAt, submittedBy } = current
-  return { id, status, submittedAt, submittedBy }
+  const { id, status, submissionNumber, submittedAt, submittedBy } = current
+  return { id, status, submissionNumber, submittedAt, submittedBy }
 }
 
 export const reportsGet = {

--- a/src/reports/routes/get.test.js
+++ b/src/reports/routes/get.test.js
@@ -173,6 +173,24 @@ describe(`GET ${reportsGetPath}`, () => {
           true
         )
       })
+
+      it('returns submissionNumber 1 for all periods when no reports exist', async () => {
+        const { server, organisationId, registrationId } = await createServer({
+          wasteProcessingType: 'exporter',
+          accreditationId: undefined
+        })
+
+        const response = await makeRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+        const payload = JSON.parse(response.payload)
+
+        expect(
+          payload.reportingPeriods.every((p) => p.submissionNumber === 1)
+        ).toBe(true)
+      })
     })
 
     describe('accredited operator', () => {
@@ -416,7 +434,13 @@ describe(`GET ${reportsGetPath}`, () => {
 
         const january = payload.reportingPeriods.find((p) => p.period === 1)
         expect(Object.keys(january.report).sort()).toStrictEqual(
-          ['id', 'status', 'submittedAt', 'submittedBy'].sort()
+          [
+            'id',
+            'status',
+            'submissionNumber',
+            'submittedAt',
+            'submittedBy'
+          ].sort()
         )
       })
 
@@ -482,6 +506,116 @@ describe(`GET ${reportsGetPath}`, () => {
 
         const january = payload.reportingPeriods.find((p) => p.period === 1)
         expect(january.report).toBeNull()
+      })
+
+      it('returns submissionNumber from stored report when report exists', async () => {
+        const reportsRepositoryFactory = createInMemoryReportsRepository()
+        const { server, organisationId, registrationId } = await createServer(
+          {
+            wasteProcessingType: 'exporter',
+            accreditationId: new ObjectId().toString()
+          },
+          reportsRepositoryFactory,
+          'approved'
+        )
+
+        const reportsRepository = reportsRepositoryFactory()
+        await reportsRepository.createReport({
+          organisationId,
+          registrationId,
+          year: new Date().getUTCFullYear(),
+          cadence: 'monthly',
+          period: 1,
+          startDate: `${new Date().getUTCFullYear()}-01-01`,
+          endDate: `${new Date().getUTCFullYear()}-01-31`,
+          dueDate: `${new Date().getUTCFullYear()}-02-20`,
+          changedBy: { id: 'user-1', name: 'Test', position: 'Officer' },
+          submissionNumber: 1,
+          material: 'plastic',
+          wasteProcessingType: 'exporter',
+          source: {
+            summaryLogId: 'sl-1',
+            lastUploadedAt: '2024-01-15T00:00:00.000Z'
+          },
+          prn: null,
+          recyclingActivity: {
+            suppliers: [],
+            totalTonnageReceived: 0,
+            tonnageRecycled: null,
+            tonnageNotRecycled: null
+          },
+          wasteSent: {
+            tonnageSentToReprocessor: 0,
+            tonnageSentToExporter: 0,
+            tonnageSentToAnotherSite: 0,
+            finalDestinations: []
+          }
+        })
+
+        const response = await makeRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+        const payload = JSON.parse(response.payload)
+
+        const january = payload.reportingPeriods.find((p) => p.period === 1)
+        expect(january.submissionNumber).toBe(1)
+      })
+
+      it('returns submissionNumber 1 for period without a persisted report', async () => {
+        const reportsRepositoryFactory = createInMemoryReportsRepository()
+        const { server, organisationId, registrationId } = await createServer(
+          {
+            wasteProcessingType: 'exporter',
+            accreditationId: new ObjectId().toString()
+          },
+          reportsRepositoryFactory,
+          'approved'
+        )
+
+        const reportsRepository = reportsRepositoryFactory()
+        await reportsRepository.createReport({
+          organisationId,
+          registrationId,
+          year: new Date().getUTCFullYear(),
+          cadence: 'monthly',
+          period: 1,
+          startDate: `${new Date().getUTCFullYear()}-01-01`,
+          endDate: `${new Date().getUTCFullYear()}-01-31`,
+          dueDate: `${new Date().getUTCFullYear()}-02-20`,
+          changedBy: { id: 'user-1', name: 'Test', position: 'Officer' },
+          submissionNumber: 1,
+          material: 'plastic',
+          wasteProcessingType: 'exporter',
+          source: {
+            summaryLogId: 'sl-1',
+            lastUploadedAt: '2024-01-15T00:00:00.000Z'
+          },
+          prn: null,
+          recyclingActivity: {
+            suppliers: [],
+            totalTonnageReceived: 0,
+            tonnageRecycled: null,
+            tonnageNotRecycled: null
+          },
+          wasteSent: {
+            tonnageSentToReprocessor: 0,
+            tonnageSentToExporter: 0,
+            tonnageSentToAnotherSite: 0,
+            finalDestinations: []
+          }
+        })
+
+        const response = await makeRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+        const payload = JSON.parse(response.payload)
+
+        const february = payload.reportingPeriods.find((p) => p.period === 2)
+        expect(february.submissionNumber).toBe(1)
       })
 
       it('returns report as null for period without persisted report', async () => {

--- a/src/reports/routes/patch.js
+++ b/src/reports/routes/patch.js
@@ -6,7 +6,7 @@ import { isNil } from '#common/helpers/is-nil.js'
 
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
 import { assertNotStale } from '#reports/domain/stale.js'
-import { fetchCurrentReport } from '#reports/application/report-service.js'
+import { fetchReportBySubmissionNumber } from '#reports/application/report-service.js'
 import { maxTwoDecimalPlaces } from '#reports/repository/schema.js'
 import { WASTE_PROCESSING_TYPE } from '#domain/organisations/model.js'
 import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
@@ -17,7 +17,7 @@ import {
 } from './shared.js'
 
 export const reportsPatchPath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}'
 
 const MAX_SUPPORTING_INFO_LENGTH = 2000
 
@@ -155,19 +155,21 @@ export const reportsPatch = {
     const { organisationId, registrationId, cadence } = params
     const year = Number(params.year)
     const period = Number(params.period)
+    const submissionNumber = Number(params.submissionNumber)
 
     const [registration, report] = await Promise.all([
       organisationsRepository.findRegistrationById(
         organisationId,
         registrationId
       ),
-      fetchCurrentReport(
+      fetchReportBySubmissionNumber(
         reportsRepository,
         organisationId,
         registrationId,
         year,
         cadence,
-        period
+        period,
+        submissionNumber
       )
     ])
 

--- a/src/reports/routes/patch.js
+++ b/src/reports/routes/patch.js
@@ -17,7 +17,7 @@ import {
 } from './shared.js'
 
 export const reportsPatchPath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/submissions/{submissionNumber}'
 
 const MAX_SUPPORTING_INFO_LENGTH = 2000
 

--- a/src/reports/routes/patch.test.js
+++ b/src/reports/routes/patch.test.js
@@ -19,8 +19,8 @@ import { reportsPatchPath, buildUpdatedPrn } from './patch.js'
 describe(`PATCH ${reportsPatchPath}`, () => {
   setupAuthContext()
 
-  const makeUrl = (orgId, regId, year, cadence, period) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}`
+  const makeUrl = (orgId, regId, year, cadence, period, submissionNumber = 1) =>
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
 
   const createServer = async (
     registrationOverrides = {},

--- a/src/reports/routes/patch.test.js
+++ b/src/reports/routes/patch.test.js
@@ -20,7 +20,7 @@ describe(`PATCH ${reportsPatchPath}`, () => {
   setupAuthContext()
 
   const makeUrl = (orgId, regId, year, cadence, period, submissionNumber = 1) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
 
   const createServer = async (
     registrationOverrides = {},

--- a/src/reports/routes/post.js
+++ b/src/reports/routes/post.js
@@ -22,11 +22,11 @@ import {
  * @import { WasteRecordsRepository } from '#repositories/waste-records/port.js'
  * @import { PackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/port.js'
  * @import { OverseasSitesRepository } from '#overseas-sites/repository/port.js'
- * @import { PeriodPathParams } from './shared.js'
+ * @import { PeriodWithSubmissionPathParams } from './shared.js'
  */
 
 export const reportsPostPath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}'
 
 /**
  * @param {TypedLogger} logger
@@ -60,7 +60,7 @@ export const reportsPost = {
   },
   /**
    * @param {HapiRequest & {
-   *   params: PeriodPathParams,
+   *   params: PeriodWithSubmissionPathParams,
    *   organisationsRepository: OrganisationsRepository,
    *   wasteRecordsRepository: WasteRecordsRepository,
    *   packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository,
@@ -79,7 +79,14 @@ export const reportsPost = {
       params,
       logger
     } = request
-    const { organisationId, registrationId, year, cadence, period } = params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = params
 
     try {
       const registration = await organisationsRepository.findRegistrationById(
@@ -100,6 +107,7 @@ export const reportsPost = {
         year,
         cadence,
         period,
+        submissionNumber,
         changedBy: extractChangedBy(request.auth.credentials)
       })
 

--- a/src/reports/routes/post.js
+++ b/src/reports/routes/post.js
@@ -26,7 +26,7 @@ import {
  */
 
 export const reportsPostPath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/submissions/{submissionNumber}'
 
 /**
  * @param {TypedLogger} logger

--- a/src/reports/routes/post.test.js
+++ b/src/reports/routes/post.test.js
@@ -28,8 +28,8 @@ vi.mock('#reports/application/audit.js', () => ({
 describe(`POST ${reportsPostPath}`, () => {
   setupAuthContext()
 
-  const makeUrl = (orgId, regId, year, cadence, period) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}`
+  const makeUrl = (orgId, regId, year, cadence, period, submissionNumber) =>
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
 
   const createServer = async (registrationOverrides = {}) => {
     const registration = buildRegistration(registrationOverrides)
@@ -80,11 +80,12 @@ describe(`POST ${reportsPostPath}`, () => {
     regId,
     year = 2025,
     cadence = 'quarterly',
-    period = 1
+    period = 1,
+    submissionNumber = 1
   ) =>
     server.inject({
       method: 'POST',
-      url: makeUrl(orgId, regId, year, cadence, period),
+      url: makeUrl(orgId, regId, year, cadence, period, submissionNumber),
       ...asStandardUser({ linkedOrgId: orgId })
     })
 
@@ -449,7 +450,7 @@ describe(`POST ${reportsPostPath}`, () => {
 
     const response = await server.inject({
       method: 'POST',
-      url: makeUrl(organisationId, registrationId, 2025, 'biweekly', 1),
+      url: makeUrl(organisationId, registrationId, 2025, 'biweekly', 1, 1),
       ...asStandardUser({ linkedOrgId: organisationId })
     })
 
@@ -615,7 +616,7 @@ describe(`POST ${reportsPostPath}`, () => {
 
     const response = await server.inject({
       method: 'POST',
-      url: makeUrl(org.id, registration.id, 2025, 'monthly', 1),
+      url: makeUrl(org.id, registration.id, 2025, 'monthly', 1, 1),
       ...asStandardUser({ linkedOrgId: org.id })
     })
 

--- a/src/reports/routes/post.test.js
+++ b/src/reports/routes/post.test.js
@@ -29,7 +29,7 @@ describe(`POST ${reportsPostPath}`, () => {
   setupAuthContext()
 
   const makeUrl = (orgId, regId, year, cadence, period, submissionNumber) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
 
   const createServer = async (registrationOverrides = {}) => {
     const registration = buildRegistration(registrationOverrides)

--- a/src/reports/routes/shared.js
+++ b/src/reports/routes/shared.js
@@ -12,7 +12,8 @@ export const periodParamsSchema = Joi.object({
   registrationId: Joi.string().required(),
   year: Joi.number().integer().min(MIN_YEAR).max(MAX_YEAR).required(),
   cadence: cadenceSchema,
-  period: periodSchema
+  period: periodSchema,
+  submissionNumber: Joi.number().integer().valid(1).required()
 })
 
 /**
@@ -25,6 +26,8 @@ export const periodParamsSchema = Joi.object({
  *   cadence: Cadence,
  *   period: number
  * }} PeriodPathParams
+ *
+ * @typedef {PeriodPathParams & { submissionNumber: number }} PeriodWithSubmissionPathParams
  */
 
 export const standardUserAuth = getAuthConfig([ROLES.standardUser])

--- a/src/reports/routes/status.js
+++ b/src/reports/routes/status.js
@@ -4,7 +4,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { auditReportStatusTransition } from '#reports/application/audit.js'
 import { assertReportComplete } from '#reports/application/assert-report-complete.js'
-import { fetchCurrentReport } from '#reports/application/report-service.js'
+import { fetchReportBySubmissionNumber } from '#reports/application/report-service.js'
 import { getOperatorCategory } from '#reports/domain/operator-category.js'
 import { REPORT_STATUS, STATUS_TO_SLOT } from '#reports/domain/report-status.js'
 import { assertNotStale } from '#reports/domain/stale.js'
@@ -16,7 +16,7 @@ import {
 } from './shared.js'
 
 export const reportsStatusPath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/status'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}/status'
 
 const payloadSchema = Joi.object({
   status: Joi.string()
@@ -49,6 +49,7 @@ export const reportsStatus = {
     const { organisationId, registrationId, cadence } = params
     const year = Number(params.year)
     const period = Number(params.period)
+    const submissionNumber = Number(params.submissionNumber)
     const { status, version } = request.payload
 
     const [registration, report] = await Promise.all([
@@ -56,13 +57,14 @@ export const reportsStatus = {
         organisationId,
         registrationId
       ),
-      fetchCurrentReport(
+      fetchReportBySubmissionNumber(
         reportsRepository,
         organisationId,
         registrationId,
         year,
         cadence,
-        period
+        period,
+        submissionNumber
       )
     ])
 

--- a/src/reports/routes/status.js
+++ b/src/reports/routes/status.js
@@ -16,7 +16,7 @@ import {
 } from './shared.js'
 
 export const reportsStatusPath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}/status'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/submissions/{submissionNumber}/status'
 
 const payloadSchema = Joi.object({
   status: Joi.string()

--- a/src/reports/routes/status.test.js
+++ b/src/reports/routes/status.test.js
@@ -24,7 +24,7 @@ describe(`POST ${reportsStatusPath}`, () => {
   setupAuthContext()
 
   const makeUrl = (orgId, regId, year, cadence, period, submissionNumber = 1) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}/status`
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}/status`
 
   describe('when feature flag is enabled', () => {
     // Defaults to a report whose manual-entry fields are populated enough

--- a/src/reports/routes/status.test.js
+++ b/src/reports/routes/status.test.js
@@ -23,8 +23,8 @@ vi.mock('#reports/application/audit.js', () => ({
 describe(`POST ${reportsStatusPath}`, () => {
   setupAuthContext()
 
-  const makeUrl = (orgId, regId, year, cadence, period) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/status`
+  const makeUrl = (orgId, regId, year, cadence, period, submissionNumber = 1) =>
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}/status`
 
   describe('when feature flag is enabled', () => {
     // Defaults to a report whose manual-entry fields are populated enough

--- a/src/reports/routes/unsubmit.js
+++ b/src/reports/routes/unsubmit.js
@@ -11,7 +11,7 @@ import {
 import { periodParamsSchema, extractChangedBy } from './shared.js'
 
 export const reportsUnsubmitPath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}/unsubmit'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/submissions/{submissionNumber}/unsubmit'
 
 export const reportsUnsubmit = {
   method: 'POST',

--- a/src/reports/routes/unsubmit.js
+++ b/src/reports/routes/unsubmit.js
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { SCOPES } from '#common/helpers/auth/constants.js'
 import { auditReportStatusTransition } from '#reports/application/audit.js'
-import { fetchCurrentReport } from '#reports/application/report-service.js'
+import { fetchReportBySubmissionNumber } from '#reports/application/report-service.js'
 import {
   REPORT_STATUS,
   REPORT_STATUS_SLOT
@@ -11,7 +11,7 @@ import {
 import { periodParamsSchema, extractChangedBy } from './shared.js'
 
 export const reportsUnsubmitPath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/unsubmit'
+  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/{submissionNumber}/unsubmit'
 
 export const reportsUnsubmit = {
   method: 'POST',
@@ -34,14 +34,16 @@ export const reportsUnsubmit = {
     const { organisationId, registrationId, cadence } = params
     const year = Number(params.year)
     const period = Number(params.period)
+    const submissionNumber = Number(params.submissionNumber)
 
-    const report = await fetchCurrentReport(
+    const report = await fetchReportBySubmissionNumber(
       reportsRepository,
       organisationId,
       registrationId,
       year,
       cadence,
-      period
+      period,
+      submissionNumber
     )
 
     if (!report) {

--- a/src/reports/routes/unsubmit.test.js
+++ b/src/reports/routes/unsubmit.test.js
@@ -31,9 +31,10 @@ describe(`POST ${reportsUnsubmitPath}`, () => {
     regId,
     year = 2024,
     cadence = 'monthly',
-    period = 1
+    period = 1,
+    submissionNumber = 1
   ) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/unsubmit`
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}/unsubmit`
 
   const buildServerWithSubmittedReport = async () => {
     const registration = buildRegistration({

--- a/src/reports/routes/unsubmit.test.js
+++ b/src/reports/routes/unsubmit.test.js
@@ -34,7 +34,7 @@ describe(`POST ${reportsUnsubmitPath}`, () => {
     period = 1,
     submissionNumber = 1
   ) =>
-    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/${submissionNumber}/unsubmit`
+    `/v1/organisations/${orgId}/registrations/${regId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}/unsubmit`
 
   const buildServerWithSubmittedReport = async () => {
     const registration = buildRegistration({


### PR DESCRIPTION
Ticket: [PAE-1554](https://eaflood.atlassian.net/browse/PAE-1554)
- Thread submissionNumber as a URL path param across all report period routes (GET, POST, PATCH, DELETE, status, unsubmit)
- Rename fetch helpers from fetchCurrentReport/findCurrentReportId to fetchReportBySubmissionNumber/findReportIdBySubmissionNumber and extend lookup to cover previousSubmissions

[PAE-1554]: https://eaflood.atlassian.net/browse/PAE-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ