### PR TITLE
PAE-1576: Coerce numeric ROW_ID to string in createRowTransformer

### DIFF
--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -894,14 +894,14 @@ describe('SummaryLogsValidator', () => {
 
       const updateCall = summaryLogsRepository.update.mock.calls[0][2]
 
-      // Note: ROW_ID values come directly from test data as numbers
+      // Note: ROW_ID is normalised to a string row identity by the transform
       // Row 10001 is excluded because EWC_CODE is missing (classifyForWasteBalance)
       expect(updateCall.loads).toEqual({
         added: {
-          valid: { count: 1, rowIds: [10000] },
-          invalid: { count: 1, rowIds: [10001] },
-          included: { count: 1, rowIds: [10000] },
-          excluded: { count: 1, rowIds: [10001] }
+          valid: { count: 1, rowIds: ['10000'] },
+          invalid: { count: 1, rowIds: ['10001'] },
+          included: { count: 1, rowIds: ['10000'] },
+          excluded: { count: 1, rowIds: ['10001'] }
         },
         unchanged: createEmptyLoadValidity(),
         adjusted: createEmptyLoadValidity()
@@ -1008,12 +1008,12 @@ describe('SummaryLogsValidator', () => {
 
       // Row 10001 is IGNORED (outside accreditation range) and counted as excluded
       expect(updateCall.loads.added.valid.count).toBe(1)
-      expect(updateCall.loads.added.valid.rowIds).toEqual([10000])
-      expect(updateCall.loads.added.included.rowIds).toEqual([10000])
+      expect(updateCall.loads.added.valid.rowIds).toEqual(['10000'])
+      expect(updateCall.loads.added.included.rowIds).toEqual(['10000'])
 
       expect(updateCall.loads.added.invalid.count).toBe(0)
       expect(updateCall.loads.added.excluded.count).toBe(1)
-      expect(updateCall.loads.added.excluded.rowIds).toEqual([10001])
+      expect(updateCall.loads.added.excluded.rowIds).toEqual(['10001'])
     })
 
     it('counts non-waste-balance table rows in valid/invalid but not included/excluded (REPROCESSED_LOADS in REPROCESSOR_INPUT)', async () => {
@@ -1173,7 +1173,7 @@ describe('SummaryLogsValidator', () => {
       const updateCall = summaryLogsRepository.update.mock.calls[0][2]
 
       expect(updateCall.loads.added.valid.count).toBe(1)
-      expect(updateCall.loads.added.valid.rowIds).toEqual([5000])
+      expect(updateCall.loads.added.valid.rowIds).toEqual(['5000'])
     })
 
     it('sets IGNORED outcome for EXPORTER loads with dates outside accreditation range', async () => {
@@ -1282,7 +1282,7 @@ describe('SummaryLogsValidator', () => {
       const updateCall = summaryLogsRepository.update.mock.calls[0][2]
 
       expect(updateCall.loads.added.valid.count).toBe(1)
-      expect(updateCall.loads.added.valid.rowIds).toEqual([3000])
+      expect(updateCall.loads.added.valid.rowIds).toEqual(['3000'])
     })
 
     it('counts non-waste-balance table rows in valid/invalid but not included/excluded (SENT_ON_LOADS in EXPORTER)', async () => {
@@ -1472,7 +1472,7 @@ describe('SummaryLogsValidator', () => {
       const updateCall = summaryLogsRepository.update.mock.calls[0][2]
 
       expect(updateCall.loads.added.valid.count).toBe(1)
-      expect(updateCall.loads.added.valid.rowIds).toEqual([3000])
+      expect(updateCall.loads.added.valid.rowIds).toEqual(['3000'])
     })
 
     it('counts non-waste-balance table rows in valid/invalid but not included/excluded (SENT_ON_LOADS in REPROCESSOR_OUTPUT)', async () => {
@@ -1703,7 +1703,7 @@ describe('SummaryLogsValidator', () => {
       const updateCall = summaryLogsRepository.update.mock.calls[0][2]
 
       expect(updateCall.loads.added.invalid.count).toBe(1)
-      expect(updateCall.loads.added.invalid.rowIds).toEqual([5000])
+      expect(updateCall.loads.added.invalid.rowIds).toEqual(['5000'])
     })
 
     it('completes validation for REPROCESSOR_OUTPUT when date field is empty', async () => {

--- a/src/application/waste-records/row-transformers/create-row-transformer.js
+++ b/src/application/waste-records/row-transformers/create-row-transformer.js
@@ -23,7 +23,7 @@ export const createRowTransformer = ({
 
     return {
       wasteRecordType,
-      rowId: rowData[rowIdField],
+      rowId: String(rowData[rowIdField]),
       data: {
         ...rowData,
         processingType

--- a/src/application/waste-records/row-transformers/create-row-transformer.test.js
+++ b/src/application/waste-records/row-transformers/create-row-transformer.test.js
@@ -13,4 +13,14 @@ describe('createRowTransformer', () => {
 
     expect(() => transform({}, 5)).toThrow('Missing ROW_ID at row 5')
   })
+
+  it('coerces a numeric ROW_ID to a string', () => {
+    const transform = createRowTransformer({
+      wasteRecordType: 'received',
+      processingType: 'REPROCESSOR_INPUT',
+      rowIdField: 'ROW_ID'
+    })
+
+    expect(transform({ ROW_ID: 1000 }, 0).rowId).toBe('1000')
+  })
 })

--- a/src/application/waste-records/sync-from-summary-log.test.js
+++ b/src/application/waste-records/sync-from-summary-log.test.js
@@ -1406,7 +1406,7 @@ describe('syncFromSummaryLog', () => {
     expect(received).toMatchObject({
       organisationId: 'org-1',
       registrationId: 'reg-1',
-      rowId: 1000,
+      rowId: '1000',
       type: WASTE_RECORD_TYPE.RECEIVED
     })
     expect(received.data.processingType).toBe('REPROCESSOR_REGISTERED_ONLY')
@@ -1418,7 +1418,7 @@ describe('syncFromSummaryLog', () => {
     expect(sentOn).toMatchObject({
       organisationId: 'org-1',
       registrationId: 'reg-1',
-      rowId: 5000,
+      rowId: '5000',
       type: WASTE_RECORD_TYPE.SENT_ON
     })
     expect(sentOn.data.processingType).toBe('REPROCESSOR_REGISTERED_ONLY')
@@ -1505,7 +1505,7 @@ describe('syncFromSummaryLog', () => {
     expect(received).toMatchObject({
       organisationId: 'org-1',
       registrationId: 'reg-1',
-      rowId: 1000,
+      rowId: '1000',
       type: WASTE_RECORD_TYPE.RECEIVED
     })
     expect(received.data.processingType).toBe('EXPORTER_REGISTERED_ONLY')
@@ -1517,7 +1517,7 @@ describe('syncFromSummaryLog', () => {
     expect(exported).toMatchObject({
       organisationId: 'org-1',
       registrationId: 'reg-1',
-      rowId: 2000,
+      rowId: '2000',
       type: WASTE_RECORD_TYPE.EXPORTED
     })
     expect(exported.data.processingType).toBe('EXPORTER_REGISTERED_ONLY')
@@ -1528,7 +1528,7 @@ describe('syncFromSummaryLog', () => {
     expect(sentOn).toMatchObject({
       organisationId: 'org-1',
       registrationId: 'reg-1',
-      rowId: 4000,
+      rowId: '4000',
       type: WASTE_RECORD_TYPE.SENT_ON
     })
     expect(sentOn.data.processingType).toBe('EXPORTER_REGISTERED_ONLY')

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -16,6 +16,8 @@ import {
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import { buildOrganisation } from '#repositories/organisations/contract/test-data.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
+import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
+import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
@@ -350,9 +352,8 @@ describe('Submission and placeholder tests', () => {
         wasteRecordsRepository,
         summaryLogExtractor: validationExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({
-          findPeriodicReports: async () => []
-        })
+        reportsRepository: createInMemoryReportsRepository()(),
+        overseasSitesRepository: createInMemoryOverseasSitesRepository()()
       })
 
       const syncWasteRecords = syncFromSummaryLog(
@@ -458,8 +459,8 @@ describe('Submission and placeholder tests', () => {
       )
 
       expect(wasteRecords).toHaveLength(2)
-      expect(wasteRecords[0].rowId).toBe(1001)
-      expect(wasteRecords[1].rowId).toBe(1002)
+      expect(wasteRecords[0].rowId).toBe('1001')
+      expect(wasteRecords[1].rowId).toBe('1002')
     })
 
     it('should update summary log status to SUBMITTED', async () => {
@@ -526,13 +527,13 @@ describe('Submission and placeholder tests', () => {
       expect(payload.status).toBe(SUMMARY_LOG_STATUS.VALIDATED)
 
       expect(payload.loads.added.valid.count).toBe(1)
-      expect(payload.loads.added.valid.rowIds).toContain(1003)
+      expect(payload.loads.added.valid.rowIds).toContain('1003')
 
       expect(payload.loads.adjusted.valid.count).toBe(1)
-      expect(payload.loads.adjusted.valid.rowIds).toContain(1002)
+      expect(payload.loads.adjusted.valid.rowIds).toContain('1002')
 
       expect(payload.loads.unchanged.valid.count).toBe(1)
-      expect(payload.loads.unchanged.valid.rowIds).toContain(1001)
+      expect(payload.loads.unchanged.valid.rowIds).toContain('1001')
 
       expect(payload.loadsByWasteRecordType).toEqual([
         expect.objectContaining({
@@ -803,9 +804,8 @@ describe('Submission and placeholder tests', () => {
         wasteRecordsRepository,
         summaryLogExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({
-          findPeriodicReports: async () => []
-        })
+        reportsRepository: createInMemoryReportsRepository()(),
+        overseasSitesRepository: createInMemoryOverseasSitesRepository()()
       })
       const featureFlags = createInMemoryFeatureFlags()
 


### PR DESCRIPTION
Ticket: [PAE-1576](https://eaflood.atlassian.net/browse/PAE-1576)

ExcelJS reads numeric `ROW_ID` cells as numbers, so `createRowTransformer` produced records whose `rowId` was a number rather than a string — violating the `WasteRecord.rowId: string` contract its own JSDoc already declares. The waste-balance path consumes pre-persist records, so this throws for any numeric row ID; it is currently masked in production only because MongoDB coerces `rowId` to a string on persist.

The fix coerces `String(rowId)` at the root in `createRowTransformer`, after the presence guard, so every downstream consumer receives the string-typed contract.

A row ID is an identifier, not a quantity. Nothing downstream relies on it being numeric — we only ever use it to refer to a specific row, and it would behave identically if it contained letters. It arrives as a number purely because Excel presents any cell containing solely decimal characters as numeric and ExcelJS parses it that way; the string is the type that matches what the value actually is.

Downstream tests that asserted the old numeric `rowId` are corrected to expect the string identity (`validate.test.js`, `sync-from-summary-log.test.js`, `integration.submission-and-placeholders.test.js`). The integration test also swaps its `any`-cast `reportsRepository` stub and missing `overseasSitesRepository` for real in-memory adapters, clearing the two pre-existing type errors in that file.

The journey-tests waste-record matcher coerced the expected row ID with `parseInt`, so it must change in lockstep to compare the string identity — paired on the `PAE-1576-coerce-row-id-to-string` branch of `epr-backend-journey-tests`, which this PR's CI runs against.

Jira: https://eaflood.atlassian.net/browse/PAE-1576

[PAE-1576]: https://eaflood.atlassian.net/browse/PAE-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
