### PR TITLE
PAE-1565: Fix duplicate accreditation links in existing organisation data

### DIFF
--- a/src/auditing/duplicate-accreditation-link-migration.js
+++ b/src/auditing/duplicate-accreditation-link-migration.js
@@ -1,0 +1,56 @@
+import { isPayloadSmallEnoughToAudit, safeAudit } from './helpers.js'
+
+/**
+ * @import {SystemLogsRepository} from '#repositories/system-logs/port.js'
+ */
+
+const SYSTEM_USER = { id: 'system', email: 'system', scope: [] }
+
+/**
+ * Audit a duplicate accreditation link fix for an organisation.
+ * This is a system-initiated action (no user request context).
+ * Logs the full organisation state before and after the fix.
+ *
+ * @param {SystemLogsRepository} systemLogsRepository
+ * @param {string} organisationId
+ * @param {Object} previous - Organisation state before fix
+ * @param {Object} next - Organisation state after fix
+ */
+async function auditDuplicateAccreditationLinkMigration(
+  systemLogsRepository,
+  organisationId,
+  previous,
+  next
+) {
+  const payload = {
+    event: {
+      category: 'entity',
+      subCategory: 'epr-organisations',
+      action: 'duplicate-accreditation-link-migration'
+    },
+    context: {
+      organisationId,
+      previous,
+      next
+    },
+    user: SYSTEM_USER
+  }
+
+  const safeAuditingPayload = isPayloadSmallEnoughToAudit(payload)
+    ? payload
+    : {
+        ...payload,
+        context: { organisationId }
+      }
+
+  safeAudit(safeAuditingPayload)
+
+  await systemLogsRepository.insert({
+    createdAt: new Date(),
+    createdBy: SYSTEM_USER,
+    event: payload.event,
+    context: payload.context
+  })
+}
+
+export { auditDuplicateAccreditationLinkMigration }

--- a/src/auditing/duplicate-accreditation-link-migration.test.js
+++ b/src/auditing/duplicate-accreditation-link-migration.test.js
@@ -1,0 +1,166 @@
+import { auditDuplicateAccreditationLinkMigration } from './duplicate-accreditation-link-migration.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { logger } from '#common/helpers/logging/logger.js'
+import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest'
+import { ObjectId } from 'mongodb'
+
+const mockAudit = vi.fn()
+
+vi.mock('@defra/cdp-auditing', () => ({
+  audit: (...args) => mockAudit(...args)
+}))
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    warn: vi.fn()
+  }
+}))
+
+vi.mock('#root/config.js', () => ({
+  config: {
+    get: vi.fn((key) => {
+      if (key === 'audit.maxPayloadSizeBytes') {
+        return 10000
+      }
+      return undefined
+    })
+  }
+}))
+
+describe('auditDuplicateAccreditationLinkMigration', () => {
+  const now = new Date('2026-02-11T12:00:00.000Z')
+
+  let systemLogsRepository
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+    systemLogsRepository = createSystemLogsRepository()(logger)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  const organisationId = new ObjectId().toString()
+  const systemUser = { id: 'system', email: 'system', scope: [] }
+
+  const findStoredLog = async () => {
+    const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
+    return systemLogs[0]
+  }
+
+  it('logs full previous/next state to both CDP audit and system log', async () => {
+    const previous = {
+      registrations: [
+        { id: new ObjectId().toString(), accreditationId: 'acc-1' },
+        { id: new ObjectId().toString(), accreditationId: 'acc-1' }
+      ]
+    }
+    const next = {
+      registrations: [
+        { id: previous.registrations[0].id, accreditationId: 'acc-1' },
+        { id: previous.registrations[1].id }
+      ]
+    }
+
+    await auditDuplicateAccreditationLinkMigration(
+      systemLogsRepository,
+      organisationId,
+      previous,
+      next
+    )
+
+    expect(mockAudit).toHaveBeenCalledWith({
+      event: {
+        category: 'entity',
+        subCategory: 'epr-organisations',
+        action: 'duplicate-accreditation-link-migration'
+      },
+      context: {
+        organisationId,
+        previous,
+        next
+      },
+      user: systemUser
+    })
+
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
+      createdAt: now,
+      createdBy: systemUser,
+      event: {
+        category: 'entity',
+        subCategory: 'epr-organisations',
+        action: 'duplicate-accreditation-link-migration'
+      },
+      context: {
+        organisationId,
+        previous,
+        next
+      }
+    })
+  })
+
+  it('sends reduced context to CDP audit but full state to system log when payload is too large', async () => {
+    const largeData = 'x'.repeat(15000)
+    const previous = {
+      registrations: [
+        {
+          id: new ObjectId().toString(),
+          accreditationId: 'acc-1',
+          data: largeData
+        },
+        {
+          id: new ObjectId().toString(),
+          accreditationId: 'acc-1',
+          data: largeData
+        }
+      ]
+    }
+    const next = {
+      registrations: [
+        {
+          id: previous.registrations[0].id,
+          accreditationId: 'acc-1',
+          data: largeData
+        },
+        { id: previous.registrations[1].id, data: largeData }
+      ]
+    }
+
+    await auditDuplicateAccreditationLinkMigration(
+      systemLogsRepository,
+      organisationId,
+      previous,
+      next
+    )
+
+    expect(mockAudit).toHaveBeenCalledWith({
+      event: {
+        category: 'entity',
+        subCategory: 'epr-organisations',
+        action: 'duplicate-accreditation-link-migration'
+      },
+      context: { organisationId },
+      user: systemUser
+    })
+
+    const storedLog = await findStoredLog()
+    expect(storedLog).toEqual({
+      createdAt: now,
+      createdBy: systemUser,
+      event: {
+        category: 'entity',
+        subCategory: 'epr-organisations',
+        action: 'duplicate-accreditation-link-migration'
+      },
+      context: {
+        organisationId,
+        previous,
+        next
+      }
+    })
+  })
+})

--- a/src/config.js
+++ b/src/config.js
@@ -357,6 +357,12 @@ const baseConfig = {
       format: Boolean,
       default: false,
       env: 'FEATURE_FLAG_COPY_FORM_FILES_TO_S3'
+    },
+    fixDuplicateAccreditationLinks: {
+      doc: 'Feature Flag: Fix duplicate accreditation links in existing organisation data on startup',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_FLAG_FIX_DUPLICATE_ACCREDITATION_LINKS'
     }
   },
   formSubmissionOverrides: {

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -7,5 +7,8 @@ export const createConfigFeatureFlags = (config) => ({
   },
   isCopyFormFilesToS3Enabled() {
     return config.get('featureFlags.copyFormFilesToS3')
+  },
+  isFixDuplicateAccreditationLinksEnabled() {
+    return config.get('featureFlags.fixDuplicateAccreditationLinks')
   }
 })

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -8,5 +8,8 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   },
   isDevEndpointsEnabled() {
     return flags.devEndpoints ?? false
+  },
+  isFixDuplicateAccreditationLinksEnabled() {
+    return flags.fixDuplicateAccreditationLinks ?? false
   }
 })

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -31,4 +31,23 @@ describe('createInMemoryFeatureFlags', () => {
     const flags = createInMemoryFeatureFlags({})
     expect(flags.isDevEndpointsEnabled()).toBe(false)
   })
+
+  it('returns true when fixDuplicateAccreditationLinks flag is enabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      fixDuplicateAccreditationLinks: true
+    })
+    expect(flags.isFixDuplicateAccreditationLinksEnabled()).toBe(true)
+  })
+
+  it('returns false when fixDuplicateAccreditationLinks flag is disabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      fixDuplicateAccreditationLinks: false
+    })
+    expect(flags.isFixDuplicateAccreditationLinksEnabled()).toBe(false)
+  })
+
+  it('returns false when fixDuplicateAccreditationLinks flag is not provided', () => {
+    const flags = createInMemoryFeatureFlags({})
+    expect(flags.isFixDuplicateAccreditationLinksEnabled()).toBe(false)
+  })
 })

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -2,12 +2,14 @@
  * @typedef {Object} FeatureFlags
  * @property {() => boolean} isDevEndpointsEnabled
  * @property {() => boolean} isCopyFormFilesToS3Enabled
+ * @property {() => boolean} isFixDuplicateAccreditationLinksEnabled
  */
 
 /**
  * @typedef {Object} FeatureFlagOverrides
  * @property {boolean} [devEndpoints]
  * @property {boolean} [copyFormFilesToS3]
+ * @property {boolean} [fixDuplicateAccreditationLinks]
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/server/run-duplicate-accreditation-link-migration.js
+++ b/src/server/run-duplicate-accreditation-link-migration.js
@@ -30,15 +30,85 @@ const resolveKeepAndUnlink = (regs) => {
   const keepReg =
     nonCreated.length === 1
       ? nonCreated[0]
-      : regs.reduce((latest, r) =>
-          new Date(r.formSubmission.time) > new Date(latest.formSubmission.time)
-            ? r
-            : latest
+      : regs.reduce(
+          (latest, r) =>
+            new Date(r.formSubmission.time) >
+            new Date(latest.formSubmission.time)
+              ? r
+              : latest,
+          regs[0]
         )
 
   return {
     keepId: keepReg.id,
     unlinkIds: regs.filter((r) => r.id !== keepReg.id).map((r) => r.id)
+  }
+}
+
+/**
+ * Groups an organisation's registrations by accreditationId, ignoring
+ * registrations that aren't linked to an accreditation.
+ *
+ * @param {Organisation} org
+ * @returns {Map<string, {id: string, status: string, formSubmission: {time: Date}}[]>}
+ */
+const groupRegistrationsByAccreditation = (org) => {
+  /** @type {Map<string, {id: string, status: string, formSubmission: {time: Date}}[]>} */
+  const accToRegs = new Map()
+
+  for (const reg of org.registrations) {
+    if (!reg.accreditationId) {
+      continue
+    }
+    const existing = accToRegs.get(reg.accreditationId) ?? []
+    existing.push({
+      id: reg.id,
+      status: reg.status,
+      formSubmission: reg.formSubmission
+    })
+    accToRegs.set(reg.accreditationId, existing)
+  }
+
+  return accToRegs
+}
+
+/**
+ * Builds a fix for one accreditation's set of linked registrations, logging
+ * the duplicate and, if ambiguous, a warning. Returns null when there is
+ * nothing to fix (skipped due to ambiguity).
+ *
+ * @param {string} organisationId
+ * @param {string} accreditationId
+ * @param {{id: string, status: string, formSubmission: {time: Date}}[]} regs
+ * @returns {{
+ *   accreditationId: string,
+ *   registrations: {id: string, status: string}[],
+ *   keepId: string,
+ *   unlinkIds: string[]
+ * } | null}
+ */
+const buildFixForAccreditation = (organisationId, accreditationId, regs) => {
+  const regSummary = regs.map(({ id, status }) => ({ id, status }))
+  const regSummaryStr = regSummary.map((r) => `${r.id}(${r.status})`).join(', ')
+
+  logger.info({
+    message: `Duplicate accreditation link: organisationId=${organisationId} accreditationId=${accreditationId} registrations=[${regSummaryStr}]`
+  })
+
+  const resolution = resolveKeepAndUnlink(regs)
+
+  if (!resolution) {
+    logger.warn({
+      message: `Duplicate accreditation link skipped (multiple non-created registrations): organisationId=${organisationId} accreditationId=${accreditationId} registrations=[${regSummaryStr}]`
+    })
+    return null
+  }
+
+  return {
+    accreditationId,
+    registrations: regSummary,
+    keepId: resolution.keepId,
+    unlinkIds: resolution.unlinkIds
   }
 }
 
@@ -59,59 +129,17 @@ const resolveKeepAndUnlink = (regs) => {
  * }}
  */
 const findFixes = (org) => {
-  /** @type {Map<string, {id: string, status: string, formSubmission: {time: Date}}[]>} */
-  const accToRegs = new Map()
+  const accToRegs = groupRegistrationsByAccreditation(org)
 
-  for (const reg of org.registrations) {
-    if (!reg.accreditationId) {
-      continue
-    }
-    const existing = accToRegs.get(reg.accreditationId) ?? []
-    existing.push({
-      id: reg.id,
-      status: reg.status,
-      formSubmission: reg.formSubmission
-    })
-    accToRegs.set(reg.accreditationId, existing)
-  }
+  const duplicateEntries = [...accToRegs].filter(([, regs]) => regs.length >= 2)
 
-  const fixes = []
-  let duplicatesFound = 0
+  const fixes = duplicateEntries
+    .map(([accreditationId, regs]) =>
+      buildFixForAccreditation(org.id, accreditationId, regs)
+    )
+    .filter((fix) => fix !== null)
 
-  for (const [accreditationId, regs] of accToRegs) {
-    if (regs.length < 2) {
-      continue
-    }
-
-    duplicatesFound += 1
-    const regSummary = regs.map(({ id, status }) => ({ id, status }))
-
-    const regSummaryStr = regSummary
-      .map((r) => `${r.id}(${r.status})`)
-      .join(', ')
-
-    logger.info({
-      message: `Duplicate accreditation link: organisationId=${org.id} accreditationId=${accreditationId} registrations=[${regSummaryStr}]`
-    })
-
-    const resolution = resolveKeepAndUnlink(regs)
-
-    if (!resolution) {
-      logger.warn({
-        message: `Duplicate accreditation link skipped (multiple non-created registrations): organisationId=${org.id} accreditationId=${accreditationId} registrations=[${regSummaryStr}]`
-      })
-      continue
-    }
-
-    fixes.push({
-      accreditationId,
-      registrations: regSummary,
-      keepId: resolution.keepId,
-      unlinkIds: resolution.unlinkIds
-    })
-  }
-
-  return { fixes, duplicatesFound }
+  return { fixes, duplicatesFound: duplicateEntries.length }
 }
 
 /**
@@ -139,6 +167,77 @@ const applyFixes = (org, fixes) => {
 }
 
 /**
+ * Logs the fixes that would be applied to an organisation without writing
+ * anything, for dry-run mode.
+ *
+ * @param {Organisation} org
+ * @param {{accreditationId: string, keepId: string, unlinkIds: string[]}[]} fixes
+ */
+const logDryRunFixes = (org, fixes) => {
+  const fixSummary = fixes
+    .map(
+      (f) =>
+        `accreditationId=${f.accreditationId} keep=${f.keepId} unlink=[${f.unlinkIds.join(',')}]`
+    )
+    .join('; ')
+  logger.info({
+    message: `Dry run — would fix duplicate accreditation links: organisationId=${org.id} fixes=[${fixSummary}]`
+  })
+}
+
+/**
+ * Analyses and, unless in dry-run mode, applies duplicate accreditation link
+ * fixes for a single organisation.
+ *
+ * @param {object} params
+ * @param {import('#repositories/organisations/port.js').OrganisationsRepository} params.organisationsRepository
+ * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} params.systemLogsRepository
+ * @param {Organisation} params.org
+ * @param {boolean} params.isDryRun
+ * @returns {Promise<{duplicatesFound: number, updated: boolean, failed: boolean}>}
+ */
+const processOrganisation = async ({
+  organisationsRepository,
+  systemLogsRepository,
+  org,
+  isDryRun
+}) => {
+  const { fixes, duplicatesFound } = findFixes(org)
+
+  if (duplicatesFound === 0) {
+    return { duplicatesFound, updated: false, failed: false }
+  }
+
+  if (isDryRun) {
+    logDryRunFixes(org, fixes)
+    return { duplicatesFound, updated: false, failed: false }
+  }
+
+  if (fixes.length === 0) {
+    return { duplicatesFound, updated: false, failed: false }
+  }
+
+  try {
+    const updatedOrg = applyFixes(org, fixes)
+    await organisationsRepository.replace(org.id, org.version, updatedOrg)
+    await auditDuplicateAccreditationLinkMigration(
+      systemLogsRepository,
+      org.id,
+      org,
+      updatedOrg
+    )
+
+    return { duplicatesFound, updated: true, failed: false }
+  } catch (error) {
+    logger.error({
+      message: `Failed to fix duplicate accreditation links for organisation: organisationId=${org.id}`,
+      err: error
+    })
+    return { duplicatesFound, updated: false, failed: true }
+  }
+}
+
+/**
  * @param {object} server
  * @param {boolean} isDryRun
  */
@@ -157,49 +256,16 @@ const runMigration = async (server, isDryRun) => {
   let totalOrgsFailed = 0
 
   for (const org of organisations) {
-    const { fixes, duplicatesFound } = findFixes(org)
+    const result = await processOrganisation({
+      organisationsRepository,
+      systemLogsRepository,
+      org,
+      isDryRun
+    })
 
-    if (duplicatesFound === 0) {
-      continue
-    }
-
-    totalDuplicateAccreditations += duplicatesFound
-
-    if (isDryRun) {
-      const fixSummary = fixes
-        .map(
-          (f) =>
-            `accreditationId=${f.accreditationId} keep=${f.keepId} unlink=[${f.unlinkIds.join(',')}]`
-        )
-        .join('; ')
-      logger.info({
-        message: `Dry run — would fix duplicate accreditation links: organisationId=${org.id} fixes=[${fixSummary}]`
-      })
-      continue
-    }
-
-    if (fixes.length === 0) {
-      continue
-    }
-
-    try {
-      const updatedOrg = applyFixes(org, fixes)
-      await organisationsRepository.replace(org.id, org.version, updatedOrg)
-      await auditDuplicateAccreditationLinkMigration(
-        systemLogsRepository,
-        org.id,
-        org,
-        updatedOrg
-      )
-
-      totalOrgsUpdated += 1
-    } catch (error) {
-      totalOrgsFailed += 1
-      logger.error({
-        message: `Failed to fix duplicate accreditation links for organisation: organisationId=${org.id}`,
-        err: error
-      })
-    }
+    totalDuplicateAccreditations += result.duplicatesFound
+    totalOrgsUpdated += result.updated ? 1 : 0
+    totalOrgsFailed += result.failed ? 1 : 0
   }
 
   logger.info({

--- a/src/server/run-duplicate-accreditation-link-migration.js
+++ b/src/server/run-duplicate-accreditation-link-migration.js
@@ -1,0 +1,249 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import { auditDuplicateAccreditationLinkMigration } from '#auditing/duplicate-accreditation-link-migration.js'
+import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
+import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+
+/** @import {Organisation} from '#domain/organisations/model.js' */
+
+const LOCK_NAME = 'duplicate-accreditation-link-migration'
+
+/**
+ * For a given set of registrations sharing the same accreditationId, determine
+ * which one to keep linked and which to unlink.
+ *
+ * Rules:
+ * - If more than one registration is in a non-created status, return null (skip with warning).
+ * - If exactly one is non-created, keep that one.
+ * - If all are created, keep the one with the latest formSubmission.time.
+ *
+ * @param {{id: string, status: string, formSubmission: {time: Date}}[]} regs
+ * @returns {{keepId: string, unlinkIds: string[]} | null}
+ */
+const resolveKeepAndUnlink = (regs) => {
+  const nonCreated = regs.filter((r) => r.status !== REG_ACC_STATUS.CREATED)
+
+  if (nonCreated.length > 1) {
+    return null
+  }
+
+  const keepReg =
+    nonCreated.length === 1
+      ? nonCreated[0]
+      : regs.reduce((latest, r) =>
+          new Date(r.formSubmission.time) > new Date(latest.formSubmission.time)
+            ? r
+            : latest
+        )
+
+  return {
+    keepId: keepReg.id,
+    unlinkIds: regs.filter((r) => r.id !== keepReg.id).map((r) => r.id)
+  }
+}
+
+/**
+ * Analyses one organisation for accreditations linked to multiple registrations.
+ * Returns fixes to apply and the total count of duplicate accreditations found
+ * (including those skipped due to ambiguity).
+ *
+ * @param {Organisation} org
+ * @returns {{
+ *   fixes: {
+ *     accreditationId: string,
+ *     registrations: {id: string, status: string}[],
+ *     keepId: string,
+ *     unlinkIds: string[]
+ *   }[],
+ *   duplicatesFound: number
+ * }}
+ */
+const findFixes = (org) => {
+  /** @type {Map<string, {id: string, status: string, formSubmission: {time: Date}}[]>} */
+  const accToRegs = new Map()
+
+  for (const reg of org.registrations) {
+    if (!reg.accreditationId) {
+      continue
+    }
+    const existing = accToRegs.get(reg.accreditationId) ?? []
+    existing.push({
+      id: reg.id,
+      status: reg.status,
+      formSubmission: reg.formSubmission
+    })
+    accToRegs.set(reg.accreditationId, existing)
+  }
+
+  const fixes = []
+  let duplicatesFound = 0
+
+  for (const [accreditationId, regs] of accToRegs) {
+    if (regs.length < 2) {
+      continue
+    }
+
+    duplicatesFound += 1
+    const regSummary = regs.map(({ id, status }) => ({ id, status }))
+
+    const regSummaryStr = regSummary
+      .map((r) => `${r.id}(${r.status})`)
+      .join(', ')
+
+    logger.info({
+      message: `Duplicate accreditation link: organisationId=${org.id} accreditationId=${accreditationId} registrations=[${regSummaryStr}]`
+    })
+
+    const resolution = resolveKeepAndUnlink(regs)
+
+    if (!resolution) {
+      logger.warn({
+        message: `Duplicate accreditation link skipped (multiple non-created registrations): organisationId=${org.id} accreditationId=${accreditationId} registrations=[${regSummaryStr}]`
+      })
+      continue
+    }
+
+    fixes.push({
+      accreditationId,
+      registrations: regSummary,
+      keepId: resolution.keepId,
+      unlinkIds: resolution.unlinkIds
+    })
+  }
+
+  return { fixes, duplicatesFound }
+}
+
+/**
+ * Applies fixes to an organisation's registrations by clearing accreditationId
+ * from all registrations in unlinkIds. Strips `id` so the result is suitable
+ * as the `updates` argument to `repository.replace()`.
+ *
+ * @param {Organisation} org
+ * @param {{accreditationId: string, unlinkIds: string[]}[]} fixes
+ * @returns {Omit<Organisation, 'id'>}
+ */
+const applyFixes = (org, fixes) => {
+  const unlinkSet = new Set(fixes.flatMap((f) => f.unlinkIds))
+
+  const updatedRegistrations = org.registrations.map((reg) => {
+    if (!unlinkSet.has(reg.id)) {
+      return reg
+    }
+    const { accreditationId: _removed, ...rest } = reg
+    return rest
+  })
+
+  const { id: _id, ...orgWithoutId } = org
+  return { ...orgWithoutId, registrations: updatedRegistrations }
+}
+
+/**
+ * @param {object} server
+ * @param {boolean} isDryRun
+ */
+const runMigration = async (server, isDryRun) => {
+  const organisationsRepository = (
+    await createOrganisationsRepository(server.db)
+  )()
+  const systemLogsRepository = (await createSystemLogsRepository(server.db))(
+    logger
+  )
+
+  const organisations = await organisationsRepository.findAll()
+
+  let totalDuplicateAccreditations = 0
+  let totalOrgsUpdated = 0
+  let totalOrgsFailed = 0
+
+  for (const org of organisations) {
+    const { fixes, duplicatesFound } = findFixes(org)
+
+    if (duplicatesFound === 0) {
+      continue
+    }
+
+    totalDuplicateAccreditations += duplicatesFound
+
+    if (isDryRun) {
+      const fixSummary = fixes
+        .map(
+          (f) =>
+            `accreditationId=${f.accreditationId} keep=${f.keepId} unlink=[${f.unlinkIds.join(',')}]`
+        )
+        .join('; ')
+      logger.info({
+        message: `Dry run — would fix duplicate accreditation links: organisationId=${org.id} fixes=[${fixSummary}]`
+      })
+      continue
+    }
+
+    if (fixes.length === 0) {
+      continue
+    }
+
+    try {
+      const updatedOrg = applyFixes(org, fixes)
+      await organisationsRepository.replace(org.id, org.version, updatedOrg)
+      await auditDuplicateAccreditationLinkMigration(
+        systemLogsRepository,
+        org.id,
+        org,
+        updatedOrg
+      )
+
+      totalOrgsUpdated += 1
+    } catch (error) {
+      totalOrgsFailed += 1
+      logger.error({
+        message: `Failed to fix duplicate accreditation links for organisation: organisationId=${org.id}`,
+        err: error
+      })
+    }
+  }
+
+  logger.info({
+    message: `Duplicate accreditation link migration complete: isDryRun=${isDryRun} totalDuplicateAccreditations=${totalDuplicateAccreditations} totalOrgsUpdated=${totalOrgsUpdated} totalOrgsFailed=${totalOrgsFailed}`
+  })
+}
+
+/**
+ * Startup migration that removes duplicate accreditation links from organisation
+ * registrations. Runs under a distributed lock so only one pod executes it per
+ * deploy.
+ *
+ * When the feature flag is disabled the migration runs in dry-run mode: it logs
+ * everything it would do but makes no database changes.
+ *
+ * @param {object} server - Hapi server instance
+ */
+export const runDuplicateAccreditationLinkMigration = async (server) => {
+  const isDryRun =
+    !server.featureFlags.isFixDuplicateAccreditationLinksEnabled()
+
+  try {
+    logger.info({
+      message: `Starting duplicate accreditation link migration: isDryRun=${isDryRun}`
+    })
+
+    const lock = await server.locker.lock(LOCK_NAME)
+    if (!lock) {
+      logger.info({
+        message:
+          'Unable to obtain lock, skipping duplicate accreditation link migration'
+      })
+      return
+    }
+
+    try {
+      await runMigration(server, isDryRun)
+    } finally {
+      await lock.free()
+    }
+  } catch (error) {
+    logger.error({
+      message: 'Failed to run duplicate accreditation link migration',
+      err: error
+    })
+  }
+}

--- a/src/server/run-duplicate-accreditation-link-migration.test.js
+++ b/src/server/run-duplicate-accreditation-link-migration.test.js
@@ -300,6 +300,13 @@ describe('runDuplicateAccreditationLinkMigration', () => {
       )
       expect(olderUpdated.accreditationId).toBeUndefined()
       expect(newerUpdated.accreditationId).toBe(accId)
+      // The kept registration must be untouched in every other field, not just accreditationId
+      expect(newerUpdated).toEqual(newerReg)
+      // The unlinked registration must only have accreditationId removed, nothing else changed
+      expect(olderUpdated).toEqual({
+        ...olderReg,
+        accreditationId: undefined
+      })
 
       expect(auditDuplicateAccreditationLinkMigration).toHaveBeenCalledWith(
         expect.anything(),
@@ -320,6 +327,55 @@ describe('runDuplicateAccreditationLinkMigration', () => {
         message:
           'Duplicate accreditation link migration complete: isDryRun=false totalDuplicateAccreditations=1 totalOrgsUpdated=1 totalOrgsFailed=0'
       })
+    })
+
+    it('leaves registrations linked to a different accreditation completely unchanged', async () => {
+      const server = buildServer(true)
+      const accId = buildAccreditationId()
+      const otherAccId = buildAccreditationId()
+      const acc = buildAccreditation({ id: accId })
+      const otherAcc = buildAccreditation({ id: otherAccId })
+      const olderReg = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-01-01')
+        }
+      })
+      const newerReg = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-06-01')
+        }
+      })
+      const unrelatedReg = buildRegistrationWithStatus('created', {
+        accreditationId: otherAccId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-03-01')
+        }
+      })
+      const org = buildOrganisation({
+        registrations: [olderReg, newerReg, unrelatedReg],
+        accreditations: [acc, otherAcc]
+      })
+      const spy = seedRepositories([org])
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(spy.replace).toHaveBeenCalledOnce()
+      const [, , updatedOrg] = /** @type {import('vitest').MockInstance} */ (
+        spy.replace
+      ).mock.calls[0]
+      const unrelatedUpdated = updatedOrg.registrations.find(
+        (r) => r.id === unrelatedReg.id
+      )
+      // The registration linked to a different (non-duplicated) accreditation
+      // must be passed through completely unchanged.
+      expect(unrelatedUpdated).toEqual(unrelatedReg)
+
+      expect(updatedOrg.accreditations).toEqual(org.accreditations)
     })
   })
 

--- a/src/server/run-duplicate-accreditation-link-migration.test.js
+++ b/src/server/run-duplicate-accreditation-link-migration.test.js
@@ -1,0 +1,617 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ObjectId } from 'mongodb'
+
+import { logger } from '#common/helpers/logging/logger.js'
+import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
+import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
+import { createSystemLogsRepository as createInMemorySystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import {
+  buildOrganisation,
+  buildRegistration,
+  buildAccreditation
+} from '#repositories/organisations/contract/test-data.js'
+
+import { runDuplicateAccreditationLinkMigration } from './run-duplicate-accreditation-link-migration.js'
+import { auditDuplicateAccreditationLinkMigration } from '#auditing/duplicate-accreditation-link-migration.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+vi.mock('#repositories/organisations/mongodb.js', () => ({
+  createOrganisationsRepository: vi.fn()
+}))
+vi.mock('#repositories/system-logs/mongodb.js', () => ({
+  createSystemLogsRepository: vi.fn()
+}))
+vi.mock('#auditing/duplicate-accreditation-link-migration.js', () => ({
+  auditDuplicateAccreditationLinkMigration: vi.fn().mockResolvedValue(undefined)
+}))
+
+const buildServer = (featureFlagEnabled = false) => {
+  const mockLock = { free: vi.fn().mockResolvedValue(undefined) }
+  return {
+    db: {},
+    locker: {
+      lock: vi.fn().mockResolvedValue(mockLock)
+    },
+    featureFlags: {
+      isFixDuplicateAccreditationLinksEnabled: () => featureFlagEnabled
+    },
+    _mockLock: mockLock
+  }
+}
+
+/**
+ * Seeds the mocked createOrganisationsRepository with an in-memory repo backed
+ * by the given organisations. Returns a shared spy object whose `replace`
+ * property is set once the factory is first invoked by the migration.
+ *
+ * Pass `mockReplace: true` to replace the `replace` method with a no-op spy
+ * so that Joi/status-transition validation inside the inmemory impl is bypassed.
+ * Use this when the test data contains status combinations (e.g. cancelled or
+ * approved registrations built from the base fixture) that would fail the
+ * schema validation inside `prepareForReplace`, and you only need to assert
+ * what was passed to `replace`, not that the DB write succeeded.
+ */
+const seedRepositories = (organisations, { mockReplace = false } = {}) => {
+  const inMemoryFactory = createInMemoryOrganisationsRepository(organisations)
+  const inMemorySystemLogsFactory = createInMemorySystemLogsRepository()
+  /** @type {{ replace: import('vitest').MockInstance | null }} */
+  const spy = { replace: null }
+
+  vi.mocked(createOrganisationsRepository).mockResolvedValue(() => {
+    const repo = inMemoryFactory()
+    if (mockReplace) {
+      repo.replace = vi.fn().mockResolvedValue(undefined)
+      spy.replace = /** @type {import('vitest').MockInstance} */ (
+        /** @type {unknown} */ (repo.replace)
+      )
+    } else {
+      spy.replace = vi.spyOn(repo, 'replace')
+    }
+    return repo
+  })
+
+  vi.mocked(createSystemLogsRepository).mockResolvedValue(
+    inMemorySystemLogsFactory
+  )
+
+  return spy
+}
+
+const buildAccreditationId = () => new ObjectId().toString()
+
+/**
+ * Builds a registration with an explicit statusHistory so that the inmemory
+ * repo's getCurrentStatus returns the desired status.
+ */
+const buildRegistrationWithStatus = (status, overrides = {}) =>
+  buildRegistration({
+    statusHistory: [
+      { status: 'created', updatedAt: new Date('2024-01-01') },
+      ...(status === 'created'
+        ? []
+        : [{ status, updatedAt: new Date('2024-02-01') }])
+    ],
+    ...overrides
+  })
+
+describe('runDuplicateAccreditationLinkMigration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('locking', () => {
+    it('acquires a lock scoped to the migration and releases it afterwards', async () => {
+      const server = buildServer(true)
+      seedRepositories([])
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(server.locker.lock).toHaveBeenCalledWith(
+        'duplicate-accreditation-link-migration'
+      )
+      expect(server._mockLock.free).toHaveBeenCalled()
+    })
+
+    it('skips the migration when the lock is held by another instance', async () => {
+      const server = buildServer(true)
+      server.locker.lock.mockResolvedValue(null)
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(createOrganisationsRepository).not.toHaveBeenCalled()
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            'Unable to obtain lock, skipping duplicate accreditation link migration'
+        })
+      )
+    })
+
+    it('releases the lock and logs an error when the migration throws', async () => {
+      const server = buildServer(true)
+      const error = new Error('mongo unavailable')
+      vi.mocked(createOrganisationsRepository).mockRejectedValue(error)
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Failed to run duplicate accreditation link migration',
+          err: error
+        })
+      )
+      expect(server._mockLock.free).toHaveBeenCalled()
+    })
+
+    it('tolerates the locker itself throwing', async () => {
+      const server = buildServer(true)
+      const error = new Error('locker unavailable')
+      server.locker.lock.mockRejectedValue(error)
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Failed to run duplicate accreditation link migration',
+          err: error
+        })
+      )
+    })
+  })
+
+  describe('no duplicate links', () => {
+    it('makes no changes and logs a zero summary when no accreditation is shared', async () => {
+      const server = buildServer(true)
+      const accId = buildAccreditationId()
+      const acc = buildAccreditation({ id: accId })
+      const reg = buildRegistrationWithStatus('created', {
+        accreditationId: accId
+      })
+      const org = buildOrganisation({
+        registrations: [reg],
+        accreditations: [acc]
+      })
+      const spy = seedRepositories([org])
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(spy.replace).not.toHaveBeenCalled()
+      expect(auditDuplicateAccreditationLinkMigration).not.toHaveBeenCalled()
+      expect(logger.warn).not.toHaveBeenCalled()
+      expect(logger.info).toHaveBeenCalledWith({
+        message:
+          'Duplicate accreditation link migration complete: isDryRun=false totalDuplicateAccreditations=0 totalOrgsUpdated=0 totalOrgsFailed=0'
+      })
+    })
+
+    it('skips registrations without an accreditationId when counting duplicates', async () => {
+      const server = buildServer(true)
+      const accId = buildAccreditationId()
+      const acc = buildAccreditation({ id: accId })
+      const regWithAcc = buildRegistrationWithStatus('created', {
+        accreditationId: accId
+      })
+      const regWithoutAcc = buildRegistrationWithStatus('created', {
+        accreditationId: undefined
+      })
+      const org = buildOrganisation({
+        registrations: [regWithAcc, regWithoutAcc],
+        accreditations: [acc]
+      })
+      const spy = seedRepositories([org])
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(spy.replace).not.toHaveBeenCalled()
+      expect(auditDuplicateAccreditationLinkMigration).not.toHaveBeenCalled()
+      expect(logger.info).toHaveBeenCalledWith({
+        message:
+          'Duplicate accreditation link migration complete: isDryRun=false totalDuplicateAccreditations=0 totalOrgsUpdated=0 totalOrgsFailed=0'
+      })
+    })
+  })
+
+  describe('dry-run mode (feature flag disabled)', () => {
+    it('logs what would change but does not call replace', async () => {
+      const server = buildServer(false)
+      const accId = buildAccreditationId()
+      const acc = buildAccreditation({ id: accId })
+      const reg1 = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-01-01')
+        }
+      })
+      const reg2 = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-06-01')
+        }
+      })
+      const org = buildOrganisation({
+        registrations: [reg1, reg2],
+        accreditations: [acc]
+      })
+      const spy = seedRepositories([org])
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(spy.replace).not.toHaveBeenCalled()
+      expect(auditDuplicateAccreditationLinkMigration).not.toHaveBeenCalled()
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            `Dry run — would fix duplicate accreditation links: organisationId=${org.id}`
+          )
+        })
+      )
+      expect(logger.info).toHaveBeenCalledWith({
+        message:
+          'Duplicate accreditation link migration complete: isDryRun=true totalDuplicateAccreditations=1 totalOrgsUpdated=0 totalOrgsFailed=0'
+      })
+    })
+  })
+
+  describe('two registrations both in created status', () => {
+    it('keeps the registration with the latest formSubmission.time and unlinks the earlier one', async () => {
+      const server = buildServer(true)
+      const accId = buildAccreditationId()
+      const acc = buildAccreditation({ id: accId })
+      const olderReg = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-01-01')
+        }
+      })
+      const newerReg = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-06-01')
+        }
+      })
+      const org = buildOrganisation({
+        registrations: [olderReg, newerReg],
+        accreditations: [acc]
+      })
+      const spy = seedRepositories([org])
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(spy.replace).toHaveBeenCalledOnce()
+      const [, , updatedOrg] = /** @type {import('vitest').MockInstance} */ (
+        spy.replace
+      ).mock.calls[0]
+      const olderUpdated = updatedOrg.registrations.find(
+        (r) => r.id === olderReg.id
+      )
+      const newerUpdated = updatedOrg.registrations.find(
+        (r) => r.id === newerReg.id
+      )
+      expect(olderUpdated.accreditationId).toBeUndefined()
+      expect(newerUpdated.accreditationId).toBe(accId)
+
+      expect(auditDuplicateAccreditationLinkMigration).toHaveBeenCalledWith(
+        expect.anything(),
+        org.id,
+        expect.objectContaining({ id: org.id }),
+        expect.objectContaining({
+          registrations: expect.arrayContaining([
+            expect.objectContaining({
+              id: newerReg.id,
+              accreditationId: accId
+            }),
+            expect.objectContaining({ id: olderReg.id })
+          ])
+        })
+      )
+
+      expect(logger.info).toHaveBeenCalledWith({
+        message:
+          'Duplicate accreditation link migration complete: isDryRun=false totalDuplicateAccreditations=1 totalOrgsUpdated=1 totalOrgsFailed=0'
+      })
+    })
+  })
+
+  describe('two registrations, one created and one non-created', () => {
+    it('keeps the non-created registration and unlinks the created one', async () => {
+      const server = buildServer(true)
+      const accId = buildAccreditationId()
+      const acc = buildAccreditation({ id: accId })
+      const createdReg = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-06-01')
+        }
+      })
+      const approvedReg = buildRegistrationWithStatus('approved', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2023-01-01')
+        }
+      })
+      const org = buildOrganisation({
+        registrations: [createdReg, approvedReg],
+        accreditations: [acc]
+      })
+      const spy = seedRepositories([org], { mockReplace: true })
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(spy.replace).toHaveBeenCalledOnce()
+      const [, , updatedOrg] = /** @type {import('vitest').MockInstance} */ (
+        spy.replace
+      ).mock.calls[0]
+      const createdUpdated = updatedOrg.registrations.find(
+        (r) => r.id === createdReg.id
+      )
+      const approvedUpdated = updatedOrg.registrations.find(
+        (r) => r.id === approvedReg.id
+      )
+      expect(createdUpdated.accreditationId).toBeUndefined()
+      expect(approvedUpdated.accreditationId).toBe(accId)
+
+      expect(auditDuplicateAccreditationLinkMigration).toHaveBeenCalledWith(
+        expect.anything(),
+        org.id,
+        expect.objectContaining({ id: org.id }),
+        expect.objectContaining({
+          registrations: expect.arrayContaining([
+            expect.objectContaining({
+              id: approvedReg.id,
+              accreditationId: accId
+            }),
+            expect.objectContaining({ id: createdReg.id })
+          ])
+        })
+      )
+    })
+  })
+
+  describe('two registrations both in non-created status (approved + cancelled)', () => {
+    it('warns and skips without calling replace', async () => {
+      const server = buildServer(true)
+      const accId = buildAccreditationId()
+      const acc = buildAccreditation({ id: accId })
+      const approvedReg = buildRegistrationWithStatus('approved', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-01-01')
+        }
+      })
+      const cancelledReg = buildRegistrationWithStatus('cancelled', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-06-01')
+        }
+      })
+      const org = buildOrganisation({
+        registrations: [approvedReg, cancelledReg],
+        accreditations: [acc]
+      })
+      const spy = seedRepositories([org])
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            `Duplicate accreditation link skipped (multiple non-created registrations): organisationId=${org.id} accreditationId=${accId}`
+          )
+        })
+      )
+      expect(spy.replace).not.toHaveBeenCalled()
+      expect(auditDuplicateAccreditationLinkMigration).not.toHaveBeenCalled()
+      expect(logger.info).toHaveBeenCalledWith({
+        message:
+          'Duplicate accreditation link migration complete: isDryRun=false totalDuplicateAccreditations=1 totalOrgsUpdated=0 totalOrgsFailed=0'
+      })
+    })
+  })
+
+  describe('three registrations all in created status', () => {
+    it('keeps the latest by formSubmission.time and unlinks the other two', async () => {
+      const server = buildServer(true)
+      const accId = buildAccreditationId()
+      const acc = buildAccreditation({ id: accId })
+      const reg1 = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-01-01')
+        }
+      })
+      const reg2 = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-09-01')
+        }
+      })
+      const reg3 = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-03-01')
+        }
+      })
+      const org = buildOrganisation({
+        registrations: [reg1, reg2, reg3],
+        accreditations: [acc]
+      })
+      const spy = seedRepositories([org])
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(spy.replace).toHaveBeenCalledOnce()
+      const [, , updatedOrg] = /** @type {import('vitest').MockInstance} */ (
+        spy.replace
+      ).mock.calls[0]
+      const reg1Updated = updatedOrg.registrations.find((r) => r.id === reg1.id)
+      const reg2Updated = updatedOrg.registrations.find((r) => r.id === reg2.id)
+      const reg3Updated = updatedOrg.registrations.find((r) => r.id === reg3.id)
+      expect(reg1Updated.accreditationId).toBeUndefined()
+      expect(reg2Updated.accreditationId).toBe(accId)
+      expect(reg3Updated.accreditationId).toBeUndefined()
+
+      expect(auditDuplicateAccreditationLinkMigration).toHaveBeenCalledWith(
+        expect.anything(),
+        org.id,
+        expect.objectContaining({ id: org.id }),
+        expect.objectContaining({
+          registrations: expect.arrayContaining([
+            expect.objectContaining({ id: reg2.id, accreditationId: accId }),
+            expect.objectContaining({ id: reg1.id }),
+            expect.objectContaining({ id: reg3.id })
+          ])
+        })
+      )
+    })
+  })
+
+  describe('summary pre-update logging', () => {
+    it('logs accreditation id and linked registration ids and statuses before each update', async () => {
+      const server = buildServer(true)
+      const accId = buildAccreditationId()
+      const acc = buildAccreditation({ id: accId })
+      const reg1 = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-01-01')
+        }
+      })
+      const reg2 = buildRegistrationWithStatus('created', {
+        accreditationId: accId,
+        formSubmission: {
+          id: new ObjectId().toString(),
+          time: new Date('2024-06-01')
+        }
+      })
+      const org = buildOrganisation({
+        registrations: [reg1, reg2],
+        accreditations: [acc]
+      })
+      seedRepositories([org])
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            `Duplicate accreditation link: organisationId=${org.id} accreditationId=${accId}`
+          )
+        })
+      )
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(reg1.id)
+        })
+      )
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(reg2.id)
+        })
+      )
+    })
+  })
+
+  describe('error resilience', () => {
+    it('continues processing remaining organisations after a per-org update failure and logs totals correctly', async () => {
+      const server = buildServer(true)
+      const accId1 = buildAccreditationId()
+      const accId2 = buildAccreditationId()
+
+      const org1 = buildOrganisation({
+        registrations: [
+          buildRegistrationWithStatus('created', {
+            accreditationId: accId1,
+            formSubmission: {
+              id: new ObjectId().toString(),
+              time: new Date('2024-01-01')
+            }
+          }),
+          buildRegistrationWithStatus('created', {
+            accreditationId: accId1,
+            formSubmission: {
+              id: new ObjectId().toString(),
+              time: new Date('2024-06-01')
+            }
+          })
+        ],
+        accreditations: [buildAccreditation({ id: accId1 })]
+      })
+
+      const org2 = buildOrganisation({
+        registrations: [
+          buildRegistrationWithStatus('created', {
+            accreditationId: accId2,
+            formSubmission: {
+              id: new ObjectId().toString(),
+              time: new Date('2024-01-01')
+            }
+          }),
+          buildRegistrationWithStatus('created', {
+            accreditationId: accId2,
+            formSubmission: {
+              id: new ObjectId().toString(),
+              time: new Date('2024-06-01')
+            }
+          })
+        ],
+        accreditations: [buildAccreditation({ id: accId2 })]
+      })
+
+      let replaceCallCount = 0
+      const inMemoryFactory = createInMemoryOrganisationsRepository(
+        // @ts-expect-error buildOrganisation returns Omit<Organisation, 'status'> — status is computed at read time
+        [org1, org2]
+      )
+
+      vi.mocked(createOrganisationsRepository).mockResolvedValue(() => {
+        const repo = inMemoryFactory()
+        const originalReplace = repo.replace.bind(repo)
+        repo.replace = async (...args) => {
+          replaceCallCount++
+          if (replaceCallCount === 1) {
+            throw new Error('simulated replace failure')
+          }
+          return originalReplace(...args)
+        }
+        return repo
+      })
+
+      vi.mocked(createSystemLogsRepository).mockResolvedValue(
+        createInMemorySystemLogsRepository()
+      )
+
+      await runDuplicateAccreditationLinkMigration(server)
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            `Failed to fix duplicate accreditation links for organisation: organisationId=${org1.id}`
+          )
+        })
+      )
+      expect(logger.info).toHaveBeenCalledWith({
+        message:
+          'Duplicate accreditation link migration complete: isDryRun=false totalDuplicateAccreditations=2 totalOrgsUpdated=1 totalOrgsFailed=1'
+      })
+    })
+  })
+})

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -43,6 +43,7 @@ import { commandQueueConsumerPlugin } from '#server/queue-consumer/queue-consume
 import { runFormsDataMigration } from '#server/run-forms-data-migration.js'
 import { copyFormFilesToS3 } from '#server/copy-form-files-to-s3.js'
 import { runOrganisationValidationSweep } from '#server/run-organisation-validation-sweep.js'
+import { runDuplicateAccreditationLinkMigration } from '#server/run-duplicate-accreditation-link-migration.js'
 
 /** @import { Lifecycle } from '@hapi/hapi' */
 
@@ -222,6 +223,7 @@ async function createServer(options = {}) {
     runFormsDataMigration(server)
     copyFormFilesToS3(server)
     runOrganisationValidationSweep(server)
+    runDuplicateAccreditationLinkMigration(server)
   })
 
   return server


### PR DESCRIPTION
Ticket: [PAE-1565](https://eaflood.atlassian.net/browse/PAE-1565)
- Add startup migration that detects and removes duplicate accreditation links across organisation registrations
- Introduce `FEATURE_FLAG_FIX_DUPLICATE_ACCREDITATION_LINKS` flag; migration runs in dry-run mode when disabled
- Run migration under distributed mongo lock so only one pod executes it per deploy
- Extract audit logic to `src/auditing/duplicate-accreditation-link-migration.js`, logging full before/after org state

[PAE-1565]: https://eaflood.atlassian.net/browse/PAE-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ