### PR TITLE
PAE-1632: surface status-transition reason in system log; drop write-only updatedBy

### DIFF
--- a/src/auditing/organisations.js
+++ b/src/auditing/organisations.js
@@ -63,8 +63,7 @@ async function auditStatusTransition(request, details) {
       subCategory: 'epr-organisations',
       action: 'status-transition'
     },
-    reason,
-    context: { organisationId, target, previousStatus, nextStatus },
+    context: { organisationId, target, previousStatus, nextStatus, reason },
     user: extractUserDetails(request)
   }
 

--- a/src/auditing/organisations.test.js
+++ b/src/auditing/organisations.test.js
@@ -142,7 +142,8 @@ describe('auditStatusTransition', () => {
     organisationId,
     target,
     previousStatus: 'created',
-    nextStatus: 'approved'
+    nextStatus: 'approved',
+    reason: 'Docs verified'
   }
 
   it('records the reason and before/after status in both the audit and the stored system log', async () => {
@@ -157,7 +158,6 @@ describe('auditStatusTransition', () => {
     expect(mockAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         event: expectedEvent,
-        reason: 'Docs verified',
         context: expectedContext
       })
     )
@@ -168,7 +168,6 @@ describe('auditStatusTransition', () => {
     })
     expect(systemLogs).toHaveLength(1)
     expect(systemLogs[0].event).toEqual(expectedEvent)
-    expect(systemLogs[0].reason).toBe('Docs verified')
     expect(systemLogs[0].context).toEqual(expectedContext)
     expect(systemLogs[0].createdBy).toEqual({
       id: 'admin-user-1',

--- a/src/domain/organisations/model.js
+++ b/src/domain/organisations/model.js
@@ -233,7 +233,6 @@ export const USER_ROLES = Object.freeze({
  * @typedef {{
  *   status: RegAccStatus;
  *   updatedAt: Date;
- *   updatedBy?: string;
  * }} StatusHistoryItem
  */
 

--- a/src/repositories/organisations/contract/append-status-history.contract.js
+++ b/src/repositories/organisations/contract/append-status-history.contract.js
@@ -89,8 +89,7 @@ export const appendStatusHistoryContract = (it) => {
           id,
           version,
           { type: 'organisation' },
-          ORGANISATION_STATUS.APPROVED,
-          'admin-user-1'
+          ORGANISATION_STATUS.APPROVED
         )
 
       expect(previousStatus).toBe(ORGANISATION_STATUS.CREATED)
@@ -99,7 +98,6 @@ export const appendStatusHistoryContract = (it) => {
 
       const lastEntry = updated.statusHistory.at(-1)
       expect(lastEntry.status).toBe(ORGANISATION_STATUS.APPROVED)
-      expect(lastEntry.updatedBy).toBe('admin-user-1')
     })
 
     it('throws conflict (409) on a stale version', async () => {
@@ -110,8 +108,7 @@ export const appendStatusHistoryContract = (it) => {
           id,
           1,
           { type: 'organisation' },
-          ORGANISATION_STATUS.APPROVED,
-          'admin-user-1'
+          ORGANISATION_STATUS.APPROVED
         )
       ).rejects.toMatchObject({
         isBoom: true,
@@ -129,8 +126,7 @@ export const appendStatusHistoryContract = (it) => {
           inserted.id,
           inserted.version,
           { type: 'organisation' },
-          ORGANISATION_STATUS.ACTIVE,
-          'admin-user-1'
+          ORGANISATION_STATUS.ACTIVE
         )
       ).rejects.toMatchObject({
         isBoom: true,
@@ -148,15 +144,13 @@ export const appendStatusHistoryContract = (it) => {
         inserted.id,
         inserted.version,
         { type: 'registration', registrationId },
-        REG_ACC_STATUS.APPROVED,
-        'admin-user-2'
+        REG_ACC_STATUS.APPROVED
       )
 
       const registration = updated.registrations.find(
         (r) => r.id === registrationId
       )
       expect(registration.status).toBe(REG_ACC_STATUS.APPROVED)
-      expect(registration.statusHistory.at(-1).updatedBy).toBe('admin-user-2')
       expect(updated.version).toBe(inserted.version + 1)
     })
 
@@ -168,8 +162,7 @@ export const appendStatusHistoryContract = (it) => {
         id,
         version,
         { type: 'registration', registrationId },
-        REG_ACC_STATUS.SUSPENDED,
-        'admin-user-3'
+        REG_ACC_STATUS.SUSPENDED
       )
 
       const registration = updated.registrations.find(
@@ -181,7 +174,6 @@ export const appendStatusHistoryContract = (it) => {
 
       expect(registration.status).toBe(REG_ACC_STATUS.SUSPENDED)
       expect(accreditation.status).toBe(REG_ACC_STATUS.SUSPENDED)
-      expect(accreditation.statusHistory.at(-1).updatedBy).toBe('admin-user-3')
     })
 
     it('throws notFound (404) for an unknown organisation id', async () => {
@@ -190,8 +182,7 @@ export const appendStatusHistoryContract = (it) => {
           new ObjectId().toString(),
           1,
           { type: 'organisation' },
-          ORGANISATION_STATUS.APPROVED,
-          'admin-user-1'
+          ORGANISATION_STATUS.APPROVED
         )
       ).rejects.toMatchObject({
         isBoom: true,
@@ -209,8 +200,7 @@ export const appendStatusHistoryContract = (it) => {
           inserted.id,
           inserted.version,
           { type: 'registration', registrationId: new ObjectId().toString() },
-          REG_ACC_STATUS.APPROVED,
-          'admin-user-1'
+          REG_ACC_STATUS.APPROVED
         )
       ).rejects.toMatchObject({
         isBoom: true,

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -21,13 +21,11 @@ import { getCurrentStatus } from './status.js'
  * Creates a status history entry for an organisation, registration, or accreditation.
  *
  * @param {string} status - The status value to record
- * @param {string} [updatedBy] - Optional user identifier who triggered the status change
- * @returns {{ status: string, updatedAt: Date, updatedBy?: string }}
+ * @returns {{ status: string, updatedAt: Date }}
  */
-export const createStatusHistoryEntry = (status, updatedBy) => ({
+export const createStatusHistoryEntry = (status) => ({
   status,
-  updatedAt: new Date(),
-  ...(updatedBy ? { updatedBy } : {})
+  updatedAt: new Date()
 })
 
 export const createInitialStatusHistory = () => {

--- a/src/repositories/organisations/helpers.test.js
+++ b/src/repositories/organisations/helpers.test.js
@@ -5,19 +5,11 @@ import {
 } from './helpers.js'
 
 describe('createStatusHistoryEntry', () => {
-  it('sets status and updatedAt and omits updatedBy when no user given', () => {
+  it('sets status and updatedAt with no other fields', () => {
     const entry = createStatusHistoryEntry('approved')
-    expect(entry.status).toBe('approved')
-    expect(entry.updatedAt).toBeInstanceOf(Date)
-    expect('updatedBy' in entry).toBe(false)
-  })
-
-  it('includes updatedBy when a user id is given', () => {
-    const entry = createStatusHistoryEntry('approved', 'user-123')
     expect(entry).toEqual({
       status: 'approved',
-      updatedAt: expect.any(Date),
-      updatedBy: 'user-123'
+      updatedAt: expect.any(Date)
     })
   })
 })

--- a/src/repositories/organisations/inmemory.js
+++ b/src/repositories/organisations/inmemory.js
@@ -126,7 +126,7 @@ const applyChangesToStored = (stored, changes) => {
 
 const performAppendStatusHistory =
   (storage, staleCache, pendingSyncRef, findById) =>
-  async (id, version, target, toStatus, updatedBy) => {
+  async (id, version, target, toStatus) => {
     const validatedId = validateId(id)
 
     const existingIndex = storage.findIndex((o) => o._id === validatedId)
@@ -146,8 +146,7 @@ const performAppendStatusHistory =
     const { changes, previousStatus } = prepareStatusHistoryAppend(
       derived,
       target,
-      toStatus,
-      updatedBy
+      toStatus
     )
 
     const updated = applyChangesToStored(existing, changes)

--- a/src/repositories/organisations/mongodb.js
+++ b/src/repositories/organisations/mongodb.js
@@ -169,7 +169,7 @@ const buildPushSpec = (changes) => {
 }
 
 const performAppendStatusHistory =
-  (db, findById) => async (id, version, target, toStatus, updatedBy) => {
+  (db, findById) => async (id, version, target, toStatus) => {
     const validatedId = validateId(id)
 
     const existing = await db
@@ -183,8 +183,7 @@ const performAppendStatusHistory =
     const { changes, previousStatus } = prepareStatusHistoryAppend(
       derived,
       target,
-      toStatus,
-      updatedBy
+      toStatus
     )
 
     const { push, arrayFilters } = buildPushSpec(changes)

--- a/src/repositories/organisations/port.js
+++ b/src/repositories/organisations/port.js
@@ -67,7 +67,7 @@
  * @typedef {Object} StatusHistoryChange
  * @property {'organisation'|'registration'|'accreditation'} itemType
  * @property {string} [id]
- * @property {{status: string, updatedAt: Date, updatedBy?: string}} entry
+ * @property {{status: string, updatedAt: Date}} entry
  */
 
 /**
@@ -96,7 +96,7 @@
  * @property {(orgId: number) => Promise<Organisation|null>} findByOrgId - Find organisation by business orgId
  * @property {(id: string, version: number, registrationId: string, entries: Record<string, {overseasSiteId: string}>) => Promise<boolean>} replaceRegistrationOverseasSites - Replace a registration's overseasSites map with the given entries
  * @property {(version: number) => Promise<Organisation[]>} findAllBySchemaVersion - Find all organisations with a given schemaVersion
- * @property {(id: string, version: number, target: StatusTransitionTarget, toStatus: string, updatedBy: string) => Promise<{ organisation: Organisation, previousStatus: string }>} appendStatusHistory - Append a status transition to the target item under whole-org version CAS; returns the updated organisation and the targeted item's status before the change. Throws Boom.conflict (409) on version mismatch.
+ * @property {(id: string, version: number, target: StatusTransitionTarget, toStatus: string) => Promise<{ organisation: Organisation, previousStatus: string }>} appendStatusHistory - Append a status transition to the target item under whole-org version CAS; returns the updated organisation and the targeted item's status before the change. Throws Boom.conflict (409) on version mismatch.
  */
 
 /**

--- a/src/repositories/organisations/schema/base.js
+++ b/src/repositories/organisations/schema/base.js
@@ -76,8 +76,7 @@ export const statusHistoryItemSchema = Joi.object({
       REG_ACC_STATUS.SUSPENDED
     )
     .required(),
-  updatedAt: Joi.date().iso().required(),
-  updatedBy: idSchema.optional()
+  updatedAt: Joi.date().iso().required()
 })
 
 export const companyDetailsSchema = Joi.object({

--- a/src/repositories/organisations/schema/validation.test.js
+++ b/src/repositories/organisations/schema/validation.test.js
@@ -35,12 +35,11 @@ describe('validateStatusHistory', () => {
     )
   })
 
-  it('validates statusHistory with optional updatedBy field', () => {
+  it('validates a statusHistory entry with status and updatedAt', () => {
     const statusHistory = [
       {
         status: REG_ACC_STATUS.CREATED,
-        updatedAt: new Date(),
-        updatedBy: new ObjectId().toString()
+        updatedAt: new Date()
       }
     ]
 

--- a/src/repositories/organisations/status-history.js
+++ b/src/repositories/organisations/status-history.js
@@ -26,37 +26,25 @@ import { createStatusHistoryEntry } from './helpers.js'
  *   organisation in derived-status shape (items carry `.status`)
  * @param {StatusTransitionTarget} target
  * @param {string} toStatus
- * @param {string} updatedBy authenticated user id
  * @returns {import('./port.js').StatusHistoryAppendResult}
  */
-export const prepareStatusHistoryAppend = (
-  existing,
-  target,
-  toStatus,
-  updatedBy
-) => {
+export const prepareStatusHistoryAppend = (existing, target, toStatus) => {
   if (target.type === 'organisation') {
-    return prepareOrganisation(existing, toStatus, updatedBy)
+    return prepareOrganisation(existing, toStatus)
   }
   if (target.type === 'registration') {
-    return prepareRegistration(
-      existing,
-      target.registrationId,
-      toStatus,
-      updatedBy
-    )
+    return prepareRegistration(existing, target.registrationId, toStatus)
   }
   return prepareAccreditation(
     existing,
     target.registrationId,
     target.accreditationId,
-    toStatus,
-    updatedBy
+    toStatus
   )
 }
 
 /** @returns {import('./port.js').StatusHistoryAppendResult} */
-const prepareOrganisation = (existing, toStatus, updatedBy) => {
+const prepareOrganisation = (existing, toStatus) => {
   if (toStatus === ORGANISATION_STATUS.ACTIVE) {
     throw Boom.badData(
       'Cannot transition organisation to active: activation is owned by the Defra ID link flow'
@@ -74,14 +62,14 @@ const prepareOrganisation = (existing, toStatus, updatedBy) => {
     changes: [
       {
         itemType: 'organisation',
-        entry: createStatusHistoryEntry(toStatus, updatedBy)
+        entry: createStatusHistoryEntry(toStatus)
       }
     ]
   }
 }
 
 /** @returns {import('./port.js').StatusHistoryAppendResult} */
-const prepareRegistration = (existing, registrationId, toStatus, updatedBy) => {
+const prepareRegistration = (existing, registrationId, toStatus) => {
   const registration = existing.registrations.find(
     (r) => r.id === registrationId
   )
@@ -106,7 +94,7 @@ const prepareRegistration = (existing, registrationId, toStatus, updatedBy) => {
     {
       itemType: 'registration',
       id: registrationId,
-      entry: createStatusHistoryEntry(toStatus, updatedBy)
+      entry: createStatusHistoryEntry(toStatus)
     }
   ]
 
@@ -121,7 +109,7 @@ const prepareRegistration = (existing, registrationId, toStatus, updatedBy) => {
       changes.push({
         itemType: 'accreditation',
         id: accreditation.id,
-        entry: createStatusHistoryEntry(accreditation.status, updatedBy)
+        entry: createStatusHistoryEntry(accreditation.status)
       })
     }
   }
@@ -134,8 +122,7 @@ const prepareAccreditation = (
   existing,
   registrationId,
   accreditationId,
-  toStatus,
-  updatedBy
+  toStatus
 ) => {
   const registration = existing.registrations.find(
     (r) => r.id === registrationId
@@ -173,7 +160,7 @@ const prepareAccreditation = (
       {
         itemType: 'accreditation',
         id: accreditationId,
-        entry: createStatusHistoryEntry(toStatus, updatedBy)
+        entry: createStatusHistoryEntry(toStatus)
       }
     ]
   }

--- a/src/repositories/organisations/status-history.test.js
+++ b/src/repositories/organisations/status-history.test.js
@@ -47,7 +47,7 @@ const acc = (overrides = {}) => ({
 })
 
 describe('prepareStatusHistoryAppend', () => {
-  it('appends an organisation status entry with updatedBy', () => {
+  it('appends an organisation status entry', () => {
     const org = orgWith({
       status: 'created',
       registrations: [reg({ status: 'approved' })]
@@ -55,8 +55,7 @@ describe('prepareStatusHistoryAppend', () => {
     const result = prepareStatusHistoryAppend(
       org,
       { type: 'organisation' },
-      'approved',
-      'user-9'
+      'approved'
     )
     expect(result.previousStatus).toBe('created')
     expect(result.changes).toEqual([
@@ -64,8 +63,7 @@ describe('prepareStatusHistoryAppend', () => {
         itemType: 'organisation',
         entry: {
           status: 'approved',
-          updatedAt: expect.any(Date),
-          updatedBy: 'user-9'
+          updatedAt: expect.any(Date)
         }
       }
     ])
@@ -74,7 +72,7 @@ describe('prepareStatusHistoryAppend', () => {
   it('rejects organisation transition to active (link-flow owned)', () => {
     const org = orgWith({ status: 'approved', registrations: [reg()] })
     expect(() =>
-      prepareStatusHistoryAppend(org, { type: 'organisation' }, 'active', 'u')
+      prepareStatusHistoryAppend(org, { type: 'organisation' }, 'active')
     ).toThrow(/active/i)
   })
 
@@ -84,14 +82,14 @@ describe('prepareStatusHistoryAppend', () => {
       registrations: [reg({ status: 'created' })]
     })
     expect(() =>
-      prepareStatusHistoryAppend(org, { type: 'organisation' }, 'approved', 'u')
+      prepareStatusHistoryAppend(org, { type: 'organisation' }, 'approved')
     ).toThrow(/at least one approved registration/i)
   })
 
   it('rejects an invalid organisation transition with 422', () => {
     const org = orgWith({ status: 'approved', registrations: [reg()] })
     expect(() =>
-      prepareStatusHistoryAppend(org, { type: 'organisation' }, 'rejected', 'u')
+      prepareStatusHistoryAppend(org, { type: 'organisation' }, 'rejected')
     ).toThrow(/Cannot transition organisation status/i)
   })
 
@@ -102,8 +100,7 @@ describe('prepareStatusHistoryAppend', () => {
     const result = prepareStatusHistoryAppend(
       org,
       { type: 'registration', registrationId: 'reg-1' },
-      'approved',
-      'user-9'
+      'approved'
     )
     expect(result.changes).toEqual([
       {
@@ -111,8 +108,7 @@ describe('prepareStatusHistoryAppend', () => {
         id: 'reg-1',
         entry: {
           status: 'approved',
-          updatedAt: expect.any(Date),
-          updatedBy: 'user-9'
+          updatedAt: expect.any(Date)
         }
       }
     ])
@@ -128,16 +124,14 @@ describe('prepareStatusHistoryAppend', () => {
     const result = prepareStatusHistoryAppend(
       org,
       { type: 'registration', registrationId: 'reg-1' },
-      'suspended',
-      'user-9'
+      'suspended'
     )
     expect(result.changes).toContainEqual({
       itemType: 'registration',
       id: 'reg-1',
       entry: {
         status: 'suspended',
-        updatedAt: expect.any(Date),
-        updatedBy: 'user-9'
+        updatedAt: expect.any(Date)
       }
     })
     expect(result.changes).toContainEqual({
@@ -145,8 +139,7 @@ describe('prepareStatusHistoryAppend', () => {
       id: 'acc-1',
       entry: {
         status: 'suspended',
-        updatedAt: expect.any(Date),
-        updatedBy: 'user-9'
+        updatedAt: expect.any(Date)
       }
     })
   })
@@ -161,16 +154,14 @@ describe('prepareStatusHistoryAppend', () => {
     const result = prepareStatusHistoryAppend(
       org,
       { type: 'registration', registrationId: 'reg-1' },
-      'cancelled',
-      'user-9'
+      'cancelled'
     )
     expect(result.changes).toContainEqual({
       itemType: 'registration',
       id: 'reg-1',
       entry: {
         status: 'cancelled',
-        updatedAt: expect.any(Date),
-        updatedBy: 'user-9'
+        updatedAt: expect.any(Date)
       }
     })
     expect(result.changes).toContainEqual({
@@ -178,8 +169,7 @@ describe('prepareStatusHistoryAppend', () => {
       id: 'acc-1',
       entry: {
         status: 'cancelled',
-        updatedAt: expect.any(Date),
-        updatedBy: 'user-9'
+        updatedAt: expect.any(Date)
       }
     })
   })
@@ -191,8 +181,7 @@ describe('prepareStatusHistoryAppend', () => {
     const result = prepareStatusHistoryAppend(
       org,
       { type: 'registration', registrationId: 'reg-1' },
-      'approved',
-      'user-9'
+      'approved'
     )
     expect(result.previousStatus).toBe('cancelled')
     expect(result.changes).toEqual([
@@ -201,8 +190,7 @@ describe('prepareStatusHistoryAppend', () => {
         id: 'reg-1',
         entry: {
           status: 'approved',
-          updatedAt: expect.any(Date),
-          updatedBy: 'user-9'
+          updatedAt: expect.any(Date)
         }
       }
     ])
@@ -222,8 +210,7 @@ describe('prepareStatusHistoryAppend', () => {
         registrationId: 'reg-1',
         accreditationId: 'acc-1'
       },
-      'suspended',
-      'user-9'
+      'suspended'
     )
     expect(result.previousStatus).toBe('approved')
     expect(result.changes).toEqual([
@@ -232,8 +219,7 @@ describe('prepareStatusHistoryAppend', () => {
         id: 'acc-1',
         entry: {
           status: 'suspended',
-          updatedAt: expect.any(Date),
-          updatedBy: 'user-9'
+          updatedAt: expect.any(Date)
         }
       }
     ])
@@ -254,8 +240,7 @@ describe('prepareStatusHistoryAppend', () => {
           registrationId: 'nope',
           accreditationId: 'acc-1'
         },
-        'suspended',
-        'u'
+        'suspended'
       )
     ).toThrow(/registration nope not found/i)
   })
@@ -275,8 +260,7 @@ describe('prepareStatusHistoryAppend', () => {
           registrationId: 'reg-1',
           accreditationId: 'acc-2'
         },
-        'suspended',
-        'u'
+        'suspended'
       )
     ).toThrow(/not linked to registration/i)
   })
@@ -296,8 +280,7 @@ describe('prepareStatusHistoryAppend', () => {
           registrationId: 'reg-1',
           accreditationId: 'acc-1'
         },
-        'approved',
-        'u'
+        'approved'
       )
     ).toThrow(/not linked to an approved registration/i)
   })
@@ -308,8 +291,7 @@ describe('prepareStatusHistoryAppend', () => {
       prepareStatusHistoryAppend(
         org,
         { type: 'registration', registrationId: 'nope' },
-        'suspended',
-        'u'
+        'suspended'
       )
     ).toThrow(/not found/i)
   })
@@ -337,16 +319,14 @@ describe('prepareStatusHistoryAppend', () => {
     const result = prepareStatusHistoryAppend(
       org,
       { type: 'registration', registrationId: 'reg-1' },
-      'suspended',
-      'user-9'
+      'suspended'
     )
     expect(result.changes).toContainEqual({
       itemType: 'registration',
       id: 'reg-1',
       entry: {
         status: 'suspended',
-        updatedAt: expect.any(Date),
-        updatedBy: 'user-9'
+        updatedAt: expect.any(Date)
       }
     })
     expect(result.changes).toContainEqual({
@@ -354,8 +334,7 @@ describe('prepareStatusHistoryAppend', () => {
       id: 'acc-1',
       entry: {
         status: 'suspended',
-        updatedAt: expect.any(Date),
-        updatedBy: 'user-9'
+        updatedAt: expect.any(Date)
       }
     })
     expect(result.changes).toHaveLength(2)
@@ -388,8 +367,7 @@ describe('prepareStatusHistoryAppend', () => {
         registrationId: 'reg-1',
         accreditationId: 'acc-1'
       },
-      'suspended',
-      'user-9'
+      'suspended'
     )
     expect(result.changes).toEqual([
       {
@@ -397,8 +375,7 @@ describe('prepareStatusHistoryAppend', () => {
         id: 'acc-1',
         entry: {
           status: 'suspended',
-          updatedAt: expect.any(Date),
-          updatedBy: 'user-9'
+          updatedAt: expect.any(Date)
         }
       }
     ])

--- a/src/routes/v1/organisations/status-history.js
+++ b/src/routes/v1/organisations/status-history.js
@@ -99,15 +99,13 @@ const makeRoute = ({ type, path }) => {
       const organisationId = request.params.organisationId
       const { status, reason, version } = request.payload
       const target = targetFor(type, request)
-      const updatedBy = request.auth.credentials.id
 
       const { organisation, previousStatus } =
         await organisationsRepository.appendStatusHistory(
           organisationId,
           version,
           target,
-          status,
-          updatedBy
+          status
         )
 
       await auditStatusTransition(request, {

--- a/src/routes/v1/organisations/status-history.test.js
+++ b/src/routes/v1/organisations/status-history.test.js
@@ -123,7 +123,6 @@ describe('POST status-history routes', () => {
     const body = JSON.parse(response.payload)
     expect(body.status).toBe(ORGANISATION_STATUS.APPROVED)
     expect(body.version).toBe(org.version + 1)
-    expect(body.statusHistory.at(-1).updatedBy).toBe('test-user-id')
 
     const logs = await findSystemLog(org.id)
     expect(logs).toHaveLength(1)

--- a/src/routes/v1/organisations/status-history.test.js
+++ b/src/routes/v1/organisations/status-history.test.js
@@ -127,7 +127,7 @@ describe('POST status-history routes', () => {
 
     const logs = await findSystemLog(org.id)
     expect(logs).toHaveLength(1)
-    expect(logs[0].reason).toBe('Documents verified')
+    expect(logs[0].context.reason).toBe('Documents verified')
     expect(logs[0].event.action).toBe('status-transition')
     expect(logs[0].context.target).toEqual({ type: 'organisation' })
     expect(logs[0].context.previousStatus).toBe(ORGANISATION_STATUS.CREATED)


### PR DESCRIPTION
Ticket: [PAE-1632](https://eaflood.atlassian.net/browse/PAE-1632)
## Summary

- **Surfaces the status-transition `reason` in the system log.** `auditStatusTransition` wrote `reason` at the top level of the log payload, but the MongoDB system-logs read-model (`performFind`) only returns `event` / `context` / `createdAt` / `createdBy` — so the reason was stored but never read back (the in-memory adapter happened to return it via `...rest`, which is why tests didn't catch it). `reason` now lives inside `context`, so it is persisted, returned by `find`, and shown in the admin log's Context block — consistent with `auditOrganisationUpdate`, which keeps all contextual data in `context`.
- **Removes the write-only `updatedBy` from the organisation/registration/accreditation `statusHistory`.** Nothing read it; the actor is already captured (id + email + role) in the system log, and the `statusHistory` record is defined as "status-at-a-date, **not** an audit log".

## Changes

- `src/auditing/organisations.js` — `auditStatusTransition` puts `reason` inside `context`.
- `src/repositories/organisations/` — `createStatusHistoryEntry(status)` (drops the `updatedBy` arg); `prepareStatusHistoryAppend` and the `appendStatusHistory` port/adapters (mongodb + inmemory) drop the `updatedBy` parameter; `schema/base.js` status-history item schema drops `updatedBy`; port + domain typedefs updated.
- `src/routes/v1/organisations/status-history.js` — stops deriving/passing `updatedBy`.
- Tests updated across the above.

## Notes

- **Backward-compatible on read:** existing stored `statusHistory` entries that still carry `updatedBy` simply have it stripped on read (Joi `stripUnknown`) — no migration needed.
- The PRN subsystem (`src/packaging-recycling-notes/`) has its own separate `updatedBy` (an actor object) and is intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAE-1632]: https://eaflood.atlassian.net/browse/PAE-1632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ