### PR TITLE
PAE-1566: Add INVALID_ACCREDITATION_LINK validation rule to organisation sweep

### DIFF
--- a/src/domain/organisations/validation/rules/index.js
+++ b/src/domain/organisations/validation/rules/index.js
@@ -4,6 +4,7 @@ import { duplicateRegistrationIdRule } from './duplicate-registration-id.js'
 import { sharedAccreditationRule } from './shared-accreditation.js'
 import { orphanAccreditationRule } from './orphan-accreditation.js'
 import { materialMismatchRule } from './material-mismatch.js'
+import { invalidAccreditationLinkRule } from './invalid-accreditation-link.js'
 
 /**
  * @typedef {{
@@ -21,5 +22,6 @@ export const rules = [
   duplicateRegistrationIdRule,
   sharedAccreditationRule,
   orphanAccreditationRule,
-  materialMismatchRule
+  materialMismatchRule,
+  invalidAccreditationLinkRule
 ]

--- a/src/domain/organisations/validation/rules/invalid-accreditation-link.js
+++ b/src/domain/organisations/validation/rules/invalid-accreditation-link.js
@@ -1,0 +1,57 @@
+import {
+  SEVERITY,
+  createIssue,
+  registrationTarget
+} from '#domain/organisations/validation/issue.js'
+import {
+  getRegAccKey,
+  isAccreditationForRegistration
+} from '#formsubmission/submission-keys.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+/** @import { Registration, Accreditation, RegistrationOrAccreditation } from '#formsubmission/types.js' */
+
+const CODE = 'INVALID_ACCREDITATION_LINK'
+const SEVERITY_LEVEL = SEVERITY.ERROR
+
+/**
+ * @param {Organisation} org
+ * @returns {import('#domain/organisations/validation/issue.js').ValidationIssue[]}
+ */
+const evaluate = (org) => {
+  const accreditationsById = new Map(
+    org.accreditations.map((acc) => [acc.id, acc])
+  )
+
+  return org.registrations.flatMap((reg) => {
+    const accreditation =
+      reg.accreditationId === undefined
+        ? undefined
+        : accreditationsById.get(reg.accreditationId)
+
+    if (
+      !accreditation ||
+      isAccreditationForRegistration(
+        /** @type {Accreditation} */ (/** @type {unknown} */ (accreditation)),
+        /** @type {Registration} */ (/** @type {unknown} */ (reg))
+      )
+    ) {
+      return []
+    }
+
+    return [
+      createIssue({
+        code: CODE,
+        severity: SEVERITY_LEVEL,
+        target: registrationTarget(reg.id),
+        message: `Registration ${reg.id} (key=${getRegAccKey(/** @type {RegistrationOrAccreditation} */ (/** @type {unknown} */ (reg)))}) is linked to accreditation ${accreditation.id} (key=${getRegAccKey(/** @type {RegistrationOrAccreditation} */ (/** @type {unknown} */ (accreditation)))}) which does not match`
+      })
+    ]
+  })
+}
+
+export const invalidAccreditationLinkRule = {
+  code: CODE,
+  severity: SEVERITY_LEVEL,
+  evaluate
+}

--- a/src/domain/organisations/validation/rules/invalid-accreditation-link.test.js
+++ b/src/domain/organisations/validation/rules/invalid-accreditation-link.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { invalidAccreditationLinkRule } from './invalid-accreditation-link.js'
+import {
+  SEVERITY,
+  TARGET_TYPE
+} from '#domain/organisations/validation/issue.js'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+
+const organisation = (registrations, accreditations) =>
+  /** @type {Organisation} */ (
+    /** @type {unknown} */ ({ id: 'org-1', registrations, accreditations })
+  )
+
+const exporterReg = (id, accreditationId) => ({
+  id,
+  accreditationId,
+  wasteProcessingType: 'exporter',
+  material: 'plastic'
+})
+
+const exporterAcc = (id) => ({
+  id,
+  wasteProcessingType: 'exporter',
+  material: 'plastic'
+})
+
+describe('invalidAccreditationLinkRule', () => {
+  it('is an error-severity rule with the correct code', () => {
+    expect(invalidAccreditationLinkRule.code).toBe('INVALID_ACCREDITATION_LINK')
+    expect(invalidAccreditationLinkRule.severity).toBe(SEVERITY.ERROR)
+  })
+
+  it('flags a registration linked to a semantically mismatched accreditation', () => {
+    const org = organisation(
+      [exporterReg('reg-1', 'acc-1')],
+      [
+        {
+          id: 'acc-1',
+          wasteProcessingType: 'reprocessor',
+          material: 'plastic',
+          site: { address: { postcode: 'SW1A 1AA' } }
+        }
+      ]
+    )
+
+    const issues = invalidAccreditationLinkRule.evaluate(org)
+
+    expect(issues).toHaveLength(1)
+    expect(issues[0]).toMatchObject({
+      code: 'INVALID_ACCREDITATION_LINK',
+      severity: SEVERITY.ERROR,
+      target: { type: TARGET_TYPE.REGISTRATION, id: 'reg-1' }
+    })
+    expect(issues[0].message).toContain('reg-1')
+    expect(issues[0].message).toContain('acc-1')
+    expect(issues[0].message).toContain('key=')
+  })
+
+  it('does not flag a registration with a fully matching accreditation link', () => {
+    const org = organisation(
+      [exporterReg('reg-1', 'acc-1')],
+      [exporterAcc('acc-1')]
+    )
+
+    expect(invalidAccreditationLinkRule.evaluate(org)).toEqual([])
+  })
+
+  it('does not flag a registration with no accreditationId', () => {
+    const org = organisation(
+      [{ id: 'reg-1', wasteProcessingType: 'exporter', material: 'plastic' }],
+      []
+    )
+
+    expect(invalidAccreditationLinkRule.evaluate(org)).toEqual([])
+  })
+
+  it('does not flag when the accreditation ID does not exist (left to dangling-ref rule)', () => {
+    const org = organisation(
+      [exporterReg('reg-1', 'acc-missing')],
+      [exporterAcc('acc-1')]
+    )
+
+    expect(invalidAccreditationLinkRule.evaluate(org)).toEqual([])
+  })
+})

--- a/src/domain/organisations/validation/validate-organisation.test.js
+++ b/src/domain/organisations/validation/validate-organisation.test.js
@@ -12,8 +12,15 @@ const organisation = (registrations, accreditations) =>
 describe('validateOrganisation', () => {
   it('returns no issues for a conforming organisation', () => {
     const org = organisation(
-      [{ id: 'reg-1', accreditationId: 'acc-1', material: 'glass' }],
-      [{ id: 'acc-1', material: 'glass' }]
+      [
+        {
+          id: 'reg-1',
+          accreditationId: 'acc-1',
+          wasteProcessingType: 'exporter',
+          material: 'glass'
+        }
+      ],
+      [{ id: 'acc-1', wasteProcessingType: 'exporter', material: 'glass' }]
     )
 
     expect(validateOrganisation(org)).toEqual([])

--- a/src/server/run-organisation-validation-sweep.test.js
+++ b/src/server/run-organisation-validation-sweep.test.js
@@ -186,4 +186,26 @@ describe('runOrganisationValidationSweep', () => {
       message: 'Failed to run organisation validation sweep'
     })
   })
+
+  it('logs an INVALID_ACCREDITATION_LINK issue when a registration is linked to a semantically mismatched accreditation', async () => {
+    const accreditation = buildAccreditation({
+      wasteProcessingType: 'exporter'
+    })
+    const registration = buildRegistration({
+      accreditationId: accreditation.id
+    })
+    const org = buildOrganisation({
+      registrations: [registration],
+      accreditations: [accreditation]
+    })
+    seedRepositoryWith([org])
+
+    await runOrganisationValidationSweep(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message: expect.stringContaining(
+        'code=INVALID_ACCREDITATION_LINK severity=error'
+      )
+    })
+  })
 })


### PR DESCRIPTION
Ticket: [PAE-1566](https://eaflood.atlassian.net/browse/PAE-1566)
Add a new ERROR-severity validation rule that checks whether a registration's linked accreditation is semantically valid using the full submission key (wasteProcessingType, material, site postcode, reprocessingType), not just ID existence. Invalid links are logged with both submission keys so mismatches are immediately diagnosable.

[PAE-1566]: https://eaflood.atlassian.net/browse/PAE-1566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ