### PR TITLE
PAE-1544: sync package-lock node engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "vitest-mongodb": "1.0.3"
       },
       "engines": {
-        "node": ">=24.15.0 <25"
+        "node": ">=24.16.0 <25"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {


### PR DESCRIPTION
Ticket: [PAE-1544](https://eaflood.atlassian.net/browse/PAE-1544)
resync package-lock.json node engine to match package.json (24.16.0) after the renovate node bump left it behind.

[PAE-1544]: https://eaflood.atlassian.net/browse/PAE-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ