### PR TITLE
PAE-1541: require processing-type on a validated summary log

### DIFF
--- a/src/routes/v1/organisations/registrations/summary-logs/get.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.test.js
@@ -8,6 +8,7 @@ import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
 import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
+import { createMockLogger } from '#test/mock-logger.js'
 import { createTestServer } from '#test/create-test-server.js'
 import { asStandardUser } from '#test/inject-auth.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
@@ -22,12 +23,8 @@ describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/
 
   const createServer = async () => {
     const summaryLogsRepositoryFactory = createInMemorySummaryLogsRepository()
-    const summaryLogsRepository = summaryLogsRepositoryFactory({
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn()
-    })
+    const summaryLogsRepository =
+      summaryLogsRepositoryFactory(createMockLogger())
 
     const server = await createTestServer({
       repositories: {
@@ -251,13 +248,14 @@ describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/
         summaryLogId,
         summaryLogFactory.invalid({ organisationId, registrationId })
       )
-      await summaryLogsRepository.update(summaryLogId, 1, {
-        meta: {
-          PROCESSING_TYPE: null,
-          MATERIAL: null,
-          ACCREDITATION_NUMBER: null
-        }
-      })
+      // Raw storage can hold null meta values; the response must omit them.
+      /** @type {Record<string, unknown>} */
+      const dirtyMeta = {
+        PROCESSING_TYPE: null,
+        MATERIAL: null,
+        ACCREDITATION_NUMBER: null
+      }
+      await summaryLogsRepository.update(summaryLogId, 1, { meta: dirtyMeta })
       await waitForVersion(summaryLogsRepository, summaryLogId, 2)
 
       const response = await makeRequest(server)

--- a/src/routes/v1/organisations/registrations/summary-logs/get.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.test.js
@@ -86,7 +86,11 @@ describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/
       const { server, summaryLogsRepository } = await createServer()
       await summaryLogsRepository.insert(
         summaryLogId,
-        summaryLogFactory.validated({ organisationId, registrationId })
+        summaryLogFactory.validated({
+          organisationId,
+          registrationId,
+          meta: { PROCESSING_TYPE: 'EXPORTER' }
+        })
       )
 
       const response = await makeRequest(server)
@@ -124,7 +128,11 @@ describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/
       const loads = createLoads()
       await summaryLogsRepository.insert(
         summaryLogId,
-        summaryLogFactory.validated({ organisationId, registrationId })
+        summaryLogFactory.validated({
+          organisationId,
+          registrationId,
+          meta: { PROCESSING_TYPE: 'EXPORTER' }
+        })
       )
       await summaryLogsRepository.update(summaryLogId, 1, { loads })
       await waitForVersion(summaryLogsRepository, summaryLogId, 2)
@@ -140,7 +148,11 @@ describe('GET /v1/organisations/{organisationId}/registrations/{registrationId}/
       const { server, summaryLogsRepository } = await createServer()
       await summaryLogsRepository.insert(
         summaryLogId,
-        summaryLogFactory.validated({ organisationId, registrationId })
+        summaryLogFactory.validated({
+          organisationId,
+          registrationId,
+          meta: { PROCESSING_TYPE: 'EXPORTER' }
+        })
       )
 
       const response = await makeRequest(server)

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
@@ -12,6 +12,7 @@ import { createTestServer } from '#test/create-test-server.js'
 import { createInMemorySummaryLogExtractor } from '#application/summary-logs/extractor-inmemory.js'
 import { createSummaryLogsValidator } from '#application/summary-logs/validate.js'
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
+import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 
 import { ObjectId } from 'mongodb'
@@ -386,6 +387,7 @@ describe('Advanced validation scenarios', () => {
         summaryLogsRepository: testSummaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
+        overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
         summaryLogExtractor,
         logger: mockLogger,
         reportsRepository: /** @type {any} */ ({
@@ -571,6 +573,7 @@ describe('Advanced validation scenarios', () => {
         summaryLogsRepository: testSummaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
+        overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
         summaryLogExtractor,
         logger: mockLogger,
         reportsRepository: /** @type {any} */ ({

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
@@ -793,7 +793,8 @@ describe('Advanced validation scenarios', () => {
         summaryLogFactory.validated({
           organisationId,
           registrationId,
-          validation: {}
+          validation: {},
+          meta: { PROCESSING_TYPE: 'EXPORTER' }
         })
       )
 

--- a/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
@@ -76,7 +76,11 @@ export const summaryLogResponseSchema = Joi.object({
     otherwise: loadsByReportingPeriodSchema.optional()
   }),
   loadsByWasteRecordType: loadsByWasteRecordTypeSchema.optional(),
-  processingType: Joi.string().optional(),
+  processingType: Joi.when('status', {
+    is: SUMMARY_LOG_STATUS.VALIDATED,
+    then: Joi.string().required(),
+    otherwise: Joi.string().optional()
+  }),
   material: Joi.string().optional(),
   accreditationNumber: Joi.string().optional()
 })

--- a/src/routes/v1/organisations/registrations/summary-logs/response.schema.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/response.schema.test.js
@@ -1,0 +1,43 @@
+import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
+import { emptyLoadsByReportingPeriod } from '#domain/summary-logs/loads-by-period-status-schema.js'
+
+import { summaryLogResponseSchema } from './response.schema.js'
+
+describe('summaryLogResponseSchema', () => {
+  describe('processing-type', () => {
+    // A validated response always pairs with loadsByReportingPeriod (required by
+    // the sibling rule), so include it to isolate the processingType assertion.
+    const validatedBase = {
+      status: SUMMARY_LOG_STATUS.VALIDATED,
+      loadsByReportingPeriod: emptyLoadsByReportingPeriod()
+    }
+
+    it('should require processing-type when status is validated', () => {
+      const { error } = summaryLogResponseSchema.validate(validatedBase)
+
+      expect(error?.details).toStrictEqual([
+        expect.objectContaining({
+          type: 'any.required',
+          path: ['processingType']
+        })
+      ])
+    })
+
+    it('should accept a validated response that includes processing-type', () => {
+      const { error } = summaryLogResponseSchema.validate({
+        ...validatedBase,
+        processingType: 'EXPORTER'
+      })
+
+      expect(error).toBeUndefined()
+    })
+
+    it('should not require processing-type before validation', () => {
+      const { error } = summaryLogResponseSchema.validate({
+        status: SUMMARY_LOG_STATUS.PREPROCESSING
+      })
+
+      expect(error).toBeUndefined()
+    })
+  })
+})

--- a/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
@@ -763,6 +763,7 @@ describe('transformValidationResponse', () => {
 
       const httpResponse = {
         status: SUMMARY_LOG_STATUS.VALIDATED,
+        processingType: 'EXPORTER',
         ...transformValidationResponse(validation),
         loadsByReportingPeriod: {
           openPeriodLoads: {


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)
- backend: response schema requires processing-type when status is validated
- frontend: validated render path narrows to required processing-type, dropping undefined-handling in the predicate and render code

[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ