### PR TITLE
PAE-1566: Prevent duplicate accreditation links when editing organisations

### DIFF
--- a/src/domain/organisations/model.js
+++ b/src/domain/organisations/model.js
@@ -2,6 +2,10 @@
 /** @import {Registration} from '#domain/organisations/registration.js' */
 
 /**
+ * @typedef {Registration | Accreditation} RegistrationOrAccreditation
+ */
+
+/**
  * Status values for registrations and accreditations
  * @typedef {typeof REG_ACC_STATUS[keyof typeof REG_ACC_STATUS]} RegAccStatus
  */

--- a/src/domain/organisations/registration.js
+++ b/src/domain/organisations/registration.js
@@ -1,4 +1,4 @@
-/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
+/** @import {Accreditation, StatusHistory} from '#domain/organisations/accreditation.js' */
 /** @import {GlassRecyclingProcess, Material, RegAccStatus, ReprocessingType, User} from '#domain/organisations/model.js' */
 
 /**
@@ -31,7 +31,7 @@
  */
 
 /**
- * @typedef {{ id: string } & {
+ * @typedef {{ id: string } & StatusHistory & {
  *  accreditation: Accreditation | null;
  *  accreditationId?: string;
  *  applicationContactDetails: User;

--- a/src/forms-submission-data/integration.test.js
+++ b/src/forms-submission-data/integration.test.js
@@ -1,17 +1,21 @@
-import exporterAccreditation from '#data/fixtures/ea/accreditation/exporter.json'
-import reprocessorGlassAccreditation from '#data/fixtures/ea/accreditation/reprocessor-glass.json'
+import exporterAccreditation from '#data/fixtures/ea/accreditation/exporter.json' with { type: 'json' }
+import reprocessorGlassAccreditation from '#data/fixtures/ea/accreditation/reprocessor-glass.json' with { type: 'json' }
+import { logger } from '#common/helpers/logging/logger.js'
 import { MATERIAL } from '#domain/organisations/model.js'
 import { createFormSubmissionsRepository } from '#repositories/form-submissions/inmemory.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
 import { readdirSync, readFileSync } from 'fs'
 import { join } from 'path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createFormDataMigrator } from './migration/migration-orchestrator.js'
 
 describe('Migration Integration Tests with Fixtures', () => {
   let sharedOrganisationsRepo
   let sharedSystemLogsRepo
+  const formsFileUploadsRepo = {
+    copyFormFileToS3: vi.fn().mockResolvedValue(undefined)
+  }
 
   function loadFixtures(fixtureType) {
     const fixturesDir = join(
@@ -57,7 +61,7 @@ describe('Migration Integration Tests with Fixtures', () => {
 
   beforeAll(() => {
     sharedOrganisationsRepo = createInMemoryOrganisationsRepository()()
-    sharedSystemLogsRepo = createSystemLogsRepository()()
+    sharedSystemLogsRepo = createSystemLogsRepository()(logger)
   })
 
   function createFormsRepo(includeAllAccreditations) {
@@ -100,7 +104,8 @@ describe('Migration Integration Tests with Fixtures', () => {
       const formsDataMigration = createFormDataMigrator(
         formsRepo,
         sharedOrganisationsRepo,
-        sharedSystemLogsRepo
+        sharedSystemLogsRepo,
+        formsFileUploadsRepo
       )
       await formsDataMigration.migrate()
 
@@ -150,7 +155,8 @@ describe('Migration Integration Tests with Fixtures', () => {
       const formsDataMigration = createFormDataMigrator(
         formsRepo,
         sharedOrganisationsRepo,
-        sharedSystemLogsRepo
+        sharedSystemLogsRepo,
+        formsFileUploadsRepo
       )
       await formsDataMigration.migrate()
 
@@ -171,10 +177,17 @@ describe('Migration Integration Tests with Fixtures', () => {
 
       const org503181 = allOrgs.find((o) => o.orgId === 503181)
       expect(org503181.accreditations).toHaveLength(1)
-      // Both split glass registrations (remelt + other) link to the same accreditation
-      for (const reg of org503181.registrations) {
-        expect(reg.accreditationId).toBe(exporterAccreditation._id.$oid)
-      }
+      // Registration is split into remelt + other (source submission selected "Both"),
+      // but the accreditation only covers "Glass other", so only that sibling links;
+      // the "Glass re-melt" sibling has no matching accreditation and stays unlinked.
+      const glassOtherReg = org503181.registrations.find(
+        (reg) => reg.glassRecyclingProcess?.[0] === 'glass_other'
+      )
+      const glassRemeltReg = org503181.registrations.find(
+        (reg) => reg.glassRecyclingProcess?.[0] === 'glass_re_melt'
+      )
+      expect(glassOtherReg.accreditationId).toBe(exporterAccreditation._id.$oid)
+      expect(glassRemeltReg.accreditationId).toBeUndefined()
 
       const org503176 = allOrgs.find((o) => o.orgId === 503176)
       expect(org503176.accreditations).toHaveLength(3)

--- a/src/forms-submission-data/link-form-submissions.js
+++ b/src/forms-submission-data/link-form-submissions.js
@@ -117,12 +117,14 @@ export function linkItemsToOrganisations(
   const itemsBySystemReference = getItemsBySystemReference(items)
   const organisationsById = getOrganisationsById(organisations)
 
-  const unlinked = []
+  const unlinked = [...itemsBySystemReference].flatMap(
+    ([systemReference, itemsPerOrg]) => {
+      const org = organisationsById.get(systemReference)
 
-  for (const [systemReference, itemsPerOrg] of itemsBySystemReference) {
-    const org = organisationsById.get(systemReference)
+      if (!org) {
+        return itemsPerOrg.map(toUnlinkedItem)
+      }
 
-    if (org) {
       const { matched, unmatched } = systemReferencesRequiringOrgIdMatch.has(
         systemReference
       )
@@ -130,11 +132,9 @@ export function linkItemsToOrganisations(
         : { matched: itemsPerOrg, unmatched: [] }
 
       org[propertyName] = (org[propertyName] ?? []).concat(matched)
-      unlinked.push(...unmatched.map(toUnlinkedItem))
-    } else {
-      unlinked.push(...itemsPerOrg.map(toUnlinkedItem))
+      return unmatched.map(toUnlinkedItem)
     }
-  }
+  )
 
   logUnlinkedItems(unlinked, propertyName)
   logOrganisationsWithoutItems(organisations, propertyName)
@@ -144,11 +144,17 @@ export function linkItemsToOrganisations(
 
 /**
  * Finds accreditations eligible for linking to a registration
- * Filters out approved accreditations to prevent linking to locked records
+ * Filters out approved accreditations to prevent linking to locked records,
+ * and accreditations already claimed by another registration
  */
-function findEligibleAccreditations(registration, accreditations) {
+function findEligibleAccreditations(
+  registration,
+  accreditations,
+  claimedAccreditationIds
+) {
   return accreditations
     .filter((acc) => acc.status !== REG_ACC_STATUS.APPROVED)
+    .filter((acc) => !claimedAccreditationIds.has(acc.id))
     .filter((acc) => isAccreditationForRegistration(acc, registration))
 }
 
@@ -183,6 +189,43 @@ function findRegistrationsToLink(registrations, accreditations) {
   )
 }
 
+function getClaimedAccreditationIds(registrations) {
+  return new Set(registrations.flatMap((reg) => reg.accreditationId ?? []))
+}
+
+function claimAccreditationForRegistration(
+  registration,
+  accreditations,
+  claimedAccreditationIds,
+  organisation
+) {
+  const matchedAccreditations = findEligibleAccreditations(
+    registration,
+    accreditations,
+    claimedAccreditationIds
+  )
+
+  if (matchedAccreditations.length === 0) {
+    return
+  }
+
+  const latestMatchedAccreditation = selectLatestAccreditation(
+    matchedAccreditations
+  )
+  registration.accreditationId = latestMatchedAccreditation.id
+  claimedAccreditationIds.add(latestMatchedAccreditation.id)
+
+  if (matchedAccreditations.length > 1) {
+    logger.warn({
+      message:
+        `Multiple accreditations match registration, picking latest by formSubmission.time: ` +
+        `orgId=${organisation.orgId},orgDbId=${organisation.id},` +
+        `registration=[${formatRegistrationDetails(registration)}],` +
+        `selected accreditation=[${formatAccreditationDetails(latestMatchedAccreditation)}]`
+    })
+  }
+}
+
 function linkAccreditationsForOrg(organisation) {
   const accreditations = organisation.accreditations ?? []
   const registrations = organisation.registrations ?? []
@@ -192,29 +235,17 @@ function linkAccreditationsForOrg(organisation) {
     accreditations
   )
 
-  for (const registration of registrationsToLink) {
-    const matchedAccreditations = findEligibleAccreditations(
+  const claimedAccreditationIds = getClaimedAccreditationIds(registrations)
+
+  registrationsToLink.forEach((registration) =>
+    claimAccreditationForRegistration(
       registration,
-      accreditations
+      accreditations,
+      claimedAccreditationIds,
+      organisation
     )
+  )
 
-    if (matchedAccreditations.length > 0) {
-      const latestMatchedAccreditation = selectLatestAccreditation(
-        matchedAccreditations
-      )
-      registration.accreditationId = latestMatchedAccreditation.id
-
-      if (matchedAccreditations.length > 1) {
-        logger.warn({
-          message:
-            `Multiple accreditations match registration, picking latest by formSubmission.time: ` +
-            `orgId=${organisation.orgId},orgDbId=${organisation.id},` +
-            `registration=[${formatRegistrationDetails(registration)}],` +
-            `selected accreditation=[${formatAccreditationDetails(latestMatchedAccreditation)}]`
-        })
-      }
-    }
-  }
   logUnlinkedAccreditations(organisation)
 }
 
@@ -307,9 +338,7 @@ function getLinkedAccCount(organisations) {
  */
 export function linkRegistrationToAccreditations(organisations) {
   const accCount = countItems(organisations, 'accreditations')
-  for (const org of organisations) {
-    linkAccreditationsForOrg(org)
-  }
+  organisations.forEach((org) => linkAccreditationsForOrg(org))
 
   const linkedRegCount = getLinkedRegCount(organisations)
   const linkedAccCount = getLinkedAccCount(organisations)

--- a/src/forms-submission-data/link-form-submissions.test.js
+++ b/src/forms-submission-data/link-form-submissions.test.js
@@ -12,6 +12,16 @@ import {
   linkRegistrationToAccreditations
 } from './link-form-submissions.js'
 
+/**
+ * @typedef {{
+ *   id: string;
+ *   orgId: number;
+ *   name: string;
+ *   registrations?: Record<string, unknown>[];
+ *   accreditations?: Record<string, unknown>[];
+ * }} LinkableOrgFixture
+ */
+
 vi.mock('#common/helpers/logging/logger.js', () => ({
   logger: {
     error: vi.fn(),
@@ -142,11 +152,13 @@ describe('linkItemsToOrganisations', () => {
 
     linkItemsToOrganisations(allOrgs, [], 'registrations', new Set())
 
-    const logCall = logger.info.mock.calls.find(([arg]) =>
-      arg.message?.includes('organisations without registrations')
-    )
+    const logCall = vi
+      .mocked(logger.info)
+      .mock.calls.find(([arg]) =>
+        arg.message?.includes('organisations without registrations')
+      )
     expect(logCall).toBeDefined()
-    const [{ message }] = logCall
+    const [{ message }] = /** @type {[{message: string}]} */ (logCall)
     expect(message).toMatch(/^12 organisations without registrations:/)
     expect(message).toContain('...and 2 more')
   })
@@ -203,11 +215,13 @@ describe('linkItemsToOrganisations', () => {
       new Set()
     )
 
-    const logCall = logger.warn.mock.calls.find(([arg]) =>
-      arg.message?.includes('not linked to an organisation')
-    )
+    const logCall = vi
+      .mocked(logger.warn)
+      .mock.calls.find(([arg]) =>
+        arg.message?.includes('not linked to an organisation')
+      )
     expect(logCall).toBeDefined()
-    const [{ message }] = logCall
+    const [{ message }] = /** @type {[{message: string}]} */ (logCall)
     expect(message).toMatch(/^11 registrations not linked to an organisation:/)
     expect(message).toContain('...and 1 more')
   })
@@ -306,7 +320,7 @@ describe('linkRegistrationToAccreditations', () => {
     const org1Id = new ObjectId().toString()
     const reg1Id = new ObjectId().toString()
     const accId1 = new ObjectId().toString()
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -328,9 +342,11 @@ describe('linkRegistrationToAccreditations', () => {
           }
         ]
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result).toHaveLength(1)
     expect(result[0].registrations[0].accreditationId).toEqual(accId1)
     expect(logger.warn).not.toHaveBeenCalled()
@@ -346,7 +362,7 @@ describe('linkRegistrationToAccreditations', () => {
     const org1Id = new ObjectId().toString()
     const reg1Id = new ObjectId().toString()
     const accId1 = new ObjectId().toString()
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -374,9 +390,11 @@ describe('linkRegistrationToAccreditations', () => {
           }
         ]
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result).toHaveLength(1)
     expect(logger.warn).not.toHaveBeenCalled()
     expect(result[0].registrations[0].accreditationId).toEqual(accId1)
@@ -394,7 +412,7 @@ describe('linkRegistrationToAccreditations', () => {
     const acc1Id = new ObjectId().toString()
     const reg2Id = new ObjectId().toString()
     const acc2Id = new ObjectId().toString()
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -432,9 +450,11 @@ describe('linkRegistrationToAccreditations', () => {
           }
         ]
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result).toHaveLength(1)
     for (const reg of result[0].registrations) {
       expect(reg.accreditationId).toBeUndefined()
@@ -443,10 +463,10 @@ describe('linkRegistrationToAccreditations', () => {
     const expectedMessage =
       `Organisation has accreditations that cant be linked to registrations: ` +
       `orgId=100,orgDbId=${org1Id},unlinked accreditations count=2,` +
-      `unlinked accreditations=[id=${acc1Id},type=reprocessor,material=aluminium,${siteInfoToLog(organisations[0].accreditations[0].site)};` +
+      `unlinked accreditations=[id=${acc1Id},type=reprocessor,material=aluminium,${siteInfoToLog(/** @type {any} */ (organisations[0]).accreditations[0].site)};` +
       `id=${acc2Id},type=exporter,material=paper],` +
       `unlinked registrations=[id=${reg1Id},type=exporter,material=wood;` +
-      `id=${reg2Id},type=reprocessor,material=aluminium,${siteInfoToLog(organisations[0].registrations[1].site)}]`
+      `id=${reg2Id},type=reprocessor,material=aluminium,${siteInfoToLog(/** @type {any} */ (organisations[0]).registrations[1].site)}]`
     expect(logger.warn).toHaveBeenCalledWith({ message: expectedMessage })
     expect(logger.info).toHaveBeenCalledWith({
       message: 'Accreditation linking complete: 0/2 linked'
@@ -476,7 +496,7 @@ describe('linkRegistrationToAccreditations', () => {
         formSubmission: { id, time: oneDayAgo }
       }
     })
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -484,15 +504,18 @@ describe('linkRegistrationToAccreditations', () => {
         registrations,
         accreditations
       }
-    ]
+    ])
 
+    // @ts-expect-error test fixtures use minimal data
     linkRegistrationToAccreditations(organisations)
 
-    const logCall = logger.warn.mock.calls.find(([arg]) =>
-      arg.message?.includes('cant be linked to registrations')
-    )
+    const logCall = vi
+      .mocked(logger.warn)
+      .mock.calls.find(([arg]) =>
+        arg.message?.includes('cant be linked to registrations')
+      )
     expect(logCall).toBeDefined()
-    const [{ message }] = logCall
+    const [{ message }] = /** @type {[{message: string}]} */ (logCall)
     expect(message).toContain('unlinked accreditations count=12')
     expect(message).toContain('; ...and 2 more')
   })
@@ -504,7 +527,7 @@ describe('linkRegistrationToAccreditations', () => {
     const acc1Id = new ObjectId().toString()
     const reg2Id = new ObjectId().toString()
     const acc2Id = new ObjectId().toString()
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -553,9 +576,11 @@ describe('linkRegistrationToAccreditations', () => {
           }
         ]
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result).toHaveLength(2)
     expect(result[0].registrations[0].accreditationId).toEqual(acc1Id)
     expect(result[1].registrations[0].accreditationId).toEqual(acc2Id)
@@ -568,12 +593,12 @@ describe('linkRegistrationToAccreditations', () => {
     })
   })
 
-  it('link when multiple registrations match to single accreditation', () => {
+  it('links only the first matching registration when multiple registrations match a single accreditation', () => {
     const org1Id = new ObjectId().toString()
     const reg1Id = new ObjectId().toString()
     const reg2Id = new ObjectId().toString()
     const accId1 = new ObjectId().toString()
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -610,24 +635,76 @@ describe('linkRegistrationToAccreditations', () => {
           }
         ]
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result).toHaveLength(1)
     expect(result[0].registrations[0].accreditationId).toBe(
       result[0].accreditations[0].id
     )
-    expect(result[0].registrations[1].accreditationId).toBe(
-      result[0].accreditations[0].id
-    )
+    expect(result[0].registrations[1].accreditationId).toBeUndefined()
 
-    expect(logger.warn).not.toHaveBeenCalled()
     expect(logger.info).toHaveBeenCalledWith({
       message: 'Accreditation linking complete: 1/1 linked'
     })
     expect(logger.info).toHaveBeenCalledWith({
-      message: 'Registrations : 2/2 linked to accreditations'
+      message: 'Registrations : 1/2 linked to accreditations'
     })
+  })
+
+  it('does not link an accreditation already linked to a different existing registration', () => {
+    const org1Id = new ObjectId().toString()
+    const reg1Id = new ObjectId().toString()
+    const reg2Id = new ObjectId().toString()
+    const accId1 = new ObjectId().toString()
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
+      {
+        id: org1Id,
+        name: 'Org 1',
+        orgId: 100,
+        registrations: [
+          {
+            id: reg1Id,
+            wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
+            material: MATERIAL.WOOD,
+            site: {
+              address: { line1: '78 Portland Place', postcode: 'W1B 1NT' }
+            },
+            formSubmission: { id: reg1Id, time: oneDayAgo },
+            accreditationId: accId1
+          },
+          {
+            id: reg2Id,
+            wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
+            material: MATERIAL.WOOD,
+            site: {
+              address: { line1: '78 Portland Place', postcode: 'W1B 1NT' }
+            },
+            formSubmission: { id: reg2Id, time: oneDayAgo }
+          }
+        ],
+        accreditations: [
+          {
+            id: accId1,
+            wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
+            material: MATERIAL.WOOD,
+            site: {
+              address: { line1: '78 Portland Place', postcode: 'W1B 1NT' }
+            },
+            formSubmission: { id: accId1, time: oneDayAgo }
+          }
+        ]
+      }
+    ])
+
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0].registrations[0].accreditationId).toBe(accId1)
+    expect(result[0].registrations[1].accreditationId).toBeUndefined()
   })
 
   it('links to latest accreditation when multiple accreditations match a registration', () => {
@@ -636,7 +713,7 @@ describe('linkRegistrationToAccreditations', () => {
     const accId2 = new ObjectId().toString()
     const accId1 = new ObjectId().toString()
     const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -673,32 +750,36 @@ describe('linkRegistrationToAccreditations', () => {
           }
         ]
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result).toHaveLength(1)
     expect(result[0].registrations[0].accreditationId).toBe(accId2)
 
     const expectedMessage =
       `Multiple accreditations match registration, picking latest by formSubmission.time: ` +
       `orgId=100,orgDbId=${org1Id},` +
-      `registration=[id=${reg1Id},type=reprocessor,material=wood,${siteInfoToLog(organisations[0].registrations[0].site)}],` +
-      `selected accreditation=[id=${accId2},type=reprocessor,material=wood,${siteInfoToLog(organisations[0].accreditations[1].site)}]`
+      `registration=[id=${reg1Id},type=reprocessor,material=wood,${siteInfoToLog(/** @type {any} */ (organisations[0]).registrations[0].site)}],` +
+      `selected accreditation=[id=${accId2},type=reprocessor,material=wood,${siteInfoToLog(/** @type {any} */ (organisations[0]).accreditations[1].site)}]`
     expect(logger.warn).toHaveBeenCalledWith({ message: expectedMessage })
   })
 
   it('handle organisations without any registrations or accreditations', () => {
     const org1Id = new ObjectId().toString()
 
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
         orgId: 100
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result).toHaveLength(1)
     expect(logger.info).toHaveBeenCalledWith({
       message: 'Accreditation linking complete: 0/0 linked'
@@ -712,7 +793,7 @@ describe('linkRegistrationToAccreditations', () => {
     const org1Id = new ObjectId().toString()
     const acc1Id = new ObjectId().toString()
     const reg1Id = new ObjectId().toString()
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -736,9 +817,11 @@ describe('linkRegistrationToAccreditations', () => {
           }
         ]
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result[0].registrations[0].accreditationId).toBeUndefined()
   })
 
@@ -747,7 +830,7 @@ describe('linkRegistrationToAccreditations', () => {
     const reg1Id = new ObjectId().toString()
     const accId1 = new ObjectId().toString()
     const accId2 = new ObjectId().toString()
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -779,9 +862,11 @@ describe('linkRegistrationToAccreditations', () => {
           }
         ]
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result).toHaveLength(1)
     expect(result[0].registrations[0].accreditationId).toEqual(accId1)
     expect(logger.warn).toHaveBeenCalledWith({
@@ -793,7 +878,7 @@ describe('linkRegistrationToAccreditations', () => {
     const org1Id = new ObjectId().toString()
     const reg1Id = new ObjectId().toString()
     const accId1 = new ObjectId().toString()
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -817,9 +902,11 @@ describe('linkRegistrationToAccreditations', () => {
           }
         ]
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result).toHaveLength(1)
     expect(result[0].registrations[0].accreditationId).toEqual(accId1)
   })
@@ -829,7 +916,7 @@ describe('linkRegistrationToAccreditations', () => {
     const reg1Id = new ObjectId().toString()
     const accId1 = new ObjectId().toString()
     const accId2 = new ObjectId().toString()
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -861,9 +948,11 @@ describe('linkRegistrationToAccreditations', () => {
           }
         ]
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result).toHaveLength(1)
     expect(result[0].registrations[0].accreditationId).toEqual(accId2)
   })
@@ -873,7 +962,7 @@ describe('linkRegistrationToAccreditations', () => {
     const reg1Id = new ObjectId().toString()
     const reg2Id = new ObjectId().toString()
     const accId1 = new ObjectId().toString()
-    const organisations = [
+    const organisations = /** @type {LinkableOrgFixture[]} */ ([
       {
         id: org1Id,
         name: 'Org 1',
@@ -905,9 +994,11 @@ describe('linkRegistrationToAccreditations', () => {
           }
         ]
       }
-    ]
+    ])
 
-    const result = linkRegistrationToAccreditations(organisations)
+    const result = /** @type {any[]} */ (
+      linkRegistrationToAccreditations(/** @type {any} */ (organisations))
+    )
     expect(result).toHaveLength(1)
     expect(result[0].registrations[0].accreditationId).toBe(accId1)
     expect(result[0].registrations[1].accreditationId).toBeUndefined()

--- a/src/forms-submission-data/submission-keys.js
+++ b/src/forms-submission-data/submission-keys.js
@@ -1,8 +1,18 @@
-import { WASTE_PROCESSING_TYPE } from '#domain/organisations/model.js'
+import { MATERIAL, WASTE_PROCESSING_TYPE } from '#domain/organisations/model.js'
 import { siteKey } from '#formsubmission/parsing-common/site.js'
 
 /**
- * @import {Registration, Accreditation, RegistrationOrAccreditation} from './types.js'
+ * Structural subset of Registration/Accreditation fields used to build the
+ * identity key. Accepts both domain (post-validation) and migration-time
+ * (forms-submission-data) shapes, which differ in fields like `status`.
+ *
+ * @typedef {{
+ *   wasteProcessingType: string;
+ *   material: string;
+ *   site?: object;
+ *   reprocessingType?: string;
+ *   glassRecyclingProcess?: string[];
+ * }} RegAccKeyFields
  */
 
 const KEY_DELIMITER = '::'
@@ -15,7 +25,7 @@ const KEY_DELIMITER = '::'
  * - For exporters: `{wasteProcessingType}::{material}[::{reprocessingType}]`
  * - For reprocessors: `{wasteProcessingType}::{material}::{normalizedPostcode}[::{reprocessingType}]`
  *
- * @param {RegistrationOrAccreditation} item - Registration or accreditation object
+ * @param {RegAccKeyFields} item - Registration or accreditation object
  * @returns {string} key for registration or accreditation
  */
 export function getRegAccKey(item) {
@@ -25,6 +35,8 @@ export function getRegAccKey(item) {
 /**
  * Extracts the identity fields as key-value pairs.
  * Uses conditional spreading for a cleaner, declarative structure.
+ *
+ * @param {RegAccKeyFields} item
  */
 function getRegAccKeyValuePairs(item) {
   return {
@@ -35,14 +47,18 @@ function getRegAccKeyValuePairs(item) {
     }),
     ...(item.reprocessingType && {
       reprocessingType: item.reprocessingType
-    })
+    }),
+    ...(item.material === MATERIAL.GLASS &&
+      item.glassRecyclingProcess?.length === 1 && {
+        glassRecyclingProcess: item.glassRecyclingProcess[0]
+      })
   }
 }
 
 /**
  * Check if an accreditation matches a registration based on type, material, and site
- * @param {Accreditation} accreditation - The accreditation to check
- * @param {Registration} registration - The registration to match against
+ * @param {RegAccKeyFields} accreditation - The accreditation to check
+ * @param {RegAccKeyFields} registration - The registration to match against
  * @returns {boolean} True if the accreditation matches the registration
  */
 export function isAccreditationForRegistration(accreditation, registration) {

--- a/src/forms-submission-data/submission-keys.test.js
+++ b/src/forms-submission-data/submission-keys.test.js
@@ -4,6 +4,7 @@ import {
   getRegAccKey
 } from './submission-keys.js'
 import {
+  GLASS_RECYCLING_PROCESS,
   MATERIAL,
   REPROCESSING_TYPE,
   WASTE_PROCESSING_TYPE
@@ -66,6 +67,57 @@ describe('keyForRegAcc', () => {
           reprocessingType: REPROCESSING_TYPE.OUTPUT
         })
       ).toBe('reprocessor::glass::W1C2AA::output')
+    })
+  })
+
+  describe('glass recycling process', () => {
+    it('includes glassRecyclingProcess in the key for glass material', () => {
+      expect(
+        getRegAccKey({
+          wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+          material: MATERIAL.GLASS,
+          glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_RE_MELT]
+        })
+      ).toBe('exporter::glass::glass_re_melt')
+      expect(
+        getRegAccKey({
+          wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+          material: MATERIAL.GLASS,
+          glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER]
+        })
+      ).toBe('exporter::glass::glass_other')
+    })
+
+    it('does not include glassRecyclingProcess in the key for non-glass material', () => {
+      expect(
+        getRegAccKey({
+          wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+          material: MATERIAL.PLASTIC,
+          glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_RE_MELT]
+        })
+      ).toBe('exporter::plastic')
+    })
+
+    it('omits glassRecyclingProcess from the key when not provided', () => {
+      expect(
+        getRegAccKey({
+          wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+          material: MATERIAL.GLASS
+        })
+      ).toBe('exporter::glass')
+    })
+
+    it('omits glassRecyclingProcess from the key when array has more than one entry', () => {
+      expect(
+        getRegAccKey({
+          wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+          material: MATERIAL.GLASS,
+          glassRecyclingProcess: [
+            GLASS_RECYCLING_PROCESS.GLASS_RE_MELT,
+            GLASS_RECYCLING_PROCESS.GLASS_OTHER
+          ]
+        })
+      ).toBe('exporter::glass')
     })
   })
 })
@@ -250,6 +302,74 @@ describe('isAccreditationForRegistration', () => {
           isAccreditationForRegistration(accreditation, registration)
         ).toBe(false)
       })
+    })
+  })
+
+  describe('glass recycling process', () => {
+    it('matches when glassRecyclingProcess is the same', () => {
+      const accreditation = {
+        wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER]
+      }
+      const registration = {
+        wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER]
+      }
+      expect(isAccreditationForRegistration(accreditation, registration)).toBe(
+        true
+      )
+    })
+
+    it('does not match when glassRecyclingProcess differs', () => {
+      const accreditation = {
+        wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER]
+      }
+      const registration = {
+        wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_RE_MELT]
+      }
+      expect(isAccreditationForRegistration(accreditation, registration)).toBe(
+        false
+      )
+    })
+
+    it('does not match when only one side has a glassRecyclingProcess', () => {
+      const accreditation = {
+        wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER]
+      }
+      const registration = {
+        wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+        material: MATERIAL.GLASS
+      }
+      expect(isAccreditationForRegistration(accreditation, registration)).toBe(
+        false
+      )
+    })
+
+    it('does not match when either side has more than one glassRecyclingProcess', () => {
+      const accreditation = {
+        wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [
+          GLASS_RECYCLING_PROCESS.GLASS_RE_MELT,
+          GLASS_RECYCLING_PROCESS.GLASS_OTHER
+        ]
+      }
+      const registration = {
+        wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+        material: MATERIAL.GLASS,
+        glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_RE_MELT]
+      }
+      expect(isAccreditationForRegistration(accreditation, registration)).toBe(
+        false
+      )
     })
   })
 })

--- a/src/forms-submission-data/types.js
+++ b/src/forms-submission-data/types.js
@@ -57,7 +57,7 @@
  *   cbduNumber: string
  *   exportPorts?: string[]
  *   formSubmission: { id: string, time: Date }
- *   glassRecyclingProcess?: string
+ *   glassRecyclingProcess?: string[]
  *   id: string
  *   material: string
  *   noticeAddress?: object
@@ -81,7 +81,7 @@
 /**
  * @typedef {{
  *   formSubmission: { id: string, time: Date }
- *   glassRecyclingProcess?: string
+ *   glassRecyclingProcess?: string[]
  *   id: string
  *   material: string
  *   orgId: number

--- a/src/reports/application/report-compliance.test.js
+++ b/src/reports/application/report-compliance.test.js
@@ -48,7 +48,10 @@ async function buildRegisteredOnlyOrg(orgRepo) {
     INITIAL_VERSION,
     prepareOrgUpdate(org, {
       status: ORGANISATION_STATUS.APPROVED,
-      registrations: approvedRegistrations
+      registrations: approvedRegistrations,
+      accreditations: [
+        { ...org.accreditations[0], reprocessingType: REPROCESSING_TYPE.INPUT }
+      ]
     })
   )
 

--- a/src/reports/routes/status.test.js
+++ b/src/reports/routes/status.test.js
@@ -60,7 +60,13 @@ describe(`POST ${reportsStatusPath}`, () => {
       registrationOverrides,
       accreditationStatus
     ) => {
-      const registration = buildRegistration(registrationOverrides)
+      const accreditationId = accreditationStatus
+        ? new ObjectId().toString()
+        : undefined
+      const registration = buildRegistration({
+        ...registrationOverrides,
+        ...(accreditationId && { accreditationId })
+      })
       const org = buildOrganisationWithRegistration(
         registration,
         accreditationStatus

--- a/src/repositories/organisations/contract/accreditation-link.contract.js
+++ b/src/repositories/organisations/contract/accreditation-link.contract.js
@@ -1,0 +1,340 @@
+import {
+  GLASS_RECYCLING_PROCESS,
+  MATERIAL,
+  REG_ACC_STATUS,
+  REPROCESSING_TYPE,
+  WASTE_PROCESSING_TYPE
+} from '#domain/organisations/model.js'
+import { beforeEach, describe, expect } from 'vitest'
+import { ObjectId } from 'mongodb'
+import {
+  buildAccreditation,
+  buildOrganisation,
+  buildRegistration,
+  getValidDateRange,
+  prepareOrgUpdate
+} from './test-data.js'
+
+export const testAccreditationLinkValidation = (it) => {
+  describe('accreditation link validation', () => {
+    let repository
+    const { VALID_FROM, VALID_TO } = getValidDateRange()
+
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import('../port.js').OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
+
+    describe('validateAccreditationLinkUniqueness', () => {
+      it('rejects linking two registrations to the same accreditation regardless of status', async () => {
+        const organisation = buildOrganisation()
+        await repository.insert(organisation)
+
+        const accreditationId = organisation.accreditations[0].id
+        const updatePayload = prepareOrgUpdate(organisation, {
+          registrations: [
+            {
+              ...organisation.registrations[0],
+              status: REG_ACC_STATUS.CREATED,
+              accreditationId
+            },
+            {
+              ...organisation.registrations[1],
+              status: REG_ACC_STATUS.APPROVED,
+              registrationNumber: 'REG123',
+              validFrom: VALID_FROM,
+              validTo: VALID_TO,
+              accreditationId
+            }
+          ]
+        })
+
+        await expect(
+          repository.replace(organisation.id, 1, updatePayload)
+        ).rejects.toThrow(
+          /Each accreditation must be linked to at most one registration/
+        )
+      })
+    })
+
+    describe('validateAccreditationLinkExists', () => {
+      it('rejects when a registration links to a non-existent accreditation', async () => {
+        const organisation = buildOrganisation()
+        await repository.insert(organisation)
+        const inserted = await repository.findById(organisation.id)
+
+        const nonExistentId = new ObjectId().toString()
+        const registrationToUpdate = {
+          ...inserted.registrations[0],
+          accreditationId: nonExistentId
+        }
+
+        await expect(
+          repository.replace(
+            organisation.id,
+            1,
+            prepareOrgUpdate(inserted, {
+              registrations: [registrationToUpdate]
+            })
+          )
+        ).rejects.toThrow(
+          `Registrations are linked to accreditations that do not exist: registration ${registrationToUpdate.id} -> accreditation ${nonExistentId}`
+        )
+      })
+
+      it('accepts when a registration links to an existing accreditation', async () => {
+        const organisation = buildOrganisation()
+        await repository.insert(organisation)
+        const inserted = await repository.findById(organisation.id)
+
+        const registrationToUpdate = {
+          ...inserted.registrations[0],
+          accreditationId: inserted.accreditations[0].id
+        }
+
+        await expect(
+          repository.replace(
+            organisation.id,
+            1,
+            prepareOrgUpdate(inserted, {
+              registrations: [registrationToUpdate]
+            })
+          )
+        ).resolves.not.toThrow()
+      })
+
+      it('accepts when a registration has no accreditationId', async () => {
+        const reg = buildRegistration()
+        const organisation = buildOrganisation({ registrations: [reg] })
+        await repository.insert(organisation)
+        const inserted = await repository.findById(organisation.id)
+
+        await expect(
+          repository.replace(
+            organisation.id,
+            1,
+            prepareOrgUpdate(inserted, {
+              registrations: [{ ...inserted.registrations[0] }]
+            })
+          )
+        ).resolves.not.toThrow()
+      })
+    })
+
+    describe('validateAccreditationLinkMatches', () => {
+      it('rejects when a registration links to an accreditation with a different material', async () => {
+        const accId = new ObjectId().toString()
+        const organisation = buildOrganisation({
+          registrations: [
+            buildRegistration({
+              wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+              material: MATERIAL.PAPER,
+              accreditationId: accId
+            })
+          ],
+          accreditations: [
+            buildAccreditation({
+              id: accId,
+              wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+              material: MATERIAL.ALUMINIUM,
+              glassRecyclingProcess: null,
+              site: undefined,
+              orsFileUploads: [
+                {
+                  defraFormUploadedFileId: 'file-ors',
+                  defraFormUserDownloadLink: 'https://example.com/ors'
+                }
+              ]
+            })
+          ]
+        })
+        await repository.insert(organisation)
+        const inserted = await repository.findById(organisation.id)
+
+        await expect(
+          repository.replace(organisation.id, 1, prepareOrgUpdate(inserted, {}))
+        ).rejects.toThrow(
+          /Registrations are linked to accreditations that do not match their type, material, or site/
+        )
+      })
+
+      it('rejects when a registration links to an accreditation with a different wasteProcessingType', async () => {
+        const accId = new ObjectId().toString()
+        const organisation = buildOrganisation({
+          registrations: [
+            buildRegistration({
+              wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+              material: MATERIAL.PAPER,
+              accreditationId: accId
+            })
+          ],
+          accreditations: [
+            buildAccreditation({
+              id: accId,
+              wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
+              material: MATERIAL.PAPER,
+              glassRecyclingProcess: null
+            })
+          ]
+        })
+        await repository.insert(organisation)
+        const inserted = await repository.findById(organisation.id)
+
+        await expect(
+          repository.replace(organisation.id, 1, prepareOrgUpdate(inserted, {}))
+        ).rejects.toThrow(
+          /Registrations are linked to accreditations that do not match their type, material, or site/
+        )
+      })
+
+      it('rejects when registration has reprocessingType but linked accreditation does not', async () => {
+        const accId = new ObjectId().toString()
+        const organisation = buildOrganisation({
+          registrations: [buildRegistration({ accreditationId: accId })],
+          accreditations: [buildAccreditation({ id: accId })]
+        })
+        await repository.insert(organisation)
+        const inserted = await repository.findById(organisation.id)
+
+        await expect(
+          repository.replace(
+            organisation.id,
+            1,
+            prepareOrgUpdate(inserted, {
+              registrations: [
+                {
+                  ...inserted.registrations[0],
+                  reprocessingType: REPROCESSING_TYPE.INPUT
+                }
+              ]
+            })
+          )
+        ).rejects.toThrow(
+          /Registrations are linked to accreditations that do not match their type, material, or site/
+        )
+      })
+
+      it('accepts when both registration and accreditation have matching reprocessingType', async () => {
+        const accId = new ObjectId().toString()
+        const organisation = buildOrganisation({
+          registrations: [buildRegistration({ accreditationId: accId })],
+          accreditations: [buildAccreditation({ id: accId })]
+        })
+        await repository.insert(organisation)
+        const inserted = await repository.findById(organisation.id)
+
+        await expect(
+          repository.replace(
+            organisation.id,
+            1,
+            prepareOrgUpdate(inserted, {
+              registrations: [
+                {
+                  ...inserted.registrations[0],
+                  reprocessingType: REPROCESSING_TYPE.INPUT
+                }
+              ],
+              accreditations: [
+                {
+                  ...inserted.accreditations[0],
+                  reprocessingType: REPROCESSING_TYPE.INPUT
+                }
+              ]
+            })
+          )
+        ).resolves.not.toThrow()
+      })
+
+      it('accepts when neither registration nor accreditation has reprocessingType', async () => {
+        const accId = new ObjectId().toString()
+        const organisation = buildOrganisation({
+          registrations: [buildRegistration({ accreditationId: accId })],
+          accreditations: [buildAccreditation({ id: accId })]
+        })
+        await repository.insert(organisation)
+        const inserted = await repository.findById(organisation.id)
+
+        await expect(
+          repository.replace(organisation.id, 1, prepareOrgUpdate(inserted, {}))
+        ).resolves.not.toThrow()
+      })
+
+      it('rejects when registration and accreditation have different glassRecyclingProcess', async () => {
+        const accId = new ObjectId().toString()
+        const organisation = buildOrganisation({
+          registrations: [
+            buildRegistration({
+              wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+              material: MATERIAL.GLASS,
+              glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_RE_MELT],
+              accreditationId: accId
+            })
+          ],
+          accreditations: [
+            buildAccreditation({
+              id: accId,
+              wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+              material: MATERIAL.GLASS,
+              glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_OTHER],
+              site: undefined,
+              orsFileUploads: [
+                {
+                  defraFormUploadedFileId: 'file-ors',
+                  defraFormUserDownloadLink: 'https://example.com/ors'
+                }
+              ]
+            })
+          ]
+        })
+        await repository.insert(organisation)
+        const inserted = await repository.findById(organisation.id)
+
+        await expect(
+          repository.replace(organisation.id, 1, prepareOrgUpdate(inserted, {}))
+        ).rejects.toThrow(
+          /Registrations are linked to accreditations that do not match their type, material, or site/
+        )
+      })
+
+      it('accepts when registration and accreditation have matching glassRecyclingProcess', async () => {
+        const accId = new ObjectId().toString()
+        const organisation = buildOrganisation({
+          registrations: [
+            buildRegistration({
+              wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+              material: MATERIAL.GLASS,
+              glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_RE_MELT],
+              accreditationId: accId
+            })
+          ],
+          accreditations: [
+            buildAccreditation({
+              id: accId,
+              wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+              material: MATERIAL.GLASS,
+              glassRecyclingProcess: [GLASS_RECYCLING_PROCESS.GLASS_RE_MELT],
+              site: undefined,
+              orsFileUploads: [
+                {
+                  defraFormUploadedFileId: 'file-ors',
+                  defraFormUserDownloadLink: 'https://example.com/ors'
+                }
+              ]
+            })
+          ]
+        })
+        await repository.insert(organisation)
+        const inserted = await repository.findById(organisation.id)
+
+        await expect(
+          repository.replace(organisation.id, 1, prepareOrgUpdate(inserted, {}))
+        ).resolves.not.toThrow()
+      })
+    })
+  })
+}

--- a/src/repositories/organisations/contract/data-isolation.contract.js
+++ b/src/repositories/organisations/contract/data-isolation.contract.js
@@ -5,9 +5,15 @@ export const testDataIsolationBehaviour = (it) => {
   describe('data isolation', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     describe('findAll isolation', () => {
       it('returns independent copies that cannot modify stored data', async () => {

--- a/src/repositories/organisations/contract/find-accreditation-by-id.contract.js
+++ b/src/repositories/organisations/contract/find-accreditation-by-id.contract.js
@@ -10,9 +10,15 @@ export const testFindAccreditationByIdBehaviour = (it) => {
   describe('findAccreditationById', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     it('returns accreditation when both organisation ID and accreditation ID are valid', async () => {
       const accreditation1 = buildAccreditation({
@@ -27,6 +33,7 @@ export const testFindAccreditationByIdBehaviour = (it) => {
       })
 
       const org = buildOrganisation({
+        registrations: [],
         accreditations: [accreditation1, accreditation2]
       })
 
@@ -48,6 +55,7 @@ export const testFindAccreditationByIdBehaviour = (it) => {
     it('throws NotFound when organisation ID does not exist', async () => {
       const accreditation = buildAccreditation()
       const org = buildOrganisation({
+        registrations: [],
         accreditations: [accreditation]
       })
 
@@ -66,6 +74,7 @@ export const testFindAccreditationByIdBehaviour = (it) => {
     it('throws NotFound when accreditation ID does not exist in the organisation', async () => {
       const accreditation = buildAccreditation()
       const org = buildOrganisation({
+        registrations: [],
         accreditations: [accreditation]
       })
 
@@ -83,6 +92,7 @@ export const testFindAccreditationByIdBehaviour = (it) => {
 
     it('throws NotFound when organisation has no accreditations', async () => {
       const org = buildOrganisation({
+        registrations: [],
         accreditations: []
       })
 
@@ -111,6 +121,7 @@ export const testFindAccreditationByIdBehaviour = (it) => {
       const accreditation = buildAccreditation()
 
       const org = buildOrganisation({
+        registrations: [],
         accreditations: [accreditation]
       })
 
@@ -130,6 +141,7 @@ export const testFindAccreditationByIdBehaviour = (it) => {
       const accreditation = buildAccreditation()
 
       const org = buildOrganisation({
+        registrations: [],
         accreditations: [accreditation]
       })
 

--- a/src/repositories/organisations/contract/find-all-by-schema-version.contract.js
+++ b/src/repositories/organisations/contract/find-all-by-schema-version.contract.js
@@ -5,9 +5,15 @@ export const testFindAllBySchemaVersionBehaviour = (it) => {
   describe('findAllBySchemaVersion', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     it('returns empty array when no organisations match the schema version', async () => {
       const org = buildOrganisation()

--- a/src/repositories/organisations/contract/find-all-ids.contract.js
+++ b/src/repositories/organisations/contract/find-all-ids.contract.js
@@ -5,9 +5,15 @@ export const testFindAllIdsBehaviour = (it) => {
   describe('findAllIds', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     it('returns empty sets when no organisations exist', async () => {
       const result = await repository.findAllIds()

--- a/src/repositories/organisations/contract/find-all-linked.contract.js
+++ b/src/repositories/organisations/contract/find-all-linked.contract.js
@@ -6,9 +6,15 @@ export const testFindAllLinkedBehaviour = (it) => {
   describe('findAllLinked', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     it('returns empty array when no organisations exist', async () => {
       const result = await repository.findAllLinked()

--- a/src/repositories/organisations/contract/find-by-ids.contract.js
+++ b/src/repositories/organisations/contract/find-by-ids.contract.js
@@ -5,9 +5,15 @@ export const testFindByIdsBehaviour = (it) => {
   describe('findByIds', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     it('returns empty array when given empty array', async () => {
       const result = await repository.findByIds([])

--- a/src/repositories/organisations/contract/find-by-linked-defra-org-id.contract.js
+++ b/src/repositories/organisations/contract/find-by-linked-defra-org-id.contract.js
@@ -22,9 +22,15 @@ export const testFindByLinkedDefraOrgIdBehaviour = (it) => {
   describe('findByLinkedDefraOrgId', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     it('returns null when no organisation is linked to the Defra org ID', async () => {
       const result = await repository.findByLinkedDefraOrgId(

--- a/src/repositories/organisations/contract/find-page.contract.js
+++ b/src/repositories/organisations/contract/find-page.contract.js
@@ -19,9 +19,15 @@ export const testFindPageBehaviour = (it) => {
   describe('findPage', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     describe('empty collection', () => {
       it('returns items=[], totalItems=0, totalPages=0', async () => {

--- a/src/repositories/organisations/contract/find-registration-by-id.contract.js
+++ b/src/repositories/organisations/contract/find-registration-by-id.contract.js
@@ -11,9 +11,15 @@ export const testFindRegistrationByIdBehaviour = (it) => {
   describe('findRegistrationById', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     it('returns registration when both organisation ID and registration ID are valid', async () => {
       const registration1 = buildRegistration({

--- a/src/repositories/organisations/contract/find.contract.js
+++ b/src/repositories/organisations/contract/find.contract.js
@@ -284,6 +284,12 @@ export const testFindBehaviour = (it) => {
               validTo: VALID_TO,
               reprocessingType: REPROCESSING_TYPE.INPUT
             }
+          ],
+          accreditations: [
+            {
+              ...inserted.accreditations[0],
+              reprocessingType: REPROCESSING_TYPE.INPUT
+            }
           ]
         })
         await repository.replace(org.id, 1, updatePayload)

--- a/src/repositories/organisations/contract/insert.contract.js
+++ b/src/repositories/organisations/contract/insert.contract.js
@@ -5,9 +5,15 @@ export const testInsertBehaviour = (it) => {
   describe('insert', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     describe('basic behaviour', () => {
       it('inserts an organisation without error', async () => {

--- a/src/repositories/organisations/contract/org-status.contract.js
+++ b/src/repositories/organisations/contract/org-status.contract.js
@@ -15,9 +15,15 @@ export const testOrgStatusTransitionBehaviour = (it) => {
     let repository
     const { VALID_FROM, VALID_TO } = getValidDateRange()
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     describe('invalid transitions', () => {
       it('rejects transition from CREATED to ACTIVE', async () => {
@@ -81,6 +87,12 @@ export const testOrgStatusTransitionBehaviour = (it) => {
               validTo: VALID_TO,
               reprocessingType: REPROCESSING_TYPE.INPUT
             }
+          ],
+          accreditations: [
+            {
+              ...orgData.accreditations[0],
+              reprocessingType: REPROCESSING_TYPE.INPUT
+            }
           ]
         })
 
@@ -98,6 +110,12 @@ export const testOrgStatusTransitionBehaviour = (it) => {
               registrationNumber: 'REG12345',
               validFrom: VALID_FROM,
               validTo: VALID_TO,
+              reprocessingType: REPROCESSING_TYPE.INPUT
+            }
+          ],
+          accreditations: [
+            {
+              ...orgData.accreditations[0],
               reprocessingType: REPROCESSING_TYPE.INPUT
             }
           ]
@@ -135,6 +153,12 @@ export const testOrgStatusTransitionBehaviour = (it) => {
               validTo: VALID_TO,
               reprocessingType: REPROCESSING_TYPE.INPUT
             }
+          ],
+          accreditations: [
+            {
+              ...orgData.accreditations[0],
+              reprocessingType: REPROCESSING_TYPE.INPUT
+            }
           ]
         })
 
@@ -159,6 +183,12 @@ export const testOrgStatusTransitionBehaviour = (it) => {
               validTo: VALID_TO,
               reprocessingType: REPROCESSING_TYPE.INPUT
             }
+          ],
+          accreditations: [
+            {
+              ...orgData.accreditations[0],
+              reprocessingType: REPROCESSING_TYPE.INPUT
+            }
           ]
         })
 
@@ -176,6 +206,12 @@ export const testOrgStatusTransitionBehaviour = (it) => {
               registrationNumber: 'REG12345',
               validFrom: VALID_FROM,
               validTo: VALID_TO,
+              reprocessingType: REPROCESSING_TYPE.INPUT
+            }
+          ],
+          accreditations: [
+            {
+              ...orgData.accreditations[0],
               reprocessingType: REPROCESSING_TYPE.INPUT
             }
           ]
@@ -200,6 +236,12 @@ export const testOrgStatusTransitionBehaviour = (it) => {
               registrationNumber: 'REG12345',
               validFrom: VALID_FROM,
               validTo: VALID_TO,
+              reprocessingType: REPROCESSING_TYPE.INPUT
+            }
+          ],
+          accreditations: [
+            {
+              ...orgData.accreditations[0],
               reprocessingType: REPROCESSING_TYPE.INPUT
             }
           ]
@@ -228,6 +270,12 @@ export const testOrgStatusTransitionBehaviour = (it) => {
               registrationNumber: 'REG12345',
               validFrom: VALID_FROM,
               validTo: VALID_TO,
+              reprocessingType: REPROCESSING_TYPE.INPUT
+            }
+          ],
+          accreditations: [
+            {
+              ...orgData.accreditations[0],
               reprocessingType: REPROCESSING_TYPE.INPUT
             }
           ]

--- a/src/repositories/organisations/contract/reg-acc-approval.contract.js
+++ b/src/repositories/organisations/contract/reg-acc-approval.contract.js
@@ -23,9 +23,15 @@ export const testRegAccApprovalValidation = (it) => {
   describe('approval validation', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import('../port.js').OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     describe('accreditation approval validation', () => {
       it('rejects when approved accreditation has no linked approved registration', async () => {
@@ -47,7 +53,13 @@ export const testRegAccApprovalValidation = (it) => {
             organisation.id,
             1,
             prepareOrgUpdate(inserted, {
-              accreditations: [accreditationToUpdate]
+              accreditations: [accreditationToUpdate],
+              registrations: [
+                {
+                  ...inserted.registrations[0],
+                  reprocessingType: REPROCESSING_TYPE.INPUT
+                }
+              ]
             })
           )
         ).rejects.toThrow(
@@ -293,6 +305,9 @@ export const testRegAccApprovalValidation = (it) => {
 
           const orgData = {
             ...organisation,
+            registrations: organisation.registrations.map(
+              ({ accreditationId: _, ...reg }) => reg
+            ),
             accreditations: [
               buildAccreditation({
                 id: acc1Id,
@@ -366,6 +381,9 @@ export const testRegAccApprovalValidation = (it) => {
 
           const orgData = {
             ...organisation,
+            registrations: organisation.registrations.map(
+              ({ accreditationId: _, ...reg }) => reg
+            ),
             accreditations: [
               buildAccreditation({
                 id: acc1Id,
@@ -437,6 +455,7 @@ export const testRegAccApprovalValidation = (it) => {
                 wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
                 material: MATERIAL.PAPER,
                 glassRecyclingProcess: null,
+                accreditationId: undefined,
                 site: {
                   address: { line1: '123 Test St', postcode: 'AB12 3CD' },
                   gridReference: 'ST123456',
@@ -454,6 +473,7 @@ export const testRegAccApprovalValidation = (it) => {
                 wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
                 material: MATERIAL.PAPER,
                 glassRecyclingProcess: null,
+                accreditationId: undefined,
                 site: {
                   address: { line1: '456 Test Ave', postcode: 'AB12 3CD' },
                   gridReference: 'ST789012',
@@ -505,6 +525,7 @@ export const testRegAccApprovalValidation = (it) => {
                 wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
                 material: MATERIAL.PAPER,
                 glassRecyclingProcess: null,
+                accreditationId: undefined,
                 site: {
                   address: { line1: '123 Test St', postcode: 'AB12 3CD' },
                   gridReference: 'ST123456',
@@ -521,6 +542,7 @@ export const testRegAccApprovalValidation = (it) => {
                 wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
                 material: MATERIAL.ALUMINIUM,
                 glassRecyclingProcess: null,
+                accreditationId: undefined,
                 site: {
                   address: { line1: '456 Test Ave', postcode: 'XY98 7ZW' },
                   gridReference: 'ST789012',
@@ -857,7 +879,13 @@ export const testRegAccApprovalValidation = (it) => {
             organisation.id,
             1,
             prepareOrgUpdate(inserted, {
-              registrations: [registrationToUpdate]
+              registrations: [registrationToUpdate],
+              accreditations: [
+                {
+                  ...inserted.accreditations[0],
+                  reprocessingType: REPROCESSING_TYPE.INPUT
+                }
+              ]
             })
           )
 
@@ -1009,11 +1037,14 @@ export const testRegAccApprovalValidation = (it) => {
             glassRecyclingProcess: null
           }
 
+          const { accreditationId: _accId, ...regWithoutLink } =
+            inserted.registrations[0]
           await repository.replace(
             organisation.id,
             1,
             prepareOrgUpdate(inserted, {
-              accreditations: [accreditationToUpdate]
+              accreditations: [accreditationToUpdate],
+              registrations: [regWithoutLink]
             })
           )
 
@@ -1103,7 +1134,13 @@ export const testRegAccApprovalValidation = (it) => {
             organisation.id,
             1,
             prepareOrgUpdate(inserted, {
-              registrations: [registrationToUpdate]
+              registrations: [registrationToUpdate],
+              accreditations: [
+                {
+                  ...inserted.accreditations[0],
+                  reprocessingType: REPROCESSING_TYPE.INPUT
+                }
+              ]
             })
           )
 
@@ -1421,8 +1458,10 @@ export const testRegAccApprovalValidation = (it) => {
           await repository.insert(organisation)
           const inserted = await repository.findById(organisation.id)
 
+          const { accreditationId: _accId2, ...regBase } =
+            inserted.registrations[0]
           const registrationToUpdate = {
-            ...inserted.registrations[0],
+            ...regBase,
             material: 'plastic',
             glassRecyclingProcess: null,
             validFrom: null,
@@ -1652,11 +1691,14 @@ export const testRegAccApprovalValidation = (it) => {
             glassRecyclingProcess: null
           }
 
+          const { accreditationId: _accId3, ...regWithoutLink3 } =
+            inserted.registrations[0]
           await repository.replace(
             organisation.id,
             1,
             prepareOrgUpdate(inserted, {
-              accreditations: [accreditationToUpdate]
+              accreditations: [accreditationToUpdate],
+              registrations: [regWithoutLink3]
             })
           )
 

--- a/src/repositories/organisations/contract/reg-acc-status-transition.contract.js
+++ b/src/repositories/organisations/contract/reg-acc-status-transition.contract.js
@@ -17,9 +17,15 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
   describe('registration/accreditation status transitions', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     describe('registration status transitions', () => {
       describe('transitions from CREATED', () => {
@@ -35,6 +41,12 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
                 registrationNumber: 'REG12345',
                 validFrom: VALID_FROM,
                 validTo: VALID_TO,
+                reprocessingType: REPROCESSING_TYPE.INPUT
+              }
+            ],
+            accreditations: [
+              {
+                ...orgData.accreditations[0],
                 reprocessingType: REPROCESSING_TYPE.INPUT
               }
             ]
@@ -321,6 +333,12 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
                 accreditationNumber: 'ACC12345',
                 validFrom: VALID_FROM,
                 validTo: VALID_TO,
+                reprocessingType: REPROCESSING_TYPE.INPUT
+              }
+            ],
+            registrations: [
+              {
+                ...orgData.registrations[0],
                 reprocessingType: REPROCESSING_TYPE.INPUT
               }
             ]

--- a/src/repositories/organisations/contract/replace-raw.contract.js
+++ b/src/repositories/organisations/contract/replace-raw.contract.js
@@ -5,9 +5,15 @@ export const testReplaceRawBehaviour = (it) => {
   describe('replaceRaw', () => {
     let repository
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     it('writes document directly without status history processing', async () => {
       const orgData = buildOrganisation()

--- a/src/repositories/organisations/contract/replace.contract.js
+++ b/src/repositories/organisations/contract/replace.contract.js
@@ -18,9 +18,15 @@ export const testReplaceBehaviour = (it) => {
     // Date strings for validFrom/validTo
     const { VALID_FROM, VALID_TO } = getValidDateRange()
 
-    beforeEach(async ({ organisationsRepository }) => {
-      repository = await organisationsRepository()
-    })
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import('../port.js').OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
 
     describe('basic behaviour', () => {
       it('updates organisation level fields successfully', async () => {
@@ -70,7 +76,8 @@ export const testReplaceBehaviour = (it) => {
         const registrationToUpdate = {
           ...originalReg,
           material: 'plastic',
-          glassRecyclingProcess: null
+          glassRecyclingProcess: null,
+          accreditationId: undefined
         }
         const beforeUpdateOrg = await repository.findById(organisation.id)
 
@@ -111,8 +118,11 @@ export const testReplaceBehaviour = (it) => {
           material: 'plastic'
         }
 
+        const { accreditationId: _, ...regWithoutLink } =
+          organisationAfterInsert.registrations[0]
         const updatePayload = prepareOrgUpdate(organisation, {
-          accreditations: [accreditationToUpdate]
+          accreditations: [accreditationToUpdate],
+          registrations: [regWithoutLink]
         })
         await repository.replace(organisation.id, 1, updatePayload)
 
@@ -163,13 +173,15 @@ export const testReplaceBehaviour = (it) => {
         )
         expect(addedReg).toBeDefined()
 
-        const { statusHistory: _, ...expectedReg } = {
+        /** @type {Record<string, any>} */
+        const newRegistrationWithDate = {
           ...newRegistration,
           formSubmission: {
             id: newRegistration.formSubmission.id,
             time: new Date(newRegistration.formSubmission.time)
           }
         }
+        const { statusHistory: _, ...expectedReg } = newRegistrationWithDate
         const { statusHistory: actualStatusHistory, ...actualReg } = addedReg
 
         expect(actualReg).toMatchObject(expectedReg)
@@ -182,13 +194,14 @@ export const testReplaceBehaviour = (it) => {
         await repository.insert(organisation)
 
         const { ObjectId } = await import('mongodb')
+        const { statusHistory: _statusHistory, ...baseAccreditation } =
+          organisation.accreditations[0]
         const newAccreditation = {
-          ...organisation.accreditations[0],
+          ...baseAccreditation,
           id: new ObjectId().toString(),
           material: 'aluminium',
           glassRecyclingProcess: null
         }
-        delete newAccreditation.statusHistory
         const updatePayload = prepareOrgUpdate(organisation, {
           accreditations: [newAccreditation]
         })
@@ -204,9 +217,7 @@ export const testReplaceBehaviour = (it) => {
         )
         expect(addedAcc).toBeDefined()
 
-        const { statusHistory: _, ...expectedAcc } = {
-          ...newAccreditation
-        }
+        const expectedAcc = { ...newAccreditation }
         const { statusHistory: actualStatusHistory, ...actualAcc } = addedAcc
         expect(actualAcc).toMatchObject(expectedAcc)
         expect(actualStatusHistory).toHaveLength(1)
@@ -353,7 +364,13 @@ export const testReplaceBehaviour = (it) => {
           reprocessingType: REPROCESSING_TYPE.INPUT
         }
         const updatePayload = prepareOrgUpdate(organisation, {
-          registrations: [registrationToUpdate]
+          registrations: [registrationToUpdate],
+          accreditations: [
+            {
+              ...organisation.accreditations[0],
+              reprocessingType: REPROCESSING_TYPE.INPUT
+            }
+          ]
         })
         await repository.replace(organisation.id, 1, updatePayload)
 
@@ -382,6 +399,12 @@ export const testReplaceBehaviour = (it) => {
               registrationNumber: 'REG12345',
               validFrom: VALID_FROM,
               validTo: VALID_TO,
+              reprocessingType: REPROCESSING_TYPE.INPUT
+            }
+          ],
+          accreditations: [
+            {
+              ...organisation.accreditations[0],
               reprocessingType: REPROCESSING_TYPE.INPUT
             }
           ]
@@ -441,6 +464,12 @@ export const testReplaceBehaviour = (it) => {
               status: REG_ACC_STATUS.REJECTED,
               reprocessingType: REPROCESSING_TYPE.INPUT
             }
+          ],
+          registrations: [
+            {
+              ...organisation.registrations[0],
+              reprocessingType: REPROCESSING_TYPE.INPUT
+            }
           ]
         })
         await repository.replace(organisation.id, 1, orgUpdate1)
@@ -495,6 +524,12 @@ export const testReplaceBehaviour = (it) => {
                 validTo: VALID_TO,
                 reprocessingType: REPROCESSING_TYPE.INPUT
               }
+            ],
+            accreditations: [
+              {
+                ...organisation.accreditations[0],
+                reprocessingType: REPROCESSING_TYPE.INPUT
+              }
             ]
           })
           await repository.replace(organisation.id, 1, updatePayload)
@@ -532,6 +567,12 @@ export const testReplaceBehaviour = (it) => {
                 registrationNumber: 'REG12345',
                 validFrom: VALID_FROM,
                 validTo: VALID_TO,
+                reprocessingType: REPROCESSING_TYPE.INPUT
+              }
+            ],
+            accreditations: [
+              {
+                ...organisation.accreditations[0],
                 reprocessingType: REPROCESSING_TYPE.INPUT
               }
             ]
@@ -650,6 +691,12 @@ export const testReplaceBehaviour = (it) => {
                 validTo: VALID_TO,
                 reprocessingType: REPROCESSING_TYPE.INPUT
               }
+            ],
+            accreditations: [
+              {
+                ...organisation.accreditations[0],
+                reprocessingType: REPROCESSING_TYPE.INPUT
+              }
             ]
           })
           await repository.replace(organisation.id, 1, updatePayload)
@@ -714,6 +761,12 @@ export const testReplaceBehaviour = (it) => {
               {
                 ...reg2,
                 status: REG_ACC_STATUS.CREATED
+              }
+            ],
+            accreditations: [
+              {
+                ...organisation.accreditations[0],
+                reprocessingType: REPROCESSING_TYPE.INPUT
               }
             ]
           })

--- a/src/repositories/organisations/contract/test-data.js
+++ b/src/repositories/organisations/contract/test-data.js
@@ -63,6 +63,10 @@ export const buildRegistration = (overrides = {}) => {
     delete registration.overseasSites
   }
 
+  if (!overrides.accreditationId) {
+    delete registration.accreditationId
+  }
+
   return registration
 }
 

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -8,7 +8,12 @@ import {
   assertAndHandleItemStateTransition,
   assertOrgStatusTransition
 } from '#repositories/organisations/schema/status-transition.js'
-import { validateApprovals } from './schema/helpers.js'
+import {
+  validateAccreditationLinkExists,
+  validateAccreditationLinkMatches,
+  validateAccreditationLinkUniqueness,
+  validateApprovals
+} from './schema/helpers.js'
 import { collateUsers } from './collate-users.js'
 import { getCurrentStatus } from './status.js'
 
@@ -93,6 +98,15 @@ function prepareRegAccForReplace(validated, existing) {
       validated.registrations,
       validated.accreditations
     )
+  validateAccreditationLinkUniqueness(validated.registrations)
+  validateAccreditationLinkExists(
+    validated.registrations,
+    accreditationsAfterUpdate
+  )
+  validateAccreditationLinkMatches(
+    validated.registrations,
+    accreditationsAfterUpdate
+  )
   validateApprovals(validated.registrations, accreditationsAfterUpdate)
   const registrations = updateStatusHistoryForItems(
     existing.registrations,

--- a/src/repositories/organisations/port.contract.js
+++ b/src/repositories/organisations/port.contract.js
@@ -1,3 +1,4 @@
+import { testAccreditationLinkValidation } from './contract/accreditation-link.contract.js'
 import { testFindBehaviour } from './contract/find.contract.js'
 import { testFindAllBySchemaVersionBehaviour } from './contract/find-all-by-schema-version.contract.js'
 import { testFindByIdsBehaviour } from './contract/find-by-ids.contract.js'
@@ -31,6 +32,7 @@ export const testOrganisationsRepositoryContract = (repositoryFactory) => {
   testFindAccreditationByIdBehaviour(repositoryFactory)
   testDataIsolationBehaviour(repositoryFactory)
   testRegAccApprovalValidation(repositoryFactory)
+  testAccreditationLinkValidation(repositoryFactory)
   testOrgStatusTransitionBehaviour(repositoryFactory)
   testRegAccStatusTransitionBehaviour(repositoryFactory)
 }

--- a/src/repositories/organisations/schema/helpers.js
+++ b/src/repositories/organisations/schema/helpers.js
@@ -1,6 +1,5 @@
 import Joi from 'joi'
 import {
-  MATERIAL,
   REG_ACC_STATUS,
   WASTE_PERMIT_TYPE,
   WASTE_PROCESSING_TYPE
@@ -10,6 +9,9 @@ import {
   isAccreditationForRegistration
 } from '#formsubmission/submission-keys.js'
 import Boom from '@hapi/boom'
+
+/** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {RegistrationOrAccreditation} from '#domain/organisations/model.js' */
 
 export const PREVIOUS_SCHEMA_VERSION = 2
 export const CURRENT_SCHEMA_VERSION = 3
@@ -121,31 +123,18 @@ function findAccreditationsWithoutApprovedRegistration(
 }
 
 /**
- * Glass registrations can be split into remelt and other processes,
- * which should be treated as distinct entities for duplicate detection.
- *
- * @param {import('#formsubmission/types.js').RegistrationOrAccreditation} item
- * @returns {string}
+ * @param {RegistrationOrAccreditation[]} items
+ * @returns {[string, RegistrationOrAccreditation[]][]}
  */
-function getDuplicateDetectionKey(item) {
-  const baseKey = getRegAccKey(item)
-
-  if (item.material === MATERIAL.GLASS && item.glassRecyclingProcess?.[0]) {
-    return `${baseKey}::${item.glassRecyclingProcess[0]}`
-  }
-
-  return baseKey
-}
-
 function findDuplicateApprovals(items) {
   const grouped = Object.groupBy(
     items.filter((item) => item.status === REG_ACC_STATUS.APPROVED),
-    (item) => getDuplicateDetectionKey(item)
+    (item) => getRegAccKey(item)
   )
 
-  return Object.entries(grouped).filter(
-    // Object.entries yields only keys that exist, so group is always present
-    ([_key, group]) => /** @type {typeof items} */ (group).length > 1
+  return (
+    /** @type {[string, RegistrationOrAccreditation[]][]} */
+    (Object.entries(grouped)).filter(([, group]) => group.length > 1)
   )
 }
 
@@ -155,6 +144,105 @@ function formatDuplicateError(duplicates, itemType) {
     .flatMap(([_key, group]) => group.map((item) => item.id))
     .join(', ')
   return `Multiple approved ${itemType} found with duplicate keys [${keys}]: ${ids}`
+}
+
+/**
+ * @param {Registration[]} registrations
+ * @returns {[string, Registration[]][]}
+ */
+function findAccreditationIdsLinkedToMultipleRegistrations(registrations) {
+  const linkedRegistrations = registrations.filter(
+    (reg) => reg.accreditationId !== undefined && reg.accreditationId !== null
+  )
+
+  const grouped = Object.groupBy(
+    linkedRegistrations,
+    (reg) => /** @type {string} */ (reg.accreditationId)
+  )
+
+  return (
+    /** @type {[string, Registration[]][]} */
+    (Object.entries(grouped)).filter(([, regs]) => regs.length > 1)
+  )
+}
+
+/**
+ * @param {Registration[]} registrations
+ */
+export function validateAccreditationLinkUniqueness(registrations) {
+  const duplicates =
+    findAccreditationIdsLinkedToMultipleRegistrations(registrations)
+
+  if (duplicates.length === 0) {
+    return
+  }
+
+  const details = duplicates
+    .map(
+      ([accId, regs]) =>
+        `accreditation ${accId} linked to registrations ${regs.map((reg) => reg.id).join(', ')}`
+    )
+    .join('; ')
+  throw Boom.badData(
+    `Each accreditation must be linked to at most one registration: ${details}`
+  )
+}
+
+/**
+ * @param {Registration[]} registrations
+ * @param {import('#domain/organisations/accreditation.js').Accreditation[]} accreditations
+ */
+export function validateAccreditationLinkExists(registrations, accreditations) {
+  const accreditationIds = new Set(accreditations.map((acc) => acc.id))
+
+  const missing = registrations.filter(
+    (reg) => !!reg.accreditationId && !accreditationIds.has(reg.accreditationId)
+  )
+
+  if (missing.length === 0) {
+    return
+  }
+
+  const details = missing
+    .map(
+      (reg) => `registration ${reg.id} -> accreditation ${reg.accreditationId}`
+    )
+    .join('; ')
+  throw Boom.badData(
+    `Registrations are linked to accreditations that do not exist: ${details}`
+  )
+}
+
+/**
+ * @param {Registration[]} registrations
+ * @param {import('#domain/organisations/accreditation.js').Accreditation[]} accreditations
+ */
+export function validateAccreditationLinkMatches(
+  registrations,
+  accreditations
+) {
+  const accreditationsById = new Map(accreditations.map((acc) => [acc.id, acc]))
+
+  const mismatched = registrations.filter((reg) => {
+    if (!reg.accreditationId) {
+      return false
+    }
+    const acc = accreditationsById.get(reg.accreditationId)
+    return acc !== undefined && !isAccreditationForRegistration(acc, reg)
+  })
+
+  if (mismatched.length === 0) {
+    return
+  }
+
+  const details = mismatched
+    .map(
+      (reg) => `registration ${reg.id} -> accreditation ${reg.accreditationId}`
+    )
+    .join('; ')
+  throw Boom.badData(
+    `Registrations are linked to accreditations that do not match their type, material, or site: ${details}`
+  )
 }
 
 export function validateApprovals(registrations, accreditations) {

--- a/src/routes/v1/organisations/link.test.js
+++ b/src/routes/v1/organisations/link.test.js
@@ -177,6 +177,12 @@ describe('POST /v1/organisations/{organisationId}/link', () => {
                   validTo: VALID_TO,
                   reprocessingType: REPROCESSING_TYPE.INPUT
                 }
+              ],
+              accreditations: [
+                {
+                  ...orgWithSubmitterDetails.accreditations[0],
+                  reprocessingType: REPROCESSING_TYPE.INPUT
+                }
               ]
             })
           )


### PR DESCRIPTION
Ticket: [PAE-1566](https://eaflood.atlassian.net/browse/PAE-1566)
## Summary
- Org replace now rejects any update where more than one registration links to the same accreditation (`validateAccreditationLinkUniqueness`), irrespective of status, with an error identifying the duplicate accreditation IDs and the registrations linked to them.
- Org replace now rejects any update where a registration's `accreditationId` references an accreditation not present in the organisation (`validateAccreditationLinkExists`).
- Org replace now rejects any update where a registration and its linked accreditation have mismatched identity fields — `wasteProcessingType`, `material`, site postcode (reprocessors only), `reprocessingType` if non-null on either side, and `glassRecyclingProcess` for glass (`validateAccreditationLinkMatches`).
- Incremental migration linking now tracks claimed accreditation IDs so an accreditation only becomes eligible for linking when it isn't already linked to a registration, and never links the same accreditation to two registrations.
- Fixed a related bug where glass registrations split into remelt/other siblings could incorrectly match and share a single accreditation, by including `glassRecyclingProcess` in the registration/accreditation identity key.

## Test plan
- [x] `npm run lint:fix`
- [x] `npm run format:check`
- [x] `npm run lint:types`
- [x] `npm run lint:types:tests` (no new errors introduced)
- [x] `npm run test` — 358 files / 6454 tests passing, 100% coverage (statements/branches/functions/lines)

[PAE-1566]: https://eaflood.atlassian.net/browse/PAE-1566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ