### PR TITLE
PAE-1541: Add per-row exclusion reasons to loadsByReportingPeriod

### DIFF
--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -29,11 +29,11 @@ const MAX_ROWS = 100
  */
 
 /**
- * @typedef {{ count: number, tonnageDelta: number, rows?: RowDetail[] }} BalanceAffectingBucket
+ * @typedef {{ count: number, tonnageDelta: number, rows: RowDetail[] }} BalanceAffectingBucket
  */
 
 /**
- * @typedef {{ count: number, rows?: RowDetail[] }} NonBalanceAffectingBucket
+ * @typedef {{ count: number, rows: RowDetail[] }} NonBalanceAffectingBucket
  */
 
 /**
@@ -68,12 +68,12 @@ const MAX_ROWS = 100
  * @property {string[]} reasons - distinct exclusion reason codes from the current row
  */
 
-// added.balanceAffecting stays count-only (no rows); the other three buckets
-// carry an expandable rows list.
+// Every bucket carries an expandable rows list, so the structure is uniform;
+// the frontend renders rows only where its design calls for them.
 /** @returns {PeriodStatusByRecordChange} */
 const emptyChange = () => ({
   added: {
-    balanceAffecting: { count: 0, tonnageDelta: 0 },
+    balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
     nonBalanceAffecting: { count: 0, rows: [] }
   },
   adjusted: {
@@ -231,15 +231,13 @@ const PERIOD_TO_KEY = {
 
 /**
  * Appends a row to a bucket's list, capped at MAX_ROWS. The bucket's count
- * still reflects the true total even when the list is truncated. The
- * count-only added.balanceAffecting bucket has no rows array, so a missing
- * list is simply skipped.
+ * still reflects the true total even when the list is truncated.
  *
- * @param {RowDetail[] | undefined} rows
+ * @param {RowDetail[]} rows
  * @param {RowDetail} row
  */
 const pushRow = (rows, row) => {
-  if (rows && rows.length < MAX_ROWS) {
+  if (rows.length < MAX_ROWS) {
     rows.push(row)
   }
 }
@@ -263,8 +261,6 @@ const reduceEntries = (entries) => {
     } else {
       group.balanceAffecting.count += count
       group.balanceAffecting.tonnageDelta += tonnageDelta
-      // added.balanceAffecting carries no rows array, so pushRow skips it;
-      // adjusted.balanceAffecting lists its rows.
       pushRow(group.balanceAffecting.rows, identity)
     }
   }

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -23,9 +23,9 @@ const MAX_ROWS = 100
 /** @typedef {typeof PROCESSING_TYPE_TABLES[keyof typeof PROCESSING_TYPE_TABLES]} ProcessingTypeSchemas */
 
 /**
- * A single load's identity and exclusion reasons, listed under an expandable
- * bucket. reasons is empty for an included row.
- * @typedef {{ rowId: string, tableName: string, reasons: string[] }} RowDetail
+ * A single load's identity and exclusion reason codes, listed under an
+ * expandable bucket. exclusionReasons is empty for an included row.
+ * @typedef {{ rowId: string, tableName: string, exclusionReasons: string[] }} RowDetail
  */
 
 /**
@@ -65,7 +65,7 @@ const MAX_ROWS = 100
  * @property {number} tonnageDelta - rounded to 2dp; non-zero means balanceAffecting
  * @property {string} rowId - the record's row ID; carried onto every leg
  * @property {string} tableName - the schema's human sheet name
- * @property {string[]} reasons - distinct exclusion reason codes from the current row
+ * @property {string[]} exclusionReasons - distinct exclusion reason codes from the current row
  */
 
 // Every bucket carries an expandable rows list, so the structure is uniform;
@@ -144,16 +144,16 @@ const determineRecordStatus = (record, summaryLogId) => {
  * @param {import('#domain/summary-logs/table-schemas/index.js').TableSchema | null} schema
  * @param {Record<string, any>} data
  * @param {ClassificationContext} context
- * @returns {{ transactionAmount: number, reasons: string[] }}
+ * @returns {{ transactionAmount: number, exclusionReasons: string[] }}
  */
 const classifyRow = (schema, data, context) => {
   const result = schema?.classifyForWasteBalance?.(data, context)
   const transactionAmount =
     result?.outcome === ROW_OUTCOME.INCLUDED ? result.transactionAmount : 0
-  const reasons = result?.reasons
+  const exclusionReasons = result?.reasons
     ? [...new Set(result.reasons.map((reason) => reason.code))]
     : []
-  return { transactionAmount, reasons }
+  return { transactionAmount, exclusionReasons }
 }
 
 /**
@@ -324,7 +324,7 @@ const classifyAdjustedWasteRecord = ({
 
   // Reasons come from the current row, so both legs (including the old-period
   // reversal) reflect what the operator is uploading now.
-  const { transactionAmount: newAmount, reasons } = classifyRow(
+  const { transactionAmount: newAmount, exclusionReasons } = classifyRow(
     schema,
     record.data,
     context
@@ -341,7 +341,7 @@ const classifyAdjustedWasteRecord = ({
     identity: {
       rowId: String(record.rowId),
       tableName: schema.sheetName,
-      reasons
+      exclusionReasons
     }
   })
 }
@@ -393,7 +393,7 @@ export const classifyByPeriodStatus = ({
         cadence
       )
       if (period) {
-        const { transactionAmount, reasons } = classifyRow(
+        const { transactionAmount, exclusionReasons } = classifyRow(
           schema,
           record.data,
           classificationContext
@@ -405,7 +405,7 @@ export const classifyByPeriodStatus = ({
             identity: {
               rowId: String(record.rowId),
               tableName: schema.sheetName,
-              reasons
+              exclusionReasons
             }
           })
         )

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -9,6 +9,9 @@ import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
 /** Internal reporting-period status. Not serialised: mapped to output keys via PERIOD_TO_KEY. */
 const PERIOD_STATUS = Object.freeze({ OPEN: 'open', CLOSED: 'closed' })
 
+/** Per-bucket cap on listed rows; mirrors MAX_ROW_IDS in load-counts.js. */
+const MAX_ROWS = 100
+
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {PeriodicReport} from '#reports/repository/port.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
@@ -20,11 +23,17 @@ const PERIOD_STATUS = Object.freeze({ OPEN: 'open', CLOSED: 'closed' })
 /** @typedef {typeof PROCESSING_TYPE_TABLES[keyof typeof PROCESSING_TYPE_TABLES]} ProcessingTypeSchemas */
 
 /**
- * @typedef {{ count: number, tonnageDelta: number }} BalanceAffectingBucket
+ * A single load's identity and exclusion reasons, listed under an expandable
+ * bucket. reasons is empty for an included row.
+ * @typedef {{ rowId: string, tableName: string, reasons: string[] }} RowDetail
  */
 
 /**
- * @typedef {{ count: number }} NonBalanceAffectingBucket
+ * @typedef {{ count: number, tonnageDelta: number, rows?: RowDetail[] }} BalanceAffectingBucket
+ */
+
+/**
+ * @typedef {{ count: number, rows?: RowDetail[] }} NonBalanceAffectingBucket
  */
 
 /**
@@ -54,17 +63,22 @@ const PERIOD_STATUS = Object.freeze({ OPEN: 'open', CLOSED: 'closed' })
  * @property {'added' | 'adjusted'} change
  * @property {number} count - 1 per leg, so a record counts once per period it touches
  * @property {number} tonnageDelta - rounded to 2dp; non-zero means balanceAffecting
+ * @property {string} rowId - the record's row ID; carried onto every leg
+ * @property {string} tableName - the schema's human sheet name
+ * @property {string[]} reasons - distinct exclusion reason codes from the current row
  */
 
+// added.balanceAffecting stays count-only (no rows); the other three buckets
+// carry an expandable rows list.
 /** @returns {PeriodStatusByRecordChange} */
 const emptyChange = () => ({
   added: {
     balanceAffecting: { count: 0, tonnageDelta: 0 },
-    nonBalanceAffecting: { count: 0 }
+    nonBalanceAffecting: { count: 0, rows: [] }
   },
   adjusted: {
-    balanceAffecting: { count: 0, tonnageDelta: 0 },
-    nonBalanceAffecting: { count: 0 }
+    balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
+    nonBalanceAffecting: { count: 0, rows: [] }
   }
 })
 
@@ -122,17 +136,24 @@ const determineRecordStatus = (record, summaryLogId) => {
 }
 
 /**
- * Computes the transaction amount for a record via classifyForWasteBalance.
- * Returns 0 if the schema has no classifier or the outcome is not INCLUDED.
+ * Classifies a record via classifyForWasteBalance, returning both the
+ * transaction amount (0 unless the outcome is INCLUDED) and the distinct
+ * exclusion reason codes. Code-only and deduped: a row missing several fields
+ * yields a single MISSING_REQUIRED_FIELD code, and an included row yields [].
  *
  * @param {import('#domain/summary-logs/table-schemas/index.js').TableSchema | null} schema
  * @param {Record<string, any>} data
  * @param {ClassificationContext} context
- * @returns {number}
+ * @returns {{ transactionAmount: number, reasons: string[] }}
  */
-const getTransactionAmount = (schema, data, context) => {
+const classifyRow = (schema, data, context) => {
   const result = schema?.classifyForWasteBalance?.(data, context)
-  return result?.outcome === ROW_OUTCOME.INCLUDED ? result.transactionAmount : 0
+  const transactionAmount =
+    result?.outcome === ROW_OUTCOME.INCLUDED ? result.transactionAmount : 0
+  const reasons = result?.reasons
+    ? [...new Set(result.reasons.map((reason) => reason.code))]
+    : []
+  return { transactionAmount, reasons }
 }
 
 /**
@@ -143,14 +164,16 @@ const getTransactionAmount = (schema, data, context) => {
  * @param {Object} params
  * @param {'open' | 'closed'} params.period
  * @param {number} params.transactionAmount
+ * @param {RowDetail} params.identity
  * @returns {PeriodStatusEntry[]}
  */
-const classifyAddedRecord = ({ period, transactionAmount }) => [
+const classifyAddedRecord = ({ period, transactionAmount, identity }) => [
   {
     period,
     change: 'added',
     count: 1,
-    tonnageDelta: roundToTwoDecimalPlaces(transactionAmount)
+    tonnageDelta: roundToTwoDecimalPlaces(transactionAmount),
+    ...identity
   }
 ]
 
@@ -166,13 +189,15 @@ const classifyAddedRecord = ({ period, transactionAmount }) => [
  * @param {'open' | 'closed' | null} params.newPeriod
  * @param {number} params.oldAmount
  * @param {number} params.newAmount
+ * @param {RowDetail} params.identity
  * @returns {PeriodStatusEntry[]}
  */
 const classifyAdjustedRecord = ({
   oldPeriod,
   newPeriod,
   oldAmount,
-  newAmount
+  newAmount,
+  identity
 }) => {
   /** @type {Map<'open' | 'closed', number>} */
   const legs = new Map()
@@ -190,7 +215,8 @@ const classifyAdjustedRecord = ({
     period,
     change: 'adjusted',
     count: 1,
-    tonnageDelta: roundToTwoDecimalPlaces(tonnageDelta)
+    tonnageDelta: roundToTwoDecimalPlaces(tonnageDelta),
+    ...identity
   }))
 }
 
@@ -204,6 +230,21 @@ const PERIOD_TO_KEY = {
 }
 
 /**
+ * Appends a row to a bucket's list, capped at MAX_ROWS. The bucket's count
+ * still reflects the true total even when the list is truncated. The
+ * count-only added.balanceAffecting bucket has no rows array, so a missing
+ * list is simply skipped.
+ *
+ * @param {RowDetail[] | undefined} rows
+ * @param {RowDetail} row
+ */
+const pushRow = (rows, row) => {
+  if (rows && rows.length < MAX_ROWS) {
+    rows.push(row)
+  }
+}
+
+/**
  * Folds an array of entries into the LoadsByReportingPeriod structure.
  *
  * @param {PeriodStatusEntry[]} entries
@@ -212,15 +253,19 @@ const PERIOD_TO_KEY = {
 const reduceEntries = (entries) => {
   const result = emptyResult()
 
-  for (const { period, change, count, tonnageDelta } of entries) {
+  for (const { period, change, count, tonnageDelta, ...identity } of entries) {
     const group = result[PERIOD_TO_KEY[period]][change]
     // A leg with no net delta is nonBalanceAffecting; any movement (rounded)
     // goes to balanceAffecting.
     if (tonnageDelta === 0) {
       group.nonBalanceAffecting.count += count
+      pushRow(group.nonBalanceAffecting.rows, identity)
     } else {
       group.balanceAffecting.count += count
       group.balanceAffecting.tonnageDelta += tonnageDelta
+      // added.balanceAffecting carries no rows array, so pushRow skips it;
+      // adjusted.balanceAffecting lists its rows.
+      pushRow(group.balanceAffecting.rows, identity)
     }
   }
 
@@ -281,16 +326,27 @@ const classifyAdjustedWasteRecord = ({
     return []
   }
 
-  const newAmount = getTransactionAmount(schema, record.data, context)
+  // Reasons come from the current row, so both legs (including the old-period
+  // reversal) reflect what the operator is uploading now.
+  const { transactionAmount: newAmount, reasons } = classifyRow(
+    schema,
+    record.data,
+    context
+  )
   const oldAmount = existing
-    ? getTransactionAmount(schema, existing.data, context)
+    ? classifyRow(schema, existing.data, context).transactionAmount
     : 0
 
   return classifyAdjustedRecord({
     oldPeriod,
     newPeriod,
     oldAmount,
-    newAmount
+    newAmount,
+    identity: {
+      rowId: String(record.rowId),
+      tableName: schema.sheetName,
+      reasons
+    }
   })
 }
 
@@ -341,7 +397,7 @@ export const classifyByPeriodStatus = ({
         cadence
       )
       if (period) {
-        const amount = getTransactionAmount(
+        const { transactionAmount, reasons } = classifyRow(
           schema,
           record.data,
           classificationContext
@@ -349,7 +405,12 @@ export const classifyByPeriodStatus = ({
         entries.push(
           ...classifyAddedRecord({
             period,
-            transactionAmount: amount
+            transactionAmount,
+            identity: {
+              rowId: String(record.rowId),
+              tableName: schema.sheetName,
+              reasons
+            }
           })
         )
       }

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -23,7 +23,7 @@ const PERIOD_STATUS = Object.freeze({ OPEN: 'open', CLOSED: 'closed' })
 /**
  * A single load's identity and exclusion reason codes, listed under an
  * expandable bucket. exclusionReasons is empty for an included row.
- * @typedef {{ rowId: string, tableName: string, exclusionReasons: string[] }} RowDetail
+ * @typedef {{ rowId: string, wasteRecordType: string, exclusionReasons: string[] }} RowDetail
  */
 
 /**
@@ -62,7 +62,7 @@ const PERIOD_STATUS = Object.freeze({ OPEN: 'open', CLOSED: 'closed' })
  * @property {number} count - 1 per leg, so a record counts once per period it touches
  * @property {number} tonnageDelta - rounded to 2dp; non-zero means balanceAffecting
  * @property {string} rowId - the record's row ID; carried onto every leg
- * @property {string} tableName - the schema's human sheet name
+ * @property {string} wasteRecordType - the schema's waste record type code (e.g. 'received', 'exported')
  * @property {string[]} exclusionReasons - distinct exclusion reason codes from the current row
  */
 
@@ -338,7 +338,7 @@ const classifyAdjustedWasteRecord = ({
     newAmount,
     identity: {
       rowId: String(record.rowId),
-      tableName: schema.sheetName,
+      wasteRecordType: schema.wasteRecordType,
       exclusionReasons
     }
   })
@@ -402,7 +402,7 @@ export const classifyByPeriodStatus = ({
             transactionAmount,
             identity: {
               rowId: String(record.rowId),
-              tableName: schema.sheetName,
+              wasteRecordType: schema.wasteRecordType,
               exclusionReasons
             }
           })

--- a/src/application/summary-logs/period-status.js
+++ b/src/application/summary-logs/period-status.js
@@ -5,12 +5,10 @@ import {
   isDateInSubmittedPeriod
 } from '#reports/domain/submitted-periods.js'
 import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
+import { MAX_ROWS_PER_BUCKET } from '#domain/summary-logs/loads-by-period-status-schema.js'
 
 /** Internal reporting-period status. Not serialised: mapped to output keys via PERIOD_TO_KEY. */
 const PERIOD_STATUS = Object.freeze({ OPEN: 'open', CLOSED: 'closed' })
-
-/** Per-bucket cap on listed rows; mirrors MAX_ROW_IDS in load-counts.js. */
-const MAX_ROWS = 100
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {PeriodicReport} from '#reports/repository/port.js' */
@@ -230,14 +228,14 @@ const PERIOD_TO_KEY = {
 }
 
 /**
- * Appends a row to a bucket's list, capped at MAX_ROWS. The bucket's count
- * still reflects the true total even when the list is truncated.
+ * Appends a row to a bucket's list, capped at MAX_ROWS_PER_BUCKET. The bucket's
+ * count still reflects the true total even when the list is truncated.
  *
  * @param {RowDetail[]} rows
  * @param {RowDetail} row
  */
 const pushRow = (rows, row) => {
-  if (rows.length < MAX_ROWS) {
+  if (rows.length < MAX_ROWS_PER_BUCKET) {
     rows.push(row)
   }
 }

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -94,19 +94,13 @@ const REGISTERED_ONLY_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
   })
 )
 
-// added.balanceAffecting stays count-only; the other three buckets carry an
-// expandable rows list, so empty added and adjusted groups differ in shape.
-const emptyAdded = () => ({
-  balanceAffecting: { count: 0, tonnageDelta: 0 },
-  nonBalanceAffecting: { count: 0, rows: [] }
-})
-const emptyAdjusted = () => ({
+const emptyChange = () => ({
   balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
   nonBalanceAffecting: { count: 0, rows: [] }
 })
 const emptyPeriod = () => ({
-  added: emptyAdded(),
-  adjusted: emptyAdjusted()
+  added: emptyChange(),
+  adjusted: emptyChange()
 })
 const emptyResult = () => ({
   openPeriodLoads: emptyPeriod(),
@@ -207,7 +201,11 @@ describe('classifyByPeriodStatus', () => {
 
       expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
         count: 2,
-        tonnageDelta: 0.3
+        tonnageDelta: 0.3,
+        rows: [
+          { rowId: '10001', tableName: 'Received', reasons: [] },
+          { rowId: '10002', tableName: 'Received', reasons: [] }
+        ]
       })
     })
 
@@ -435,7 +433,8 @@ describe('classifyByPeriodStatus', () => {
 
       expect(result.closedPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
-        tonnageDelta: 10
+        tonnageDelta: 10,
+        rows: [{ rowId: '10001', tableName: 'Received', reasons: [] }]
       })
     })
   })
@@ -578,7 +577,8 @@ describe('classifyByPeriodStatus', () => {
 
       expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
-        tonnageDelta: 10
+        tonnageDelta: 10,
+        rows: [{ rowId: '10001', tableName: 'Received', reasons: [] }]
       })
     })
   })

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { classifyByPeriodStatus } from './period-status.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { VERSION_STATUS } from '#domain/waste-records/model.js'
+import { MAX_ROWS_PER_BUCKET } from '#domain/summary-logs/loads-by-period-status-schema.js'
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {PeriodicReport} from '#reports/repository/port.js' */
@@ -211,8 +212,9 @@ describe('classifyByPeriodStatus', () => {
 
     it('caps a bucket rows list at 100 while count keeps the true total', () => {
       // Zero-tonnage loads are balance-neutral, so they land in
-      // nonBalanceAffecting, which lists rows. 101 of them exceed the cap.
-      const wasteRecords = Array.from({ length: 101 }, (_, index) =>
+      // nonBalanceAffecting, which lists rows. One more than the cap overflows.
+      const overCap = MAX_ROWS_PER_BUCKET + 1
+      const wasteRecords = Array.from({ length: overCap }, (_, index) =>
         buildWasteRecord({
           rowId: String(10001 + index),
           data: {
@@ -225,8 +227,8 @@ describe('classifyByPeriodStatus', () => {
       const result = classifyByPeriodStatus({ ...baseParams, wasteRecords })
 
       const bucket = result.openPeriodLoads.added.nonBalanceAffecting
-      expect(bucket.count).toBe(101)
-      expect(bucket.rows).toHaveLength(100)
+      expect(bucket.count).toBe(overCap)
+      expect(bucket.rows).toHaveLength(MAX_ROWS_PER_BUCKET)
     })
   })
 

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -68,6 +68,7 @@ const SINGLE_DATE_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
     RECEIVED_LOADS_FOR_REPROCESSING: {
       reportingDateFields: ['DATE_RECEIVED_FOR_REPROCESSING'],
       wasteRecordType: 'received',
+      sheetName: 'Received',
       classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
         outcome: ROW_OUTCOME.INCLUDED,
         reasons: [],
@@ -83,6 +84,7 @@ const REGISTERED_ONLY_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
     RECEIVED_LOADS_FOR_REPROCESSING: {
       reportingDateFields: ['MONTH_RECEIVED_FOR_REPROCESSING'],
       wasteRecordType: 'received',
+      sheetName: 'Received',
       classifyForWasteBalance: (/** @type {Record<string, any>} */ data) => ({
         outcome: ROW_OUTCOME.INCLUDED,
         reasons: [],
@@ -92,13 +94,19 @@ const REGISTERED_ONLY_TABLE_SCHEMAS = /** @type {ProcessingTypeSchemas} */ (
   })
 )
 
-const emptyChange = () => ({
+// added.balanceAffecting stays count-only; the other three buckets carry an
+// expandable rows list, so empty added and adjusted groups differ in shape.
+const emptyAdded = () => ({
   balanceAffecting: { count: 0, tonnageDelta: 0 },
-  nonBalanceAffecting: { count: 0 }
+  nonBalanceAffecting: { count: 0, rows: [] }
+})
+const emptyAdjusted = () => ({
+  balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
+  nonBalanceAffecting: { count: 0, rows: [] }
 })
 const emptyPeriod = () => ({
-  added: emptyChange(),
-  adjusted: emptyChange()
+  added: emptyAdded(),
+  adjusted: emptyAdjusted()
 })
 const emptyResult = () => ({
   openPeriodLoads: emptyPeriod(),
@@ -202,6 +210,26 @@ describe('classifyByPeriodStatus', () => {
         tonnageDelta: 0.3
       })
     })
+
+    it('caps a bucket rows list at 100 while count keeps the true total', () => {
+      // Zero-tonnage loads are balance-neutral, so they land in
+      // nonBalanceAffecting, which lists rows. 101 of them exceed the cap.
+      const wasteRecords = Array.from({ length: 101 }, (_, index) =>
+        buildWasteRecord({
+          rowId: String(10001 + index),
+          data: {
+            DATE_RECEIVED_FOR_REPROCESSING: '2026-01-15',
+            GROSS_WEIGHT: '0'
+          }
+        })
+      )
+
+      const result = classifyByPeriodStatus({ ...baseParams, wasteRecords })
+
+      const bucket = result.openPeriodLoads.added.nonBalanceAffecting
+      expect(bucket.count).toBe(101)
+      expect(bucket.rows).toHaveLength(100)
+    })
   })
 
   describe('adjusted records', () => {
@@ -286,7 +314,8 @@ describe('classifyByPeriodStatus', () => {
       // No existing record so oldPeriod is null, oldAmount is 0
       expect(result.openPeriodLoads.adjusted.balanceAffecting).toEqual({
         count: 1,
-        tonnageDelta: 50
+        tonnageDelta: 50,
+        rows: [{ rowId: '10001', tableName: 'Received', reasons: [] }]
       })
     })
 

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { classifyByPeriodStatus } from './period-status.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
-import { VERSION_STATUS } from '#domain/waste-records/model.js'
+import {
+  VERSION_STATUS,
+  WASTE_RECORD_TYPE
+} from '#domain/waste-records/model.js'
 import { MAX_ROWS_PER_BUCKET } from '#domain/summary-logs/loads-by-period-status-schema.js'
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
@@ -204,8 +207,16 @@ describe('classifyByPeriodStatus', () => {
         count: 2,
         tonnageDelta: 0.3,
         rows: [
-          { rowId: '10001', tableName: 'Received', exclusionReasons: [] },
-          { rowId: '10002', tableName: 'Received', exclusionReasons: [] }
+          {
+            rowId: '10001',
+            wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+            exclusionReasons: []
+          },
+          {
+            rowId: '10002',
+            wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+            exclusionReasons: []
+          }
         ]
       })
     })
@@ -315,7 +326,13 @@ describe('classifyByPeriodStatus', () => {
       expect(result.openPeriodLoads.adjusted.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 50,
-        rows: [{ rowId: '10001', tableName: 'Received', exclusionReasons: [] }]
+        rows: [
+          {
+            rowId: '10001',
+            wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+            exclusionReasons: []
+          }
+        ]
       })
     })
 
@@ -436,7 +453,13 @@ describe('classifyByPeriodStatus', () => {
       expect(result.closedPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 10,
-        rows: [{ rowId: '10001', tableName: 'Received', exclusionReasons: [] }]
+        rows: [
+          {
+            rowId: '10001',
+            wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+            exclusionReasons: []
+          }
+        ]
       })
     })
   })
@@ -580,7 +603,13 @@ describe('classifyByPeriodStatus', () => {
       expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 10,
-        rows: [{ rowId: '10001', tableName: 'Received', exclusionReasons: [] }]
+        rows: [
+          {
+            rowId: '10001',
+            wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+            exclusionReasons: []
+          }
+        ]
       })
     })
   })

--- a/src/application/summary-logs/period-status.test.js
+++ b/src/application/summary-logs/period-status.test.js
@@ -203,8 +203,8 @@ describe('classifyByPeriodStatus', () => {
         count: 2,
         tonnageDelta: 0.3,
         rows: [
-          { rowId: '10001', tableName: 'Received', reasons: [] },
-          { rowId: '10002', tableName: 'Received', reasons: [] }
+          { rowId: '10001', tableName: 'Received', exclusionReasons: [] },
+          { rowId: '10002', tableName: 'Received', exclusionReasons: [] }
         ]
       })
     })
@@ -313,7 +313,7 @@ describe('classifyByPeriodStatus', () => {
       expect(result.openPeriodLoads.adjusted.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 50,
-        rows: [{ rowId: '10001', tableName: 'Received', reasons: [] }]
+        rows: [{ rowId: '10001', tableName: 'Received', exclusionReasons: [] }]
       })
     })
 
@@ -434,7 +434,7 @@ describe('classifyByPeriodStatus', () => {
       expect(result.closedPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 10,
-        rows: [{ rowId: '10001', tableName: 'Received', reasons: [] }]
+        rows: [{ rowId: '10001', tableName: 'Received', exclusionReasons: [] }]
       })
     })
   })
@@ -578,7 +578,7 @@ describe('classifyByPeriodStatus', () => {
       expect(result.openPeriodLoads.added.balanceAffecting).toEqual({
         count: 1,
         tonnageDelta: 10,
-        rows: [{ rowId: '10001', tableName: 'Received', reasons: [] }]
+        rows: [{ rowId: '10001', tableName: 'Received', exclusionReasons: [] }]
       })
     })
   })

--- a/src/domain/summary-logs/loads-by-period-status-schema.js
+++ b/src/domain/summary-logs/loads-by-period-status-schema.js
@@ -14,7 +14,8 @@ const rowDetailSchema = Joi.object({
   reasons: Joi.array().items(Joi.string()).required()
 })
 
-// rows is optional: the count-only added.balanceAffecting bucket omits it.
+// rows is optional for backward compatibility: summary logs validated before
+// this field existed have no rows. Newly validated logs always populate it.
 const rowsSchema = Joi.array().items(rowDetailSchema).max(100)
 
 const balanceAffectingBucketSchema = Joi.object({
@@ -43,18 +44,13 @@ export const loadsByReportingPeriodSchema = Joi.object({
   closedPeriodLoads: periodStatusByChangeSchema.required()
 })
 
-// added.balanceAffecting stays count-only; the other three buckets carry an
-// empty rows list, matching the populated shape in period-status.js.
-const emptyChange = () => ({
-  added: {
-    balanceAffecting: { count: 0, tonnageDelta: 0 },
-    nonBalanceAffecting: { count: 0, rows: [] }
-  },
-  adjusted: {
-    balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
-    nonBalanceAffecting: { count: 0, rows: [] }
-  }
+// Every bucket carries an empty rows list, matching the uniform populated
+// shape produced in period-status.js.
+const emptyGroup = () => ({
+  balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
+  nonBalanceAffecting: { count: 0, rows: [] }
 })
+const emptyChange = () => ({ added: emptyGroup(), adjusted: emptyGroup() })
 
 /** Default loadsByReportingPeriod for validated logs without period-status data. */
 export const emptyLoadsByReportingPeriod = () => ({

--- a/src/domain/summary-logs/loads-by-period-status-schema.js
+++ b/src/domain/summary-logs/loads-by-period-status-schema.js
@@ -11,12 +11,12 @@ import Joi from 'joi'
 const rowDetailSchema = Joi.object({
   rowId: Joi.string().required(),
   tableName: Joi.string().required(),
-  reasons: Joi.array().items(Joi.string()).required()
+  exclusionReasons: Joi.array().items(Joi.string()).required()
 })
 
-// rows is optional for backward compatibility: summary logs validated before
-// this field existed have no rows. Newly validated logs always populate it.
-const rowsSchema = Joi.array().items(rowDetailSchema).max(100)
+// Every bucket carries a rows list; the frontend renders it only where its
+// design calls for them.
+const rowsSchema = Joi.array().items(rowDetailSchema).max(100).required()
 
 const balanceAffectingBucketSchema = Joi.object({
   count: Joi.number().integer().min(0).required(),

--- a/src/domain/summary-logs/loads-by-period-status-schema.js
+++ b/src/domain/summary-logs/loads-by-period-status-schema.js
@@ -6,13 +6,26 @@ import Joi from 'joi'
  * Used by both repository (storage validation) and route (response validation).
  */
 
+// One listed load: its identity and distinct exclusion reason codes (empty for
+// an included load). Capped at 100 per bucket, mirroring MAX_ROW_IDS.
+const rowDetailSchema = Joi.object({
+  rowId: Joi.string().required(),
+  tableName: Joi.string().required(),
+  reasons: Joi.array().items(Joi.string()).required()
+})
+
+// rows is optional: the count-only added.balanceAffecting bucket omits it.
+const rowsSchema = Joi.array().items(rowDetailSchema).max(100)
+
 const balanceAffectingBucketSchema = Joi.object({
   count: Joi.number().integer().min(0).required(),
-  tonnageDelta: Joi.number().required()
+  tonnageDelta: Joi.number().required(),
+  rows: rowsSchema
 })
 
 const nonBalanceAffectingBucketSchema = Joi.object({
-  count: Joi.number().integer().min(0).required()
+  count: Joi.number().integer().min(0).required(),
+  rows: rowsSchema
 })
 
 const periodStatusGroupSchema = Joi.object({
@@ -30,11 +43,18 @@ export const loadsByReportingPeriodSchema = Joi.object({
   closedPeriodLoads: periodStatusByChangeSchema.required()
 })
 
-const emptyGroup = () => ({
-  balanceAffecting: { count: 0, tonnageDelta: 0 },
-  nonBalanceAffecting: { count: 0 }
+// added.balanceAffecting stays count-only; the other three buckets carry an
+// empty rows list, matching the populated shape in period-status.js.
+const emptyChange = () => ({
+  added: {
+    balanceAffecting: { count: 0, tonnageDelta: 0 },
+    nonBalanceAffecting: { count: 0, rows: [] }
+  },
+  adjusted: {
+    balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
+    nonBalanceAffecting: { count: 0, rows: [] }
+  }
 })
-const emptyChange = () => ({ added: emptyGroup(), adjusted: emptyGroup() })
 
 /** Default loadsByReportingPeriod for validated logs without period-status data. */
 export const emptyLoadsByReportingPeriod = () => ({

--- a/src/domain/summary-logs/loads-by-period-status-schema.js
+++ b/src/domain/summary-logs/loads-by-period-status-schema.js
@@ -1,5 +1,7 @@
 import Joi from 'joi'
 
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
 /**
  * Shared Joi schema for loads classified by reporting period status.
  *
@@ -15,7 +17,9 @@ export const MAX_ROWS_PER_BUCKET = 100
 // an included load).
 const rowDetailSchema = Joi.object({
   rowId: Joi.string().required(),
-  tableName: Joi.string().required(),
+  wasteRecordType: Joi.string()
+    .valid(...Object.values(WASTE_RECORD_TYPE))
+    .required(),
   exclusionReasons: Joi.array().items(Joi.string()).required()
 })
 

--- a/src/domain/summary-logs/loads-by-period-status-schema.js
+++ b/src/domain/summary-logs/loads-by-period-status-schema.js
@@ -6,8 +6,13 @@ import Joi from 'joi'
  * Used by both repository (storage validation) and route (response validation).
  */
 
+// Per-bucket cap on listed rows. The producer (period-status.js) truncates to
+// this and the schema validates it; sharing one constant keeps them in step.
+// Matches MAX_ROW_IDS in load-counts.js.
+export const MAX_ROWS_PER_BUCKET = 100
+
 // One listed load: its identity and distinct exclusion reason codes (empty for
-// an included load). Capped at 100 per bucket, mirroring MAX_ROW_IDS.
+// an included load).
 const rowDetailSchema = Joi.object({
   rowId: Joi.string().required(),
   tableName: Joi.string().required(),
@@ -16,7 +21,10 @@ const rowDetailSchema = Joi.object({
 
 // Every bucket carries a rows list; the frontend renders it only where its
 // design calls for them.
-const rowsSchema = Joi.array().items(rowDetailSchema).max(100).required()
+const rowsSchema = Joi.array()
+  .items(rowDetailSchema)
+  .max(MAX_ROWS_PER_BUCKET)
+  .required()
 
 const balanceAffectingBucketSchema = Joi.object({
   count: Joi.number().integer().min(0).required(),

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
@@ -9,6 +9,7 @@ import {
   MONTHLY_PERIODS,
   QUARTERLY_PERIODS
 } from '#reports/domain/period-labels.js'
+import { CLASSIFICATION_REASON } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 import { createAndSubmitReport } from '#reports/repository/contract/test-data.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 
@@ -145,9 +146,15 @@ describe('loadsByReportingPeriod population at validate time', () => {
       dueDate: '2025-02-20T00:00:00.000Z'
     })
 
-  const emptyChange = () => ({
+  // added.balanceAffecting stays count-only; the other three buckets carry an
+  // expandable rows list, so empty added and adjusted groups differ in shape.
+  const emptyAdded = () => ({
     balanceAffecting: { count: 0, tonnageDelta: 0 },
-    nonBalanceAffecting: { count: 0 }
+    nonBalanceAffecting: { count: 0, rows: [] }
+  })
+  const emptyAdjusted = () => ({
+    balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
+    nonBalanceAffecting: { count: 0, rows: [] }
   })
 
   it('splits added loads into balanceAffecting and nonBalanceAffecting by ORS approval', async () => {
@@ -174,13 +181,22 @@ describe('loadsByReportingPeriod population at validate time', () => {
       openPeriodLoads: {
         added: {
           balanceAffecting: { count: 1, tonnageDelta: 100 },
-          nonBalanceAffecting: { count: 1 }
+          nonBalanceAffecting: {
+            count: 1,
+            rows: [
+              {
+                rowId: '2001',
+                tableName: 'Exported',
+                reasons: [CLASSIFICATION_REASON.ORS_NOT_APPROVED]
+              }
+            ]
+          }
         },
-        adjusted: emptyChange()
+        adjusted: emptyAdjusted()
       },
       closedPeriodLoads: {
-        added: emptyChange(),
-        adjusted: emptyChange()
+        added: emptyAdded(),
+        adjusted: emptyAdjusted()
       }
     })
   })
@@ -203,8 +219,45 @@ describe('loadsByReportingPeriod population at validate time', () => {
 
     expect(loadsByReportingPeriod.openPeriodLoads.added).toEqual({
       balanceAffecting: { count: 0, tonnageDelta: 0 },
-      nonBalanceAffecting: { count: 1 }
+      nonBalanceAffecting: {
+        count: 1,
+        rows: [
+          {
+            rowId: '1001',
+            tableName: 'Exported',
+            reasons: [CLASSIFICATION_REASON.PRN_ISSUED]
+          }
+        ]
+      }
     })
+  })
+
+  it('records each nonBalanceAffecting row with its identity and exclusion reason', async () => {
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'exporter'
+    })
+
+    // A PRN/PERN-issued load is excluded from the waste balance for a known
+    // reason. The expandable bucket must carry the row's identity and the
+    // exclusion reason code so the check page can list it.
+    const loadsByReportingPeriod = await uploadAndValidate(
+      env,
+      'sl-prn-rows',
+      'file-prn-rows',
+      createUploadData([
+        { rowId: 1001, osrId: 100, exportTonnage: 100, prnIssued: 'Yes' }
+      ])
+    )
+
+    expect(
+      loadsByReportingPeriod.openPeriodLoads.added.nonBalanceAffecting.rows
+    ).toEqual([
+      {
+        rowId: '1001',
+        tableName: 'Exported',
+        reasons: [CLASSIFICATION_REASON.PRN_ISSUED]
+      }
+    ])
   })
 
   it('classifies an added load dated in a closed period as a closed-period load', async () => {
@@ -320,7 +373,11 @@ describe('loadsByReportingPeriod population at validate time', () => {
 
     expect(
       loadsByReportingPeriod.openPeriodLoads.adjusted.balanceAffecting
-    ).toEqual({ count: 1, tonnageDelta: 50 })
+    ).toEqual({
+      count: 1,
+      tonnageDelta: 50,
+      rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+    })
     expect(
       loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
     ).toBe(0)
@@ -371,10 +428,18 @@ describe('loadsByReportingPeriod population at validate time', () => {
     // (+100); each period it touches counts the load once.
     expect(
       loadsByReportingPeriod.closedPeriodLoads.adjusted.balanceAffecting
-    ).toEqual({ count: 1, tonnageDelta: -100 })
+    ).toEqual({
+      count: 1,
+      tonnageDelta: -100,
+      rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+    })
     expect(
       loadsByReportingPeriod.openPeriodLoads.adjusted.balanceAffecting
-    ).toEqual({ count: 1, tonnageDelta: 100 })
+    ).toEqual({
+      count: 1,
+      tonnageDelta: 100,
+      rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+    })
   })
 
   it('classifies a re-upload that nets to zero as nonBalanceAffecting', async () => {
@@ -415,8 +480,11 @@ describe('loadsByReportingPeriod population at validate time', () => {
     )
 
     expect(loadsByReportingPeriod.openPeriodLoads.adjusted).toEqual({
-      balanceAffecting: { count: 0, tonnageDelta: 0 },
-      nonBalanceAffecting: { count: 1 }
+      balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
+      nonBalanceAffecting: {
+        count: 1,
+        rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+      }
     })
   })
 
@@ -447,7 +515,17 @@ describe('loadsByReportingPeriod population at validate time', () => {
 
     expect(
       loadsByReportingPeriod.openPeriodLoads.adjusted.balanceAffecting
-    ).toEqual({ count: 1, tonnageDelta: -100 })
+    ).toEqual({
+      count: 1,
+      tonnageDelta: -100,
+      rows: [
+        {
+          rowId: '1001',
+          tableName: 'Exported',
+          reasons: [CLASSIFICATION_REASON.PRN_ISSUED]
+        }
+      ]
+    })
     expect(
       loadsByReportingPeriod.openPeriodLoads.adjusted.nonBalanceAffecting.count
     ).toBe(0)

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
@@ -146,13 +146,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
       dueDate: '2025-02-20T00:00:00.000Z'
     })
 
-  // added.balanceAffecting stays count-only; the other three buckets carry an
-  // expandable rows list, so empty added and adjusted groups differ in shape.
-  const emptyAdded = () => ({
-    balanceAffecting: { count: 0, tonnageDelta: 0 },
-    nonBalanceAffecting: { count: 0, rows: [] }
-  })
-  const emptyAdjusted = () => ({
+  const emptyChange = () => ({
     balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
     nonBalanceAffecting: { count: 0, rows: [] }
   })
@@ -180,7 +174,11 @@ describe('loadsByReportingPeriod population at validate time', () => {
     expect(loadsByReportingPeriod).toEqual({
       openPeriodLoads: {
         added: {
-          balanceAffecting: { count: 1, tonnageDelta: 100 },
+          balanceAffecting: {
+            count: 1,
+            tonnageDelta: 100,
+            rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+          },
           nonBalanceAffecting: {
             count: 1,
             rows: [
@@ -192,11 +190,11 @@ describe('loadsByReportingPeriod population at validate time', () => {
             ]
           }
         },
-        adjusted: emptyAdjusted()
+        adjusted: emptyChange()
       },
       closedPeriodLoads: {
-        added: emptyAdded(),
-        adjusted: emptyAdjusted()
+        added: emptyChange(),
+        adjusted: emptyChange()
       }
     })
   })
@@ -218,7 +216,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
     )
 
     expect(loadsByReportingPeriod.openPeriodLoads.added).toEqual({
-      balanceAffecting: { count: 0, tonnageDelta: 0 },
+      balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
       nonBalanceAffecting: {
         count: 1,
         rows: [
@@ -280,7 +278,11 @@ describe('loadsByReportingPeriod population at validate time', () => {
 
     expect(
       loadsByReportingPeriod.closedPeriodLoads.added.balanceAffecting
-    ).toEqual({ count: 1, tonnageDelta: 100 })
+    ).toEqual({
+      count: 1,
+      tonnageDelta: 100,
+      rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+    })
     expect(
       loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
     ).toBe(0)
@@ -341,7 +343,11 @@ describe('loadsByReportingPeriod population at validate time', () => {
       loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting
     ).toEqual({
       count: 2,
-      tonnageDelta: 300
+      tonnageDelta: 300,
+      rows: [
+        { rowId: '1001', tableName: 'Exported', reasons: [] },
+        { rowId: '1002', tableName: 'Exported', reasons: [] }
+      ]
     })
   })
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
@@ -10,6 +10,7 @@ import {
   QUARTERLY_PERIODS
 } from '#reports/domain/period-labels.js'
 import { CLASSIFICATION_REASON } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createAndSubmitReport } from '#reports/repository/contract/test-data.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 
@@ -178,7 +179,11 @@ describe('loadsByReportingPeriod population at validate time', () => {
             count: 1,
             tonnageDelta: 100,
             rows: [
-              { rowId: '1001', tableName: 'Exported', exclusionReasons: [] }
+              {
+                rowId: '1001',
+                wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+                exclusionReasons: []
+              }
             ]
           },
           nonBalanceAffecting: {
@@ -186,7 +191,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
             rows: [
               {
                 rowId: '2001',
-                tableName: 'Exported',
+                wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
                 exclusionReasons: [CLASSIFICATION_REASON.ORS_NOT_APPROVED]
               }
             ]
@@ -224,7 +229,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
         rows: [
           {
             rowId: '1001',
-            tableName: 'Exported',
+            wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
             exclusionReasons: [CLASSIFICATION_REASON.PRN_ISSUED]
           }
         ]
@@ -254,7 +259,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
     ).toEqual([
       {
         rowId: '1001',
-        tableName: 'Exported',
+        wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
         exclusionReasons: [CLASSIFICATION_REASON.PRN_ISSUED]
       }
     ])
@@ -283,7 +288,13 @@ describe('loadsByReportingPeriod population at validate time', () => {
     ).toEqual({
       count: 1,
       tonnageDelta: 100,
-      rows: [{ rowId: '1001', tableName: 'Exported', exclusionReasons: [] }]
+      rows: [
+        {
+          rowId: '1001',
+          wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+          exclusionReasons: []
+        }
+      ]
     })
     expect(
       loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
@@ -347,8 +358,16 @@ describe('loadsByReportingPeriod population at validate time', () => {
       count: 2,
       tonnageDelta: 300,
       rows: [
-        { rowId: '1001', tableName: 'Exported', exclusionReasons: [] },
-        { rowId: '1002', tableName: 'Exported', exclusionReasons: [] }
+        {
+          rowId: '1001',
+          wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+          exclusionReasons: []
+        },
+        {
+          rowId: '1002',
+          wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+          exclusionReasons: []
+        }
       ]
     })
   })
@@ -384,7 +403,13 @@ describe('loadsByReportingPeriod population at validate time', () => {
     ).toEqual({
       count: 1,
       tonnageDelta: 50,
-      rows: [{ rowId: '1001', tableName: 'Exported', exclusionReasons: [] }]
+      rows: [
+        {
+          rowId: '1001',
+          wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+          exclusionReasons: []
+        }
+      ]
     })
     expect(
       loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
@@ -439,14 +464,26 @@ describe('loadsByReportingPeriod population at validate time', () => {
     ).toEqual({
       count: 1,
       tonnageDelta: -100,
-      rows: [{ rowId: '1001', tableName: 'Exported', exclusionReasons: [] }]
+      rows: [
+        {
+          rowId: '1001',
+          wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+          exclusionReasons: []
+        }
+      ]
     })
     expect(
       loadsByReportingPeriod.openPeriodLoads.adjusted.balanceAffecting
     ).toEqual({
       count: 1,
       tonnageDelta: 100,
-      rows: [{ rowId: '1001', tableName: 'Exported', exclusionReasons: [] }]
+      rows: [
+        {
+          rowId: '1001',
+          wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+          exclusionReasons: []
+        }
+      ]
     })
   })
 
@@ -491,7 +528,13 @@ describe('loadsByReportingPeriod population at validate time', () => {
       balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
       nonBalanceAffecting: {
         count: 1,
-        rows: [{ rowId: '1001', tableName: 'Exported', exclusionReasons: [] }]
+        rows: [
+          {
+            rowId: '1001',
+            wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+            exclusionReasons: []
+          }
+        ]
       }
     })
   })
@@ -529,7 +572,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
       rows: [
         {
           rowId: '1001',
-          tableName: 'Exported',
+          wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
           exclusionReasons: [CLASSIFICATION_REASON.PRN_ISSUED]
         }
       ]

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
@@ -177,7 +177,9 @@ describe('loadsByReportingPeriod population at validate time', () => {
           balanceAffecting: {
             count: 1,
             tonnageDelta: 100,
-            rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+            rows: [
+              { rowId: '1001', tableName: 'Exported', exclusionReasons: [] }
+            ]
           },
           nonBalanceAffecting: {
             count: 1,
@@ -185,7 +187,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
               {
                 rowId: '2001',
                 tableName: 'Exported',
-                reasons: [CLASSIFICATION_REASON.ORS_NOT_APPROVED]
+                exclusionReasons: [CLASSIFICATION_REASON.ORS_NOT_APPROVED]
               }
             ]
           }
@@ -223,7 +225,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
           {
             rowId: '1001',
             tableName: 'Exported',
-            reasons: [CLASSIFICATION_REASON.PRN_ISSUED]
+            exclusionReasons: [CLASSIFICATION_REASON.PRN_ISSUED]
           }
         ]
       }
@@ -253,7 +255,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
       {
         rowId: '1001',
         tableName: 'Exported',
-        reasons: [CLASSIFICATION_REASON.PRN_ISSUED]
+        exclusionReasons: [CLASSIFICATION_REASON.PRN_ISSUED]
       }
     ])
   })
@@ -281,7 +283,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
     ).toEqual({
       count: 1,
       tonnageDelta: 100,
-      rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+      rows: [{ rowId: '1001', tableName: 'Exported', exclusionReasons: [] }]
     })
     expect(
       loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
@@ -345,8 +347,8 @@ describe('loadsByReportingPeriod population at validate time', () => {
       count: 2,
       tonnageDelta: 300,
       rows: [
-        { rowId: '1001', tableName: 'Exported', reasons: [] },
-        { rowId: '1002', tableName: 'Exported', reasons: [] }
+        { rowId: '1001', tableName: 'Exported', exclusionReasons: [] },
+        { rowId: '1002', tableName: 'Exported', exclusionReasons: [] }
       ]
     })
   })
@@ -382,7 +384,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
     ).toEqual({
       count: 1,
       tonnageDelta: 50,
-      rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+      rows: [{ rowId: '1001', tableName: 'Exported', exclusionReasons: [] }]
     })
     expect(
       loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
@@ -437,14 +439,14 @@ describe('loadsByReportingPeriod population at validate time', () => {
     ).toEqual({
       count: 1,
       tonnageDelta: -100,
-      rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+      rows: [{ rowId: '1001', tableName: 'Exported', exclusionReasons: [] }]
     })
     expect(
       loadsByReportingPeriod.openPeriodLoads.adjusted.balanceAffecting
     ).toEqual({
       count: 1,
       tonnageDelta: 100,
-      rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+      rows: [{ rowId: '1001', tableName: 'Exported', exclusionReasons: [] }]
     })
   })
 
@@ -489,7 +491,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
       balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
       nonBalanceAffecting: {
         count: 1,
-        rows: [{ rowId: '1001', tableName: 'Exported', reasons: [] }]
+        rows: [{ rowId: '1001', tableName: 'Exported', exclusionReasons: [] }]
       }
     })
   })
@@ -528,7 +530,7 @@ describe('loadsByReportingPeriod population at validate time', () => {
         {
           rowId: '1001',
           tableName: 'Exported',
-          reasons: [CLASSIFICATION_REASON.PRN_ISSUED]
+          exclusionReasons: [CLASSIFICATION_REASON.PRN_ISSUED]
         }
       ]
     })

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
@@ -144,21 +144,21 @@ describe('Summary logs upload lifecycle', () => {
             openPeriodLoads: {
               added: {
                 balanceAffecting: { count: 0, tonnageDelta: 0 },
-                nonBalanceAffecting: { count: 0 }
+                nonBalanceAffecting: { count: 0, rows: [] }
               },
               adjusted: {
-                balanceAffecting: { count: 0, tonnageDelta: 0 },
-                nonBalanceAffecting: { count: 0 }
+                balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
+                nonBalanceAffecting: { count: 0, rows: [] }
               }
             },
             closedPeriodLoads: {
               added: {
                 balanceAffecting: { count: 0, tonnageDelta: 0 },
-                nonBalanceAffecting: { count: 0 }
+                nonBalanceAffecting: { count: 0, rows: [] }
               },
               adjusted: {
-                balanceAffecting: { count: 0, tonnageDelta: 0 },
-                nonBalanceAffecting: { count: 0 }
+                balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
+                nonBalanceAffecting: { count: 0, rows: [] }
               }
             }
           },

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.upload-lifecycle.test.js
@@ -143,7 +143,7 @@ describe('Summary logs upload lifecycle', () => {
           loadsByReportingPeriod: {
             openPeriodLoads: {
               added: {
-                balanceAffecting: { count: 0, tonnageDelta: 0 },
+                balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
                 nonBalanceAffecting: { count: 0, rows: [] }
               },
               adjusted: {
@@ -153,7 +153,7 @@ describe('Summary logs upload lifecycle', () => {
             },
             closedPeriodLoads: {
               added: {
-                balanceAffecting: { count: 0, tonnageDelta: 0 },
+                balanceAffecting: { count: 0, tonnageDelta: 0, rows: [] },
                 nonBalanceAffecting: { count: 0, rows: [] }
               },
               adjusted: {

--- a/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/transform-validation-response.test.js
@@ -2,6 +2,7 @@ import { transformValidationResponse } from './transform-validation-response.js'
 import { VALIDATION_SEVERITY } from '#common/enums/validation.js'
 import { summaryLogResponseSchema } from './response.schema.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
+import { emptyLoadsByReportingPeriod } from '#domain/summary-logs/loads-by-period-status-schema.js'
 
 describe('transformValidationResponse', () => {
   describe('when validation is empty or has no issues', () => {
@@ -765,28 +766,7 @@ describe('transformValidationResponse', () => {
         status: SUMMARY_LOG_STATUS.VALIDATED,
         processingType: 'EXPORTER',
         ...transformValidationResponse(validation),
-        loadsByReportingPeriod: {
-          openPeriodLoads: {
-            added: {
-              balanceAffecting: { count: 0, tonnageDelta: 0 },
-              nonBalanceAffecting: { count: 0 }
-            },
-            adjusted: {
-              balanceAffecting: { count: 0, tonnageDelta: 0 },
-              nonBalanceAffecting: { count: 0 }
-            }
-          },
-          closedPeriodLoads: {
-            added: {
-              balanceAffecting: { count: 0, tonnageDelta: 0 },
-              nonBalanceAffecting: { count: 0 }
-            },
-            adjusted: {
-              balanceAffecting: { count: 0, tonnageDelta: 0 },
-              nonBalanceAffecting: { count: 0 }
-            }
-          }
-        }
+        loadsByReportingPeriod: emptyLoadsByReportingPeriod()
       }
       const { error } = summaryLogResponseSchema.validate(httpResponse)
       expect(error).toBeUndefined()


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)
## What

Enriches each expandable bucket in a summary log's `loadsByReportingPeriod` with a `rows` list, so the CMA check page can show, per load, its identity and the reason(s) it was excluded from the waste balance.

Each listed row carries:

- `rowId` — the load's row ID
- `wasteRecordType` — the table's waste record type code (`received`, `processed`, `sentOn`, `exported`), needed because a row ID is not unique across tables. A code rather than the human sheet name, so the frontend owns the operator-facing copy and the value is validated against the `WASTE_RECORD_TYPE` enum
- `exclusionReasons` — the distinct exclusion reason codes (e.g. `PRN_ISSUED`, `ORS_NOT_APPROVED`, `MISSING_REQUIRED_FIELD`), empty for an included load

All four leaf buckets (`added`/`adjusted` x `balanceAffecting`/`nonBalanceAffecting`, across both open and closed periods) carry `rows` uniformly. The frontend renders the rows only where its design calls for them. Lists are capped at 100 per bucket while `count` continues to reflect the true total.

## Why

The check page previously could only state a count and a single hardcoded "missing data" reason. Operators need to see exactly which loads were not added to their waste balance and why, including reasons beyond missing data (PRN issued, overseas site not approved, outside the accreditation period). Reason codes are surfaced raw so the frontend owns the operator-facing copy.

## Notes

- Reason codes come from the existing `classifyForWasteBalance` result, deduped per row. The single completeness flag considered earlier is dropped: it is derivable from `reasons`.
- For an adjusted load, both reporting-period legs carry the current upload's reasons, reflecting what the operator is submitting now.
- Reasons are captured from the current row, so the reversal leg of a cross-period amendment stays consistent with the new submission.
- The `rows` field is required on every bucket in the storage and response schema; every bucket carries the list uniformly, with an empty `rows: []` where no rows are listed (e.g. the count-only `added.balanceAffecting` bucket).
- No new persistence wiring: the structure is enriched in place and flows through storage validation and the GET response via the shared schema.

[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
