### PR TITLE
PAE-1565: Hold global-agent on its current major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,16 @@ updates:
       # Include direct package.json updates
       - dependency-type: direct
 
+    ignore:
+      # global-agent 4.x and undici 8.x break the service (reverted in #1327);
+      # hold both on their current major line until the breakage is resolved.
+      - dependency-name: global-agent
+        update-types:
+          - version-update:semver-major
+      - dependency-name: undici
+        update-types:
+          - version-update:semver-major
+
   # Update GitHub Actions
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,12 +53,9 @@ updates:
       - dependency-type: direct
 
     ignore:
-      # global-agent 4.x and undici 8.x break the service (reverted in #1327);
-      # hold both on their current major line until the breakage is resolved.
+      # global-agent 4.x breaks the service (reverted in #1327);
+      # hold it on its current major line until the breakage is resolved.
       - dependency-name: global-agent
-        update-types:
-          - version-update:semver-major
-      - dependency-name: undici
         update-types:
           - version-update:semver-major
 


### PR DESCRIPTION
Ticket: [PAE-1565](https://eaflood.atlassian.net/browse/PAE-1565)
`global-agent` 4.x broke the service and was reverted to `global-agent@3.0.0` in #1327. Dependabot would otherwise re-raise the major bump on its next run, since major version updates aren't grouped and come through as standalone PRs.

This adds an `ignore` block to `.github/dependabot.yml` scoped to `version-update:semver-major` for `global-agent`. Dependabot will no longer open the 4.x major bump, but minor and patch updates on the current 3.x line still flow so the dependency stays maintained. The filter applies to security updates as well, so a major can't return under a security advisory.

[PAE-1565]: https://eaflood.atlassian.net/browse/PAE-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ