### PR TITLE
PAE-1476: Make submissionDeclaredBy mandatory for submitted status

### DIFF
--- a/src/reports/repository/contract/updateReportStatus.contract.js
+++ b/src/reports/repository/contract/updateReportStatus.contract.js
@@ -204,6 +204,30 @@ export const testUpdateReportStatusBehaviour = (it) => {
       ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 409 } })
     })
 
+    it('throws bad request when submissionDeclaredBy is missing for submitted status', async () => {
+      const { id: reportId } = await repository.createReport(
+        buildCreateReportParams()
+      )
+
+      await repository.updateReportStatus({
+        reportId,
+        version: 1,
+        status: REPORT_STATUS.READY_TO_SUBMIT,
+        slot: REPORT_STATUS_SLOT.READY,
+        changedBy
+      })
+
+      await expect(
+        repository.updateReportStatus({
+          reportId,
+          version: 2,
+          status: REPORT_STATUS.SUBMITTED,
+          slot: REPORT_STATUS_SLOT.SUBMITTED,
+          changedBy
+        })
+      ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 400 } })
+    })
+
     it('throws error on invalid status', async () => {
       const { id: reportId } = await repository.createReport(
         buildCreateReportParams()

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -206,7 +206,7 @@ export const updateReportStatusSchema = Joi.object({
   changedBy: userSummarySchema.required(),
   submissionDeclaredBy: Joi.string().min(2).when('status', {
     is: REPORT_STATUS.SUBMITTED,
-    then: Joi.optional(),
+    then: Joi.required(),
     otherwise: Joi.forbidden()
   })
 })

--- a/src/reports/routes/status.js
+++ b/src/reports/routes/status.js
@@ -37,7 +37,7 @@ const payloadSchema = Joi.object({
     .pattern(INVALID_DECLARED_BY_CHARS, { invert: true })
     .when('status', {
       is: REPORT_STATUS.SUBMITTED,
-      then: Joi.optional(),
+      then: Joi.required(),
       otherwise: Joi.forbidden()
     })
 })

--- a/src/reports/routes/status.test.js
+++ b/src/reports/routes/status.test.js
@@ -567,6 +567,23 @@ describe(`POST ${reportsStatusPath}`, () => {
         expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
       })
 
+      it('returns 422 when submissionDeclaredBy is missing for submitted status', async () => {
+        const { server, organisationId, registrationId } =
+          await createServerWithReport({
+            wasteProcessingType: 'reprocessor',
+            accreditationId: undefined
+          })
+
+        const response = await postStatus(
+          server,
+          organisationId,
+          registrationId,
+          { status: 'submitted', version: 1 }
+        )
+
+        expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      })
+
       it('returns 422 when submissionDeclaredBy is a single character', async () => {
         const { server, organisationId, registrationId } =
           await createServerWithReport({


### PR DESCRIPTION
Ticket: [PAE-1476](https://eaflood.atlassian.net/browse/PAE-1476)
- Change `Joi.optional()` to `Joi.required()` for `submissionDeclaredBy` when status is `SUBMITTED` in route payload schema and repository schema
- Add test asserting 422 when `submissionDeclaredBy` is omitted on a submitted transition

[PAE-1476]: https://eaflood.atlassian.net/browse/PAE-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ