### PR TITLE
PAE-1560: Read the CSV export from committed row states

### DIFF
--- a/src/waste-balances/repository/inmemory.plugin.js
+++ b/src/waste-balances/repository/inmemory.plugin.js
@@ -16,6 +16,7 @@ export function createInMemoryWasteBalancesRepositoryPlugin() {
       const repository = factory()
       registerRepository(server, 'wasteBalancesRepository', () => repository)
       registerRepository(server, 'streamRepository', () => streamRepository)
+      registerRepository(server, 'rowStateRepository', () => rowStateRepository)
     }
   }
 }

--- a/src/waste-balances/repository/mongodb.plugin.js
+++ b/src/waste-balances/repository/mongodb.plugin.js
@@ -23,5 +23,6 @@ export const mongoWasteBalancesRepositoryPlugin = {
 
     registerRepository(server, 'wasteBalancesRepository', () => repository)
     registerRepository(server, 'streamRepository', () => streamRepository)
+    registerRepository(server, 'rowStateRepository', () => rowStateRepository)
   }
 }

--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -3,38 +3,43 @@ import { Readable } from 'node:stream'
 
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
 import { resolveAccreditation } from '#domain/organisations/registration-utils.js'
+import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/index.js'
+import {
+  coerceRowData,
+  ROW_OUTCOME
+} from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { committedRowStatesForRegistration } from '#waste-balances/application/read-committed-row-states.js'
+import { latestCommittedSummaryLogId } from '#waste-balances/application/latest-committed-summary-log-id.js'
 import {
   buildHeaderRow,
   buildDataRow,
   buildDataFieldColumns
 } from '../domain/csv-columns.js'
-import { isIncludedInWasteBalance } from '../domain/is-included-in-waste-balance.js'
-import { buildOverseasSitesContext } from '../domain/overseas-sites-context.js'
 import { loadSummaryLogMap } from './load-summary-log-map.js'
 
 const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
 /** @import {Organisation} from '#domain/organisations/model.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
-/** @import {WasteRecord, WasteRecordVersion} from '#domain/waste-records/model.js' */
-/** @import {OverseasSite} from '#overseas-sites/repository/port.js' */
 /** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
 /** @import {WasteRecordsRepository} from '#repositories/waste-records/port.js' */
 /** @import {SummaryLogsRepository} from '#repositories/summary-logs/port.js' */
-/** @import {OverseasSitesRepository} from '#overseas-sites/repository/port.js' */
+/** @import {WasteBalanceStreamRepository} from '#waste-balances/repository/stream-port.js' */
+/** @import {RowStateRepository} from '#waste-balances/repository/row-states-port.js' */
 
 /**
  * @typedef {Object} StreamCsvExportDeps
  * @property {Pick<OrganisationsRepository, 'findAll'>} organisationsRepository
- * @property {Pick<WasteRecordsRepository, 'findByRegistration' | 'findDistinctDataKeys'>} wasteRecordsRepository
+ * @property {Pick<WasteRecordsRepository, 'findDistinctDataKeys'>} wasteRecordsRepository
  * @property {Pick<SummaryLogsRepository, 'findAllByOrgReg'>} summaryLogsRepository
- * @property {Pick<OverseasSitesRepository, 'findAll'>} overseasSitesRepository
+ * @property {WasteBalanceStreamRepository} streamRepository
+ * @property {RowStateRepository} rowStateRepository
  */
 
 const sortById = (a, b) => a.id.localeCompare(b.id)
 
-const sortRecords = (a, b) => {
-  const t = a.type.localeCompare(b.type)
+const sortRowStates = (a, b) => {
+  const t = a.wasteRecordType.localeCompare(b.wasteRecordType)
   // `numeric: true` gives natural ordering ('9' before '10') while still
   // working for non-numeric rowIds.
   return (
@@ -43,6 +48,28 @@ const sortRecords = (a, b) => {
       numeric: true
     })
   )
+}
+
+/**
+ * Surface a committed row's data in the schema's canonical types — the same
+ * read-time coercion the rest of the system applies. A column that arrives
+ * mixed-typed from ExcelJS (a number in one submission, a numeric-string in
+ * another) is committed verbatim, so coercing on read is what makes the
+ * exported column hold a single type across rows.
+ *
+ * @param {Record<string, any>} data
+ * @param {import('#domain/waste-records/model.js').WasteRecordType} wasteRecordType
+ * @returns {Record<string, any>}
+ */
+const coerceForExport = (data, wasteRecordType) => {
+  const schema = findSchemaForProcessingType(
+    data?.processingType,
+    wasteRecordType
+  )
+  if (!schema) {
+    return data
+  }
+  return coerceRowData(data, schema).data
 }
 
 /**
@@ -60,94 +87,72 @@ const encodeRow = async (cells) => {
 }
 
 /**
- * Build one CSV data row for a record under a given (org, registration) pair.
+ * Yield one CSV row per committed row state under a single (org, registration)
+ * pair. Inclusion and the row's data are read from the committed state stamped
+ * at submission — not recomputed — so the export reflects exactly what counted
+ * toward the waste balance when it committed.
  *
  * @param {Object} input
  * @param {Organisation} input.org
  * @param {Registration} input.registration
- * @param {import('#domain/organisations/accreditation.js').Accreditation | null} input.accreditation
- * @param {Record<string, { validFrom: Date | null }>} input.overseasSites
- * @param {Map<string, { submittedAt: string }>} input.summaryLogMap
- * @param {WasteRecord} input.record
  * @param {string[]} input.dataFieldColumns
- * @returns {string[]}
- */
-const rowForRecord = ({
-  org,
-  registration,
-  accreditation,
-  overseasSites,
-  summaryLogMap,
-  record,
-  dataFieldColumns
-}) => {
-  // `record.versions` is a non-empty array per the WasteRecord schema, so
-  // `.at(-1)` is always defined here. The cast tells tsc to drop the
-  // `| undefined` from the .at() return type rather than adding a guard
-  // for a state that cannot occur.
-  const lastVersion = /** @type {WasteRecordVersion} */ (record.versions.at(-1))
-  const summaryLogEntry = summaryLogMap.get(lastVersion.summaryLog.id) ?? null
-  const includedInWasteBalance = isIncludedInWasteBalance(
-    record,
-    accreditation,
-    overseasSites
-  )
-  return buildDataRow({
-    org,
-    registration,
-    accreditation,
-    record,
-    summaryLogEntry,
-    includedInWasteBalance,
-    dataFieldColumns
-  })
-}
-
-/**
- * Yield one CSV row per waste record under a single (org, registration) pair.
- * Records for the pair are fetched into memory together (bounded by the count
- * per registration, not the whole system) and yielded one row at a time.
- *
- * @param {Object} input
- * @param {Organisation} input.org
- * @param {Registration} input.registration
- * @param {Map<string, OverseasSite>} input.sitesById
- * @param {string[]} input.dataFieldColumns
- * @param {Pick<WasteRecordsRepository, 'findByRegistration'>} input.wasteRecordsRepository
+ * @param {WasteBalanceStreamRepository} input.streamRepository
+ * @param {RowStateRepository} input.rowStateRepository
  * @param {Pick<SummaryLogsRepository, 'findAllByOrgReg'>} input.summaryLogsRepository
  * @returns {AsyncGenerator<string>}
  */
 async function* streamRegistrationRows({
   org,
   registration,
-  sitesById,
   dataFieldColumns,
-  wasteRecordsRepository,
+  streamRepository,
+  rowStateRepository,
   summaryLogsRepository
 }) {
   const accreditation = resolveAccreditation(registration, org)
-  const overseasSites = buildOverseasSitesContext(registration, sitesById)
+  const accreditationId = accreditation?.id ?? null
+
+  // Every committed row in the snapshot belongs to the head submission, so the
+  // head's timestamp is the "Submitted At" column. A registration with no
+  // committed submission contributes no rows.
+  const head = await latestCommittedSummaryLogId(streamRepository, {
+    registrationId: registration.id,
+    accreditationId
+  })
+
+  if (head === null) {
+    return
+  }
+
+  const rowStates = await committedRowStatesForRegistration({
+    streamRepository,
+    rowStateRepository,
+    organisationId: org.id,
+    registrationId: registration.id,
+    accreditationId
+  })
+
   const summaryLogMap = await loadSummaryLogMap(
     summaryLogsRepository,
     org.id,
     registration.id
   )
+  const summaryLogEntry = summaryLogMap.get(head) ?? null
 
-  const records = await wasteRecordsRepository.findByRegistration(
-    org.id,
-    registration.id
-  )
-  const recordsSorted = [...records].sort(sortRecords)
+  const rowStatesSorted = [...rowStates].sort(sortRowStates)
 
-  for (const record of recordsSorted) {
+  for (const rowState of rowStatesSorted) {
     yield await encodeRow(
-      rowForRecord({
+      buildDataRow({
         org,
         registration,
         accreditation,
-        overseasSites,
-        summaryLogMap,
-        record,
+        data: coerceForExport(rowState.data, rowState.wasteRecordType),
+        wasteRecordType: rowState.wasteRecordType,
+        rowId: rowState.rowId,
+        summaryLogEntry,
+        includedInWasteBalance:
+          rowState.classification.outcome === ROW_OUTCOME.INCLUDED,
         dataFieldColumns
       })
     )
@@ -155,7 +160,7 @@ async function* streamRegistrationRows({
 }
 
 /**
- * Yields CSV-encoded lines (header first, then one per waste record).
+ * Yields CSV-encoded lines (header first, then one per committed row state).
  * Hard-fails on any iterator error — caller must close the response stream.
  *
  * The header row is dynamically composed from the union of schema-declared
@@ -164,7 +169,7 @@ async function* streamRegistrationRows({
  * (`findDistinctDataKeys`) so the export does not need to materialise any
  * waste-record document to compose the header. Rows are then streamed one
  * registration at a time — memory is bounded by the largest single
- * registration's record count, not the total record count in the system.
+ * registration's committed-state count, not the total in the system.
  *
  * @param {StreamCsvExportDeps} deps
  * @returns {AsyncGenerator<string>}
@@ -174,16 +179,15 @@ export async function* streamCsvExport(deps) {
     organisationsRepository,
     wasteRecordsRepository,
     summaryLogsRepository,
-    overseasSitesRepository
+    streamRepository,
+    rowStateRepository
   } = deps
 
-  const [allSites, orgs, observedKeys] = await Promise.all([
-    overseasSitesRepository.findAll(),
+  const [orgs, observedKeys] = await Promise.all([
     organisationsRepository.findAll(),
     wasteRecordsRepository.findDistinctDataKeys()
   ])
 
-  const sitesById = new Map(allSites.map((s) => [s.id, s]))
   const dataFieldColumns = buildDataFieldColumns(observedKeys)
   yield await encodeRow(buildHeaderRow(dataFieldColumns))
 
@@ -196,9 +200,9 @@ export async function* streamCsvExport(deps) {
       yield* streamRegistrationRows({
         org,
         registration,
-        sitesById,
         dataFieldColumns,
-        wasteRecordsRepository,
+        streamRepository,
+        rowStateRepository,
         summaryLogsRepository
       })
     }

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -9,6 +9,10 @@ import {
 } from '../domain/csv-columns.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { createInMemoryRowStateRepository } from '#waste-balances/repository/row-states-inmemory.js'
+import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
+import { buildStreamEvent } from '#waste-balances/repository/stream-test-data.js'
 
 const collect = async (gen) => {
   const out = []
@@ -16,12 +20,27 @@ const collect = async (gen) => {
   return out
 }
 
+const cellsOf = (line) => line.trim().split(',')
+
+const dataCellIndex = (observedKeys, field) =>
+  METADATA_COLUMNS.length + buildDataFieldColumns(observedKeys).indexOf(field)
+
+const accreditationFixture = {
+  id: 'acc-1',
+  status: 'approved',
+  accreditationNumber: 'ACC-001',
+  validFrom: '2026-01-01',
+  validTo: '2026-12-31',
+  statusHistory: []
+}
+
 const baseOrg = (overrides = {}) => ({
   id: 'org-1',
+  orgId: 123456,
   companyDetails: { name: 'Acme Ltd' },
   submittedToRegulator: 'ea',
   registrations: [],
-  accreditations: [],
+  accreditations: [accreditationFixture],
   ...overrides
 })
 
@@ -29,59 +48,97 @@ const baseRegistration = (overrides = {}) => ({
   id: 'reg-1',
   material: 'plastic',
   submittedToRegulator: 'ea',
-  accreditation: {
-    id: 'acc-1',
-    validFrom: '2026-01-01',
-    validTo: '2027-01-01',
-    statusHistory: []
-  },
-  overseasSites: {},
+  accreditationId: 'acc-1',
   ...overrides
 })
 
-const reprocessorReceivedRecord = (overrides = {}) => ({
-  type: WASTE_RECORD_TYPE.RECEIVED,
+const ACCREDITED_PARTITION = {
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  accreditationId: 'acc-1'
+}
+
+const receivedData = (overrides = {}) => ({
+  processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+  DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01',
+  ...overrides
+})
+
+const includedEntry = (overrides = {}) => ({
   rowId: '1001',
-  data: {
-    processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
-    DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01'
+  wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+  data: receivedData(),
+  classification: {
+    outcome: ROW_OUTCOME.INCLUDED,
+    reasons: [],
+    transactionAmount: 10
   },
-  versions: [{ summaryLog: { id: 'sl-1' } }],
   ...overrides
 })
 
-const defaultDeps = () => ({
-  organisationsRepository: {
-    findAll: vi.fn().mockResolvedValue([])
-  },
+/**
+ * @typedef {{ organisationId: string, registrationId: string, accreditationId: string | null }} Partition
+ * @typedef {{ summaryLogId: string, number: number, entries: any[], partition?: Partition }} Submission
+ */
+
+/**
+ * Seed committed row states + their stream submissions into fresh in-memory
+ * adapters. Each submission upserts its entries under a partition and appends a
+ * matching summary-log-submitted event so the head resolves to the latest.
+ *
+ * @param {Submission[]} submissions
+ */
+const seedRepos = async (submissions) => {
+  const rowStateRepository = createInMemoryRowStateRepository()()
+  const events = []
+  for (const submission of submissions) {
+    const partition = submission.partition ?? ACCREDITED_PARTITION
+    await rowStateRepository.upsertRowStates(
+      partition,
+      submission.entries,
+      submission.summaryLogId
+    )
+    events.push(
+      buildStreamEvent({
+        registrationId: partition.registrationId,
+        accreditationId: partition.accreditationId,
+        organisationId: partition.organisationId,
+        number: submission.number,
+        payload: { summaryLogId: submission.summaryLogId, creditTotal: 100 }
+      })
+    )
+  }
+  return {
+    rowStateRepository,
+    streamRepository: createInMemoryStreamRepository(events)()
+  }
+}
+
+/**
+ * @param {{ orgs?: any[], summaryLogs?: any[], observedKeys?: string[], rowStateRepository?: any, streamRepository?: any }} [opts]
+ */
+const buildDeps = ({
+  orgs = [],
+  summaryLogs = [],
+  observedKeys = [],
+  rowStateRepository = createInMemoryRowStateRepository()(),
+  streamRepository = createInMemoryStreamRepository()()
+} = {}) => ({
+  organisationsRepository: { findAll: vi.fn().mockResolvedValue(orgs) },
   wasteRecordsRepository: {
-    findByRegistration: vi.fn().mockResolvedValue([]),
-    findDistinctDataKeys: vi.fn().mockResolvedValue([])
+    findDistinctDataKeys: vi.fn().mockResolvedValue(observedKeys)
   },
   summaryLogsRepository: {
-    findAllByOrgReg: vi.fn().mockResolvedValue([])
+    findAllByOrgReg: vi.fn().mockResolvedValue(summaryLogs)
   },
-  overseasSitesRepository: {
-    findAll: vi.fn().mockResolvedValue([])
-  }
+  streamRepository,
+  rowStateRepository
 })
-
-// Shallow-merges per-repo overrides so individual tests can swap a single
-// method (e.g. `findByRegistration`) without losing the default mocks for
-// other methods on the same repository.
-const baseDeps = (overrides = {}) => {
-  const merged = defaultDeps()
-  for (const [key, value] of Object.entries(overrides)) {
-    merged[key] = { ...merged[key], ...value }
-  }
-  return merged
-}
 
 describe('streamCsvExport', () => {
   it('emits the header row even when no organisations exist', async () => {
-    const out = await collect(streamCsvExport(baseDeps()))
+    const out = await collect(streamCsvExport(buildDeps()))
     expect(out).toHaveLength(1)
-    // The header row is CSV-encoded and ends with a newline
     expect(out[0].endsWith('\n')).toBe(true)
     for (const column of METADATA_COLUMNS) {
       expect(out[0]).toContain(column)
@@ -91,24 +148,17 @@ describe('streamCsvExport', () => {
     }
   })
 
-  it('emits one data row per waste record with org/registration/record/summaryLog data populated', async () => {
-    const org = baseOrg({
-      registrations: [baseRegistration()]
-    })
-    const record = reprocessorReceivedRecord()
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi.fn().mockResolvedValue([record])
-      },
-      summaryLogsRepository: {
-        findAllByOrgReg: vi.fn().mockResolvedValue([
-          {
-            id: 'sl-1',
-            summaryLog: { submittedAt: '2026-04-15T09:00:00Z' }
-          }
-        ])
-      }
+  it('emits one data row per committed row state with org/registration/state/summaryLog data populated', async () => {
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      { summaryLogId: 'log-1', number: 1, entries: [includedEntry()] }
+    ])
+    const deps = buildDeps({
+      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      summaryLogs: [
+        { id: 'log-1', summaryLog: { submittedAt: '2026-04-15T09:00:00Z' } }
+      ],
+      rowStateRepository,
+      streamRepository
     })
 
     const out = await collect(streamCsvExport(deps))
@@ -124,319 +174,270 @@ describe('streamCsvExport', () => {
       'org-1',
       'reg-1'
     )
-    expect(deps.wasteRecordsRepository.findByRegistration).toHaveBeenCalledWith(
-      'org-1',
-      'reg-1'
-    )
+  })
+
+  it('reads inclusion from the stamped classification rather than recomputing it', async () => {
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      {
+        summaryLogId: 'log-1',
+        number: 1,
+        entries: [
+          includedEntry({ rowId: '1001' }),
+          includedEntry({
+            rowId: '1002',
+            classification: {
+              outcome: ROW_OUTCOME.EXCLUDED,
+              reasons: [{ code: 'PRN_ISSUED' }],
+              transactionAmount: 0
+            }
+          })
+        ]
+      }
+    ])
+    const deps = buildDeps({
+      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      rowStateRepository,
+      streamRepository
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    expect(out).toHaveLength(3)
+    // Included in Waste Balance is metadata column index 9.
+    expect(cellsOf(out[1])[9]).toBe('"true"') // rowId 1001 INCLUDED
+    expect(cellsOf(out[2])[9]).toBe('"false"') // rowId 1002 EXCLUDED
+  })
+
+  it('exports a single coerced type for a column that arrived mixed-typed across submissions', async () => {
+    const observedKeys = ['processingType', 'GROSS_WEIGHT']
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      {
+        summaryLogId: 'log-1',
+        number: 1,
+        entries: [
+          includedEntry({
+            rowId: '1001',
+            data: receivedData({ GROSS_WEIGHT: 9 }) // number from ExcelJS
+          }),
+          includedEntry({
+            rowId: '1002',
+            data: receivedData({ GROSS_WEIGHT: '9.0' }) // numeric-string from ExcelJS
+          })
+        ]
+      }
+    ])
+    const deps = buildDeps({
+      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      observedKeys,
+      rowStateRepository,
+      streamRepository
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    expect(out).toHaveLength(3)
+    const grossIdx = dataCellIndex(observedKeys, 'GROSS_WEIGHT')
+    // The PAE-1560 discrepancy was that number 9 exported as "9" while the
+    // numeric-string "9.0" exported as "9.0". Read-time coercion lands both on
+    // the schema's canonical number, so the column is single-typed.
+    expect(cellsOf(out[1])[grossIdx]).toBe('"9"')
+    expect(cellsOf(out[2])[grossIdx]).toBe('"9"')
+    expect(cellsOf(out[1])[grossIdx]).toBe(cellsOf(out[2])[grossIdx])
+  })
+
+  it('passes data through uncoerced when no schema matches the processing type', async () => {
+    const observedKeys = ['processingType', 'GROSS_WEIGHT']
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      {
+        summaryLogId: 'log-1',
+        number: 1,
+        entries: [
+          includedEntry({
+            data: { processingType: 'UNKNOWN_TYPE', GROSS_WEIGHT: '9.0' }
+          })
+        ]
+      }
+    ])
+    const deps = buildDeps({
+      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      observedKeys,
+      rowStateRepository,
+      streamRepository
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const grossIdx = dataCellIndex(observedKeys, 'GROSS_WEIGHT')
+    expect(cellsOf(out[1])[grossIdx]).toBe('"9.0"') // raw, no schema to coerce
   })
 
   it('emits registration and accreditation numbers and the detailed glass material', async () => {
-    const accreditation = {
-      id: 'acc-1',
-      status: 'approved',
-      accreditationNumber: 'ACC-777',
-      validFrom: '2026-01-01',
-      validTo: '2026-12-31',
-      statusHistory: []
-    }
-    const org = baseOrg({
-      accreditations: [accreditation],
-      registrations: [
-        baseRegistration({
-          accreditation: null,
-          accreditationId: 'acc-1',
-          registrationNumber: 'REG-555',
-          material: 'glass',
-          glassRecyclingProcess: ['glass_re_melt']
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      { summaryLogId: 'log-1', number: 1, entries: [includedEntry()] }
+    ])
+    const deps = buildDeps({
+      orgs: [
+        baseOrg({
+          registrations: [
+            baseRegistration({
+              registrationNumber: 'REG-555',
+              material: 'glass',
+              glassRecyclingProcess: ['glass_re_melt']
+            })
+          ]
         })
-      ]
-    })
-    const record = reprocessorReceivedRecord()
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi.fn().mockResolvedValue([record])
-      }
+      ],
+      rowStateRepository,
+      streamRepository
     })
 
     const out = await collect(streamCsvExport(deps))
-    expect(out).toHaveLength(2)
-    const cells = out[1].trim().split(',')
+    const cells = cellsOf(out[1])
     expect(cells[2]).toBe('"REG-555"') // Registration Number
     expect(cells[3]).toBe('"glass_re_melt"') // Material (detailed)
     expect(cells[5]).toBe('"Yes"') // Accredited
-    expect(cells[6]).toBe('"ACC-777"') // Accreditation Number
+    expect(cells[6]).toBe('"ACC-001"') // Accreditation Number
   })
 
-  it('emits empty Submitted At when the record references a missing summary log', async () => {
-    const org = baseOrg({ registrations: [baseRegistration()] })
-    const record = reprocessorReceivedRecord({
-      versions: [{ summaryLog: { id: 'sl-missing' } }]
-    })
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi.fn().mockResolvedValue([record])
-      },
-      summaryLogsRepository: {
-        findAllByOrgReg: vi.fn().mockResolvedValue([])
+  it('treats a registration with no accreditation as registered-only', async () => {
+    const partition = { ...ACCREDITED_PARTITION, accreditationId: null }
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      {
+        summaryLogId: 'log-1',
+        number: 1,
+        entries: [includedEntry()],
+        partition
       }
+    ])
+    const deps = buildDeps({
+      orgs: [
+        baseOrg({
+          accreditations: [],
+          registrations: [baseRegistration({ accreditationId: null })]
+        })
+      ],
+      rowStateRepository,
+      streamRepository
     })
 
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(2)
-    // The Submitted At column (index 8) should be an empty quoted cell
-    const cells = out[1].trim().split(',')
-    expect(cells[8]).toBe('""')
+    const cells = cellsOf(out[1])
+    expect(cells[5]).toBe('"No"') // Accredited
+    expect(cells[6]).toBe('""') // Accreditation Number
   })
 
-  it('processes received, processed, sentOn and exported records on the same registration', async () => {
-    const org = baseOrg({ registrations: [baseRegistration()] })
-    const received = reprocessorReceivedRecord({ rowId: '1001' })
-    const processed = {
-      type: WASTE_RECORD_TYPE.PROCESSED,
-      rowId: '2001',
-      data: { processingType: PROCESSING_TYPES.REPROCESSOR_OUTPUT },
-      versions: [{ summaryLog: { id: 'sl-1' } }]
-    }
-    const sentOn = {
-      type: WASTE_RECORD_TYPE.SENT_ON,
-      rowId: '3001',
-      data: {
-        processingType: PROCESSING_TYPES.EXPORTER,
-        FINAL_DESTINATION_NAME: 'Other Co'
-      },
-      versions: [{ summaryLog: { id: 'sl-1' } }]
-    }
-    const exported = {
-      type: WASTE_RECORD_TYPE.EXPORTED,
-      rowId: '4001',
-      data: {
-        processingType: PROCESSING_TYPES.EXPORTER,
-        DATE_OF_EXPORT: '2026-03-01'
-      },
-      versions: [{ summaryLog: { id: 'sl-1' } }]
-    }
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi
-          .fn()
-          .mockResolvedValue([received, processed, sentOn, exported])
-      }
+  it('emits empty Submitted At when the head submission is absent from the summary-log map', async () => {
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      { summaryLogId: 'log-1', number: 1, entries: [includedEntry()] }
+    ])
+    const deps = buildDeps({
+      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      summaryLogs: [],
+      rowStateRepository,
+      streamRepository
     })
 
     const out = await collect(streamCsvExport(deps))
-    expect(out).toHaveLength(5) // header + 4 records
-    // After sort by (type, rowId): exported < processed < received < sentOn (alphabetical)
+    expect(out).toHaveLength(2)
+    expect(cellsOf(out[1])[8]).toBe('""') // Submitted At
+  })
+
+  it('emits no rows for a registration with no committed submission', async () => {
+    const deps = buildDeps({
+      orgs: [baseOrg({ registrations: [baseRegistration()] })]
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    expect(out).toHaveLength(1) // header only
+  })
+
+  it('emits committed rows sorted by (wasteRecordType, rowId)', async () => {
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      {
+        summaryLogId: 'log-1',
+        number: 1,
+        entries: [
+          includedEntry({
+            rowId: '4001',
+            wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+            data: { processingType: PROCESSING_TYPES.EXPORTER }
+          }),
+          includedEntry({
+            rowId: '1001',
+            wasteRecordType: WASTE_RECORD_TYPE.RECEIVED
+          }),
+          includedEntry({
+            rowId: '3001',
+            wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
+            data: { processingType: PROCESSING_TYPES.EXPORTER }
+          })
+        ]
+      }
+    ])
+    const deps = buildDeps({
+      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      rowStateRepository,
+      streamRepository
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    expect(out).toHaveLength(4)
     expect(out[1]).toContain('exported')
-    expect(out[2]).toContain('processed')
-    expect(out[3]).toContain('received')
-    expect(out[4]).toContain('sentOn')
-    expect(out[4]).toContain('Other Co')
+    expect(out[2]).toContain('received')
+    expect(out[3]).toContain('sentOn')
   })
 
-  it('builds the ORS context once per registration from the pre-loaded sites map', async () => {
-    const validFrom = new Date('2026-01-01')
-    const org = baseOrg({
-      registrations: [
-        baseRegistration({
-          overseasSites: {
-            '001': { overseasSiteId: 'site-a' }
-          }
-        })
-      ]
-    })
-    // An EXPORTED record with all required fields and OSR_ID '001'.
-    // With validFrom matching the export date, classifyForWasteBalance should INCLUDE it.
-    const exportedRecord = {
-      type: WASTE_RECORD_TYPE.EXPORTED,
-      rowId: '4001',
-      data: {
-        processingType: PROCESSING_TYPES.EXPORTER,
-        ROW_ID: '4001',
-        DATE_RECEIVED_FOR_EXPORT: '2026-02-01',
-        EWC_CODE: '15 01 02',
-        DESCRIPTION_WASTE: 'Plastic packaging',
-        WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
-        GROSS_WEIGHT: 10,
-        TARE_WEIGHT: 1,
-        PALLET_WEIGHT: 0,
-        NET_WEIGHT: 9,
-        BAILING_WIRE_PROTOCOL: 'No',
-        HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
-        WEIGHT_OF_NON_TARGET_MATERIALS: 0,
-        RECYCLABLE_PROPORTION_PERCENTAGE: 100,
-        TONNAGE_RECEIVED_FOR_EXPORT: 9,
-        TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 9,
-        DATE_OF_EXPORT: '2026-03-01',
-        BASEL_EXPORT_CODE: 'B3010',
-        CUSTOMS_CODES: '391510',
-        CONTAINER_NUMBER: 'CN-001',
-        DATE_RECEIVED_BY_OSR: '2026-04-01',
-        OSR_ID: '001',
-        DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE: 'No'
-      },
-      versions: [{ summaryLog: { id: 'sl-1' } }]
-    }
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi.fn().mockResolvedValue([exportedRecord])
-      },
-      overseasSitesRepository: {
-        findAll: vi.fn().mockResolvedValue([{ id: 'site-a', validFrom }])
+  it('orders rowIds naturally so "9" comes before "10"', async () => {
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      {
+        summaryLogId: 'log-1',
+        number: 1,
+        entries: [includedEntry({ rowId: '10' }), includedEntry({ rowId: '9' })]
       }
+    ])
+    const deps = buildDeps({
+      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      rowStateRepository,
+      streamRepository
     })
 
     const out = await collect(streamCsvExport(deps))
-    expect(out).toHaveLength(2)
-    expect(deps.overseasSitesRepository.findAll).toHaveBeenCalledTimes(1)
-    // "Included in Waste Balance" is the 10th metadata column (index 9) → "true"
-    const cells = out[1].trim().split(',')
-    expect(cells[9]).toBe('"true"')
-  })
-
-  const exporterAccreditation = {
-    id: 'acc-1',
-    status: 'approved',
-    validFrom: '2026-01-01',
-    validTo: '2026-12-31',
-    statusHistory: []
-  }
-
-  const exportedRecordForAccreditationTests = (dateOfExport) => ({
-    type: WASTE_RECORD_TYPE.EXPORTED,
-    rowId: '5001',
-    data: {
-      processingType: PROCESSING_TYPES.EXPORTER,
-      ROW_ID: '5001',
-      DATE_RECEIVED_FOR_EXPORT: '2026-02-01',
-      EWC_CODE: '15 01 02',
-      DESCRIPTION_WASTE: 'Plastic packaging',
-      WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
-      GROSS_WEIGHT: 10,
-      TARE_WEIGHT: 1,
-      PALLET_WEIGHT: 0,
-      NET_WEIGHT: 9,
-      BAILING_WIRE_PROTOCOL: 'No',
-      HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
-      WEIGHT_OF_NON_TARGET_MATERIALS: 0,
-      RECYCLABLE_PROPORTION_PERCENTAGE: 100,
-      TONNAGE_RECEIVED_FOR_EXPORT: 9,
-      TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 9,
-      DATE_OF_EXPORT: dateOfExport,
-      BASEL_EXPORT_CODE: 'B3010',
-      CUSTOMS_CODES: '391510',
-      CONTAINER_NUMBER: 'CN-001',
-      DATE_RECEIVED_BY_OSR: '2026-04-01',
-      OSR_ID: '001',
-      DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE: 'No'
-    },
-    versions: [{ summaryLog: { id: 'sl-1' } }]
-  })
-
-  it('marks accredited exporter row as included when DATE_OF_EXPORT is within accreditation period', async () => {
-    const org = baseOrg({
-      accreditations: [exporterAccreditation],
-      registrations: [
-        baseRegistration({
-          accreditation: null,
-          accreditationId: 'acc-1',
-          overseasSites: { '001': { overseasSiteId: 'site-a' } }
-        })
-      ]
-    })
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi
-          .fn()
-          .mockResolvedValue([
-            exportedRecordForAccreditationTests('2026-03-01')
-          ])
-      },
-      overseasSitesRepository: {
-        findAll: vi
-          .fn()
-          .mockResolvedValue([
-            { id: 'site-a', validFrom: new Date('2026-01-01') }
-          ])
-      }
-    })
-
-    const out = await collect(streamCsvExport(deps))
-    const cells = out[1].trim().split(',')
-    expect(cells[5]).toBe('"Yes"') // Accredited column
-    expect(cells[9]).toBe('"true"')
-  })
-
-  it('marks accredited exporter row as not included when DATE_OF_EXPORT is outside accreditation period', async () => {
-    const org = baseOrg({
-      accreditations: [exporterAccreditation],
-      registrations: [
-        baseRegistration({
-          accreditation: null,
-          accreditationId: 'acc-1',
-          overseasSites: { '001': { overseasSiteId: 'site-a' } }
-        })
-      ]
-    })
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi
-          .fn()
-          .mockResolvedValue([
-            exportedRecordForAccreditationTests('2025-06-01')
-          ])
-      },
-      overseasSitesRepository: {
-        findAll: vi
-          .fn()
-          .mockResolvedValue([
-            { id: 'site-a', validFrom: new Date('2026-01-01') }
-          ])
-      }
-    })
-
-    const out = await collect(streamCsvExport(deps))
-    const cells = out[1].trim().split(',')
-    expect(cells[5]).toBe('"Yes"') // Accredited column
-    expect(cells[9]).toBe('"false"')
-  })
-
-  it('reads Accredited "Yes" with the number for a suspended accreditation', async () => {
-    const suspendedAccreditation = {
-      id: 'acc-1',
-      status: 'suspended',
-      accreditationNumber: 'ACC-SUS-1',
-      validFrom: '2026-01-01',
-      validTo: '2026-12-31',
-      statusHistory: []
-    }
-    const org = baseOrg({
-      accreditations: [suspendedAccreditation],
-      registrations: [
-        baseRegistration({ accreditation: null, accreditationId: 'acc-1' })
-      ]
-    })
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi
-          .fn()
-          .mockResolvedValue([reprocessorReceivedRecord()])
-      }
-    })
-
-    const out = await collect(streamCsvExport(deps))
-    const cells = out[1].trim().split(',')
-    expect(cells[5]).toBe('"Yes"') // Accredited
-    expect(cells[6]).toBe('"ACC-SUS-1"') // Accreditation Number
+    expect(out).toHaveLength(3)
+    expect(out[1]).toContain('"9"')
+    expect(out[2]).toContain('"10"')
   })
 
   it('iterates organisations and registrations sorted by id for deterministic output', async () => {
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      {
+        summaryLogId: 'log-x',
+        number: 1,
+        entries: [includedEntry({ rowId: 'rx' })],
+        partition: {
+          organisationId: 'org-a',
+          registrationId: 'reg-x',
+          accreditationId: 'acc-1'
+        }
+      },
+      {
+        summaryLogId: 'log-1',
+        number: 1,
+        entries: [includedEntry({ rowId: 'r1' })],
+        partition: {
+          organisationId: 'org-b',
+          registrationId: 'reg-1',
+          accreditationId: 'acc-1'
+        }
+      },
+      {
+        summaryLogId: 'log-2',
+        number: 1,
+        entries: [includedEntry({ rowId: 'r2' })],
+        partition: {
+          organisationId: 'org-b',
+          registrationId: 'reg-2',
+          accreditationId: 'acc-1'
+        }
+      }
+    ])
     const orgB = baseOrg({
       id: 'org-b',
       companyDetails: { name: 'Beta' },
@@ -450,128 +451,57 @@ describe('streamCsvExport', () => {
       companyDetails: { name: 'Alpha' },
       registrations: [baseRegistration({ id: 'reg-x' })]
     })
-    const callOrder = []
-    const deps = baseDeps({
-      organisationsRepository: {
-        findAll: vi.fn().mockResolvedValue([orgB, orgA])
-      },
-      wasteRecordsRepository: {
-        findByRegistration: vi.fn(async (orgId, regId) => {
-          callOrder.push(`${orgId}/${regId}`)
-          return []
-        })
-      }
-    })
-
-    await collect(streamCsvExport(deps))
-    expect(callOrder).toEqual(['org-a/reg-x', 'org-b/reg-1', 'org-b/reg-2'])
-  })
-
-  it('emits records sorted by (type, rowId) for determinism', async () => {
-    const org = baseOrg({ registrations: [baseRegistration()] })
-    const recordHigh = reprocessorReceivedRecord({ rowId: '2002' })
-    const recordLow = reprocessorReceivedRecord({ rowId: '1001' })
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi.fn().mockResolvedValue([recordHigh, recordLow])
-      }
+    const deps = buildDeps({
+      orgs: [orgB, orgA],
+      rowStateRepository,
+      streamRepository
     })
 
     const out = await collect(streamCsvExport(deps))
-    expect(out).toHaveLength(3)
-    // Within the same type, lower rowId emits first
-    expect(out[1]).toContain('"1001"')
-    expect(out[2]).toContain('"2002"')
-  })
-
-  it('orders rowIds naturally so "9" comes before "10"', async () => {
-    const org = baseOrg({ registrations: [baseRegistration()] })
-    const recordTen = reprocessorReceivedRecord({ rowId: '10' })
-    const recordNine = reprocessorReceivedRecord({ rowId: '9' })
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi.fn().mockResolvedValue([recordTen, recordNine])
-      }
-    })
-
-    const out = await collect(streamCsvExport(deps))
-    expect(out).toHaveLength(3)
-    expect(out[1]).toContain('"9"')
-    expect(out[2]).toContain('"10"')
-  })
-
-  it('treats a missing accreditation as registered-only', async () => {
-    const org = baseOrg({
-      registrations: [baseRegistration({ accreditation: undefined })]
-    })
-    const record = reprocessorReceivedRecord()
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi.fn().mockResolvedValue([record])
-      }
-    })
-
-    const out = await collect(streamCsvExport(deps))
-    expect(out).toHaveLength(2)
-    const cells = out[1].trim().split(',')
-    expect(cells[5]).toBe('"No"') // Accredited column
+    expect(out).toHaveLength(4)
+    expect(out[1]).toContain('rx') // org-a / reg-x
+    expect(out[2]).toContain('r1') // org-b / reg-1
+    expect(out[3]).toContain('r2') // org-b / reg-2
   })
 
   it('skips organisations that have no registrations array', async () => {
-    const org = baseOrg({ registrations: undefined })
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) }
-    })
-
+    const deps = buildDeps({ orgs: [baseOrg({ registrations: undefined })] })
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(1) // header only
   })
 
   it('excludes organisations configured as test organisations', async () => {
-    // 999999 is set as a test organisation via process.env.TEST_ORGANISATIONS
-    // in .vite/setup-files.js, matching the prod pattern of gating test orgs
-    // out of admin-visible data.
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      { summaryLogId: 'log-1', number: 1, entries: [includedEntry()] }
+    ])
     const testOrg = baseOrg({
       id: 'org-test',
       orgId: 999999,
       companyDetails: { name: 'Test Org' },
       registrations: [baseRegistration({ id: 'reg-test' })]
     })
-    const realOrg = baseOrg({
-      id: 'org-real',
-      orgId: 123456,
-      companyDetails: { name: 'Real Org' },
-      registrations: [baseRegistration({ id: 'reg-real' })]
-    })
-    const findByRegistration = vi
-      .fn()
-      .mockResolvedValue([reprocessorReceivedRecord()])
-    const deps = baseDeps({
-      organisationsRepository: {
-        findAll: vi.fn().mockResolvedValue([testOrg, realOrg])
-      },
-      wasteRecordsRepository: { findByRegistration }
+    const realOrg = baseOrg({ registrations: [baseRegistration()] })
+    const deps = buildDeps({
+      orgs: [testOrg, realOrg],
+      rowStateRepository,
+      streamRepository
     })
 
     const out = await collect(streamCsvExport(deps))
-
-    expect(out).toHaveLength(2) // header + one row for the real org only
-    expect(out[1]).toContain('Real Org')
+    expect(out).toHaveLength(2) // header + the real org only
+    expect(out[1]).toContain('Acme Ltd')
     expect(out[1]).not.toContain('Test Org')
-    expect(findByRegistration).toHaveBeenCalledTimes(1)
-    expect(findByRegistration).toHaveBeenCalledWith('org-real', 'reg-real')
   })
 
-  it('propagates errors from the waste records iterator', async () => {
-    const org = baseOrg({ registrations: [baseRegistration()] })
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi.fn().mockRejectedValue(new Error('cursor died'))
-      }
+  it('propagates errors from the committed-state reads', async () => {
+    const streamRepository = createInMemoryStreamRepository()()
+    vi.spyOn(
+      streamRepository,
+      'findLatestByPartitionAndKind'
+    ).mockRejectedValue(new Error('cursor died'))
+    const deps = buildDeps({
+      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      streamRepository
     })
 
     await expect(collect(streamCsvExport(deps))).rejects.toThrow('cursor died')
@@ -580,7 +510,7 @@ describe('streamCsvExport', () => {
 
 describe('streamCsvExportToReadable', () => {
   it('returns a Readable stream that emits the same lines as the generator', async () => {
-    const readable = streamCsvExportToReadable(baseDeps())
+    const readable = streamCsvExportToReadable(buildDeps())
     const chunks = []
     for await (const chunk of readable) {
       chunks.push(chunk.toString('utf8'))
@@ -591,49 +521,32 @@ describe('streamCsvExportToReadable', () => {
     }
   })
 
-  it('includes runtime-observed data keys in the header even when not in any schema constant', async () => {
-    const org = baseOrg({ registrations: [baseRegistration()] })
-    const record = reprocessorReceivedRecord({
-      data: {
-        processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
-        DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01',
-        BILL_OF_LANDING_REFERENCE_NUMBER: 'BL-99'
+  it('includes runtime-observed data keys in the header and emits their values', async () => {
+    const observedKeys = [
+      'processingType',
+      'DATE_RECEIVED_FOR_REPROCESSING',
+      'BILL_OF_LANDING_REFERENCE_NUMBER'
+    ]
+    const { rowStateRepository, streamRepository } = await seedRepos([
+      {
+        summaryLogId: 'log-1',
+        number: 1,
+        entries: [
+          includedEntry({
+            data: receivedData({ BILL_OF_LANDING_REFERENCE_NUMBER: 'BL-99' })
+          })
+        ]
       }
+    ])
+    const deps = buildDeps({
+      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      observedKeys,
+      rowStateRepository,
+      streamRepository
     })
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi.fn().mockResolvedValue([record]),
-        findDistinctDataKeys: vi
-          .fn()
-          .mockResolvedValue([
-            'processingType',
-            'DATE_RECEIVED_FOR_REPROCESSING',
-            'BILL_OF_LANDING_REFERENCE_NUMBER'
-          ])
-      }
-    })
+
     const out = await collect(streamCsvExport(deps))
     expect(out[0]).toContain('BILL_OF_LANDING_REFERENCE_NUMBER')
     expect(out[1]).toContain('BL-99')
-  })
-
-  it('uses findDistinctDataKeys to compose the header without buffering any record document', async () => {
-    const org = baseOrg({ registrations: [baseRegistration()] })
-    const record = reprocessorReceivedRecord()
-    const deps = baseDeps({
-      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
-      wasteRecordsRepository: {
-        findByRegistration: vi.fn().mockResolvedValue([record]),
-        findDistinctDataKeys: vi.fn().mockResolvedValue(['WASTE_TRANSFER_NOTE'])
-      }
-    })
-
-    const out = await collect(streamCsvExport(deps))
-
-    expect(
-      deps.wasteRecordsRepository.findDistinctDataKeys
-    ).toHaveBeenCalledTimes(1)
-    expect(out[0]).toContain('WASTE_TRANSFER_NOTE')
   })
 })

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -11,7 +11,7 @@ import * as shared from '#domain/summary-logs/table-schemas/shared/fields.js'
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 /** @import {Organisation} from '#domain/organisations/model.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
-/** @import {WasteRecord} from '#domain/waste-records/model.js' */
+/** @import {WasteRecordType} from '#domain/waste-records/model.js' */
 
 export const METADATA_COLUMNS = Object.freeze([
   'Regulator',
@@ -99,7 +99,9 @@ export const buildHeaderRow = (dataFieldColumns) => [
  * @property {Organisation} org
  * @property {Registration} registration
  * @property {Accreditation | null} accreditation
- * @property {WasteRecord} record
+ * @property {Record<string, any>} data
+ * @property {WasteRecordType} wasteRecordType
+ * @property {string} rowId
  * @property {{ submittedAt: string } | null | undefined} summaryLogEntry
  * @property {boolean} includedInWasteBalance
  * @property {string[]} dataFieldColumns
@@ -116,13 +118,14 @@ export const buildDataRow = ({
   org,
   registration,
   accreditation,
-  record,
+  data,
+  wasteRecordType,
+  rowId,
   summaryLogEntry,
   includedInWasteBalance,
   dataFieldColumns
 }) => {
   const accredited = accreditation !== null ? 'Yes' : 'No'
-  const data = record.data
 
   const metadata = [
     uppercaseString(registration.submittedToRegulator),
@@ -132,10 +135,10 @@ export const buildDataRow = ({
     data.processingType,
     accredited,
     accreditation?.accreditationNumber ?? '',
-    record.type,
+    wasteRecordType,
     summaryLogEntry?.submittedAt ?? '',
     includedInWasteBalance ? 'true' : 'false',
-    String(record.rowId)
+    String(rowId)
   ]
 
   const dataCells = dataFieldColumns.map((field) => {

--- a/src/waste-records-export/domain/csv-columns.test.js
+++ b/src/waste-records-export/domain/csv-columns.test.js
@@ -192,14 +192,13 @@ describe('csv-columns', () => {
     /** @returns {Registration} */
     const buildReg = (overrides = {}) => ({ ...regFixture, ...overrides })
 
-    /** @returns {WasteRecord} */
-    const buildRecord = (overrides = {}) => ({ ...recordFixture, ...overrides })
-
     const baseInput = {
       org: orgFixture,
       registration: regFixture,
       accreditation: accreditationFixture,
-      record: recordFixture,
+      data: recordFixture.data,
+      wasteRecordType: recordFixture.type,
+      rowId: recordFixture.rowId,
       summaryLogEntry: {
         submittedAt: '2026-04-15T09:00:00Z'
       },
@@ -271,12 +270,10 @@ describe('csv-columns', () => {
       const cols = buildDataFieldColumns(observedKeys)
       const row = buildDataRow({
         ...baseInput,
-        record: buildRecord({
-          data: {
-            ...recordFixture.data,
-            BILL_OF_LANDING_REFERENCE_NUMBER: 'BL-99'
-          }
-        }),
+        data: {
+          ...recordFixture.data,
+          BILL_OF_LANDING_REFERENCE_NUMBER: 'BL-99'
+        },
         dataFieldColumns: cols
       })
       const idx =

--- a/src/waste-records-export/routes/export.js
+++ b/src/waste-records-export/routes/export.js
@@ -6,7 +6,8 @@ import { streamCsvExportToReadable } from '../application/stream-csv-export.js'
 /** @import { OrganisationsRepository } from '#repositories/organisations/port.js' */
 /** @import { WasteRecordsRepository } from '#repositories/waste-records/port.js' */
 /** @import { SummaryLogsRepository } from '#repositories/summary-logs/port.js' */
-/** @import { OverseasSitesRepository } from '#overseas-sites/repository/port.js' */
+/** @import { WasteBalanceStreamRepository } from '#waste-balances/repository/stream-port.js' */
+/** @import { RowStateRepository } from '#waste-balances/repository/row-states-port.js' */
 
 export const getWasteRecordsExportPath = '/v1/admin/waste-records/export.csv'
 
@@ -36,7 +37,8 @@ export const wasteRecordsExportRoute = {
    *   organisationsRepository: OrganisationsRepository,
    *   wasteRecordsRepository: WasteRecordsRepository,
    *   summaryLogsRepository: SummaryLogsRepository,
-   *   overseasSitesRepository: OverseasSitesRepository
+   *   streamRepository: WasteBalanceStreamRepository,
+   *   rowStateRepository: RowStateRepository
    * }} request
    */
   handler: (request, h) => {
@@ -44,7 +46,8 @@ export const wasteRecordsExportRoute = {
       organisationsRepository: request.organisationsRepository,
       wasteRecordsRepository: request.wasteRecordsRepository,
       summaryLogsRepository: request.summaryLogsRepository,
-      overseasSitesRepository: request.overseasSitesRepository
+      streamRepository: request.streamRepository,
+      rowStateRepository: request.rowStateRepository
     })
 
     return h

--- a/src/waste-records-export/routes/export.test.js
+++ b/src/waste-records-export/routes/export.test.js
@@ -2,17 +2,30 @@ import { StatusCodes } from 'http-status-codes'
 
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { buildStreamEvent } from '#waste-balances/repository/stream-test-data.js'
 import { createTestServer } from '#test/create-test-server.js'
 import { asServiceMaintainer, asStandardUser } from '#test/inject-auth.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 
 import { getWasteRecordsExportPath, wasteRecordsExportRoute } from './export.js'
 
+const accreditationFixture = {
+  id: 'acc-1',
+  status: 'approved',
+  accreditationNumber: 'ACC-001',
+  validFrom: '2026-01-01',
+  validTo: '2026-12-31',
+  statusHistory: []
+}
+
 const buildOrganisation = (overrides = {}) => ({
   id: 'org-1',
+  orgId: 123456,
   companyDetails: { name: 'Acme Ltd' },
   submittedToRegulator: 'ea',
   registrations: [],
+  accreditations: [accreditationFixture],
   ...overrides
 })
 
@@ -20,56 +33,81 @@ const buildRegistration = (overrides = {}) => ({
   id: 'reg-1',
   material: 'plastic',
   submittedToRegulator: 'ea',
-  accreditation: null,
-  overseasSites: {},
+  accreditationId: 'acc-1',
   ...overrides
 })
 
-const buildReceivedRecord = (overrides = {}) => ({
-  type: WASTE_RECORD_TYPE.RECEIVED,
+const PARTITION = {
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  accreditationId: 'acc-1'
+}
+
+const includedReceivedEntry = (overrides = {}) => ({
   rowId: '1001',
+  wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   data: {
     processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
     DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01'
   },
-  versions: [{ summaryLog: { id: 'sl-1' } }],
+  classification: {
+    outcome: ROW_OUTCOME.INCLUDED,
+    reasons: [],
+    transactionAmount: 10
+  },
   ...overrides
 })
 
-const createServerWithRepos = ({
+/**
+ * @param {{ organisations?: any[], committed?: any[], summaryLogs?: any[], observedKeys?: string[] }} [opts]
+ */
+const createServerWithRepos = async ({
   organisations = [],
-  wasteRecords = [],
+  committed = [],
   summaryLogs = [],
-  overseasSites = []
+  observedKeys = []
 } = {}) => {
   const organisationsRepository = {
     findAll: vi.fn().mockResolvedValue(organisations)
   }
-  const observedKeys = new Set()
-  for (const record of wasteRecords) {
-    for (const key of Object.keys(record.data ?? {})) {
-      observedKeys.add(key)
-    }
-  }
   const wasteRecordsRepository = {
-    findByRegistration: vi.fn().mockResolvedValue(wasteRecords),
-    findDistinctDataKeys: vi.fn().mockResolvedValue([...observedKeys])
+    findDistinctDataKeys: vi.fn().mockResolvedValue(observedKeys)
   }
   const summaryLogsRepository = {
     findAllByOrgReg: vi.fn().mockResolvedValue(summaryLogs)
   }
-  const overseasSitesRepository = {
-    findAll: vi.fn().mockResolvedValue(overseasSites)
-  }
 
-  return createTestServer({
+  const server = await createTestServer({
     repositories: {
       organisationsRepository: () => organisationsRepository,
       wasteRecordsRepository: () => wasteRecordsRepository,
-      summaryLogsRepository: () => summaryLogsRepository,
-      overseasSitesRepository: () => overseasSitesRepository
+      summaryLogsRepository: () => summaryLogsRepository
     }
   })
+
+  const rowStateRepository =
+    /** @type {import('#waste-balances/repository/row-states-port.js').RowStateRepository} */ (
+      server.app.rowStateRepository
+    )
+  const streamRepository =
+    /** @type {import('#waste-balances/repository/stream-port.js').WasteBalanceStreamRepository} */ (
+      server.app.streamRepository
+    )
+  for (const submission of committed) {
+    await rowStateRepository.upsertRowStates(
+      PARTITION,
+      submission.entries,
+      submission.summaryLogId
+    )
+    await streamRepository.appendEvent(
+      buildStreamEvent({
+        number: submission.number,
+        payload: { summaryLogId: submission.summaryLogId, creditTotal: 100 }
+      })
+    )
+  }
+
+  return server
 }
 
 describe(`GET ${getWasteRecordsExportPath}`, () => {
@@ -105,23 +143,25 @@ describe(`GET ${getWasteRecordsExportPath}`, () => {
 
       const lines = response.payload.split('\n').filter((line) => line !== '')
       expect(lines).toHaveLength(1)
-      // Header includes well-known metadata column names
       expect(lines[0]).toContain('Organisation Name')
       expect(lines[0]).toContain('Regulator')
     })
 
-    it('streams a header row plus one data row for a single waste record', async () => {
+    it('streams a header row plus one data row for a single committed row state', async () => {
       const organisation = buildOrganisation({
         registrations: [buildRegistration()]
       })
       const server = await createServerWithRepos({
         organisations: [organisation],
-        wasteRecords: [buildReceivedRecord()],
-        summaryLogs: [
+        committed: [
           {
-            id: 'sl-1',
-            summaryLog: { submittedAt: '2026-04-15T09:00:00Z' }
+            summaryLogId: 'log-1',
+            number: 1,
+            entries: [includedReceivedEntry()]
           }
+        ],
+        summaryLogs: [
+          { id: 'log-1', summaryLog: { submittedAt: '2026-04-15T09:00:00Z' } }
         ]
       })
 
@@ -152,7 +192,13 @@ describe(`GET ${getWasteRecordsExportPath}`, () => {
       })
       const server = await createServerWithRepos({
         organisations: [organisation],
-        wasteRecords: [buildReceivedRecord()]
+        committed: [
+          {
+            summaryLogId: 'log-1',
+            number: 1,
+            entries: [includedReceivedEntry()]
+          }
+        ]
       })
 
       const response = await server.inject({
@@ -164,9 +210,6 @@ describe(`GET ${getWasteRecordsExportPath}`, () => {
       await server.stop()
 
       expect(response.statusCode).toBe(StatusCodes.OK)
-      // Each generator-yielded chunk ends with its own '\n', so the body must
-      // contain at least one internal newline separator on top of the trailing
-      // newline of the last row.
       const trimmed = response.payload.replace(/\n$/, '')
       expect(trimmed.split('\n').length).toBeGreaterThan(1)
     })


### PR DESCRIPTION
Ticket: [PAE-1560](https://eaflood.atlassian.net/browse/PAE-1560)
## What

Repoints the admin waste-records CSV export at the committed row-state read layer (ADR-0037 Stage 1), so it stops recomputing waste-balance inclusion and stops emitting record data verbatim.

Two discrepancy classes the previous export was prone to:

- **Inclusion drift** — the export recomputed `Included in Waste Balance` from current accreditation/ORS/schema state, which can differ from what actually committed at submission. It now reads each row's **stamped classification** (`outcome === INCLUDED`), so the column reflects exactly what counted when the row committed.
- **Mixed-typed columns** — a value that arrived from ExcelJS as a number in one submission and a numeric-string in another (e.g. `9` vs `"9.0"`) exported under two representations. Committed row states store data verbatim by design, so the export now applies the system's canonical schema-driven read-time coercion (`coerceRowData`), landing such a column on a single type across rows.

## How

- `streamCsvExport` reads `committedRowStatesForRegistration` per registration; the head submission supplies the `Submitted At` column. The overseas-sites recompute path is no longer wired into the export.
- `buildDataRow` takes a row's `data`/`wasteRecordType`/`rowId` directly instead of a `WasteRecord`.
- `rowStateRepository` is decorated onto the request alongside the existing `streamRepository`.

Inclusion computation itself is unchanged — this only changes where the export *reads* from. Registrations whose submissions predate the Stage 1 write hook (no committed row state) are not in the export; that is the forward-only Stage 1 semantic, tracked separately.

Jira: https://eaflood.atlassian.net/browse/PAE-1560

[PAE-1560]: https://eaflood.atlassian.net/browse/PAE-1560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ