### PR TITLE
PAE-1476: Add submissionDeclaredBy to report status transition

### DIFF
--- a/.vite/helpers/build-submitted-report.js
+++ b/.vite/helpers/build-submitted-report.js
@@ -26,7 +26,8 @@ export async function buildSubmittedReport(reportsRepository, overrides = {}) {
     version: 2,
     status: REPORT_STATUS.SUBMITTED,
     slot: 'submitted',
-    changedBy: SUBMITTER
+    changedBy: SUBMITTER,
+    submissionDeclaredBy: 'Test User'
   })
   return id
 }

--- a/src/reports/application/report-service.test.js
+++ b/src/reports/application/report-service.test.js
@@ -210,7 +210,8 @@ describe('report-service', () => {
         version: 1,
         status: 'submitted',
         slot: REPORT_STATUS_SLOT.SUBMITTED,
-        changedBy
+        changedBy,
+        submissionDeclaredBy: 'Test User'
       })
       await reportsRepository.createReport({
         ...baseReport,

--- a/src/reports/application/summary-log-events.test.js
+++ b/src/reports/application/summary-log-events.test.js
@@ -180,7 +180,8 @@ async function createAndSubmitReport(repo) {
     version: 2,
     status: REPORT_STATUS.SUBMITTED,
     slot: REPORT_STATUS_SLOT.SUBMITTED,
-    changedBy: DEFAULT_CHANGED_BY
+    changedBy: DEFAULT_CHANGED_BY,
+    submissionDeclaredBy: 'Test User'
   })
   return { id }
 }

--- a/src/reports/repository/contract/createReport.contract.js
+++ b/src/reports/repository/contract/createReport.contract.js
@@ -16,13 +16,19 @@ import {
   DEFAULT_REPORT_YEAR
 } from './test-data.js'
 
+/** @import { ReportsRepositoryFactory } from '../port.js' */
+
+/** @typedef {{ reportsRepository: ReportsRepositoryFactory }} ReportsFixture */
+
 export const testCreateReportBehaviour = (it) => {
   describe('createReport', () => {
     let repository
 
-    beforeEach(async ({ reportsRepository }) => {
-      repository = reportsRepository()
-    })
+    beforeEach(
+      /** @param {ReportsFixture} fixture */ async ({ reportsRepository }) => {
+        repository = reportsRepository()
+      }
+    )
 
     it('creates a report with in_progress status and correct initial fields', async () => {
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Manager' }
@@ -131,7 +137,8 @@ export const testCreateReportBehaviour = (it) => {
         version: 1,
         status: REPORT_STATUS.SUBMITTED,
         slot: REPORT_STATUS_SLOT.SUBMITTED,
-        changedBy
+        changedBy,
+        submissionDeclaredBy: 'Test User'
       })
 
       const { id: secondId } = await repository.createReport(

--- a/src/reports/repository/contract/test-data.js
+++ b/src/reports/repository/contract/test-data.js
@@ -56,7 +56,8 @@ export const createAndSubmitReport = async (repository, overrides = {}) => {
     version: 2,
     status: REPORT_STATUS.SUBMITTED,
     slot: REPORT_STATUS_SLOT.SUBMITTED,
-    changedBy: DEFAULT_CHANGED_BY
+    changedBy: DEFAULT_CHANGED_BY,
+    submissionDeclaredBy: 'Test User'
   })
   return id
 }

--- a/src/reports/repository/contract/updateReportStatus.contract.js
+++ b/src/reports/repository/contract/updateReportStatus.contract.js
@@ -5,15 +5,21 @@ import {
 import { beforeEach, describe, expect } from 'vitest'
 import { buildCreateReportParams, createAndSubmitReport } from './test-data.js'
 
+/** @import { ReportsRepositoryFactory } from '../port.js' */
+
+/** @typedef {{ reportsRepository: ReportsRepositoryFactory }} ReportsFixture */
+
 export const testUpdateReportStatusBehaviour = (it) => {
   describe('updateReportStatus', () => {
     let repository
 
     const changedBy = { id: 'user-2', name: 'Bob', position: 'Reviewer' }
 
-    beforeEach(async ({ reportsRepository }) => {
-      repository = reportsRepository()
-    })
+    beforeEach(
+      /** @param {ReportsFixture} fixture */ async ({ reportsRepository }) => {
+        repository = reportsRepository()
+      }
+    )
 
     it('transitions in_progress → ready_to_submit, sets slot and appends history', async () => {
       const { id: reportId } = await repository.createReport(
@@ -69,12 +75,14 @@ export const testUpdateReportStatusBehaviour = (it) => {
         version: 2,
         status: REPORT_STATUS.SUBMITTED,
         slot: REPORT_STATUS_SLOT.SUBMITTED,
-        changedBy
+        changedBy,
+        submissionDeclaredBy: 'Jane Smith'
       })
 
       expect(result).toMatchObject({
         id: reportId,
         version: 3,
+        submissionDeclaredBy: 'Jane Smith',
         status: {
           currentStatus: REPORT_STATUS.SUBMITTED,
           [REPORT_STATUS_SLOT.SUBMITTED]: {
@@ -100,6 +108,24 @@ export const testUpdateReportStatusBehaviour = (it) => {
           ]
         }
       })
+    })
+
+    it('does not set submissionDeclaredBy on ready_to_submit slot', async () => {
+      const { id: reportId } = await repository.createReport(
+        buildCreateReportParams()
+      )
+
+      const result = await repository.updateReportStatus({
+        reportId,
+        version: 1,
+        status: REPORT_STATUS.READY_TO_SUBMIT,
+        slot: REPORT_STATUS_SLOT.READY,
+        changedBy
+      })
+
+      expect(result.status[REPORT_STATUS_SLOT.READY]).not.toHaveProperty(
+        'submissionDeclaredBy'
+      )
     })
 
     it('transitions submitted → ready_to_submit with unsubmitted slot, preserving prior slots', async () => {

--- a/src/reports/repository/contract/updateReportStatus.contract.js
+++ b/src/reports/repository/contract/updateReportStatus.contract.js
@@ -82,12 +82,12 @@ export const testUpdateReportStatusBehaviour = (it) => {
       expect(result).toMatchObject({
         id: reportId,
         version: 3,
-        submissionDeclaredBy: 'Jane Smith',
         status: {
           currentStatus: REPORT_STATUS.SUBMITTED,
           [REPORT_STATUS_SLOT.SUBMITTED]: {
             at: expect.any(String),
-            by: changedBy
+            by: changedBy,
+            declaredBy: 'Jane Smith'
           },
           history: [
             {

--- a/src/reports/repository/inmemory.js
+++ b/src/reports/repository/inmemory.js
@@ -169,9 +169,9 @@ const updateReportStatus = async (reports, params) => {
 
   const now = new Date().toISOString()
   const slotValue =
-    submissionDeclaredBy !== undefined
-      ? { at: now, by: changedBy, declaredBy: submissionDeclaredBy }
-      : { at: now, by: changedBy }
+    submissionDeclaredBy === undefined
+      ? { at: now, by: changedBy }
+      : { at: now, by: changedBy, declaredBy: submissionDeclaredBy }
 
   const updated = {
     ...existing,

--- a/src/reports/repository/inmemory.js
+++ b/src/reports/repository/inmemory.js
@@ -152,7 +152,7 @@ const updateReport = async (reports, params) => {
  */
 const updateReportStatus = async (reports, params) => {
   const { slot, ...statusParams } = params
-  const { reportId, version, status, changedBy } =
+  const { reportId, version, status, changedBy, submissionDeclaredBy } =
     validateUpdateReportStatus(statusParams)
 
   const existing = reports.get(reportId)
@@ -168,15 +168,17 @@ const updateReportStatus = async (reports, params) => {
   }
 
   const now = new Date().toISOString()
+  const slotValue = { at: now, by: changedBy }
 
   const updated = {
     ...existing,
+    ...(submissionDeclaredBy !== undefined && { submissionDeclaredBy }),
     version: existing.version + 1,
     status: {
       ...existing.status,
       currentStatus: status,
       currentStatusAt: now,
-      [slot]: { at: now, by: changedBy },
+      [slot]: slotValue,
       history: [...existing.status.history, { status, at: now, by: changedBy }]
     }
   }

--- a/src/reports/repository/inmemory.js
+++ b/src/reports/repository/inmemory.js
@@ -168,11 +168,13 @@ const updateReportStatus = async (reports, params) => {
   }
 
   const now = new Date().toISOString()
-  const slotValue = { at: now, by: changedBy }
+  const slotValue =
+    submissionDeclaredBy !== undefined
+      ? { at: now, by: changedBy, declaredBy: submissionDeclaredBy }
+      : { at: now, by: changedBy }
 
   const updated = {
     ...existing,
-    ...(submissionDeclaredBy !== undefined && { submissionDeclaredBy }),
     version: existing.version + 1,
     status: {
       ...existing.status,

--- a/src/reports/repository/mongodb.js
+++ b/src/reports/repository/mongodb.js
@@ -191,7 +191,10 @@ const performUpdateReportStatus = async (db, params) => {
     validateUpdateReportStatus(statusParams)
 
   const now = new Date().toISOString()
-  const slotValue = { at: now, by: changedBy }
+  const slotValue =
+    submissionDeclaredBy !== undefined
+      ? { at: now, by: changedBy, declaredBy: submissionDeclaredBy }
+      : { at: now, by: changedBy }
 
   const doc = await reportsCollection(db).findOneAndUpdate(
     { id: reportId, version },
@@ -199,8 +202,7 @@ const performUpdateReportStatus = async (db, params) => {
       $set: {
         'status.currentStatus': status,
         'status.currentStatusAt': now,
-        [`status.${slot}`]: slotValue,
-        ...(submissionDeclaredBy !== undefined && { submissionDeclaredBy })
+        [`status.${slot}`]: slotValue
       },
       $push: /** @type {any} */ ({
         'status.history': { status, at: now, by: changedBy }

--- a/src/reports/repository/mongodb.js
+++ b/src/reports/repository/mongodb.js
@@ -192,9 +192,9 @@ const performUpdateReportStatus = async (db, params) => {
 
   const now = new Date().toISOString()
   const slotValue =
-    submissionDeclaredBy !== undefined
-      ? { at: now, by: changedBy, declaredBy: submissionDeclaredBy }
-      : { at: now, by: changedBy }
+    submissionDeclaredBy === undefined
+      ? { at: now, by: changedBy }
+      : { at: now, by: changedBy, declaredBy: submissionDeclaredBy }
 
   const doc = await reportsCollection(db).findOneAndUpdate(
     { id: reportId, version },

--- a/src/reports/repository/mongodb.js
+++ b/src/reports/repository/mongodb.js
@@ -187,10 +187,11 @@ const performUpdateReport = async (db, params) => {
  */
 const performUpdateReportStatus = async (db, params) => {
   const { slot, ...statusParams } = params
-  const { reportId, version, status, changedBy } =
+  const { reportId, version, status, changedBy, submissionDeclaredBy } =
     validateUpdateReportStatus(statusParams)
 
   const now = new Date().toISOString()
+  const slotValue = { at: now, by: changedBy }
 
   const doc = await reportsCollection(db).findOneAndUpdate(
     { id: reportId, version },
@@ -198,7 +199,8 @@ const performUpdateReportStatus = async (db, params) => {
       $set: {
         'status.currentStatus': status,
         'status.currentStatusAt': now,
-        [`status.${slot}`]: { at: now, by: changedBy }
+        [`status.${slot}`]: slotValue,
+        ...(submissionDeclaredBy !== undefined && { submissionDeclaredBy })
       },
       $push: /** @type {any} */ ({
         'status.history': { status, at: now, by: changedBy }

--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -19,12 +19,16 @@
  */
 
 /**
+ * @typedef {ReportOperation & { declaredBy?: string }} ReportSubmittedSlot
+ */
+
+/**
  * @typedef {Object} ReportStatusObject
  * @property {ReportStatus} currentStatus
  * @property {string} currentStatusAt - ISO timestamp
  * @property {ReportOperation} created
  * @property {ReportOperation} [ready]
- * @property {ReportOperation} [submitted]
+ * @property {ReportSubmittedSlot} [submitted]
  * @property {ReportOperation} [unsubmitted]
  * @property {ReportStatusHistoryItem[]} history
  */
@@ -129,7 +133,6 @@
  * @property {string} [supportingInformation]
  * @property {SourceData} [sourceData]
  * @property {ReportStale} [stale]
- * @property {string} [submissionDeclaredBy]
  */
 
 /**
@@ -220,7 +223,7 @@
  * @property {ReportStatus} status
  * @property {string} slot - the status object key to record this transition (e.g. 'ready', 'submitted', 'unsubmitted')
  * @property {UserSummary} [changedBy]
- * @property {string} [submissionDeclaredBy] - full name typed by the user on the declaration form; required for SUBMITTED transitions
+ * @property {string} [submissionDeclaredBy] - full name typed by the user on the declaration form; stored in status.submitted.declaredBy
  */
 
 /**

--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -129,6 +129,7 @@
  * @property {string} [supportingInformation]
  * @property {SourceData} [sourceData]
  * @property {ReportStale} [stale]
+ * @property {string} [submissionDeclaredBy]
  */
 
 /**
@@ -219,6 +220,7 @@
  * @property {ReportStatus} status
  * @property {string} slot - the status object key to record this transition (e.g. 'ready', 'submitted', 'unsubmitted')
  * @property {UserSummary} [changedBy]
+ * @property {string} [submissionDeclaredBy] - full name typed by the user on the declaration form; required for SUBMITTED transitions
  */
 
 /**

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -203,7 +203,12 @@ export const updateReportStatusSchema = Joi.object({
   status: Joi.string()
     .valid(...Object.values(REPORT_STATUS))
     .required(),
-  changedBy: userSummarySchema.required()
+  changedBy: userSummarySchema.required(),
+  submissionDeclaredBy: Joi.string().when('status', {
+    is: REPORT_STATUS.SUBMITTED,
+    then: Joi.required(),
+    otherwise: Joi.forbidden()
+  })
 })
 
 export const findPeriodicReportsSchema = Joi.object({

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -204,9 +204,9 @@ export const updateReportStatusSchema = Joi.object({
     .valid(...Object.values(REPORT_STATUS))
     .required(),
   changedBy: userSummarySchema.required(),
-  submissionDeclaredBy: Joi.string().when('status', {
+  submissionDeclaredBy: Joi.string().min(2).when('status', {
     is: REPORT_STATUS.SUBMITTED,
-    then: Joi.required(),
+    then: Joi.optional(),
     otherwise: Joi.forbidden()
   })
 })

--- a/src/reports/routes/delete.test.js
+++ b/src/reports/routes/delete.test.js
@@ -220,7 +220,8 @@ describe(`DELETE ${reportsDeletePath}`, () => {
           version: 2,
           status: 'submitted',
           slot: REPORT_STATUS_SLOT.SUBMITTED,
-          changedBy: { id: 'test', name: 'Test', position: 'Officer' }
+          changedBy: { id: 'test', name: 'Test', position: 'Officer' },
+          submissionDeclaredBy: 'Test User'
         })
 
         const response = await deleteReport(

--- a/src/reports/routes/patch.test.js
+++ b/src/reports/routes/patch.test.js
@@ -797,7 +797,8 @@ describe(`PATCH ${reportsPatchPath}`, () => {
         version: 2,
         status: 'submitted',
         slot: REPORT_STATUS_SLOT.SUBMITTED,
-        changedBy: { id: 'test', name: 'Test', position: 'Officer' }
+        changedBy: { id: 'test', name: 'Test', position: 'Officer' },
+        submissionDeclaredBy: 'Test User'
       })
 
       const response = await patchReport(

--- a/src/reports/routes/status.js
+++ b/src/reports/routes/status.js
@@ -18,6 +18,10 @@ import {
 export const reportsStatusPath =
   '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}/submissions/{submissionNumber}/status'
 
+const MIN_DECLARED_BY_LENGTH = 2
+const MAX_DECLARED_BY_LENGTH = 255
+const INVALID_DECLARED_BY_CHARS = /[@#$%&<>]/
+
 const payloadSchema = Joi.object({
   status: Joi.string()
     .valid(
@@ -27,11 +31,15 @@ const payloadSchema = Joi.object({
     )
     .required(),
   version: Joi.number().integer().min(1).required(),
-  submissionDeclaredBy: Joi.string().when('status', {
-    is: REPORT_STATUS.SUBMITTED,
-    then: Joi.required(),
-    otherwise: Joi.forbidden()
-  })
+  submissionDeclaredBy: Joi.string()
+    .min(MIN_DECLARED_BY_LENGTH)
+    .max(MAX_DECLARED_BY_LENGTH)
+    .pattern(INVALID_DECLARED_BY_CHARS, { invert: true })
+    .when('status', {
+      is: REPORT_STATUS.SUBMITTED,
+      then: Joi.optional(),
+      otherwise: Joi.forbidden()
+    })
 })
 
 export const reportsStatus = {

--- a/src/reports/routes/status.js
+++ b/src/reports/routes/status.js
@@ -26,7 +26,12 @@ const payloadSchema = Joi.object({
       REPORT_STATUS.SUBMITTED
     )
     .required(),
-  version: Joi.number().integer().min(1).required()
+  version: Joi.number().integer().min(1).required(),
+  submissionDeclaredBy: Joi.string().when('status', {
+    is: REPORT_STATUS.SUBMITTED,
+    then: Joi.required(),
+    otherwise: Joi.forbidden()
+  })
 })
 
 export const reportsStatus = {
@@ -41,7 +46,7 @@ export const reportsStatus = {
     }
   },
   /**
-   * @param {HapiRequest<{ status: ReportStatus, version: number }> & { reportsRepository: ReportsRepository, systemLogsRepository: SystemLogsRepository }} request
+   * @param {HapiRequest<{ status: ReportStatus, version: number, submissionDeclaredBy?: string }> & { reportsRepository: ReportsRepository, systemLogsRepository: SystemLogsRepository }} request
    * @param {HapiResponseToolkit} h
    */
   handler: async (request, h) => {
@@ -50,7 +55,7 @@ export const reportsStatus = {
     const year = Number(params.year)
     const period = Number(params.period)
     const submissionNumber = Number(params.submissionNumber)
-    const { status, version } = request.payload
+    const { status, version, submissionDeclaredBy } = request.payload
 
     const [registration, report] = await Promise.all([
       organisationsRepository.findRegistrationById(
@@ -89,7 +94,8 @@ export const reportsStatus = {
       version,
       status,
       slot: STATUS_TO_SLOT[status],
-      changedBy: extractChangedBy(request.auth.credentials)
+      changedBy: extractChangedBy(request.auth.credentials),
+      ...(submissionDeclaredBy !== undefined && { submissionDeclaredBy })
     })
 
     await auditReportStatusTransition(request, {

--- a/src/reports/routes/status.test.js
+++ b/src/reports/routes/status.test.js
@@ -223,7 +223,7 @@ describe(`POST ${reportsStatusPath}`, () => {
         expect(JSON.parse(response.payload)).toEqual({ status: 'submitted' })
 
         const updatedReport = await reportsRepository.findReportById(reportId)
-        expect(updatedReport.status.submitted.declaredBy).toBe('Jane Smith')
+        expect(updatedReport.status.submitted?.declaredBy).toBe('Jane Smith')
       })
     })
 

--- a/src/reports/routes/status.test.js
+++ b/src/reports/routes/status.test.js
@@ -187,6 +187,44 @@ describe(`POST ${reportsStatusPath}`, () => {
           status: 'ready_to_submit'
         })
       })
+
+      it('advances status to submitted with submissionDeclaredBy stored', async () => {
+        const {
+          server,
+          organisationId,
+          registrationId,
+          reportsRepository,
+          reportId
+        } = await createServerWithReport({
+          wasteProcessingType: 'reprocessor',
+          accreditationId: undefined
+        })
+
+        await reportsRepository.updateReportStatus({
+          reportId,
+          version: 1,
+          status: 'ready_to_submit',
+          slot: REPORT_STATUS_SLOT.READY,
+          changedBy: { id: 'test', name: 'Test', position: 'Officer' }
+        })
+
+        const response = await postStatus(
+          server,
+          organisationId,
+          registrationId,
+          {
+            status: 'submitted',
+            version: 2,
+            submissionDeclaredBy: 'Jane Smith'
+          }
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(JSON.parse(response.payload)).toEqual({ status: 'submitted' })
+
+        const updatedReport = await reportsRepository.findReportById(reportId)
+        expect(updatedReport.submissionDeclaredBy).toBe('Jane Smith')
+      })
     })
 
     describe('auditing', () => {
@@ -411,7 +449,11 @@ describe(`POST ${reportsStatusPath}`, () => {
           server,
           organisationId,
           registrationId,
-          { status: 'submitted', version: 1 }
+          {
+            status: 'submitted',
+            version: 1,
+            submissionDeclaredBy: 'Jane Smith'
+          }
         )
 
         expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
@@ -441,7 +483,8 @@ describe(`POST ${reportsStatusPath}`, () => {
           version: 2,
           status: 'submitted',
           slot: REPORT_STATUS_SLOT.SUBMITTED,
-          changedBy: { id: 'test', name: 'Test', position: 'Officer' }
+          changedBy: { id: 'test', name: 'Test', position: 'Officer' },
+          submissionDeclaredBy: 'Test User'
         })
 
         const response = await postStatus(
@@ -519,6 +562,44 @@ describe(`POST ${reportsStatusPath}`, () => {
           organisationId,
           registrationId,
           {}
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      })
+
+      it('returns 422 when submissionDeclaredBy is missing for submitted transition', async () => {
+        const { server, organisationId, registrationId } =
+          await createServerWithReport({
+            wasteProcessingType: 'reprocessor',
+            accreditationId: undefined
+          })
+
+        const response = await postStatus(
+          server,
+          organisationId,
+          registrationId,
+          { status: 'submitted', version: 1 }
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      })
+
+      it('returns 422 when submissionDeclaredBy is provided for non-submitted transition', async () => {
+        const { server, organisationId, registrationId } =
+          await createServerWithReport({
+            wasteProcessingType: 'reprocessor',
+            accreditationId: undefined
+          })
+
+        const response = await postStatus(
+          server,
+          organisationId,
+          registrationId,
+          {
+            status: 'ready_to_submit',
+            version: 1,
+            submissionDeclaredBy: 'Jane Smith'
+          }
         )
 
         expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)

--- a/src/reports/routes/status.test.js
+++ b/src/reports/routes/status.test.js
@@ -223,7 +223,7 @@ describe(`POST ${reportsStatusPath}`, () => {
         expect(JSON.parse(response.payload)).toEqual({ status: 'submitted' })
 
         const updatedReport = await reportsRepository.findReportById(reportId)
-        expect(updatedReport.submissionDeclaredBy).toBe('Jane Smith')
+        expect(updatedReport.status.submitted.declaredBy).toBe('Jane Smith')
       })
     })
 
@@ -567,7 +567,7 @@ describe(`POST ${reportsStatusPath}`, () => {
         expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
       })
 
-      it('returns 422 when submissionDeclaredBy is missing for submitted transition', async () => {
+      it('returns 422 when submissionDeclaredBy is a single character', async () => {
         const { server, organisationId, registrationId } =
           await createServerWithReport({
             wasteProcessingType: 'reprocessor',
@@ -578,11 +578,56 @@ describe(`POST ${reportsStatusPath}`, () => {
           server,
           organisationId,
           registrationId,
-          { status: 'submitted', version: 1 }
+          { status: 'submitted', version: 1, submissionDeclaredBy: 'A' }
         )
 
         expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
       })
+
+      it('returns 422 when submissionDeclaredBy exceeds 255 characters', async () => {
+        const { server, organisationId, registrationId } =
+          await createServerWithReport({
+            wasteProcessingType: 'reprocessor',
+            accreditationId: undefined
+          })
+
+        const response = await postStatus(
+          server,
+          organisationId,
+          registrationId,
+          {
+            status: 'submitted',
+            version: 1,
+            submissionDeclaredBy: 'A'.repeat(256)
+          }
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      })
+
+      it.each(['@', '#', '$', '%', '&', '<', '>'])(
+        'returns 422 when submissionDeclaredBy contains invalid character %s',
+        async (char) => {
+          const { server, organisationId, registrationId } =
+            await createServerWithReport({
+              wasteProcessingType: 'reprocessor',
+              accreditationId: undefined
+            })
+
+          const response = await postStatus(
+            server,
+            organisationId,
+            registrationId,
+            {
+              status: 'submitted',
+              version: 1,
+              submissionDeclaredBy: `Jane ${char} Smith`
+            }
+          )
+
+          expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+        }
+      )
 
       it('returns 422 when submissionDeclaredBy is provided for non-submitted transition', async () => {
         const { server, organisationId, registrationId } =


### PR DESCRIPTION
Ticket: [PAE-1476](https://eaflood.atlassian.net/browse/PAE-1476)
## Summary

- Adds `submissionDeclaredBy` field to the `updateReportStatus` repository method — required when transitioning to SUBMITTED, forbidden otherwise (via `Joi.when()`)
- Validates the field in both the route payload schema (`status.js`) and repository schema (`schema.js`): min 2 chars, max 255 chars, no `@#$%&<>` characters
- Stores `submissionDeclaredBy` on the `status.submitted` MongoDB slot alongside `at` and `by`
- Adds unit tests for all validation cases and updates existing SUBMITTED transition tests

[PAE-1476]: https://eaflood.atlassian.net/browse/PAE-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ