### PR TITLE
PAE-250: Fix grpc-js, inert, tmp and cdp-auditing vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,14 @@
         "@aws-sdk/credential-providers": "3.1000.0",
         "@aws-sdk/lib-storage": "3.1000.0",
         "@aws-sdk/s3-request-presigner": "3.1000.0",
-        "@defra/cdp-auditing": "0.6.0",
+        "@defra/cdp-auditing": "0.6.1",
         "@defra/hapi-secure-context": "0.4.0",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@fast-csv/format": "5.0.5",
         "@hapi/boom": "10.0.1",
         "@hapi/hapi": "21.4.6",
-        "@hapi/inert": "7.1.0",
+        "@hapi/inert": "7.1.1",
         "@hapi/jwt": "3.2.3",
         "@hapi/vision": "7.0.3",
         "aws-embedded-metrics": "4.2.1",
@@ -74,7 +74,7 @@
         "vitest-mongodb": "1.0.3"
       },
       "engines": {
-        "node": ">=24.15.0 <25"
+        "node": ">=24.16.0 <25"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -1292,35 +1292,16 @@
       "license": "MIT"
     },
     "node_modules/@defra/cdp-auditing": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defra/cdp-auditing/-/cdp-auditing-0.6.0.tgz",
-      "integrity": "sha512-CVysJOutZ3CLn8McdMxA0hIs+XgoaHOOwRQGmMt7BZU2SGSbjfdb/T+pLVg1SZk1XsIK6VQ7cufIc6t7L3T2XQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@defra/cdp-auditing/-/cdp-auditing-0.6.1.tgz",
+      "integrity": "sha512-KJiKDTpAqolaxbm/8D345kKeZeK2uqDxhD7QOAI9sd7hEQzy9qj4pcAZSh0Xo6/7VNi6AuN0Y+jllTZZBPcIyA==",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "joi": "18.0.2",
         "pino": "10.1.0"
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/@defra/cdp-auditing/node_modules/joi": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/address": "^5.1.1",
-        "@hapi/formula": "^3.0.2",
-        "@hapi/hoek": "^11.0.7",
-        "@hapi/pinpoint": "^2.0.1",
-        "@hapi/tlds": "^1.1.1",
-        "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/@defra/cdp-auditing/node_modules/pino": {
@@ -1598,9 +1579,9 @@
       "license": "MIT"
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.0.tgz",
-      "integrity": "sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1657,18 +1638,6 @@
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/address": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
-      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@hapi/ammo": {
@@ -1783,12 +1752,6 @@
       "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@hapi/formula": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
-      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@hapi/hapi": {
       "version": "21.4.6",
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.4.6.tgz",
@@ -1836,9 +1799,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/inert": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-7.1.0.tgz",
-      "integrity": "sha512-5X+cl/Ozm0U9uPGGX1dSKhnhTQIf161bH/kkTN9OBVAZKFG+nrj8j/NMj6S1zBBZWmQrkVRNPfCUGrXzB4fCFQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-7.1.1.tgz",
+      "integrity": "sha512-vKSTXYbk1cDt7sLdmRIj8CofJRCcjAH9fUCUJViVzqb7Vi+ajUSfz+pAdwwY315BddwGdoXk0H3i94S0JWEKGQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/ammo": "^6.0.1",
@@ -1931,12 +1894,6 @@
         "@hapi/nigel": "^5.0.1"
       }
     },
-    "node_modules/@hapi/pinpoint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
-      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@hapi/podium": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.2.tgz",
@@ -2002,15 +1959,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.1.tgz",
       "integrity": "sha512-52OXRslUfYwXAOG8k58f2h2ngXYQGP0x5RPOo+eWA/FtyLgHjGMrE3+e9LSXP/0q2YfHAK5wj9aA9DTy1K+kyQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@hapi/tlds": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.4.tgz",
-      "integrity": "sha512-Fq+20dxsxLaUn5jSSWrdtSRcIUba2JquuorF9UW1wIJS5cSUwxIsO2GIhaWynPRflvxSzFN+gxKte2HEW1OuoA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=14.0.0"
@@ -3907,6 +3855,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin": {
@@ -12984,9 +12933,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -65,14 +65,14 @@
     "@aws-sdk/credential-providers": "3.1000.0",
     "@aws-sdk/lib-storage": "3.1000.0",
     "@aws-sdk/s3-request-presigner": "3.1000.0",
-    "@defra/cdp-auditing": "0.6.0",
+    "@defra/cdp-auditing": "0.6.1",
     "@defra/hapi-secure-context": "0.4.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@fast-csv/format": "5.0.5",
     "@hapi/boom": "10.0.1",
     "@hapi/hapi": "21.4.6",
-    "@hapi/inert": "7.1.0",
+    "@hapi/inert": "7.1.1",
     "@hapi/jwt": "3.2.3",
     "@hapi/vision": "7.0.3",
     "aws-embedded-metrics": "4.2.1",
@@ -105,8 +105,10 @@
     "unzipper": "0.10.14"
   },
   "overrides": {
+    "@grpc/grpc-js": "1.14.4",
     "fast-xml-parser": "5.7.3",
     "glob": "11.1.0",
+    "tmp": "0.2.7",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Fixes several vulnerabilities flagged by the dependency audit.

- Pins `@grpc/grpc-js` to 1.14.4 via an override, clearing GHSA-5375-pq7m-f5r2 and GHSA-99f4-grh7-6pcq (a malformed request or compressed message can crash the client or server). It is pulled in transitively through `testcontainers`. An override is used so the fix does not disturb `@hapi/wreck`, which is owned by a separate security PR.
- Bumps `@hapi/inert` to 7.1.1, clearing GHSA-rcvq-m9j9-6f4g (static-file confinement bypass via sibling-prefix path). As a direct dependency it was bumped directly rather than via an override.
- Pins `tmp` to 0.2.7 via an override, clearing SNYK-JS-TMP-17315641 (directory traversal), pulled in through `exceljs` and `testcontainers`.
- Bumps `@defra/cdp-auditing` to 0.6.1, which drops its `joi` dependency entirely and removes that joi path.

Existing `fast-xml-parser`, `glob` and `uuid` overrides were each checked and confirmed still needed, so they are retained.

A `joi` advisory (GHSA-q7cg-457f-vx79, moderate DoS) remains: the application depends on joi 17.x directly and several hapi packages pin joi 17.x, with no fixed 17.x release published. Clearing it would require a coordinated joi 17→18 major upgrade, tracked separately.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ