### PR TITLE
PAE-1560: Persist and read committed waste-balance row states (ADR-0037 Stage 1)

### DIFF
--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -894,14 +894,14 @@ describe('SummaryLogsValidator', () => {
 
       const updateCall = summaryLogsRepository.update.mock.calls[0][2]
 
-      // Note: ROW_ID values come directly from test data as numbers
+      // Note: ROW_ID is normalised to a string row identity by the transform
       // Row 10001 is excluded because EWC_CODE is missing (classifyForWasteBalance)
       expect(updateCall.loads).toEqual({
         added: {
-          valid: { count: 1, rowIds: [10000] },
-          invalid: { count: 1, rowIds: [10001] },
-          included: { count: 1, rowIds: [10000] },
-          excluded: { count: 1, rowIds: [10001] }
+          valid: { count: 1, rowIds: ['10000'] },
+          invalid: { count: 1, rowIds: ['10001'] },
+          included: { count: 1, rowIds: ['10000'] },
+          excluded: { count: 1, rowIds: ['10001'] }
         },
         unchanged: createEmptyLoadValidity(),
         adjusted: createEmptyLoadValidity()
@@ -1008,12 +1008,12 @@ describe('SummaryLogsValidator', () => {
 
       // Row 10001 is IGNORED (outside accreditation range) and counted as excluded
       expect(updateCall.loads.added.valid.count).toBe(1)
-      expect(updateCall.loads.added.valid.rowIds).toEqual([10000])
-      expect(updateCall.loads.added.included.rowIds).toEqual([10000])
+      expect(updateCall.loads.added.valid.rowIds).toEqual(['10000'])
+      expect(updateCall.loads.added.included.rowIds).toEqual(['10000'])
 
       expect(updateCall.loads.added.invalid.count).toBe(0)
       expect(updateCall.loads.added.excluded.count).toBe(1)
-      expect(updateCall.loads.added.excluded.rowIds).toEqual([10001])
+      expect(updateCall.loads.added.excluded.rowIds).toEqual(['10001'])
     })
 
     it('counts non-waste-balance table rows in valid/invalid but not included/excluded (REPROCESSED_LOADS in REPROCESSOR_INPUT)', async () => {
@@ -1173,7 +1173,7 @@ describe('SummaryLogsValidator', () => {
       const updateCall = summaryLogsRepository.update.mock.calls[0][2]
 
       expect(updateCall.loads.added.valid.count).toBe(1)
-      expect(updateCall.loads.added.valid.rowIds).toEqual([5000])
+      expect(updateCall.loads.added.valid.rowIds).toEqual(['5000'])
     })
 
     it('sets IGNORED outcome for EXPORTER loads with dates outside accreditation range', async () => {
@@ -1282,7 +1282,7 @@ describe('SummaryLogsValidator', () => {
       const updateCall = summaryLogsRepository.update.mock.calls[0][2]
 
       expect(updateCall.loads.added.valid.count).toBe(1)
-      expect(updateCall.loads.added.valid.rowIds).toEqual([3000])
+      expect(updateCall.loads.added.valid.rowIds).toEqual(['3000'])
     })
 
     it('counts non-waste-balance table rows in valid/invalid but not included/excluded (SENT_ON_LOADS in EXPORTER)', async () => {
@@ -1472,7 +1472,7 @@ describe('SummaryLogsValidator', () => {
       const updateCall = summaryLogsRepository.update.mock.calls[0][2]
 
       expect(updateCall.loads.added.valid.count).toBe(1)
-      expect(updateCall.loads.added.valid.rowIds).toEqual([3000])
+      expect(updateCall.loads.added.valid.rowIds).toEqual(['3000'])
     })
 
     it('counts non-waste-balance table rows in valid/invalid but not included/excluded (SENT_ON_LOADS in REPROCESSOR_OUTPUT)', async () => {
@@ -1703,7 +1703,7 @@ describe('SummaryLogsValidator', () => {
       const updateCall = summaryLogsRepository.update.mock.calls[0][2]
 
       expect(updateCall.loads.added.invalid.count).toBe(1)
-      expect(updateCall.loads.added.invalid.rowIds).toEqual([5000])
+      expect(updateCall.loads.added.invalid.rowIds).toEqual(['5000'])
     })
 
     it('completes validation for REPROCESSOR_OUTPUT when date field is empty', async () => {

--- a/src/application/waste-records/row-transformers/create-row-transformer.js
+++ b/src/application/waste-records/row-transformers/create-row-transformer.js
@@ -23,7 +23,7 @@ export const createRowTransformer = ({
 
     return {
       wasteRecordType,
-      rowId: rowData[rowIdField],
+      rowId: String(rowData[rowIdField]),
       data: {
         ...rowData,
         processingType

--- a/src/application/waste-records/sync-from-summary-log.test.js
+++ b/src/application/waste-records/sync-from-summary-log.test.js
@@ -1406,7 +1406,7 @@ describe('syncFromSummaryLog', () => {
     expect(received).toMatchObject({
       organisationId: 'org-1',
       registrationId: 'reg-1',
-      rowId: 1000,
+      rowId: '1000',
       type: WASTE_RECORD_TYPE.RECEIVED
     })
     expect(received.data.processingType).toBe('REPROCESSOR_REGISTERED_ONLY')
@@ -1418,7 +1418,7 @@ describe('syncFromSummaryLog', () => {
     expect(sentOn).toMatchObject({
       organisationId: 'org-1',
       registrationId: 'reg-1',
-      rowId: 5000,
+      rowId: '5000',
       type: WASTE_RECORD_TYPE.SENT_ON
     })
     expect(sentOn.data.processingType).toBe('REPROCESSOR_REGISTERED_ONLY')
@@ -1505,7 +1505,7 @@ describe('syncFromSummaryLog', () => {
     expect(received).toMatchObject({
       organisationId: 'org-1',
       registrationId: 'reg-1',
-      rowId: 1000,
+      rowId: '1000',
       type: WASTE_RECORD_TYPE.RECEIVED
     })
     expect(received.data.processingType).toBe('EXPORTER_REGISTERED_ONLY')
@@ -1517,7 +1517,7 @@ describe('syncFromSummaryLog', () => {
     expect(exported).toMatchObject({
       organisationId: 'org-1',
       registrationId: 'reg-1',
-      rowId: 2000,
+      rowId: '2000',
       type: WASTE_RECORD_TYPE.EXPORTED
     })
     expect(exported.data.processingType).toBe('EXPORTER_REGISTERED_ONLY')
@@ -1528,7 +1528,7 @@ describe('syncFromSummaryLog', () => {
     expect(sentOn).toMatchObject({
       organisationId: 'org-1',
       registrationId: 'reg-1',
-      rowId: 4000,
+      rowId: '4000',
       type: WASTE_RECORD_TYPE.SENT_ON
     })
     expect(sentOn.data.processingType).toBe('EXPORTER_REGISTERED_ONLY')

--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -14,6 +14,7 @@ import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
 import { createWasteBalancesRepository } from '#waste-balances/repository/repository.js'
 import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
+import { createInMemoryRowStateRepository } from '#waste-balances/repository/row-states-inmemory.js'
 import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
@@ -540,6 +541,7 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
   const featureFlags = createInMemoryFeatureFlags(featureFlagOverrides)
 
   const streamRepository = createInMemoryStreamRepository()()
+  const rowStateRepository = createInMemoryRowStateRepository()()
 
   const systemLogsForBalanceAudit = {
     insert: vi.fn().mockResolvedValue(undefined),
@@ -550,6 +552,7 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
 
   const wasteBalancesRepositoryFactory = createWasteBalancesRepository({
     streamRepository,
+    rowStateRepository,
     systemLogsRepository: systemLogsForBalanceAudit
   })
   const wasteBalancesRepository = wasteBalancesRepositoryFactory()

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -16,6 +16,8 @@ import {
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import { buildOrganisation } from '#repositories/organisations/contract/test-data.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
+import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
+import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
@@ -350,9 +352,8 @@ describe('Submission and placeholder tests', () => {
         wasteRecordsRepository,
         summaryLogExtractor: validationExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({
-          findPeriodicReports: async () => []
-        })
+        reportsRepository: createInMemoryReportsRepository()(),
+        overseasSitesRepository: createInMemoryOverseasSitesRepository()()
       })
 
       const syncWasteRecords = syncFromSummaryLog(
@@ -803,9 +804,8 @@ describe('Submission and placeholder tests', () => {
         wasteRecordsRepository,
         summaryLogExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({
-          findPeriodicReports: async () => []
-        })
+        reportsRepository: createInMemoryReportsRepository()(),
+        overseasSitesRepository: createInMemoryOverseasSitesRepository()()
       })
       const featureFlags = createInMemoryFeatureFlags()
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -458,8 +458,8 @@ describe('Submission and placeholder tests', () => {
       )
 
       expect(wasteRecords).toHaveLength(2)
-      expect(wasteRecords[0].rowId).toBe(1001)
-      expect(wasteRecords[1].rowId).toBe(1002)
+      expect(wasteRecords[0].rowId).toBe('1001')
+      expect(wasteRecords[1].rowId).toBe('1002')
     })
 
     it('should update summary log status to SUBMITTED', async () => {
@@ -526,13 +526,13 @@ describe('Submission and placeholder tests', () => {
       expect(payload.status).toBe(SUMMARY_LOG_STATUS.VALIDATED)
 
       expect(payload.loads.added.valid.count).toBe(1)
-      expect(payload.loads.added.valid.rowIds).toContain(1003)
+      expect(payload.loads.added.valid.rowIds).toContain('1003')
 
       expect(payload.loads.adjusted.valid.count).toBe(1)
-      expect(payload.loads.adjusted.valid.rowIds).toContain(1002)
+      expect(payload.loads.adjusted.valid.rowIds).toContain('1002')
 
       expect(payload.loads.unchanged.valid.count).toBe(1)
-      expect(payload.loads.unchanged.valid.rowIds).toContain(1001)
+      expect(payload.loads.unchanged.valid.rowIds).toContain('1001')
 
       expect(payload.loadsByWasteRecordType).toEqual([
         expect.objectContaining({

--- a/src/waste-balances/application/latest-committed-summary-log-id.js
+++ b/src/waste-balances/application/latest-committed-summary-log-id.js
@@ -1,0 +1,29 @@
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+
+/**
+ * Resolve the `summaryLogId` of the most recent committed submission for a
+ * stream partition — the committed head the row-state reads pivot on. Returns
+ * `null` when the partition has no summary-log submission yet.
+ *
+ * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} streamRepository
+ * @param {{ registrationId: string, accreditationId: string | null }} partition
+ * @returns {Promise<string | null>}
+ */
+export const latestCommittedSummaryLogId = async (
+  streamRepository,
+  { registrationId, accreditationId }
+) => {
+  const latest = await streamRepository.findLatestByPartitionAndKind(
+    registrationId,
+    accreditationId,
+    STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED
+  )
+
+  if (latest === null) {
+    return null
+  }
+
+  return /** @type {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} */ (
+    latest.payload
+  ).summaryLogId
+}

--- a/src/waste-balances/application/latest-committed-summary-log-id.test.js
+++ b/src/waste-balances/application/latest-committed-summary-log-id.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+
+import { createInMemoryStreamRepository } from '../repository/stream-inmemory.js'
+import {
+  buildStreamEvent,
+  buildPrnCreatedEvent
+} from '../repository/stream-test-data.js'
+import { latestCommittedSummaryLogId } from './latest-committed-summary-log-id.js'
+
+const PARTITION = { registrationId: 'reg-1', accreditationId: 'acc-1' }
+
+describe('latestCommittedSummaryLogId', () => {
+  it('returns null when the partition has no events', async () => {
+    const streamRepository = createInMemoryStreamRepository()()
+
+    expect(
+      await latestCommittedSummaryLogId(streamRepository, PARTITION)
+    ).toBeNull()
+  })
+
+  it('returns null when the partition has events but no submission', async () => {
+    const streamRepository = createInMemoryStreamRepository([
+      buildPrnCreatedEvent({ number: 1 })
+    ])()
+
+    expect(
+      await latestCommittedSummaryLogId(streamRepository, PARTITION)
+    ).toBeNull()
+  })
+
+  it('returns the summaryLogId of the only submission', async () => {
+    const streamRepository = createInMemoryStreamRepository([
+      buildStreamEvent({
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      })
+    ])()
+
+    expect(await latestCommittedSummaryLogId(streamRepository, PARTITION)).toBe(
+      'log-1'
+    )
+  })
+
+  it('returns the latest submission, ignoring a later PRN event', async () => {
+    const streamRepository = createInMemoryStreamRepository([
+      buildStreamEvent({
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      }),
+      buildStreamEvent({
+        number: 2,
+        payload: { summaryLogId: 'log-2', creditTotal: 150 }
+      }),
+      buildPrnCreatedEvent({ number: 3 })
+    ])()
+
+    expect(await latestCommittedSummaryLogId(streamRepository, PARTITION)).toBe(
+      'log-2'
+    )
+  })
+
+  it('resolves the committed head for a registered-only stream', async () => {
+    const streamRepository = createInMemoryStreamRepository([
+      buildStreamEvent({
+        number: 1,
+        accreditationId: null,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      })
+    ])()
+
+    expect(
+      await latestCommittedSummaryLogId(streamRepository, {
+        registrationId: 'reg-1',
+        accreditationId: null
+      })
+    ).toBe('log-1')
+  })
+})

--- a/src/waste-balances/application/read-committed-row-states.js
+++ b/src/waste-balances/application/read-committed-row-states.js
@@ -1,0 +1,217 @@
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import { latestCommittedSummaryLogId } from './latest-committed-summary-log-id.js'
+
+/**
+ * @typedef {import('../repository/row-states-schema.js').RowState} RowState
+ */
+
+/**
+ * @typedef {import('../repository/row-states-schema.js').RowClassification} RowClassification
+ */
+
+/**
+ * One submission's appearance of a row in its history. Content-match dedup
+ * means a single state document can carry several submissions in its
+ * membership (a row reverting A->B->A reuses the earlier A document), so each
+ * membership entry expands into its own occurrence — what the row said in that
+ * submission, and whether and why it counted.
+ *
+ * @typedef {Object} RowHistoryEntry
+ * @property {string} summaryLogId
+ * @property {number} streamPosition
+ * @property {Record<string, any>} data
+ * @property {RowClassification} classification
+ */
+
+/**
+ * Membership query for a resolved committed head: every row whose committed
+ * state belongs to that submission, or nothing when there is no head.
+ *
+ * @param {import('../repository/row-states-port.js').RowStateRepository} rowStateRepository
+ * @param {string | null} head
+ * @returns {Promise<RowState[]>}
+ */
+const rowStatesForHead = async (rowStateRepository, head) =>
+  head === null ? [] : rowStateRepository.findBySummaryLogId(head)
+
+/**
+ * Resolve the committed head as of an instant — the latest summary-log
+ * submission whose stream event committed at or before `at`. Returns `null`
+ * when the partition has no such submission.
+ *
+ * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} streamRepository
+ * @param {{ registrationId: string, accreditationId: string | null }} partition
+ * @param {string} at
+ * @returns {Promise<string | null>}
+ */
+const committedHeadAt = async (
+  streamRepository,
+  { registrationId, accreditationId },
+  at
+) => {
+  const instant = new Date(at).getTime()
+  const events = await streamRepository.findAllByPartition(
+    registrationId,
+    accreditationId
+  )
+  const submissions = events.filter(
+    (event) =>
+      event.kind === STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED &&
+      event.createdAt.getTime() <= instant
+  )
+
+  if (submissions.length === 0) {
+    return null
+  }
+
+  const latest = submissions[submissions.length - 1]
+  return /** @type {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} */ (
+    latest.payload
+  ).summaryLogId
+}
+
+/**
+ * Committed row states of a registration at its current head submission. The
+ * head resolves in one stream lookup; the membership query then returns every
+ * row whose committed state belongs to that submission.
+ *
+ * @param {{
+ *   streamRepository: import('../repository/stream-port.js').WasteBalanceStreamRepository,
+ *   rowStateRepository: import('../repository/row-states-port.js').RowStateRepository,
+ *   organisationId: string,
+ *   registrationId: string,
+ *   accreditationId: string | null
+ * }} context
+ * @returns {Promise<RowState[]>}
+ */
+export const committedRowStatesForRegistration = async ({
+  streamRepository,
+  rowStateRepository,
+  registrationId,
+  accreditationId
+}) => {
+  const head = await latestCommittedSummaryLogId(streamRepository, {
+    registrationId,
+    accreditationId
+  })
+
+  return rowStatesForHead(rowStateRepository, head)
+}
+
+/**
+ * Committed row states of a registration as of an instant — the snapshot of
+ * the latest submission committed at or before `at` (an ISO timestamp matched
+ * against each stream event's `createdAt`).
+ *
+ * @param {{
+ *   streamRepository: import('../repository/stream-port.js').WasteBalanceStreamRepository,
+ *   rowStateRepository: import('../repository/row-states-port.js').RowStateRepository,
+ *   organisationId: string,
+ *   registrationId: string,
+ *   accreditationId: string | null,
+ *   at: string
+ * }} context
+ * @returns {Promise<RowState[]>}
+ */
+export const committedRowStatesAt = async ({
+  streamRepository,
+  rowStateRepository,
+  registrationId,
+  accreditationId,
+  at
+}) => {
+  const head = await committedHeadAt(
+    streamRepository,
+    { registrationId, accreditationId },
+    at
+  )
+
+  return rowStatesForHead(rowStateRepository, head)
+}
+
+/**
+ * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} streamRepository
+ * @param {string} registrationId
+ * @param {RowState[]} documents
+ * @returns {Promise<Map<string, number>>}
+ */
+const streamPositionsForDocuments = async (
+  streamRepository,
+  registrationId,
+  documents
+) => {
+  const accreditationIds = [
+    ...new Set(documents.map((document) => document.accreditationId))
+  ]
+
+  const eventsByPartition = await Promise.all(
+    accreditationIds.map((accreditationId) =>
+      streamRepository.findAllByPartition(registrationId, accreditationId)
+    )
+  )
+
+  const positions = new Map()
+  for (const event of eventsByPartition.flat()) {
+    if (event.kind === STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED) {
+      const payload =
+        /** @type {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} */ (
+          event.payload
+        )
+      positions.set(payload.summaryLogId, event.number)
+    }
+  }
+  return positions
+}
+
+/**
+ * Per-submission history of a single row, oldest first. Each state document's
+ * membership is expanded into one occurrence per submission, ordered by the
+ * stream position of that submission — so a row reverting A->B->A renders three
+ * occurrences from two documents.
+ *
+ * @param {{
+ *   streamRepository: import('../repository/stream-port.js').WasteBalanceStreamRepository,
+ *   rowStateRepository: import('../repository/row-states-port.js').RowStateRepository,
+ *   organisationId: string,
+ *   registrationId: string,
+ *   rowId: string,
+ *   wasteRecordType: import('#domain/waste-records/model.js').WasteRecordType
+ * }} context
+ * @returns {Promise<RowHistoryEntry[]>}
+ */
+export const rowHistory = async ({
+  streamRepository,
+  rowStateRepository,
+  organisationId,
+  registrationId,
+  rowId,
+  wasteRecordType
+}) => {
+  const documents = await rowStateRepository.findRowHistory(
+    organisationId,
+    registrationId,
+    rowId,
+    wasteRecordType
+  )
+
+  if (documents.length === 0) {
+    return []
+  }
+
+  const positions = await streamPositionsForDocuments(
+    streamRepository,
+    registrationId,
+    documents
+  )
+
+  return documents
+    .flatMap((document) =>
+      document.summaryLogIds.map((summaryLogId) => ({
+        summaryLogId,
+        streamPosition: /** @type {number} */ (positions.get(summaryLogId)),
+        data: document.data,
+        classification: document.classification
+      }))
+    )
+    .sort((a, b) => a.streamPosition - b.streamPosition)
+}

--- a/src/waste-balances/application/read-committed-row-states.test.js
+++ b/src/waste-balances/application/read-committed-row-states.test.js
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest'
+
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+import { createInMemoryRowStateRepository } from '../repository/row-states-inmemory.js'
+import { createInMemoryStreamRepository } from '../repository/stream-inmemory.js'
+import {
+  buildRowStateEntry,
+  DEFAULT_PARTITION
+} from '../repository/row-states-test-data.js'
+import {
+  buildStreamEvent,
+  buildPrnCreatedEvent
+} from '../repository/stream-test-data.js'
+import {
+  committedRowStatesForRegistration,
+  committedRowStatesAt,
+  rowHistory
+} from './read-committed-row-states.js'
+
+const submissionEvent = (number, summaryLogId) =>
+  buildStreamEvent({
+    number,
+    payload: { summaryLogId, creditTotal: number * 10 }
+  })
+
+const registration = {
+  organisationId: DEFAULT_PARTITION.organisationId,
+  registrationId: DEFAULT_PARTITION.registrationId,
+  accreditationId: DEFAULT_PARTITION.accreditationId
+}
+
+describe('committedRowStatesForRegistration', () => {
+  it('returns an empty array when the stream has no submission', async () => {
+    const states = await committedRowStatesForRegistration({
+      streamRepository: createInMemoryStreamRepository()(),
+      rowStateRepository: createInMemoryRowStateRepository()(),
+      ...registration
+    })
+
+    expect(states).toEqual([])
+  })
+
+  it('returns the full committed snapshot at the head submission', async () => {
+    const rowStateRepository = createInMemoryRowStateRepository()()
+    await rowStateRepository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [
+        buildRowStateEntry({ rowId: 'row-1', data: { tonnage: 10 } }),
+        buildRowStateEntry({ rowId: 'row-2', data: { tonnage: 20 } })
+      ],
+      'log-1'
+    )
+    await rowStateRepository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [
+        buildRowStateEntry({ rowId: 'row-1', data: { tonnage: 99 } }),
+        buildRowStateEntry({ rowId: 'row-2', data: { tonnage: 20 } })
+      ],
+      'log-2'
+    )
+
+    const streamRepository = createInMemoryStreamRepository([
+      submissionEvent(1, 'log-1'),
+      submissionEvent(2, 'log-2')
+    ])()
+
+    const states = await committedRowStatesForRegistration({
+      streamRepository,
+      rowStateRepository,
+      ...registration
+    })
+
+    const dataByRowId = Object.fromEntries(
+      states.map((state) => [state.rowId, state.data])
+    )
+    expect(dataByRowId).toEqual({
+      'row-1': { tonnage: 99 },
+      'row-2': { tonnage: 20 }
+    })
+  })
+})
+
+describe('committedRowStatesAt', () => {
+  const submittedAt = (number, summaryLogId, iso) => ({
+    ...submissionEvent(number, summaryLogId),
+    createdAt: new Date(iso)
+  })
+
+  it('returns an empty array when no submission committed at or before the instant', async () => {
+    const streamRepository = createInMemoryStreamRepository([
+      submittedAt(1, 'log-1', '2026-02-01T00:00:00.000Z')
+    ])()
+
+    const states = await committedRowStatesAt({
+      streamRepository,
+      rowStateRepository: createInMemoryRowStateRepository()(),
+      ...registration,
+      at: '2026-01-01T00:00:00.000Z'
+    })
+
+    expect(states).toEqual([])
+  })
+
+  it('resolves the snapshot as of the latest submission at or before the instant', async () => {
+    const rowStateRepository = createInMemoryRowStateRepository()()
+    await rowStateRepository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 10 } })],
+      'log-1'
+    )
+    await rowStateRepository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 20 } })],
+      'log-2'
+    )
+
+    const streamRepository = createInMemoryStreamRepository([
+      submittedAt(1, 'log-1', '2026-02-01T00:00:00.000Z'),
+      submittedAt(2, 'log-2', '2026-03-01T00:00:00.000Z')
+    ])()
+
+    const states = await committedRowStatesAt({
+      streamRepository,
+      rowStateRepository,
+      ...registration,
+      at: '2026-02-15T00:00:00.000Z'
+    })
+
+    expect(states.map((s) => s.data.tonnage)).toEqual([10])
+  })
+
+  it('includes a submission committed exactly at the instant', async () => {
+    const rowStateRepository = createInMemoryRowStateRepository()()
+    await rowStateRepository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 10 } })],
+      'log-1'
+    )
+
+    const streamRepository = createInMemoryStreamRepository([
+      submittedAt(1, 'log-1', '2026-02-01T00:00:00.000Z')
+    ])()
+
+    const states = await committedRowStatesAt({
+      streamRepository,
+      rowStateRepository,
+      ...registration,
+      at: '2026-02-01T00:00:00.000Z'
+    })
+
+    expect(states.map((s) => s.data.tonnage)).toEqual([10])
+  })
+})
+
+describe('rowHistory', () => {
+  const historyFor = (streamRepository, rowStateRepository, overrides = {}) =>
+    rowHistory({
+      streamRepository,
+      rowStateRepository,
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      rowId: 'row-1',
+      wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+      ...overrides
+    })
+
+  it('returns an empty array for a row with no committed states', async () => {
+    const history = await historyFor(
+      createInMemoryStreamRepository()(),
+      createInMemoryRowStateRepository()()
+    )
+
+    expect(history).toEqual([])
+  })
+
+  it('expands membership into one occurrence per submission, ordered by stream position', async () => {
+    const rowStateRepository = createInMemoryRowStateRepository()()
+    await rowStateRepository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 10 } })],
+      'log-1'
+    )
+    await rowStateRepository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 20 } })],
+      'log-2'
+    )
+    await rowStateRepository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 10 } })],
+      'log-3'
+    )
+
+    const streamRepository = createInMemoryStreamRepository([
+      submissionEvent(1, 'log-1'),
+      submissionEvent(2, 'log-2'),
+      submissionEvent(3, 'log-3'),
+      buildPrnCreatedEvent({ number: 4 })
+    ])()
+
+    const history = await historyFor(streamRepository, rowStateRepository)
+
+    expect(history.map((h) => h.summaryLogId)).toEqual([
+      'log-1',
+      'log-2',
+      'log-3'
+    ])
+    expect(history.map((h) => h.streamPosition)).toEqual([1, 2, 3])
+    expect(history.map((h) => h.data.tonnage)).toEqual([10, 20, 10])
+  })
+
+  it('carries each submission classification — whether and why it counted', async () => {
+    const rowStateRepository = createInMemoryRowStateRepository()()
+    await rowStateRepository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry()],
+      'log-1'
+    )
+    await rowStateRepository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [
+        buildRowStateEntry({
+          classification: {
+            outcome: ROW_OUTCOME.EXCLUDED,
+            reasons: [{ code: 'PRN_ISSUED' }],
+            transactionAmount: 0
+          }
+        })
+      ],
+      'log-2'
+    )
+
+    const streamRepository = createInMemoryStreamRepository([
+      submissionEvent(1, 'log-1'),
+      submissionEvent(2, 'log-2')
+    ])()
+
+    const history = await historyFor(streamRepository, rowStateRepository)
+
+    expect(history.map((h) => h.classification.outcome)).toEqual([
+      ROW_OUTCOME.INCLUDED,
+      ROW_OUTCOME.EXCLUDED
+    ])
+    expect(history[1].classification.reasons).toEqual([{ code: 'PRN_ISSUED' }])
+  })
+
+  it('resolves stream positions for a registered-only row', async () => {
+    const partition = { ...DEFAULT_PARTITION, accreditationId: null }
+    const rowStateRepository = createInMemoryRowStateRepository()()
+    await rowStateRepository.upsertRowStates(
+      partition,
+      [buildRowStateEntry({ data: { tonnage: 10 } })],
+      'log-1'
+    )
+
+    const streamRepository = createInMemoryStreamRepository([
+      { ...submissionEvent(1, 'log-1'), accreditationId: null }
+    ])()
+
+    const history = await historyFor(streamRepository, rowStateRepository)
+
+    expect(history.map((h) => h.streamPosition)).toEqual([1])
+  })
+})

--- a/src/waste-balances/application/target-amount.js
+++ b/src/waste-balances/application/target-amount.js
@@ -2,30 +2,90 @@ import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 
 /**
- * Per-record waste-balance contribution: the tonnage a single summary-log
- * waste record adds to its accreditation's balance, or zero when the record is
- * excluded. Consumed when building the stream events for a summary-log
- * submission.
+ * @import {RowOutcome, WasteBalanceClassificationReason} from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+ */
+
+/**
+ * A summary-log waste record's waste-balance classification: the outcome, the
+ * reasons behind it, and the tonnage it contributes (zero unless INCLUDED).
+ *
+ * @typedef {Object} RowClassification
+ * @property {RowOutcome} outcome
+ * @property {WasteBalanceClassificationReason[]} reasons
+ * @property {number} transactionAmount
+ */
+
+/**
+ * A waste record paired with its waste-balance classification, retaining the
+ * row identity and data so downstream consumers can persist row state and
+ * balance membership without re-deriving them.
+ *
+ * @typedef {Object} ClassifiedRow
+ * @property {string} rowId
+ * @property {string} wasteRecordType
+ * @property {Record<string, any>} data
+ * @property {RowClassification} classification
+ */
+
+/**
+ * Classifies a single summary-log waste record for the waste balance, reusing
+ * the coercion the table schema's `classifyForWasteBalance` already performs.
+ * Records flagged out of the balance, or with no matching schema, are EXCLUDED
+ * with no reasons and no contribution.
  *
  * @param {import('#domain/waste-records/model.js').WasteRecord} record
  * @param {Object} accreditation
  * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} overseasSites
- * @returns {number}
+ * @returns {RowClassification}
  */
-export const getTargetAmount = (record, accreditation, overseasSites) => {
+const classify = (record, accreditation, overseasSites) => {
   if (record.excludedFromWasteBalance) {
-    return 0
+    return { outcome: ROW_OUTCOME.EXCLUDED, reasons: [], transactionAmount: 0 }
   }
   const schema = findSchemaForProcessingType(
     record.data?.processingType,
     record.type
   )
   if (!schema?.classifyForWasteBalance) {
-    return 0
+    return { outcome: ROW_OUTCOME.EXCLUDED, reasons: [], transactionAmount: 0 }
   }
   const result = schema.classifyForWasteBalance(record.data, {
     accreditation,
     overseasSites
   })
-  return result.outcome === ROW_OUTCOME.INCLUDED ? result.transactionAmount : 0
+  return {
+    outcome: result.outcome,
+    reasons: result.reasons,
+    transactionAmount:
+      result.outcome === ROW_OUTCOME.INCLUDED ? result.transactionAmount : 0
+  }
 }
+
+/**
+ * Pairs a waste record with its waste-balance classification, retaining the
+ * row identity and data alongside.
+ *
+ * @param {import('#domain/waste-records/model.js').WasteRecord} record
+ * @param {Object} accreditation
+ * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} overseasSites
+ * @returns {ClassifiedRow}
+ */
+export const classifyWasteRecord = (record, accreditation, overseasSites) => ({
+  rowId: record.rowId,
+  wasteRecordType: record.type,
+  data: record.data,
+  classification: classify(record, accreditation, overseasSites)
+})
+
+/**
+ * Per-record waste-balance contribution: the tonnage a classified row adds to
+ * its accreditation's balance, or zero when the row is not INCLUDED. Consumed
+ * when building the stream events for a summary-log submission.
+ *
+ * @param {RowClassification} classification
+ * @returns {number}
+ */
+export const getTargetAmount = (classification) =>
+  classification.outcome === ROW_OUTCOME.INCLUDED
+    ? classification.transactionAmount
+    : 0

--- a/src/waste-balances/application/target-amount.js
+++ b/src/waste-balances/application/target-amount.js
@@ -22,7 +22,7 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
  *
  * @typedef {Object} ClassifiedRow
  * @property {string} rowId
- * @property {string} wasteRecordType
+ * @property {import('#domain/waste-records/model.js').WasteRecordType} wasteRecordType
  * @property {Record<string, any>} data
  * @property {RowClassification} classification
  */

--- a/src/waste-balances/application/target-amount.test.js
+++ b/src/waste-balances/application/target-amount.test.js
@@ -1,29 +1,159 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-import { getTargetAmount } from './target-amount.js'
+import { classifyWasteRecord, getTargetAmount } from './target-amount.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+
+vi.mock('#domain/summary-logs/table-schemas/index.js', () => ({
+  findSchemaForProcessingType: vi.fn()
+}))
 
 const accreditation = { id: 'acc-1' }
 const overseasSites = /** @type {*} */ (new Map())
 
-describe('getTargetAmount', () => {
-  it('contributes zero for a record excluded from the waste balance', () => {
-    const record = /** @type {*} */ ({
-      type: 'unknown-type',
-      data: { processingType: PROCESSING_TYPES.EXPORTER },
-      excludedFromWasteBalance: true
-    })
-
-    expect(getTargetAmount(record, accreditation, overseasSites)).toBe(0)
+const buildRecord = (overrides = {}) =>
+  /** @type {*} */ ({
+    rowId: 'row-1',
+    type: 'EXPORTED',
+    data: { processingType: PROCESSING_TYPES.EXPORTER, tonnage: 100 },
+    excludedFromWasteBalance: false,
+    ...overrides
   })
 
-  it('contributes zero when no schema classifies the record type', () => {
-    const record = /** @type {*} */ ({
-      type: 'unknown-type',
-      data: { processingType: PROCESSING_TYPES.EXPORTER },
-      excludedFromWasteBalance: false
+const setSchema = async (schema) => {
+  const { findSchemaForProcessingType } =
+    await import('#domain/summary-logs/table-schemas/index.js')
+  vi.mocked(findSchemaForProcessingType).mockReturnValue(
+    /** @type {*} */ (schema)
+  )
+}
+
+describe('classifyWasteRecord', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('carries the row identity and data alongside the classification', async () => {
+    await setSchema({
+      classifyForWasteBalance: () => ({
+        outcome: ROW_OUTCOME.INCLUDED,
+        reasons: [],
+        transactionAmount: 42
+      })
+    })
+    const record = buildRecord({
+      rowId: 'row-7',
+      type: 'EXPORTED',
+      data: { processingType: PROCESSING_TYPES.EXPORTER, tonnage: 42 }
     })
 
-    expect(getTargetAmount(record, accreditation, overseasSites)).toBe(0)
+    const result = classifyWasteRecord(record, accreditation, overseasSites)
+
+    expect(result.rowId).toBe('row-7')
+    expect(result.wasteRecordType).toBe('EXPORTED')
+    expect(result.data).toEqual({
+      processingType: PROCESSING_TYPES.EXPORTER,
+      tonnage: 42
+    })
+  })
+
+  it('classifies an excluded-from-waste-balance record as EXCLUDED with no amount', async () => {
+    const record = buildRecord({ excludedFromWasteBalance: true })
+
+    const { classification } = classifyWasteRecord(
+      record,
+      accreditation,
+      overseasSites
+    )
+
+    expect(classification).toEqual({
+      outcome: ROW_OUTCOME.EXCLUDED,
+      reasons: [],
+      transactionAmount: 0
+    })
+  })
+
+  it('classifies a record with no matching schema as EXCLUDED with no amount', async () => {
+    await setSchema(null)
+    const record = buildRecord()
+
+    const { classification } = classifyWasteRecord(
+      record,
+      accreditation,
+      overseasSites
+    )
+
+    expect(classification).toEqual({
+      outcome: ROW_OUTCOME.EXCLUDED,
+      reasons: [],
+      transactionAmount: 0
+    })
+  })
+
+  it('surfaces the included outcome, reasons and amount from the schema classifier', async () => {
+    await setSchema({
+      classifyForWasteBalance: () => ({
+        outcome: ROW_OUTCOME.INCLUDED,
+        reasons: [{ code: 'WITHIN_ACCREDITATION_PERIOD' }],
+        transactionAmount: 100
+      })
+    })
+    const record = buildRecord()
+
+    const { classification } = classifyWasteRecord(
+      record,
+      accreditation,
+      overseasSites
+    )
+
+    expect(classification).toEqual({
+      outcome: ROW_OUTCOME.INCLUDED,
+      reasons: [{ code: 'WITHIN_ACCREDITATION_PERIOD' }],
+      transactionAmount: 100
+    })
+  })
+
+  it('surfaces an excluded classifier outcome and reasons, contributing no amount', async () => {
+    await setSchema({
+      classifyForWasteBalance: () => ({
+        outcome: ROW_OUTCOME.IGNORED,
+        reasons: [{ code: 'PRN_ISSUED' }]
+      })
+    })
+    const record = buildRecord()
+
+    const { classification } = classifyWasteRecord(
+      record,
+      accreditation,
+      overseasSites
+    )
+
+    expect(classification).toEqual({
+      outcome: ROW_OUTCOME.IGNORED,
+      reasons: [{ code: 'PRN_ISSUED' }],
+      transactionAmount: 0
+    })
+  })
+})
+
+describe('getTargetAmount', () => {
+  it('returns the transaction amount for an included classification', () => {
+    expect(
+      getTargetAmount({
+        outcome: ROW_OUTCOME.INCLUDED,
+        reasons: [],
+        transactionAmount: 75
+      })
+    ).toBe(75)
+  })
+
+  it('returns zero for a non-included classification', () => {
+    expect(
+      getTargetAmount({
+        outcome: ROW_OUTCOME.EXCLUDED,
+        reasons: [],
+        transactionAmount: 0
+      })
+    ).toBe(0)
   })
 })

--- a/src/waste-balances/application/update-via-stream.js
+++ b/src/waste-balances/application/update-via-stream.js
@@ -10,15 +10,21 @@ import { classifyWasteRecord, getTargetAmount } from './target-amount.js'
 /**
  * Apply a summary-log submission to the event stream.
  *
- * Computes the aggregate `creditTotal` (sum of all row-level target
- * amounts), then appends a single `summary-log-submitted` event. The
- * stream's delta arithmetic (creditTotal minus previous creditTotal)
+ * Persists each row's committed state first (idempotent upsert keyed by row
+ * identity, coerced data and classification, `$addToSet`ing this submission's
+ * `summaryLogId` onto membership), then computes the aggregate `creditTotal`
+ * (sum of all row-level target amounts) and appends a single
+ * `summary-log-submitted` event. The row-state write precedes the event append
+ * so a failed append leaves no committed balance change and the partially
+ * written row states stay invisible to committed reads until a retry commits
+ * them. The stream's delta arithmetic (creditTotal minus previous creditTotal)
  * replaces the per-row delta reconciliation of the ADR-0031 ledger.
  *
  * @param {Object} params
  * @param {Array<import('#domain/waste-records/model.js').WasteRecord>} params.wasteRecords
  * @param {{ id: string, validFrom?: string, validTo?: string }} params.accreditation
  * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} params.streamRepository
+ * @param {import('../repository/row-states-port.js').RowStateRepository} params.rowStateRepository
  * @param {Object} [params.dependencies]
  * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [params.dependencies.systemLogsRepository]
  * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} params.user
@@ -29,6 +35,7 @@ export const performUpdateViaStream = async ({
   wasteRecords,
   accreditation,
   streamRepository,
+  rowStateRepository,
   dependencies = {},
   user,
   overseasSites,
@@ -43,6 +50,12 @@ export const performUpdateViaStream = async ({
 
   const classifiedRows = wasteRecords.map((record) =>
     classifyWasteRecord(record, accreditation, overseasSites)
+  )
+
+  await rowStateRepository.upsertRowStates(
+    { organisationId, registrationId, accreditationId: accreditation.id },
+    classifiedRows,
+    summaryLogId
   )
 
   let creditTotal = 0

--- a/src/waste-balances/application/update-via-stream.js
+++ b/src/waste-balances/application/update-via-stream.js
@@ -5,7 +5,7 @@ import { add, toNumber } from '#common/helpers/decimal-utils.js'
 import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
 import { appendToStream } from './append-to-stream.js'
 import { recordWasteBalanceUpdateAudit } from './audit.js'
-import { getTargetAmount } from './target-amount.js'
+import { classifyWasteRecord, getTargetAmount } from './target-amount.js'
 
 /**
  * Apply a summary-log submission to the event stream.
@@ -41,11 +41,13 @@ export const performUpdateViaStream = async ({
   const organisationId = wasteRecords[0].organisationId
   const registrationId = wasteRecords[0].registrationId
 
+  const classifiedRows = wasteRecords.map((record) =>
+    classifyWasteRecord(record, accreditation, overseasSites)
+  )
+
   let creditTotal = 0
-  for (const record of wasteRecords) {
-    creditTotal = toNumber(
-      add(creditTotal, getTargetAmount(record, accreditation, overseasSites))
-    )
+  for (const { classification } of classifiedRows) {
+    creditTotal = toNumber(add(creditTotal, getTargetAmount(classification)))
   }
 
   const event = await appendToStream(

--- a/src/waste-balances/application/update-via-stream.test.js
+++ b/src/waste-balances/application/update-via-stream.test.js
@@ -202,6 +202,39 @@ describe('performUpdateViaStream', () => {
     })
   })
 
+  describe('credit total invariant', () => {
+    it('sums exactly the INCLUDED transaction amounts, dropping excluded rows', async () => {
+      const includedTonnages = [120, 30, 45]
+      const records = [
+        buildExporterRecord({ rowId: '1', tonnage: includedTonnages[0] }),
+        buildExporterRecord({ rowId: '2', tonnage: includedTonnages[1] }),
+        {
+          ...buildExporterRecord({ rowId: '3', tonnage: 999 }),
+          excludedFromWasteBalance: true
+        },
+        buildExporterRecord({ rowId: '4', tonnage: includedTonnages[2] })
+      ]
+
+      await performUpdateViaStream({
+        wasteRecords: records,
+        accreditation,
+        streamRepository,
+        dependencies: { systemLogsRepository },
+        user,
+        overseasSites,
+        summaryLogId: 'log-A'
+      })
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        accreditationId
+      )
+      expect(latest.payload.creditTotal).toBe(
+        includedTonnages.reduce((sum, tonnage) => sum + tonnage, 0)
+      )
+    })
+  })
+
   describe('empty input', () => {
     it('does not touch the stream when no waste records are provided', async () => {
       const appendSpy = vi.spyOn(streamRepository, 'appendEvent')

--- a/src/waste-balances/application/update-via-stream.test.js
+++ b/src/waste-balances/application/update-via-stream.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { createInMemoryStreamRepository } from '../repository/stream-inmemory.js'
+import { createInMemoryRowStateRepository } from '../repository/row-states-inmemory.js'
 import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
 import { performUpdateViaStream } from './update-via-stream.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
@@ -35,6 +36,7 @@ vi.mock('#common/helpers/logging/logger.js', () => ({
 const includingSchema = /** @type {*} */ ({
   classifyForWasteBalance: (data) => ({
     outcome: ROW_OUTCOME.INCLUDED,
+    reasons: [],
     transactionAmount: data.tonnage
   })
 })
@@ -85,10 +87,12 @@ const buildExporterRecord = ({
 
 describe('performUpdateViaStream', () => {
   let streamRepository
+  let rowStateRepository
   let systemLogsRepository
 
   beforeEach(async () => {
     streamRepository = createInMemoryStreamRepository()()
+    rowStateRepository = createInMemoryRowStateRepository()()
     systemLogsRepository = createSystemLogsRepository()(logger)
     const { findSchemaForProcessingType } =
       await import('#domain/summary-logs/table-schemas/index.js')
@@ -106,6 +110,7 @@ describe('performUpdateViaStream', () => {
         wasteRecords: records,
         accreditation,
         streamRepository,
+        rowStateRepository,
         dependencies: { systemLogsRepository },
         user,
         overseasSites,
@@ -138,6 +143,7 @@ describe('performUpdateViaStream', () => {
         ],
         accreditation,
         streamRepository,
+        rowStateRepository,
         dependencies: { systemLogsRepository },
         user,
         overseasSites,
@@ -152,6 +158,7 @@ describe('performUpdateViaStream', () => {
         ],
         accreditation,
         streamRepository,
+        rowStateRepository,
         dependencies: { systemLogsRepository },
         user,
         overseasSites,
@@ -188,6 +195,7 @@ describe('performUpdateViaStream', () => {
         wasteRecords: records,
         accreditation,
         streamRepository,
+        rowStateRepository,
         dependencies: { systemLogsRepository },
         user,
         overseasSites,
@@ -219,6 +227,7 @@ describe('performUpdateViaStream', () => {
         wasteRecords: records,
         accreditation,
         streamRepository,
+        rowStateRepository,
         dependencies: { systemLogsRepository },
         user,
         overseasSites,
@@ -243,6 +252,7 @@ describe('performUpdateViaStream', () => {
         wasteRecords: [],
         accreditation,
         streamRepository,
+        rowStateRepository,
         dependencies: { systemLogsRepository },
         user,
         overseasSites,
@@ -264,6 +274,7 @@ describe('performUpdateViaStream', () => {
         ],
         accreditation,
         streamRepository,
+        rowStateRepository,
         dependencies: { systemLogsRepository },
         user,
         overseasSites,
@@ -301,7 +312,7 @@ describe('performUpdateViaStream', () => {
       vi.mocked(findSchemaForProcessingType).mockReturnValue(
         /** @type {*} */ ({
           classifyForWasteBalance: () => ({
-            outcome: 'ignored',
+            outcome: ROW_OUTCOME.IGNORED,
             reasons: [{ code: 'OUTSIDE_ACCREDITATION_PERIOD' }]
           })
         })
@@ -311,6 +322,7 @@ describe('performUpdateViaStream', () => {
         wasteRecords: [buildExporterRecord({ rowId: '1', tonnage: 100 })],
         accreditation,
         streamRepository,
+        rowStateRepository,
         dependencies: { systemLogsRepository },
         user,
         overseasSites,
@@ -331,6 +343,7 @@ describe('performUpdateViaStream', () => {
         wasteRecords: [buildExporterRecord({ rowId: '1', tonnage: 50 })],
         accreditation,
         streamRepository,
+        rowStateRepository,
         dependencies: { systemLogsRepository },
         user,
         overseasSites,
@@ -353,6 +366,7 @@ describe('performUpdateViaStream', () => {
         wasteRecords: [buildExporterRecord({ rowId: '1', tonnage: 50 })],
         accreditation,
         streamRepository,
+        rowStateRepository,
         dependencies: { systemLogsRepository },
         user: { id: 'user-2', email: 'noname@example.test', scope: [] },
         overseasSites,
@@ -367,6 +381,140 @@ describe('performUpdateViaStream', () => {
         id: 'user-2',
         email: 'noname@example.test'
       })
+    })
+  })
+
+  describe('committed row states', () => {
+    const submit = (wasteRecords, summaryLogId) =>
+      performUpdateViaStream({
+        wasteRecords,
+        accreditation,
+        streamRepository,
+        rowStateRepository,
+        dependencies: { systemLogsRepository },
+        user,
+        overseasSites,
+        summaryLogId
+      })
+
+    it('persists the full committed row state of the submission, including excluded rows', async () => {
+      await submit(
+        [
+          buildExporterRecord({ rowId: '1', tonnage: 100 }),
+          buildExporterRecord({ rowId: '2', tonnage: 50 }),
+          {
+            ...buildExporterRecord({ rowId: '3', tonnage: 999 }),
+            excludedFromWasteBalance: true
+          }
+        ],
+        'log-A'
+      )
+
+      const committed = await rowStateRepository.findBySummaryLogId('log-A')
+      expect(committed.map((doc) => doc.rowId).sort()).toEqual(['1', '2', '3'])
+      expect(committed.find((doc) => doc.rowId === '1')).toMatchObject({
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        accreditationId,
+        wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+        data: { processingType: 'EXPORTER', tonnage: 100 },
+        classification: {
+          outcome: ROW_OUTCOME.INCLUDED,
+          reasons: [],
+          transactionAmount: 100
+        },
+        summaryLogIds: ['log-A']
+      })
+      expect(committed.find((doc) => doc.rowId === '3').classification).toEqual(
+        {
+          outcome: ROW_OUTCOME.EXCLUDED,
+          reasons: [],
+          transactionAmount: 0
+        }
+      )
+    })
+
+    it('is idempotent — re-submitting the same content adds no duplicate document or membership entry', async () => {
+      const records = [buildExporterRecord({ rowId: '1', tonnage: 100 })]
+
+      await submit(records, 'log-A')
+      await submit(records, 'log-A')
+
+      const committed = await rowStateRepository.findBySummaryLogId('log-A')
+      expect(committed).toHaveLength(1)
+      expect(committed[0].summaryLogIds).toEqual(['log-A'])
+    })
+
+    it('grows membership for an unchanged row and inserts a new state for a changed row', async () => {
+      await submit([buildExporterRecord({ rowId: '1', tonnage: 100 })], 'log-A')
+      await submit(
+        [buildExporterRecord({ rowId: '1', tonnage: 100, versionId: 'v2' })],
+        'log-B'
+      )
+      await submit(
+        [buildExporterRecord({ rowId: '1', tonnage: 250, versionId: 'v3' })],
+        'log-C'
+      )
+
+      const history = await rowStateRepository.findRowHistory(
+        'org-1',
+        'reg-1',
+        '1',
+        WASTE_RECORD_TYPE.EXPORTED
+      )
+      expect(history).toHaveLength(2)
+      expect(
+        history.find((doc) => doc.classification.transactionAmount === 100)
+          .summaryLogIds
+      ).toEqual(['log-A', 'log-B'])
+      expect(
+        history.find((doc) => doc.classification.transactionAmount === 250)
+          .summaryLogIds
+      ).toEqual(['log-C'])
+    })
+
+    it('writes row states without disturbing the event payload or closing balance', async () => {
+      await submit(
+        [
+          buildExporterRecord({ rowId: '1', tonnage: 100 }),
+          buildExporterRecord({ rowId: '2', tonnage: 50 })
+        ],
+        'log-A'
+      )
+
+      const latest = await streamRepository.findLatestByPartition(
+        'reg-1',
+        accreditationId
+      )
+      expect(latest.payload).toEqual({
+        summaryLogId: 'log-A',
+        creditTotal: 150
+      })
+      expect(latest.closingBalance).toEqual({
+        amount: 150,
+        availableAmount: 150
+      })
+      expect(await rowStateRepository.findBySummaryLogId('log-A')).toHaveLength(
+        2
+      )
+    })
+
+    it('persists row states before appending the event, so a failed append leaves the row state written for an idempotent retry', async () => {
+      const records = [buildExporterRecord({ rowId: '1', tonnage: 100 })]
+      vi.spyOn(streamRepository, 'appendEvent').mockRejectedValueOnce(
+        new Error('append boom')
+      )
+
+      await expect(submit(records, 'log-A')).rejects.toThrow('append boom')
+      expect(await rowStateRepository.findBySummaryLogId('log-A')).toHaveLength(
+        1
+      )
+
+      await submit(records, 'log-A')
+
+      const committed = await rowStateRepository.findBySummaryLogId('log-A')
+      expect(committed).toHaveLength(1)
+      expect(committed[0].summaryLogIds).toEqual(['log-A'])
     })
   })
 })

--- a/src/waste-balances/repository/helpers.js
+++ b/src/waste-balances/repository/helpers.js
@@ -59,6 +59,10 @@ const dispatchToStream = async ({
       /** @type {import('./stream-port.js').WasteBalanceStreamRepository} */ (
         dependencies.streamRepository
       ),
+    rowStateRepository:
+      /** @type {import('./row-states-port.js').RowStateRepository} */ (
+        dependencies.rowStateRepository
+      ),
     dependencies: {
       systemLogsRepository: dependencies.systemLogsRepository
     },
@@ -82,6 +86,7 @@ const dispatchToStream = async ({
  * @param {Object} params.dependencies
  * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [params.dependencies.systemLogsRepository]
  * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} params.dependencies.streamRepository
+ * @param {import('../repository/row-states-port.js').RowStateRepository} [params.dependencies.rowStateRepository]
  * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} [params.user]
  * @param {OverseasSitesContext} params.overseasSites - Resolved ORS lookup map or ORS_VALIDATION_DISABLED
  * @param {string} [params.summaryLogId]

--- a/src/waste-balances/repository/inmemory.plugin.js
+++ b/src/waste-balances/repository/inmemory.plugin.js
@@ -1,5 +1,6 @@
 import { createWasteBalancesRepository } from './repository.js'
 import { createInMemoryStreamRepository } from './stream-inmemory.js'
+import { createInMemoryRowStateRepository } from './row-states-inmemory.js'
 import { registerRepository } from '#plugins/register-repository.js'
 
 export function createInMemoryWasteBalancesRepositoryPlugin() {
@@ -7,7 +8,11 @@ export function createInMemoryWasteBalancesRepositoryPlugin() {
     name: 'wasteBalancesRepository',
     register: (server) => {
       const streamRepository = createInMemoryStreamRepository()()
-      const factory = createWasteBalancesRepository({ streamRepository })
+      const rowStateRepository = createInMemoryRowStateRepository()()
+      const factory = createWasteBalancesRepository({
+        streamRepository,
+        rowStateRepository
+      })
       const repository = factory()
       registerRepository(server, 'wasteBalancesRepository', () => repository)
       registerRepository(server, 'streamRepository', () => streamRepository)

--- a/src/waste-balances/repository/inmemory.test.js
+++ b/src/waste-balances/repository/inmemory.test.js
@@ -1,6 +1,7 @@
 import { describe, it as base, expect, it } from 'vitest'
 import { createWasteBalancesRepository } from './repository.js'
 import { createInMemoryStreamRepository } from './stream-inmemory.js'
+import { createInMemoryRowStateRepository } from './row-states-inmemory.js'
 import { buildStreamEvent } from './stream-test-data.js'
 import { testWasteBalancesRepositoryContract } from './port.contract.js'
 
@@ -10,12 +11,20 @@ const extendedIt = base.extend({
     const repository = createInMemoryStreamRepository()()
     await use(repository)
   },
+  // eslint-disable-next-line no-empty-pattern
+  rowStateRepository: async ({}, use) => {
+    const repository = createInMemoryRowStateRepository()()
+    await use(repository)
+  },
   wasteBalancesRepository: async (
     // @ts-expect-error -- vitest .extend() fixture typing
-    { streamRepository },
+    { streamRepository, rowStateRepository },
     use
   ) => {
-    const factory = createWasteBalancesRepository({ streamRepository })
+    const factory = createWasteBalancesRepository({
+      streamRepository,
+      rowStateRepository
+    })
     await use(factory)
   },
   seedBalance: async (

--- a/src/waste-balances/repository/mongodb.plugin.js
+++ b/src/waste-balances/repository/mongodb.plugin.js
@@ -1,5 +1,6 @@
 import { createWasteBalancesRepository } from './repository.js'
 import { createMongoStreamRepository } from './stream-mongodb.js'
+import { createMongoRowStateRepository } from './row-states-mongodb.js'
 import { registerRepository } from '#plugins/register-repository.js'
 
 export const mongoWasteBalancesRepositoryPlugin = {
@@ -11,7 +12,13 @@ export const mongoWasteBalancesRepositoryPlugin = {
     const streamFactory = await createMongoStreamRepository(server.db)
     const streamRepository = streamFactory()
 
-    const factory = createWasteBalancesRepository({ streamRepository })
+    const rowStateFactory = await createMongoRowStateRepository(server.db)
+    const rowStateRepository = rowStateFactory()
+
+    const factory = createWasteBalancesRepository({
+      streamRepository,
+      rowStateRepository
+    })
     const repository = factory()
 
     registerRepository(server, 'wasteBalancesRepository', () => repository)

--- a/src/waste-balances/repository/mongodb.test.js
+++ b/src/waste-balances/repository/mongodb.test.js
@@ -6,6 +6,10 @@ import {
   createMongoStreamRepository,
   WASTE_BALANCE_EVENTS_COLLECTION_NAME
 } from './stream-mongodb.js'
+import {
+  createMongoRowStateRepository,
+  WASTE_BALANCE_ROW_STATES_COLLECTION_NAME
+} from './row-states-mongodb.js'
 import { buildStreamEvent } from './stream-test-data.js'
 import { testWasteBalancesRepositoryContract } from './port.contract.js'
 
@@ -21,6 +25,7 @@ const DATABASE_NAME = 'epr-backend'
  * @typedef {object} WasteBalancesRepoFixtures
  * @property {import('mongodb').MongoClient} mongoClient
  * @property {import('./stream-port.js').WasteBalanceStreamRepository} streamRepository
+ * @property {import('./row-states-port.js').RowStateRepository} rowStateRepository
  * @property {import('./port.js').WasteBalancesRepositoryFactory} wasteBalancesRepository
  * @property {(event: object) => Promise<void>} seedBalance
  */
@@ -39,8 +44,20 @@ const it = /** @type {import('vitest').TestAPI<WasteBalancesRepoFixtures>} */ (
       await use(factory())
     },
 
-    wasteBalancesRepository: async ({ streamRepository }, use) => {
-      const factory = createWasteBalancesRepository({ streamRepository })
+    rowStateRepository: async ({ mongoClient }, use) => {
+      const database = mongoClient.db(DATABASE_NAME)
+      const factory = await createMongoRowStateRepository(database)
+      await use(factory())
+    },
+
+    wasteBalancesRepository: async (
+      { streamRepository, rowStateRepository },
+      use
+    ) => {
+      const factory = createWasteBalancesRepository({
+        streamRepository,
+        rowStateRepository
+      })
       await use(factory)
     },
 
@@ -67,6 +84,9 @@ describe('MongoDB waste balances repository', () => {
       const database = mongoClient.db(DATABASE_NAME)
       await database
         .collection(WASTE_BALANCE_EVENTS_COLLECTION_NAME)
+        .deleteMany({})
+      await database
+        .collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME)
         .deleteMany({})
     })
 

--- a/src/waste-balances/repository/repository.js
+++ b/src/waste-balances/repository/repository.js
@@ -18,6 +18,7 @@ import { findBalanceByPartition } from './read-balance.js'
  *
  * @param {Object} dependencies
  * @param {import('./stream-port.js').WasteBalanceStreamRepository} dependencies.streamRepository
+ * @param {import('./row-states-port.js').RowStateRepository} [dependencies.rowStateRepository]
  * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [dependencies.systemLogsRepository]
  * @returns {import('./port.js').WasteBalancesRepositoryFactory}
  */

--- a/src/waste-balances/repository/row-states-contract/findBySummaryLogId.contract.js
+++ b/src/waste-balances/repository/row-states-contract/findBySummaryLogId.contract.js
@@ -1,0 +1,71 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import {
+  buildRowStateEntry,
+  DEFAULT_PARTITION
+} from '../row-states-test-data.js'
+
+export const testFindBySummaryLogIdBehaviour = (it) => {
+  describe('findBySummaryLogId', () => {
+    let repository
+
+    beforeEach((/** @type {*} */ { rowStateRepository }) => {
+      repository = rowStateRepository()
+    })
+
+    it('returns an empty list for a submission with no committed rows', async () => {
+      expect(await repository.findBySummaryLogId('unknown-log')).toEqual([])
+    })
+
+    it('returns only documents whose membership contains the id', async () => {
+      await repository.upsertRowStates(
+        DEFAULT_PARTITION,
+        [
+          buildRowStateEntry({ rowId: 'row-1' }),
+          buildRowStateEntry({ rowId: 'row-2' })
+        ],
+        'log-1'
+      )
+      await repository.upsertRowStates(
+        DEFAULT_PARTITION,
+        [buildRowStateEntry({ rowId: 'row-1', data: { tonnage: 99 } })],
+        'log-2'
+      )
+
+      const atLog2 = await repository.findBySummaryLogId('log-2')
+      expect(atLog2).toHaveLength(1)
+      expect(atLog2[0].rowId).toBe('row-1')
+      expect(atLog2[0].data).toEqual({ tonnage: 99 })
+    })
+
+    it('returns the full committed state of a submission', async () => {
+      await repository.upsertRowStates(
+        DEFAULT_PARTITION,
+        [
+          buildRowStateEntry({ rowId: 'row-1' }),
+          buildRowStateEntry({ rowId: 'row-2' }),
+          buildRowStateEntry({ rowId: 'row-3' })
+        ],
+        'log-1'
+      )
+
+      const committed = await repository.findBySummaryLogId('log-1')
+      expect(committed.map((s) => s.rowId).sort()).toEqual([
+        'row-1',
+        'row-2',
+        'row-3'
+      ])
+    })
+
+    it('returns the full membership verbatim on each document', async () => {
+      const entry = buildRowStateEntry()
+
+      await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
+      await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-2')
+      await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-3')
+
+      const [doc] = await repository.findBySummaryLogId('log-2')
+      expect(doc.summaryLogIds).toEqual(['log-1', 'log-2', 'log-3'])
+    })
+  })
+}

--- a/src/waste-balances/repository/row-states-contract/findRowHistory.contract.js
+++ b/src/waste-balances/repository/row-states-contract/findRowHistory.contract.js
@@ -1,0 +1,115 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+import {
+  buildRowStateEntry,
+  DEFAULT_PARTITION
+} from '../row-states-test-data.js'
+
+export const testFindRowHistoryBehaviour = (it) => {
+  describe('findRowHistory', () => {
+    let repository
+
+    beforeEach((/** @type {*} */ { rowStateRepository }) => {
+      repository = rowStateRepository()
+    })
+
+    it('returns an empty list for a row that has never committed', async () => {
+      expect(
+        await repository.findRowHistory(
+          'org-1',
+          'reg-1',
+          'row-1',
+          WASTE_RECORD_TYPE.RECEIVED
+        )
+      ).toEqual([])
+    })
+
+    it('returns every committed state of a row in insertion order', async () => {
+      await repository.upsertRowStates(
+        DEFAULT_PARTITION,
+        [buildRowStateEntry({ data: { tonnage: 1 } })],
+        'log-1'
+      )
+      await repository.upsertRowStates(
+        DEFAULT_PARTITION,
+        [buildRowStateEntry({ data: { tonnage: 2 } })],
+        'log-2'
+      )
+      await repository.upsertRowStates(
+        DEFAULT_PARTITION,
+        [buildRowStateEntry({ data: { tonnage: 3 } })],
+        'log-3'
+      )
+
+      const history = await repository.findRowHistory(
+        'org-1',
+        'reg-1',
+        'row-1',
+        WASTE_RECORD_TYPE.RECEIVED
+      )
+      expect(history.map((s) => s.data.tonnage)).toEqual([1, 2, 3])
+    })
+
+    it('isolates history to the requested row identity', async () => {
+      await repository.upsertRowStates(
+        DEFAULT_PARTITION,
+        [
+          buildRowStateEntry({ rowId: 'row-1' }),
+          buildRowStateEntry({ rowId: 'row-2' })
+        ],
+        'log-1'
+      )
+
+      const history = await repository.findRowHistory(
+        'org-1',
+        'reg-1',
+        'row-1',
+        WASTE_RECORD_TYPE.RECEIVED
+      )
+      expect(history).toHaveLength(1)
+      expect(history[0].rowId).toBe('row-1')
+    })
+
+    it('isolates history by waste-record type for the same rowId', async () => {
+      await repository.upsertRowStates(
+        DEFAULT_PARTITION,
+        [
+          buildRowStateEntry({ wasteRecordType: WASTE_RECORD_TYPE.RECEIVED }),
+          buildRowStateEntry({ wasteRecordType: WASTE_RECORD_TYPE.PROCESSED })
+        ],
+        'log-1'
+      )
+
+      const received = await repository.findRowHistory(
+        'org-1',
+        'reg-1',
+        'row-1',
+        WASTE_RECORD_TYPE.RECEIVED
+      )
+      expect(received).toHaveLength(1)
+      expect(received[0].wasteRecordType).toBe(WASTE_RECORD_TYPE.RECEIVED)
+    })
+
+    it('returns membership verbatim on each historical state', async () => {
+      const stateA = buildRowStateEntry({ data: { tonnage: 10 } })
+      const stateB = buildRowStateEntry({ data: { tonnage: 20 } })
+
+      await repository.upsertRowStates(DEFAULT_PARTITION, [stateA], 'log-1')
+      await repository.upsertRowStates(DEFAULT_PARTITION, [stateB], 'log-2')
+      await repository.upsertRowStates(DEFAULT_PARTITION, [stateA], 'log-3')
+
+      const history = await repository.findRowHistory(
+        'org-1',
+        'reg-1',
+        'row-1',
+        WASTE_RECORD_TYPE.RECEIVED
+      )
+      expect(history.map((s) => s.summaryLogIds)).toEqual([
+        ['log-1', 'log-3'],
+        ['log-2']
+      ])
+    })
+  })
+}

--- a/src/waste-balances/repository/row-states-contract/upsertRowStates.contract.js
+++ b/src/waste-balances/repository/row-states-contract/upsertRowStates.contract.js
@@ -1,0 +1,295 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+import {
+  buildRowStateEntry,
+  DEFAULT_PARTITION
+} from '../row-states-test-data.js'
+
+const excludedClassification = {
+  outcome: ROW_OUTCOME.EXCLUDED,
+  reasons: [{ code: 'PRN_ISSUED' }],
+  transactionAmount: 0
+}
+
+export const testUpsertRowStatesBehaviour = (it) => {
+  describe('upsertRowStates', () => {
+    let repository
+
+    beforeEach((/** @type {*} */ { rowStateRepository }) => {
+      repository = rowStateRepository()
+    })
+
+    it('inserts a new state document for a previously unseen row', async () => {
+      const [state] = await repository.upsertRowStates(
+        DEFAULT_PARTITION,
+        [buildRowStateEntry()],
+        'log-1'
+      )
+
+      expect(state.id).toEqual(expect.any(String))
+      expect(state.id).not.toBe('')
+      expect(state.organisationId).toBe(DEFAULT_PARTITION.organisationId)
+      expect(state.registrationId).toBe(DEFAULT_PARTITION.registrationId)
+      expect(state.accreditationId).toBe(DEFAULT_PARTITION.accreditationId)
+      expect(state.rowId).toBe('row-1')
+      expect(state.summaryLogIds).toEqual(['log-1'])
+    })
+
+    it('returns one state document per entry, in input order', async () => {
+      const states = await repository.upsertRowStates(
+        DEFAULT_PARTITION,
+        [
+          buildRowStateEntry({ rowId: 'row-a' }),
+          buildRowStateEntry({ rowId: 'row-b' }),
+          buildRowStateEntry({ rowId: 'row-c' })
+        ],
+        'log-1'
+      )
+
+      expect(states.map((s) => s.rowId)).toEqual(['row-a', 'row-b', 'row-c'])
+    })
+
+    it('stores a registered-only state with a null accreditationId', async () => {
+      const [state] = await repository.upsertRowStates(
+        {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          accreditationId: null
+        },
+        [buildRowStateEntry()],
+        'log-1'
+      )
+
+      expect(state.accreditationId).toBeNull()
+    })
+
+    describe('content-match dedup', () => {
+      it('reuses the existing document when an unchanged row recommits, growing membership', async () => {
+        const entry = buildRowStateEntry()
+
+        const [first] = await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [entry],
+          'log-1'
+        )
+        const [second] = await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [entry],
+          'log-2'
+        )
+
+        expect(second.id).toBe(first.id)
+        expect(second.summaryLogIds).toEqual(['log-1', 'log-2'])
+        expect(
+          await repository.findRowHistory(
+            'org-1',
+            'reg-1',
+            'row-1',
+            WASTE_RECORD_TYPE.RECEIVED
+          )
+        ).toHaveLength(1)
+      })
+
+      it('inserts a new document when only the row data changes', async () => {
+        await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [buildRowStateEntry({ data: { tonnage: 10 } })],
+          'log-1'
+        )
+        await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [buildRowStateEntry({ data: { tonnage: 20 } })],
+          'log-2'
+        )
+
+        const history = await repository.findRowHistory(
+          'org-1',
+          'reg-1',
+          'row-1',
+          WASTE_RECORD_TYPE.RECEIVED
+        )
+        expect(history).toHaveLength(2)
+        expect(history.map((s) => s.summaryLogIds)).toEqual([
+          ['log-1'],
+          ['log-2']
+        ])
+      })
+
+      it('inserts a new document when only the classification changes', async () => {
+        await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [buildRowStateEntry()],
+          'log-1'
+        )
+        await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [buildRowStateEntry({ classification: excludedClassification })],
+          'log-2'
+        )
+
+        expect(
+          await repository.findRowHistory(
+            'org-1',
+            'reg-1',
+            'row-1',
+            WASTE_RECORD_TYPE.RECEIVED
+          )
+        ).toHaveLength(2)
+      })
+
+      it('reuses the original document when a row reverts A→B→A', async () => {
+        const stateA = buildRowStateEntry({ data: { tonnage: 10 } })
+        const stateB = buildRowStateEntry({ data: { tonnage: 20 } })
+
+        const [a1] = await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [stateA],
+          'log-1'
+        )
+        await repository.upsertRowStates(DEFAULT_PARTITION, [stateB], 'log-2')
+        const [a3] = await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [stateA],
+          'log-3'
+        )
+
+        expect(a3.id).toBe(a1.id)
+        expect(a3.summaryLogIds).toEqual(['log-1', 'log-3'])
+
+        const history = await repository.findRowHistory(
+          'org-1',
+          'reg-1',
+          'row-1',
+          WASTE_RECORD_TYPE.RECEIVED
+        )
+        expect(history).toHaveLength(2)
+      })
+
+      it('keeps partitions isolated when deduping identical content', async () => {
+        const entry = buildRowStateEntry()
+
+        await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
+        await repository.upsertRowStates(
+          {
+            organisationId: 'org-1',
+            registrationId: 'reg-2',
+            accreditationId: 'acc-1'
+          },
+          [entry],
+          'log-2'
+        )
+
+        expect(await repository.findBySummaryLogId('log-1')).toHaveLength(1)
+        expect(await repository.findBySummaryLogId('log-2')).toHaveLength(1)
+      })
+
+      it('keeps waste-record types of the same rowId isolated when deduping', async () => {
+        const entry = buildRowStateEntry()
+
+        await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
+        await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [
+            buildRowStateEntry({ wasteRecordType: WASTE_RECORD_TYPE.PROCESSED })
+          ],
+          'log-1'
+        )
+
+        expect(await repository.findBySummaryLogId('log-1')).toHaveLength(2)
+      })
+    })
+
+    describe('idempotent-upsert', () => {
+      it('adds no document and no duplicate membership when a submission is replayed', async () => {
+        const entry = buildRowStateEntry()
+
+        await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
+        const [state] = await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [entry],
+          'log-1'
+        )
+
+        expect(state.summaryLogIds).toEqual(['log-1'])
+        expect(
+          await repository.findRowHistory(
+            'org-1',
+            'reg-1',
+            'row-1',
+            WASTE_RECORD_TYPE.RECEIVED
+          )
+        ).toHaveLength(1)
+      })
+    })
+
+    describe('membership-only-grows', () => {
+      it('appends new submissions without dropping or reordering earlier ones', async () => {
+        const entry = buildRowStateEntry()
+
+        await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
+        await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-2')
+        const [state] = await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [entry],
+          'log-3'
+        )
+
+        expect(state.summaryLogIds).toEqual(['log-1', 'log-2', 'log-3'])
+      })
+    })
+
+    describe('never-mutate', () => {
+      it('leaves stored data and classification unchanged across recommits', async () => {
+        const entry = buildRowStateEntry({
+          data: { supplierName: 'Acme', tonnage: 10 }
+        })
+
+        const [first] = await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [entry],
+          'log-1'
+        )
+        await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-2')
+
+        const [stored] = await repository.findRowHistory(
+          'org-1',
+          'reg-1',
+          'row-1',
+          WASTE_RECORD_TYPE.RECEIVED
+        )
+        expect(stored.data).toEqual(first.data)
+        expect(stored.classification).toEqual(first.classification)
+      })
+
+      it('does not retroactively mutate documents already returned to a caller', async () => {
+        const entry = buildRowStateEntry()
+
+        const [first] = await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [entry],
+          'log-1'
+        )
+        await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-2')
+
+        expect(first.summaryLogIds).toEqual(['log-1'])
+      })
+
+      it('does not let a mutated caller copy bleed back into storage', async () => {
+        const [returned] = await repository.upsertRowStates(
+          DEFAULT_PARTITION,
+          [buildRowStateEntry()],
+          'log-1'
+        )
+        returned.data.tonnage = 999
+        returned.summaryLogIds.push('log-injected')
+
+        const [stored] = await repository.findBySummaryLogId('log-1')
+        expect(stored.data.tonnage).toBe(10)
+        expect(stored.summaryLogIds).toEqual(['log-1'])
+      })
+    })
+  })
+}

--- a/src/waste-balances/repository/row-states-inmemory.js
+++ b/src/waste-balances/repository/row-states-inmemory.js
@@ -1,0 +1,128 @@
+import { randomUUID } from 'node:crypto'
+import { isDeepStrictEqual } from 'node:util'
+
+import { validateRowStateInsert } from './row-states-validation.js'
+
+/**
+ * In-memory adapter for committed row states.
+ *
+ * Backed by a single array — fine for tests, fixtures, and contract
+ * verification. Not durable, not concurrent-safe across processes.
+ */
+
+/**
+ * @typedef {import('./row-states-schema.js').RowState} RowState
+ */
+
+/**
+ * @typedef {import('./row-states-schema.js').RowStateInsert} RowStateInsert
+ */
+
+/**
+ * @typedef {import('./row-states-schema.js').RowStateEntry} RowStateEntry
+ */
+
+/**
+ * @typedef {import('./row-states-schema.js').RowStatePartition} RowStatePartition
+ */
+
+/**
+ * @param {RowState} doc
+ * @param {RowStateInsert} candidate
+ */
+const matchesRowIdentity = (doc, candidate) =>
+  doc.organisationId === candidate.organisationId &&
+  doc.registrationId === candidate.registrationId &&
+  doc.accreditationId === candidate.accreditationId &&
+  doc.rowId === candidate.rowId &&
+  doc.wasteRecordType === candidate.wasteRecordType
+
+/**
+ * @param {RowState} doc
+ * @param {RowStateInsert} candidate
+ */
+const matchesCommittedState = (doc, candidate) =>
+  matchesRowIdentity(doc, candidate) &&
+  isDeepStrictEqual(doc.data, candidate.data) &&
+  isDeepStrictEqual(doc.classification, candidate.classification)
+
+/**
+ * @param {RowState[]} storage
+ * @param {RowStatePartition} partition
+ * @param {RowStateEntry} entry
+ * @param {string} summaryLogId
+ * @returns {RowState}
+ */
+const upsertOne = (storage, partition, entry, summaryLogId) => {
+  const candidate = validateRowStateInsert({
+    organisationId: partition.organisationId,
+    registrationId: partition.registrationId,
+    accreditationId: partition.accreditationId,
+    wasteRecordType: entry.wasteRecordType,
+    rowId: entry.rowId,
+    data: entry.data,
+    classification: entry.classification,
+    summaryLogIds: [summaryLogId]
+  })
+
+  const match = storage.find((doc) => matchesCommittedState(doc, candidate))
+
+  if (match) {
+    if (!match.summaryLogIds.includes(summaryLogId)) {
+      match.summaryLogIds.push(summaryLogId)
+    }
+    return structuredClone(match)
+  }
+
+  const persisted = { id: randomUUID(), ...candidate }
+  storage.push(persisted)
+  return structuredClone(persisted)
+}
+
+/**
+ * @param {RowState[]} [initialRowStates]
+ * @returns {import('./row-states-port.js').RowStateRepositoryFactory}
+ */
+export const createInMemoryRowStateRepository = (initialRowStates = []) => {
+  const storage = initialRowStates
+
+  return () => ({
+    /**
+     * @param {RowStatePartition} partition
+     * @param {RowStateEntry[]} rowStates
+     * @param {string} summaryLogId
+     */
+    upsertRowStates: async (partition, rowStates, summaryLogId) =>
+      rowStates.map((entry) =>
+        upsertOne(storage, partition, entry, summaryLogId)
+      ),
+
+    /** @param {string} summaryLogId */
+    findBySummaryLogId: async (summaryLogId) =>
+      structuredClone(
+        storage.filter((doc) => doc.summaryLogIds.includes(summaryLogId))
+      ),
+
+    /**
+     * @param {string} organisationId
+     * @param {string} registrationId
+     * @param {string} rowId
+     * @param {string} wasteRecordType
+     */
+    findRowHistory: async (
+      organisationId,
+      registrationId,
+      rowId,
+      wasteRecordType
+    ) =>
+      structuredClone(
+        storage.filter(
+          (doc) =>
+            doc.organisationId === organisationId &&
+            doc.registrationId === registrationId &&
+            doc.rowId === rowId &&
+            doc.wasteRecordType === wasteRecordType
+        )
+      )
+  })
+}

--- a/src/waste-balances/repository/row-states-inmemory.test.js
+++ b/src/waste-balances/repository/row-states-inmemory.test.js
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest'
+
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+import { createInMemoryRowStateRepository } from './row-states-inmemory.js'
+import {
+  buildRowStateEntry,
+  DEFAULT_PARTITION
+} from './row-states-test-data.js'
+
+const newRepository = (initial = []) =>
+  createInMemoryRowStateRepository(initial)()
+
+describe('committed row-states repository - in-memory implementation', () => {
+  it('exposes the row-state port surface', () => {
+    const repository = newRepository()
+    expect(repository.upsertRowStates).toBeTypeOf('function')
+    expect(repository.findBySummaryLogId).toBeTypeOf('function')
+    expect(repository.findRowHistory).toBeTypeOf('function')
+  })
+
+  it('inserts a new state document for a previously unseen row', async () => {
+    const repository = newRepository()
+
+    const [state] = await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry()],
+      'log-1'
+    )
+
+    expect(state.id).toBeTypeOf('string')
+    expect(state.organisationId).toBe(DEFAULT_PARTITION.organisationId)
+    expect(state.summaryLogIds).toEqual(['log-1'])
+
+    const committed = await repository.findBySummaryLogId('log-1')
+    expect(committed).toHaveLength(1)
+    expect(committed[0].rowId).toBe('row-1')
+  })
+
+  it('grows membership when an unchanged row recommits in a later submission', async () => {
+    const repository = newRepository()
+    const entry = buildRowStateEntry()
+
+    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
+    const [state] = await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [entry],
+      'log-2'
+    )
+
+    expect(state.summaryLogIds).toEqual(['log-1', 'log-2'])
+    expect(
+      await repository.findRowHistory(
+        'org-1',
+        'reg-1',
+        'row-1',
+        WASTE_RECORD_TYPE.RECEIVED
+      )
+    ).toHaveLength(1)
+  })
+
+  it('inserts a new document when a row changes its data', async () => {
+    const repository = newRepository()
+
+    await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 10 } })],
+      'log-1'
+    )
+    await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 20 } })],
+      'log-2'
+    )
+
+    const history = await repository.findRowHistory(
+      'org-1',
+      'reg-1',
+      'row-1',
+      WASTE_RECORD_TYPE.RECEIVED
+    )
+    expect(history).toHaveLength(2)
+    expect(history.map((s) => s.summaryLogIds)).toEqual([['log-1'], ['log-2']])
+  })
+
+  it('inserts a new document when only the classification changes', async () => {
+    const repository = newRepository()
+
+    await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry()],
+      'log-1'
+    )
+    await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [
+        buildRowStateEntry({
+          classification: {
+            outcome: ROW_OUTCOME.EXCLUDED,
+            reasons: [{ code: 'PRN_ISSUED' }],
+            transactionAmount: 0
+          }
+        })
+      ],
+      'log-2'
+    )
+
+    expect(
+      await repository.findRowHistory(
+        'org-1',
+        'reg-1',
+        'row-1',
+        WASTE_RECORD_TYPE.RECEIVED
+      )
+    ).toHaveLength(2)
+  })
+
+  it('is idempotent — re-running a submission adds no document and no duplicate membership', async () => {
+    const repository = newRepository()
+    const entry = buildRowStateEntry()
+
+    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
+    const [state] = await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [entry],
+      'log-1'
+    )
+
+    expect(state.summaryLogIds).toEqual(['log-1'])
+    expect(
+      await repository.findRowHistory(
+        'org-1',
+        'reg-1',
+        'row-1',
+        WASTE_RECORD_TYPE.RECEIVED
+      )
+    ).toHaveLength(1)
+  })
+
+  it('findBySummaryLogId returns only documents whose membership contains the id', async () => {
+    const repository = newRepository()
+
+    await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [
+        buildRowStateEntry({ rowId: 'row-1' }),
+        buildRowStateEntry({ rowId: 'row-2' })
+      ],
+      'log-1'
+    )
+    await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ rowId: 'row-1', data: { tonnage: 99 } })],
+      'log-2'
+    )
+
+    const atLog2 = await repository.findBySummaryLogId('log-2')
+    expect(atLog2).toHaveLength(1)
+    expect(atLog2[0].data).toEqual({ tonnage: 99 })
+  })
+
+  it('keeps partitions isolated when deduping', async () => {
+    const repository = newRepository()
+    const entry = buildRowStateEntry()
+
+    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
+    await repository.upsertRowStates(
+      {
+        organisationId: 'org-1',
+        registrationId: 'reg-2',
+        accreditationId: 'acc-1'
+      },
+      [entry],
+      'log-2'
+    )
+
+    expect(await repository.findBySummaryLogId('log-1')).toHaveLength(1)
+    expect(await repository.findBySummaryLogId('log-2')).toHaveLength(1)
+  })
+
+  it('handles registered-only partitions with a null accreditationId', async () => {
+    const repository = newRepository()
+
+    const [state] = await repository.upsertRowStates(
+      {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        accreditationId: null
+      },
+      [buildRowStateEntry()],
+      'log-1'
+    )
+
+    expect(state.accreditationId).toBeNull()
+  })
+
+  it('returns row history in insertion order', async () => {
+    const repository = newRepository()
+
+    await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 1 } })],
+      'log-1'
+    )
+    await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 2 } })],
+      'log-2'
+    )
+    await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 3 } })],
+      'log-3'
+    )
+
+    const history = await repository.findRowHistory(
+      'org-1',
+      'reg-1',
+      'row-1',
+      WASTE_RECORD_TYPE.RECEIVED
+    )
+    expect(history.map((s) => s.data.tonnage)).toEqual([1, 2, 3])
+  })
+
+  it('does not mutate stored documents returned to earlier callers', async () => {
+    const repository = newRepository()
+    const entry = buildRowStateEntry()
+
+    const [first] = await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [entry],
+      'log-1'
+    )
+    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-2')
+
+    expect(first.summaryLogIds).toEqual(['log-1'])
+  })
+})

--- a/src/waste-balances/repository/row-states-inmemory.test.js
+++ b/src/waste-balances/repository/row-states-inmemory.test.js
@@ -1,239 +1,46 @@
-import { describe, it, expect } from 'vitest'
-
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
-import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { describe, it as base, expect } from 'vitest'
 
 import { createInMemoryRowStateRepository } from './row-states-inmemory.js'
-import {
-  buildRowStateEntry,
-  DEFAULT_PARTITION
-} from './row-states-test-data.js'
+import { testRowStateRepositoryContract } from './row-states-port.contract.js'
 
-const newRepository = (initial = []) =>
-  createInMemoryRowStateRepository(initial)()
+const it = base.extend({
+  // eslint-disable-next-line no-empty-pattern
+  rowStateRepository: async ({}, use) => {
+    await use(createInMemoryRowStateRepository())
+  }
+})
 
 describe('committed row-states repository - in-memory implementation', () => {
   it('exposes the row-state port surface', () => {
-    const repository = newRepository()
+    const repository = createInMemoryRowStateRepository()()
     expect(repository.upsertRowStates).toBeTypeOf('function')
     expect(repository.findBySummaryLogId).toBeTypeOf('function')
     expect(repository.findRowHistory).toBeTypeOf('function')
   })
 
-  it('inserts a new state document for a previously unseen row', async () => {
-    const repository = newRepository()
-
-    const [state] = await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [buildRowStateEntry()],
-      'log-1'
-    )
-
-    expect(state.id).toBeTypeOf('string')
-    expect(state.organisationId).toBe(DEFAULT_PARTITION.organisationId)
-    expect(state.summaryLogIds).toEqual(['log-1'])
-
-    const committed = await repository.findBySummaryLogId('log-1')
-    expect(committed).toHaveLength(1)
-    expect(committed[0].rowId).toBe('row-1')
-  })
-
-  it('grows membership when an unchanged row recommits in a later submission', async () => {
-    const repository = newRepository()
-    const entry = buildRowStateEntry()
-
-    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
-    const [state] = await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [entry],
-      'log-2'
-    )
-
-    expect(state.summaryLogIds).toEqual(['log-1', 'log-2'])
-    expect(
-      await repository.findRowHistory(
-        'org-1',
-        'reg-1',
-        'row-1',
-        WASTE_RECORD_TYPE.RECEIVED
-      )
-    ).toHaveLength(1)
-  })
-
-  it('inserts a new document when a row changes its data', async () => {
-    const repository = newRepository()
-
-    await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [buildRowStateEntry({ data: { tonnage: 10 } })],
-      'log-1'
-    )
-    await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [buildRowStateEntry({ data: { tonnage: 20 } })],
-      'log-2'
-    )
-
-    const history = await repository.findRowHistory(
-      'org-1',
-      'reg-1',
-      'row-1',
-      WASTE_RECORD_TYPE.RECEIVED
-    )
-    expect(history).toHaveLength(2)
-    expect(history.map((s) => s.summaryLogIds)).toEqual([['log-1'], ['log-2']])
-  })
-
-  it('inserts a new document when only the classification changes', async () => {
-    const repository = newRepository()
-
-    await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [buildRowStateEntry()],
-      'log-1'
-    )
-    await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [
-        buildRowStateEntry({
-          classification: {
-            outcome: ROW_OUTCOME.EXCLUDED,
-            reasons: [{ code: 'PRN_ISSUED' }],
-            transactionAmount: 0
-          }
-        })
-      ],
-      'log-2'
-    )
-
-    expect(
-      await repository.findRowHistory(
-        'org-1',
-        'reg-1',
-        'row-1',
-        WASTE_RECORD_TYPE.RECEIVED
-      )
-    ).toHaveLength(2)
-  })
-
-  it('is idempotent — re-running a submission adds no document and no duplicate membership', async () => {
-    const repository = newRepository()
-    const entry = buildRowStateEntry()
-
-    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
-    const [state] = await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [entry],
-      'log-1'
-    )
-
-    expect(state.summaryLogIds).toEqual(['log-1'])
-    expect(
-      await repository.findRowHistory(
-        'org-1',
-        'reg-1',
-        'row-1',
-        WASTE_RECORD_TYPE.RECEIVED
-      )
-    ).toHaveLength(1)
-  })
-
-  it('findBySummaryLogId returns only documents whose membership contains the id', async () => {
-    const repository = newRepository()
-
-    await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [
-        buildRowStateEntry({ rowId: 'row-1' }),
-        buildRowStateEntry({ rowId: 'row-2' })
-      ],
-      'log-1'
-    )
-    await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [buildRowStateEntry({ rowId: 'row-1', data: { tonnage: 99 } })],
-      'log-2'
-    )
-
-    const atLog2 = await repository.findBySummaryLogId('log-2')
-    expect(atLog2).toHaveLength(1)
-    expect(atLog2[0].data).toEqual({ tonnage: 99 })
-  })
-
-  it('keeps partitions isolated when deduping', async () => {
-    const repository = newRepository()
-    const entry = buildRowStateEntry()
-
-    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
-    await repository.upsertRowStates(
+  it('seeds storage from the provided initial state documents', async () => {
+    const repository = createInMemoryRowStateRepository([
       {
-        organisationId: 'org-1',
-        registrationId: 'reg-2',
-        accreditationId: 'acc-1'
-      },
-      [entry],
-      'log-2'
-    )
-
-    expect(await repository.findBySummaryLogId('log-1')).toHaveLength(1)
-    expect(await repository.findBySummaryLogId('log-2')).toHaveLength(1)
-  })
-
-  it('handles registered-only partitions with a null accreditationId', async () => {
-    const repository = newRepository()
-
-    const [state] = await repository.upsertRowStates(
-      {
+        id: 'seed-1',
         organisationId: 'org-1',
         registrationId: 'reg-1',
-        accreditationId: null
-      },
-      [buildRowStateEntry()],
-      'log-1'
-    )
+        accreditationId: 'acc-1',
+        wasteRecordType: 'received',
+        rowId: 'row-1',
+        data: { tonnage: 10 },
+        classification: {
+          outcome: 'INCLUDED',
+          reasons: [],
+          transactionAmount: 10
+        },
+        summaryLogIds: ['log-seed']
+      }
+    ])()
 
-    expect(state.accreditationId).toBeNull()
+    const committed = await repository.findBySummaryLogId('log-seed')
+    expect(committed).toHaveLength(1)
+    expect(committed[0].id).toBe('seed-1')
   })
 
-  it('returns row history in insertion order', async () => {
-    const repository = newRepository()
-
-    await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [buildRowStateEntry({ data: { tonnage: 1 } })],
-      'log-1'
-    )
-    await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [buildRowStateEntry({ data: { tonnage: 2 } })],
-      'log-2'
-    )
-    await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [buildRowStateEntry({ data: { tonnage: 3 } })],
-      'log-3'
-    )
-
-    const history = await repository.findRowHistory(
-      'org-1',
-      'reg-1',
-      'row-1',
-      WASTE_RECORD_TYPE.RECEIVED
-    )
-    expect(history.map((s) => s.data.tonnage)).toEqual([1, 2, 3])
-  })
-
-  it('does not mutate stored documents returned to earlier callers', async () => {
-    const repository = newRepository()
-    const entry = buildRowStateEntry()
-
-    const [first] = await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [entry],
-      'log-1'
-    )
-    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-2')
-
-    expect(first.summaryLogIds).toEqual(['log-1'])
-  })
+  testRowStateRepositoryContract(it)
 })

--- a/src/waste-balances/repository/row-states-mongodb.js
+++ b/src/waste-balances/repository/row-states-mongodb.js
@@ -1,0 +1,173 @@
+/** @import { Collection, Db } from 'mongodb' */
+
+import { isDeepStrictEqual } from 'node:util'
+
+/**
+ * @typedef {import('./row-states-schema.js').RowState} RowState
+ */
+
+/**
+ * @typedef {import('./row-states-schema.js').RowStateInsert} RowStateInsert
+ */
+
+/**
+ * @typedef {import('./row-states-schema.js').RowStateEntry} RowStateEntry
+ */
+
+/**
+ * @typedef {import('./row-states-schema.js').RowStatePartition} RowStatePartition
+ */
+
+import {
+  validateRowStateInsert,
+  validateRowStateRead
+} from './row-states-validation.js'
+
+export const WASTE_BALANCE_ROW_STATES_COLLECTION_NAME =
+  'waste-balance-row-states'
+
+/**
+ * Ensures the row-states collection exists with the indexes required by the
+ * committed row-state design: a multikey index on `summaryLogIds` for the
+ * committed-state membership query, and a row-identity index for row history.
+ *
+ * Safe to call multiple times — MongoDB `createIndex` is idempotent for
+ * matching specifications.
+ *
+ * @param {Db} db
+ * @returns {Promise<Collection>}
+ */
+export async function ensureRowStatesCollection(db) {
+  const collection = db.collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME)
+
+  await collection.createIndex({ summaryLogIds: 1 }, { name: 'membership' })
+
+  await collection.createIndex(
+    {
+      organisationId: 1,
+      registrationId: 1,
+      rowId: 1,
+      wasteRecordType: 1
+    },
+    { name: 'row_history' }
+  )
+
+  return collection
+}
+
+const toRowState = (doc) => {
+  const { _id, ...rest } = doc
+  return validateRowStateRead({ id: _id.toString(), ...rest })
+}
+
+/**
+ * @param {Collection} collection
+ * @param {RowStateInsert} candidate
+ * @returns {Promise<{ _id: import('mongodb').ObjectId } | undefined>}
+ */
+const findCommittedStateDoc = async (collection, candidate) => {
+  const existing = await collection
+    .find({
+      organisationId: candidate.organisationId,
+      registrationId: candidate.registrationId,
+      accreditationId: candidate.accreditationId,
+      rowId: candidate.rowId,
+      wasteRecordType: candidate.wasteRecordType
+    })
+    .toArray()
+
+  return existing.find(
+    (doc) =>
+      isDeepStrictEqual(doc.data, candidate.data) &&
+      isDeepStrictEqual(doc.classification, candidate.classification)
+  )
+}
+
+/**
+ * @param {Collection} collection
+ * @param {RowStatePartition} partition
+ * @param {RowStateEntry} entry
+ * @param {string} summaryLogId
+ * @returns {Promise<RowState>}
+ */
+const upsertOne = async (collection, partition, entry, summaryLogId) => {
+  const candidate = validateRowStateInsert({
+    organisationId: partition.organisationId,
+    registrationId: partition.registrationId,
+    accreditationId: partition.accreditationId,
+    wasteRecordType: entry.wasteRecordType,
+    rowId: entry.rowId,
+    data: entry.data,
+    classification: entry.classification,
+    summaryLogIds: [summaryLogId]
+  })
+
+  const match = await findCommittedStateDoc(collection, candidate)
+
+  if (match) {
+    await collection.updateOne(
+      { _id: match._id },
+      { $addToSet: { summaryLogIds: summaryLogId } }
+    )
+    const updated = await collection.findOne({ _id: match._id })
+    return toRowState(updated)
+  }
+
+  const result = await collection.insertOne(candidate)
+  return toRowState({ _id: result.insertedId, ...candidate })
+}
+
+/**
+ * @param {Collection} collection
+ * @returns {(partition: RowStatePartition, rowStates: RowStateEntry[], summaryLogId: string) => Promise<RowState[]>}
+ */
+const performUpsertRowStates =
+  (collection) => async (partition, rowStates, summaryLogId) => {
+    const results = []
+    for (const entry of rowStates) {
+      results.push(await upsertOne(collection, partition, entry, summaryLogId))
+    }
+    return results
+  }
+
+/**
+ * @param {Collection} collection
+ * @returns {(summaryLogId: string) => Promise<RowState[]>}
+ */
+const performFindBySummaryLogId = (collection) => async (summaryLogId) => {
+  const docs = await collection
+    .find({ summaryLogIds: summaryLogId })
+    .sort({ _id: 1 })
+    .toArray()
+  return docs.map(toRowState)
+}
+
+/**
+ * @param {Collection} collection
+ * @returns {(organisationId: string, registrationId: string, rowId: string, wasteRecordType: string) => Promise<RowState[]>}
+ */
+const performFindRowHistory =
+  (collection) =>
+  async (organisationId, registrationId, rowId, wasteRecordType) => {
+    const docs = await collection
+      .find({ organisationId, registrationId, rowId, wasteRecordType })
+      .sort({ _id: 1 })
+      .toArray()
+    return docs.map(toRowState)
+  }
+
+/**
+ * Creates a MongoDB-backed committed row-state repository.
+ *
+ * @param {Db} db
+ * @returns {Promise<import('./row-states-port.js').RowStateRepositoryFactory>}
+ */
+export const createMongoRowStateRepository = async (db) => {
+  const collection = await ensureRowStatesCollection(db)
+
+  return () => ({
+    upsertRowStates: performUpsertRowStates(collection),
+    findBySummaryLogId: performFindBySummaryLogId(collection),
+    findRowHistory: performFindRowHistory(collection)
+  })
+}

--- a/src/waste-balances/repository/row-states-mongodb.test.js
+++ b/src/waste-balances/repository/row-states-mongodb.test.js
@@ -2,18 +2,12 @@ import { describe, beforeEach, expect } from 'vitest'
 import { it as mongoIt } from '#vite/fixtures/mongo.js'
 import { MongoClient } from 'mongodb'
 
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
-import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
-
 import {
   createMongoRowStateRepository,
   ensureRowStatesCollection,
   WASTE_BALANCE_ROW_STATES_COLLECTION_NAME
 } from './row-states-mongodb.js'
-import {
-  buildRowStateEntry,
-  DEFAULT_PARTITION
-} from './row-states-test-data.js'
+import { testRowStateRepositoryContract } from './row-states-port.contract.js'
 
 const DATABASE_NAME = 'epr-backend'
 
@@ -69,128 +63,28 @@ describe('ensureRowStatesCollection', () => {
       wasteRecordType: 1
     })
   })
+
+  it('is safe to call multiple times', async (/** @type {*} */ {
+    mongoClient
+  }) => {
+    const database = mongoClient.db(DATABASE_NAME)
+    await ensureRowStatesCollection(database)
+    await expect(ensureRowStatesCollection(database)).resolves.toBeDefined()
+  })
 })
 
 describe('committed row-states repository - mongodb implementation', () => {
-  it('inserts a new state document and finds it by submission', async (/** @type {*} */ {
-    rowStateRepository
+  it('exposes the row-state port surface', async (/** @type {*} */ {
+    mongoClient
   }) => {
-    const repository = rowStateRepository()
-
-    const [state] = await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [buildRowStateEntry()],
-      'log-1'
-    )
-
-    expect(state.id).toBeTypeOf('string')
-    expect(state.summaryLogIds).toEqual(['log-1'])
-
-    const committed = await repository.findBySummaryLogId('log-1')
-    expect(committed).toHaveLength(1)
-    expect(committed[0].rowId).toBe('row-1')
+    const database = mongoClient.db(DATABASE_NAME)
+    const repository = (await createMongoRowStateRepository(database))()
+    expect(repository.upsertRowStates).toBeTypeOf('function')
+    expect(repository.findBySummaryLogId).toBeTypeOf('function')
+    expect(repository.findRowHistory).toBeTypeOf('function')
   })
 
-  it('grows membership when an unchanged row recommits', async (/** @type {*} */ {
-    rowStateRepository
-  }) => {
-    const repository = rowStateRepository()
-    const entry = buildRowStateEntry()
-
-    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
-    const [state] = await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [entry],
-      'log-2'
-    )
-
-    expect(state.summaryLogIds).toEqual(['log-1', 'log-2'])
-    expect(
-      await repository.findRowHistory(
-        'org-1',
-        'reg-1',
-        'row-1',
-        WASTE_RECORD_TYPE.RECEIVED
-      )
-    ).toHaveLength(1)
-  })
-
-  it('inserts a new document when a row changes', async (/** @type {*} */ {
-    rowStateRepository
-  }) => {
-    const repository = rowStateRepository()
-
-    await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [buildRowStateEntry({ data: { tonnage: 10 } })],
-      'log-1'
-    )
-    await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [
-        buildRowStateEntry({
-          data: { tonnage: 20 },
-          classification: {
-            outcome: ROW_OUTCOME.EXCLUDED,
-            reasons: [{ code: 'MISSING_REQUIRED_FIELD', field: 'tonnage' }],
-            transactionAmount: 0
-          }
-        })
-      ],
-      'log-2'
-    )
-
-    const history = await repository.findRowHistory(
-      'org-1',
-      'reg-1',
-      'row-1',
-      WASTE_RECORD_TYPE.RECEIVED
-    )
-    expect(history).toHaveLength(2)
-    expect(history.map((s) => s.data.tonnage)).toEqual([10, 20])
-  })
-
-  it('is idempotent on a repeated submission', async (/** @type {*} */ {
-    rowStateRepository
-  }) => {
-    const repository = rowStateRepository()
-    const entry = buildRowStateEntry()
-
-    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
-    const [state] = await repository.upsertRowStates(
-      DEFAULT_PARTITION,
-      [entry],
-      'log-1'
-    )
-
-    expect(state.summaryLogIds).toEqual(['log-1'])
-    expect(
-      await repository.findRowHistory(
-        'org-1',
-        'reg-1',
-        'row-1',
-        WASTE_RECORD_TYPE.RECEIVED
-      )
-    ).toHaveLength(1)
-  })
-
-  it('stores a registered-only state with a null accreditationId', async (/** @type {*} */ {
-    rowStateRepository
-  }) => {
-    const repository = rowStateRepository()
-
-    const [state] = await repository.upsertRowStates(
-      {
-        organisationId: 'org-1',
-        registrationId: 'reg-1',
-        accreditationId: null
-      },
-      [buildRowStateEntry()],
-      'log-1'
-    )
-
-    expect(state.accreditationId).toBeNull()
-    const committed = await repository.findBySummaryLogId('log-1')
-    expect(committed[0].accreditationId).toBeNull()
+  describe('row-state repository contract', () => {
+    testRowStateRepositoryContract(it)
   })
 })

--- a/src/waste-balances/repository/row-states-mongodb.test.js
+++ b/src/waste-balances/repository/row-states-mongodb.test.js
@@ -1,0 +1,196 @@
+import { describe, beforeEach, expect } from 'vitest'
+import { it as mongoIt } from '#vite/fixtures/mongo.js'
+import { MongoClient } from 'mongodb'
+
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+import {
+  createMongoRowStateRepository,
+  ensureRowStatesCollection,
+  WASTE_BALANCE_ROW_STATES_COLLECTION_NAME
+} from './row-states-mongodb.js'
+import {
+  buildRowStateEntry,
+  DEFAULT_PARTITION
+} from './row-states-test-data.js'
+
+const DATABASE_NAME = 'epr-backend'
+
+const it = mongoIt.extend({
+  mongoClient: async (/** @type {*} */ { db }, use) => {
+    const client = await MongoClient.connect(db)
+    await use(client)
+    await client.close()
+  },
+
+  rowStatesCollection: async (/** @type {*} */ { mongoClient }, use) => {
+    const database = mongoClient.db(DATABASE_NAME)
+    await ensureRowStatesCollection(database)
+    await use(database.collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME))
+  },
+
+  rowStateRepository: async (/** @type {*} */ { mongoClient }, use) => {
+    const database = mongoClient.db(DATABASE_NAME)
+    await database
+      .collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME)
+      .deleteMany({})
+    const factory = await createMongoRowStateRepository(database)
+    await use(factory)
+  }
+})
+
+const indexKeyFor = (indexes, name) =>
+  indexes.find((idx) => idx.name === name)?.key
+
+describe('ensureRowStatesCollection', () => {
+  beforeEach(async (/** @type {*} */ { mongoClient }) => {
+    await mongoClient
+      .db(DATABASE_NAME)
+      .collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME)
+      .deleteMany({})
+  })
+
+  it('creates the membership multikey index', async (/** @type {*} */ {
+    rowStatesCollection
+  }) => {
+    const indexes = await rowStatesCollection.indexes()
+    expect(indexKeyFor(indexes, 'membership')).toEqual({ summaryLogIds: 1 })
+  })
+
+  it('creates the row-history index', async (/** @type {*} */ {
+    rowStatesCollection
+  }) => {
+    const indexes = await rowStatesCollection.indexes()
+    expect(indexKeyFor(indexes, 'row_history')).toEqual({
+      organisationId: 1,
+      registrationId: 1,
+      rowId: 1,
+      wasteRecordType: 1
+    })
+  })
+})
+
+describe('committed row-states repository - mongodb implementation', () => {
+  it('inserts a new state document and finds it by submission', async (/** @type {*} */ {
+    rowStateRepository
+  }) => {
+    const repository = rowStateRepository()
+
+    const [state] = await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry()],
+      'log-1'
+    )
+
+    expect(state.id).toBeTypeOf('string')
+    expect(state.summaryLogIds).toEqual(['log-1'])
+
+    const committed = await repository.findBySummaryLogId('log-1')
+    expect(committed).toHaveLength(1)
+    expect(committed[0].rowId).toBe('row-1')
+  })
+
+  it('grows membership when an unchanged row recommits', async (/** @type {*} */ {
+    rowStateRepository
+  }) => {
+    const repository = rowStateRepository()
+    const entry = buildRowStateEntry()
+
+    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
+    const [state] = await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [entry],
+      'log-2'
+    )
+
+    expect(state.summaryLogIds).toEqual(['log-1', 'log-2'])
+    expect(
+      await repository.findRowHistory(
+        'org-1',
+        'reg-1',
+        'row-1',
+        WASTE_RECORD_TYPE.RECEIVED
+      )
+    ).toHaveLength(1)
+  })
+
+  it('inserts a new document when a row changes', async (/** @type {*} */ {
+    rowStateRepository
+  }) => {
+    const repository = rowStateRepository()
+
+    await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [buildRowStateEntry({ data: { tonnage: 10 } })],
+      'log-1'
+    )
+    await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [
+        buildRowStateEntry({
+          data: { tonnage: 20 },
+          classification: {
+            outcome: ROW_OUTCOME.EXCLUDED,
+            reasons: [{ code: 'MISSING_REQUIRED_FIELD', field: 'tonnage' }],
+            transactionAmount: 0
+          }
+        })
+      ],
+      'log-2'
+    )
+
+    const history = await repository.findRowHistory(
+      'org-1',
+      'reg-1',
+      'row-1',
+      WASTE_RECORD_TYPE.RECEIVED
+    )
+    expect(history).toHaveLength(2)
+    expect(history.map((s) => s.data.tonnage)).toEqual([10, 20])
+  })
+
+  it('is idempotent on a repeated submission', async (/** @type {*} */ {
+    rowStateRepository
+  }) => {
+    const repository = rowStateRepository()
+    const entry = buildRowStateEntry()
+
+    await repository.upsertRowStates(DEFAULT_PARTITION, [entry], 'log-1')
+    const [state] = await repository.upsertRowStates(
+      DEFAULT_PARTITION,
+      [entry],
+      'log-1'
+    )
+
+    expect(state.summaryLogIds).toEqual(['log-1'])
+    expect(
+      await repository.findRowHistory(
+        'org-1',
+        'reg-1',
+        'row-1',
+        WASTE_RECORD_TYPE.RECEIVED
+      )
+    ).toHaveLength(1)
+  })
+
+  it('stores a registered-only state with a null accreditationId', async (/** @type {*} */ {
+    rowStateRepository
+  }) => {
+    const repository = rowStateRepository()
+
+    const [state] = await repository.upsertRowStates(
+      {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        accreditationId: null
+      },
+      [buildRowStateEntry()],
+      'log-1'
+    )
+
+    expect(state.accreditationId).toBeNull()
+    const committed = await repository.findBySummaryLogId('log-1')
+    expect(committed[0].accreditationId).toBeNull()
+  })
+})

--- a/src/waste-balances/repository/row-states-port.contract.js
+++ b/src/waste-balances/repository/row-states-port.contract.js
@@ -1,0 +1,9 @@
+import { testUpsertRowStatesBehaviour } from './row-states-contract/upsertRowStates.contract.js'
+import { testFindBySummaryLogIdBehaviour } from './row-states-contract/findBySummaryLogId.contract.js'
+import { testFindRowHistoryBehaviour } from './row-states-contract/findRowHistory.contract.js'
+
+export const testRowStateRepositoryContract = (it) => {
+  testUpsertRowStatesBehaviour(it)
+  testFindBySummaryLogIdBehaviour(it)
+  testFindRowHistoryBehaviour(it)
+}

--- a/src/waste-balances/repository/row-states-port.js
+++ b/src/waste-balances/repository/row-states-port.js
@@ -1,0 +1,53 @@
+/**
+ * Storage-level port for committed row states (ADR-0037 Stage 1).
+ *
+ * One document per *distinct committed state* of a row, carrying a
+ * `summaryLogIds` membership array of every submission that committed that
+ * exact `(data, classification)`. The dedup comparison and membership growth
+ * are the only behaviour where two correct adapters could differ; everything
+ * downstream (committed-state reads, row history) is a query over the same
+ * documents.
+ *
+ * Invariants the adapters must hold (ADR-0037 calls these "disciplinary"):
+ * `data` and `classification` never change once written; `summaryLogIds` only
+ * ever grows; `upsertRowStates` is an idempotent no-op on a repeated
+ * submission.
+ */
+
+/**
+ * @typedef {import('./row-states-schema.js').RowState} RowState
+ */
+
+/**
+ * @typedef {import('./row-states-schema.js').RowStateInsert} RowStateInsert
+ */
+
+/**
+ * @typedef {import('./row-states-schema.js').RowStateEntry} RowStateEntry
+ */
+
+/**
+ * @typedef {import('./row-states-schema.js').RowStatePartition} RowStatePartition
+ */
+
+/**
+ * @typedef {Object} RowStateRepository
+ * @property {(partition: RowStatePartition, rowStates: RowStateEntry[], summaryLogId: string) => Promise<RowState[]>} upsertRowStates
+ *   For each row, find the existing state document for that row identity whose
+ *   coerced `data` and `classification` equal the incoming entry. If one
+ *   exists, `$addToSet` `summaryLogId` onto its membership; otherwise insert a
+ *   new state document whose membership starts with `summaryLogId`. Idempotent:
+ *   re-running the same submission adds no document and no membership entry.
+ *   Returns the resulting state document for each entry, in input order.
+ * @property {(summaryLogId: string) => Promise<RowState[]>} findBySummaryLogId
+ *   Return every state document whose membership contains `summaryLogId` — the
+ *   full committed row state of the submission that produced it.
+ * @property {(organisationId: string, registrationId: string, rowId: string, wasteRecordType: string) => Promise<RowState[]>} findRowHistory
+ *   Return every state document for the given row identity.
+ */
+
+/**
+ * @typedef {() => RowStateRepository} RowStateRepositoryFactory
+ */
+
+export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/waste-balances/repository/row-states-schema.js
+++ b/src/waste-balances/repository/row-states-schema.js
@@ -1,0 +1,95 @@
+import Joi from 'joi'
+
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+/**
+ * @typedef {import('#domain/summary-logs/table-schemas/validation-pipeline.js').RowOutcome} RowOutcome
+ */
+
+/**
+ * Stamped classification for a committed row state. `outcome` and
+ * `transactionAmount` are the row's contribution to the waste balance at the
+ * time it committed; `reasons` carry the codes explaining a non-included row.
+ *
+ * @typedef {Object} RowClassification
+ * @property {RowOutcome} outcome
+ * @property {Array<{ code: string, field?: string }>} reasons
+ * @property {number} transactionAmount
+ */
+
+/**
+ * Partition a row state belongs to. Mirrors the event stream partition
+ * `(registrationId, accreditationId)` with `organisationId` denormalised on,
+ * exactly as stream events carry it. `accreditationId` is null for
+ * registered-only streams.
+ *
+ * @typedef {Object} RowStatePartition
+ * @property {string} organisationId
+ * @property {string} registrationId
+ * @property {string | null} accreditationId
+ */
+
+/**
+ * A single row from the 1.1 per-row classification list — the unit
+ * `upsertRowStates` compares and stores. Carries no partition fields (supplied
+ * separately) and no membership (assigned at write).
+ *
+ * @typedef {Object} RowStateEntry
+ * @property {string} rowId
+ * @property {import('#domain/waste-records/model.js').WasteRecordType} wasteRecordType
+ * @property {Record<string, any>} data
+ * @property {RowClassification} classification
+ */
+
+/**
+ * Shape accepted by the row-states schema for a stored document — a partition,
+ * a row entry's content + classification, and the membership of submissions
+ * that committed this exact state.
+ *
+ * @typedef {Object} RowStateInsert
+ * @property {string} organisationId
+ * @property {string} registrationId
+ * @property {string | null} accreditationId
+ * @property {import('#domain/waste-records/model.js').WasteRecordType} wasteRecordType
+ * @property {string} rowId
+ * @property {Record<string, any>} data
+ * @property {RowClassification} classification
+ * @property {string[]} summaryLogIds
+ */
+
+/**
+ * Shape returned by reads — `RowStateInsert` plus the storage-assigned `id`.
+ *
+ * @typedef {RowStateInsert & { id: string }} RowState
+ */
+
+const classificationReasonSchema = Joi.object({
+  code: Joi.string().required(),
+  field: Joi.string()
+})
+
+const classificationSchema = Joi.object({
+  outcome: Joi.string()
+    .valid(...Object.values(ROW_OUTCOME))
+    .required(),
+  reasons: Joi.array().items(classificationReasonSchema).required(),
+  transactionAmount: Joi.number().required()
+})
+
+export const rowStateInsertSchema = Joi.object({
+  organisationId: Joi.string().required(),
+  registrationId: Joi.string().required(),
+  accreditationId: Joi.string().allow(null).required(),
+  wasteRecordType: Joi.string()
+    .valid(...Object.values(WASTE_RECORD_TYPE))
+    .required(),
+  rowId: Joi.string().required(),
+  data: Joi.object().required(),
+  classification: classificationSchema.required(),
+  summaryLogIds: Joi.array().items(Joi.string().required()).min(1).required()
+})
+
+export const rowStateReadSchema = rowStateInsertSchema.keys({
+  id: Joi.string().required()
+})

--- a/src/waste-balances/repository/row-states-schema.test.js
+++ b/src/waste-balances/repository/row-states-schema.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+
+import { rowStateInsertSchema } from './row-states-schema.js'
+import {
+  validateRowStateInsert,
+  validateRowStateRead
+} from './row-states-validation.js'
+import { buildRowState } from './row-states-test-data.js'
+
+const validate = (data) =>
+  rowStateInsertSchema.validate(data, { abortEarly: false })
+
+describe('row state insert schema', () => {
+  it('accepts a valid INCLUDED row state', () => {
+    const { error } = validate(buildRowState())
+    expect(error).toBeUndefined()
+  })
+
+  it('accepts an EXCLUDED row state carrying a reason', () => {
+    const { error } = validate(
+      buildRowState({
+        classification: {
+          outcome: ROW_OUTCOME.EXCLUDED,
+          reasons: [{ code: 'MISSING_REQUIRED_FIELD', field: 'tonnage' }],
+          transactionAmount: 0
+        }
+      })
+    )
+    expect(error).toBeUndefined()
+  })
+
+  it('accepts accreditationId: null for registered-only streams', () => {
+    const { error } = validate(buildRowState({ accreditationId: null }))
+    expect(error).toBeUndefined()
+  })
+
+  it('preserves arbitrary coerced data keys', () => {
+    const data = { supplierName: 'Acme', tonnage: 10, wasteCode: '12 34 56' }
+    const { value } = validate(buildRowState({ data }))
+    expect(value.data).toEqual(data)
+  })
+
+  it('rejects an unknown outcome', () => {
+    const { error } = validate(
+      buildRowState({
+        classification: { outcome: 'WAT', reasons: [], transactionAmount: 0 }
+      })
+    )
+    expect(error).toBeDefined()
+  })
+
+  it('rejects an unknown waste record type', () => {
+    const { error } = validate(buildRowState({ wasteRecordType: 'nonsense' }))
+    expect(error).toBeDefined()
+  })
+
+  it('rejects an empty summaryLogIds membership', () => {
+    const { error } = validate(buildRowState({ summaryLogIds: [] }))
+    expect(error).toBeDefined()
+  })
+
+  it('rejects missing required top-level fields', () => {
+    const { error } = validate({})
+    expect(error).toBeDefined()
+    const missing = error?.details.map((d) => d.path[0])
+    expect(missing).toContain('organisationId')
+    expect(missing).toContain('registrationId')
+    expect(missing).toContain('rowId')
+    expect(missing).toContain('wasteRecordType')
+    expect(missing).toContain('data')
+    expect(missing).toContain('classification')
+    expect(missing).toContain('summaryLogIds')
+  })
+})
+
+describe('row state validation', () => {
+  describe('validateRowStateInsert', () => {
+    it('returns the validated document for valid input', () => {
+      const doc = buildRowState()
+      const result = validateRowStateInsert(doc)
+      expect(result.rowId).toBe(doc.rowId)
+    })
+
+    it('throws Boom.badData for invalid input', () => {
+      expect(() => validateRowStateInsert({})).toThrow(/Invalid row state data/)
+    })
+  })
+
+  describe('validateRowStateRead', () => {
+    it('returns the validated document for valid input with id', () => {
+      const doc = { id: 'state-1', ...buildRowState() }
+      const result = validateRowStateRead(doc)
+      expect(result.id).toBe('state-1')
+    })
+
+    it('throws Boom.badImplementation for invalid input', () => {
+      expect(() => validateRowStateRead({ id: 'bad' })).toThrow(
+        /Invalid row state/
+      )
+    })
+  })
+})

--- a/src/waste-balances/repository/row-states-test-data.js
+++ b/src/waste-balances/repository/row-states-test-data.js
@@ -1,0 +1,46 @@
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+/**
+ * Build a committed row-state document (insert shape — no `id`).
+ * Defaults to an INCLUDED received-waste row in one submission's membership.
+ * @param {object} [overrides]
+ */
+export const buildRowState = (overrides = {}) => ({
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  accreditationId: 'acc-1',
+  wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+  rowId: 'row-1',
+  data: { supplierName: 'Acme', tonnage: 10 },
+  classification: {
+    outcome: ROW_OUTCOME.INCLUDED,
+    reasons: [],
+    transactionAmount: 10
+  },
+  summaryLogIds: ['log-1'],
+  ...overrides
+})
+
+/**
+ * Build a per-row entry as produced by the 1.1 classification list — the
+ * shape `upsertRowStates` consumes (no partition fields, no membership).
+ * @param {object} [overrides]
+ */
+export const buildRowStateEntry = (overrides = {}) => ({
+  rowId: 'row-1',
+  wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+  data: { supplierName: 'Acme', tonnage: 10 },
+  classification: {
+    outcome: ROW_OUTCOME.INCLUDED,
+    reasons: [],
+    transactionAmount: 10
+  },
+  ...overrides
+})
+
+export const DEFAULT_PARTITION = Object.freeze({
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  accreditationId: 'acc-1'
+})

--- a/src/waste-balances/repository/row-states-validation.js
+++ b/src/waste-balances/repository/row-states-validation.js
@@ -1,0 +1,38 @@
+import Boom from '@hapi/boom'
+
+import {
+  rowStateInsertSchema,
+  rowStateReadSchema
+} from './row-states-schema.js'
+
+/**
+ * @returns {import('./row-states-schema.js').RowStateInsert}
+ */
+export const validateRowStateInsert = (data) => {
+  const { error, value } = rowStateInsertSchema.validate(data, {
+    abortEarly: false
+  })
+
+  if (error) {
+    const details = error.details.map((d) => d.message).join('; ')
+    throw Boom.badData(`Invalid row state data: ${details}`)
+  }
+
+  return value
+}
+
+/**
+ * @returns {import('./row-states-schema.js').RowState}
+ */
+export const validateRowStateRead = (data) => {
+  const { error, value } = rowStateReadSchema.validate(data, {
+    abortEarly: false
+  })
+
+  if (error) {
+    const details = error.details.map((d) => d.message).join('; ')
+    throw Boom.badImplementation(`Invalid row state ${data.id}: ${details}`)
+  }
+
+  return value
+}


### PR DESCRIPTION
Ticket: [PAE-1560](https://eaflood.atlassian.net/browse/PAE-1560)
Implements Stage 1 of ADR-0037 (committed row states with summary-log membership), building on the ADR-0036 event-sourced waste-balance stream. Establishes one new collection and the write and read paths over it; the operator/admin row drill-down, trustworthy CSV/FOI export and creditTotal decomposition surfaces are all reads over this foundation and follow separately.

## Committed row-states repository
- New `waste-balance-row-states` collection with a port and both in-memory and MongoDB adapters, Joi insert/read schemas and validation, and a membership multikey index on `summaryLogIds`.
- A cross-adapter contract suite (`row-states-port.contract.js` + `row-states-contract/`) runs the ADR-0037 disciplines against both adapters: never-mutate, membership-only-grows, idempotent upsert, content-match dedup (including the A→B→A revert reuse case) and verbatim deterministic-order reads.

## Capture per-row classification
- The per-record waste-balance classification (outcome, reasons, transaction amount) is now retained as a per-row list during a summary-log submission rather than being summed into the credit total and discarded.

## Persist committed row states on submission
- `performUpdateViaStream` upserts committed row states before appending the stream event; membership grows by `$addToSet` so a re-submission adds its id without duplicating documents.
- Writing row states ahead of the event append keeps a failed append retry-safe and invisible to committed reads. The event payload and credit-total arithmetic are unchanged.

## Read layer
- `committedRowStatesForRegistration` resolves the committed head and returns its full row state; `latestCommittedSummaryLogId` is extracted as a shared committed-head helper.
- `rowHistory` expands each membership entry into its own submission occurrence ordered by stream position, so an A→B→A sequence renders three occurrences from two documents — each carrying what that submission said and whether and why it counted.
- A point-in-time committed read is included.

## rowId contract fix
- `createRowTransformer` now coerces `rowId` to a string at source, honouring the `WasteRecord.rowId: string` contract. Previously a numeric `ROW_ID` spreadsheet cell produced a numeric `rowId` that was masked only by the persistence schema's coercion and would have thrown on the pre-persist balance path for numeric row ids.

[PAE-1560]: https://eaflood.atlassian.net/browse/PAE-1560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ