### PR TITLE
PAE-1662: Add excluded from waste balance reason column to WB record export

### DIFF
--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -8,7 +8,7 @@ import {
   buildDataRow,
   buildDataFieldColumns
 } from '../domain/csv-columns.js'
-import { isIncludedInWasteBalance } from '../domain/is-included-in-waste-balance.js'
+import { getWasteBalanceClassification } from '../domain/is-included-in-waste-balance.js'
 import { buildOverseasSitesContext } from '../domain/overseas-sites-context.js'
 import { loadSummaryLogMap } from './load-summary-log-map.js'
 
@@ -88,18 +88,17 @@ const rowForRecord = ({
   // for a state that cannot occur.
   const lastVersion = /** @type {WasteRecordVersion} */ (record.versions.at(-1))
   const summaryLogEntry = summaryLogMap.get(lastVersion.summaryLog.id) ?? null
-  const includedInWasteBalance = isIncludedInWasteBalance(
-    record,
-    accreditation,
-    overseasSites
-  )
   return buildDataRow({
     org,
     registration,
     accreditation,
     record,
     summaryLogEntry,
-    includedInWasteBalance,
+    wasteBalanceClassification: getWasteBalanceClassification(
+      record,
+      accreditation,
+      overseasSites
+    ),
     dataFieldColumns
   })
 }

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -448,6 +448,42 @@ describe('streamCsvExport', () => {
     const cells = out[1].trim().split(',')
     expect(cells[5]).toBe('Yes') // Accredited column
     expect(cells[9]).toBe('false')
+    expect(cells[10]).toContain('OUTSIDE_ACCREDITATION_PERIOD')
+  })
+
+  it('emits empty Waste Balance Exclusion Reason when the record is included', async () => {
+    const org = baseOrg({
+      accreditations: [exporterAccreditation],
+      registrations: [
+        baseRegistration({
+          accreditation: null,
+          accreditationId: 'acc-1',
+          overseasSites: { '001': { overseasSiteId: 'site-a' } }
+        })
+      ]
+    })
+    const deps = baseDeps({
+      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
+      wasteRecordsRepository: {
+        findByRegistration: vi
+          .fn()
+          .mockResolvedValue([
+            exportedRecordForAccreditationTests('2026-03-01')
+          ])
+      },
+      overseasSitesRepository: {
+        findAll: vi
+          .fn()
+          .mockResolvedValue([
+            { id: 'site-a', validFrom: new Date('2026-01-01') }
+          ])
+      }
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const cells = out[1].trim().split(',')
+    expect(cells[9]).toBe('true')
+    expect(cells[10]).toBe('')
   })
 
   it('reads Accredited "Yes" with the number for a suspended accreditation', async () => {
@@ -524,9 +560,9 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(3)
-    // Within the same type, lower rowId emits first (Row ID is metadata col 10)
-    expect(out[1].trim().split(',')[10]).toBe('1001')
-    expect(out[2].trim().split(',')[10]).toBe('2002')
+    // Within the same type, lower rowId emits first (Row ID is metadata col 11)
+    expect(out[1].trim().split(',')[11]).toBe('1001')
+    expect(out[2].trim().split(',')[11]).toBe('2002')
   })
 
   it('orders rowIds naturally so "9" comes before "10"', async () => {
@@ -542,8 +578,8 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(3)
-    expect(out[1].trim().split(',')[10]).toBe('9')
-    expect(out[2].trim().split(',')[10]).toBe('10')
+    expect(out[1].trim().split(',')[11]).toBe('9')
+    expect(out[2].trim().split(',')[11]).toBe('10')
   })
 
   it('treats a missing accreditation as registered-only', async () => {

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -12,6 +12,7 @@ import * as shared from '#domain/summary-logs/table-schemas/shared/fields.js'
 /** @import {Organisation} from '#domain/organisations/model.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
+/** @import {WasteBalanceClassification} from './is-included-in-waste-balance.js' */
 
 const FORMULA_INJECTION_PREFIX = /^[=+\-@]/
 
@@ -39,6 +40,7 @@ export const METADATA_COLUMNS = Object.freeze([
   'Waste Record Type',
   'Submitted At',
   'Included in Waste Balance',
+  'Waste Balance Exclusion Reason',
   'Row ID'
 ])
 
@@ -116,7 +118,7 @@ export const buildHeaderRow = (dataFieldColumns) => [
  * @property {Accreditation | null} accreditation
  * @property {WasteRecord} record
  * @property {{ submittedAt: string } | null | undefined} summaryLogEntry
- * @property {boolean} includedInWasteBalance
+ * @property {WasteBalanceClassification} wasteBalanceClassification
  * @property {string[]} dataFieldColumns
  */
 
@@ -135,7 +137,7 @@ export const buildDataRow = ({
   accreditation,
   record,
   summaryLogEntry,
-  includedInWasteBalance,
+  wasteBalanceClassification,
   dataFieldColumns
 }) => {
   const accredited = accreditation !== null ? 'Yes' : 'No'
@@ -151,7 +153,10 @@ export const buildDataRow = ({
     accreditation?.accreditationNumber ?? '',
     record.type,
     summaryLogEntry?.submittedAt ?? '',
-    includedInWasteBalance ? 'true' : 'false',
+    wasteBalanceClassification.included ? 'true' : 'false',
+    wasteBalanceClassification.reasons
+      .map((r) => (r.field ? `${r.code}: ${r.field}` : r.code))
+      .join('; '),
     String(record.rowId)
   ]
 

--- a/src/waste-records-export/domain/csv-columns.test.js
+++ b/src/waste-records-export/domain/csv-columns.test.js
@@ -27,6 +27,7 @@ describe('csv-columns', () => {
         'Waste Record Type',
         'Submitted At',
         'Included in Waste Balance',
+        'Waste Balance Exclusion Reason',
         'Row ID'
       ])
     })
@@ -204,7 +205,7 @@ describe('csv-columns', () => {
       summaryLogEntry: {
         submittedAt: '2026-04-15T09:00:00Z'
       },
-      includedInWasteBalance: true,
+      wasteBalanceClassification: { included: true, reasons: [] },
       dataFieldColumns
     }
 
@@ -225,7 +226,8 @@ describe('csv-columns', () => {
       expect(row[7]).toBe('received') // Waste Record Type
       expect(row[8]).toBe('2026-04-15T09:00:00Z') // Submitted At
       expect(row[9]).toBe('true') // Included in Waste Balance
-      expect(row[10]).toBe('1001') // Row ID
+      expect(row[10]).toBe('') // Waste Balance Exclusion Reason
+      expect(row[11]).toBe('1001') // Row ID
     })
 
     it('emits the glass recycling process in place of "glass" for the Material column', () => {
@@ -343,9 +345,19 @@ describe('csv-columns', () => {
       expect(row[8]).toBe('')
     })
 
-    it('emits "false" for Included in Waste Balance when input is false', () => {
-      const row = buildDataRow({ ...baseInput, includedInWasteBalance: false })
-      expect(row[9]).toBe('false')
+    it('emits waste balance columns from the classification', () => {
+      const excluded = buildDataRow({
+        ...baseInput,
+        wasteBalanceClassification: {
+          included: false,
+          reasons: [
+            { code: 'PRN_ISSUED' },
+            { code: 'MISSING_REQUIRED_FIELD', field: 'EWC_CODE' }
+          ]
+        }
+      })
+      expect(excluded[9]).toBe('false') // Included in Waste Balance
+      expect(excluded[10]).toBe('PRN_ISSUED; MISSING_REQUIRED_FIELD: EWC_CODE') // Exclusion Reason
     })
   })
 })

--- a/src/waste-records-export/domain/is-included-in-waste-balance.js
+++ b/src/waste-records-export/domain/is-included-in-waste-balance.js
@@ -3,26 +3,31 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
 
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 /** @import {OverseasSitesContext} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
+/** @import {WasteBalanceClassificationReason} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
 
 /**
- * Boolean version of waste-balances/application/target-amount#getTargetAmount.
- * Returns true iff the record currently counts toward the waste balance for
- * its accreditation. Mirrors the same logic; differs only by returning a
- * boolean rather than a tonnage.
+ * @typedef {Object} WasteBalanceClassification
+ * @property {boolean} included - Whether the record is included in the waste balance
+ * @property {WasteBalanceClassificationReason[]} reasons - Exclusion reasons; empty when included
+ */
+
+/**
+ * Returns the waste balance inclusion status and any exclusion reasons for a record.
+ * Mirrors the same logic as the waste-balances calculation path.
  *
  * @param {WasteRecord} record
  * @param {Accreditation | null} accreditation
  * @param {OverseasSitesContext} overseasSites
- * @returns {boolean}
+ * @returns {WasteBalanceClassification}
  */
-export const isIncludedInWasteBalance = (
+export const getWasteBalanceClassification = (
   record,
   accreditation,
   overseasSites
 ) => {
   if (record.excludedFromWasteBalance) {
-    return false
+    return { included: false, reasons: [] }
   }
 
   const schema = findSchemaForProcessingType(
@@ -31,7 +36,7 @@ export const isIncludedInWasteBalance = (
   )
 
   if (!schema?.classifyForWasteBalance) {
-    return false
+    return { included: false, reasons: [] }
   }
 
   const result = schema.classifyForWasteBalance(record.data, {
@@ -39,5 +44,9 @@ export const isIncludedInWasteBalance = (
     overseasSites
   })
 
-  return result.outcome === ROW_OUTCOME.INCLUDED
+  if (result.outcome === ROW_OUTCOME.INCLUDED) {
+    return { included: true, reasons: [] }
+  }
+
+  return { included: false, reasons: result.reasons }
 }

--- a/src/waste-records-export/domain/is-included-in-waste-balance.test.js
+++ b/src/waste-records-export/domain/is-included-in-waste-balance.test.js
@@ -1,4 +1,4 @@
-import { isIncludedInWasteBalance } from './is-included-in-waste-balance.js'
+import { getWasteBalanceClassification } from './is-included-in-waste-balance.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
@@ -7,107 +7,125 @@ import { buildAccreditation } from '#repositories/organisations/contract/test-da
 
 /** @typedef {import('#domain/organisations/accreditation.js').Accreditation} Accreditation */
 
-describe('isIncludedInWasteBalance', () => {
-  const accreditation = /** @type {Accreditation} */ (
-    /** @type {unknown} */ (
-      buildAccreditation({
-        id: 'acc-1',
-        validFrom: '2026-01-01',
-        validTo: '2027-01-01'
-      })
-    )
+const accreditation = /** @type {Accreditation} */ (
+  /** @type {unknown} */ (
+    buildAccreditation({
+      id: 'acc-1',
+      validFrom: '2026-01-01',
+      validTo: '2027-01-01'
+    })
   )
+)
 
-  it('returns false when record.excludedFromWasteBalance is true', () => {
+const fullyFilledReprocessorRecord = buildWasteRecord({
+  type: WASTE_RECORD_TYPE.RECEIVED,
+  data: {
+    processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+    ROW_ID: '1001',
+    DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01',
+    EWC_CODE: '15 01 02',
+    DESCRIPTION_WASTE: 'Plastic packaging',
+    WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+    GROSS_WEIGHT: 10,
+    TARE_WEIGHT: 1,
+    PALLET_WEIGHT: 0,
+    NET_WEIGHT: 9,
+    BAILING_WIRE_PROTOCOL: 'No',
+    HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
+    WEIGHT_OF_NON_TARGET_MATERIALS: 0,
+    RECYCLABLE_PROPORTION_PERCENTAGE: 100,
+    TONNAGE_RECEIVED_FOR_RECYCLING: 9
+  }
+})
+
+const prnIssuedExporterRecord = buildWasteRecord({
+  type: WASTE_RECORD_TYPE.EXPORTED,
+  data: {
+    processingType: PROCESSING_TYPES.EXPORTER,
+    ROW_ID: '1001',
+    DATE_RECEIVED_FOR_EXPORT: '2026-02-01',
+    EWC_CODE: '15 01 02',
+    DESCRIPTION_WASTE: 'Plastic packaging',
+    WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'Yes',
+    GROSS_WEIGHT: 10,
+    TARE_WEIGHT: 1,
+    PALLET_WEIGHT: 0,
+    NET_WEIGHT: 9,
+    BAILING_WIRE_PROTOCOL: 'No',
+    HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
+    WEIGHT_OF_NON_TARGET_MATERIALS: 0,
+    RECYCLABLE_PROPORTION_PERCENTAGE: 100,
+    TONNAGE_RECEIVED_FOR_EXPORT: 9,
+    TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 9,
+    DATE_OF_EXPORT: '2026-03-01',
+    BASEL_EXPORT_CODE: 'B3010',
+    CUSTOMS_CODES: '391510',
+    CONTAINER_NUMBER: 'CN-001',
+    DATE_RECEIVED_BY_OSR: '2026-04-01',
+    OSR_ID: '099',
+    DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE: 'No'
+  }
+})
+
+describe('getWasteBalanceClassification', () => {
+  it('returns included:false and empty reasons when record is manually excluded', () => {
     const record = buildWasteRecord({
       type: WASTE_RECORD_TYPE.RECEIVED,
       data: { processingType: PROCESSING_TYPES.REPROCESSOR_INPUT },
       excludedFromWasteBalance: true
     })
     expect(
-      isIncludedInWasteBalance(record, accreditation, ORS_VALIDATION_DISABLED)
-    ).toBe(false)
+      getWasteBalanceClassification(
+        record,
+        accreditation,
+        ORS_VALIDATION_DISABLED
+      )
+    ).toEqual({ included: false, reasons: [] })
   })
 
-  it('returns false when no schema can be found for the record', () => {
-    const record = buildWasteRecord({
+  it('returns included:false and empty reasons when no schema or classifyForWasteBalance exists', () => {
+    const noSchemaRecord = buildWasteRecord({
       type: WASTE_RECORD_TYPE.RECEIVED,
       data: { processingType: 'NOT_A_REAL_TYPE' }
     })
     expect(
-      isIncludedInWasteBalance(record, accreditation, ORS_VALIDATION_DISABLED)
-    ).toBe(false)
-  })
+      getWasteBalanceClassification(
+        noSchemaRecord,
+        accreditation,
+        ORS_VALIDATION_DISABLED
+      )
+    ).toEqual({ included: false, reasons: [] })
 
-  it('returns false when the schema does not have classifyForWasteBalance', () => {
-    // SENT_ON records typically lack classifyForWasteBalance
-    const record = buildWasteRecord({
+    const noClassifyRecord = buildWasteRecord({
       type: WASTE_RECORD_TYPE.SENT_ON,
       data: { processingType: PROCESSING_TYPES.EXPORTER }
     })
     expect(
-      isIncludedInWasteBalance(record, accreditation, ORS_VALIDATION_DISABLED)
-    ).toBe(false)
+      getWasteBalanceClassification(
+        noClassifyRecord,
+        accreditation,
+        ORS_VALIDATION_DISABLED
+      )
+    ).toEqual({ included: false, reasons: [] })
   })
 
-  it('returns true when classifyForWasteBalance returns INCLUDED', () => {
-    // A reprocessor RECEIVED record with all required fields should classify INCLUDED
-    const record = buildWasteRecord({
-      type: WASTE_RECORD_TYPE.RECEIVED,
-      data: {
-        processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
-        ROW_ID: '1001',
-        DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01',
-        EWC_CODE: '15 01 02',
-        DESCRIPTION_WASTE: 'Plastic packaging',
-        WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
-        GROSS_WEIGHT: 10,
-        TARE_WEIGHT: 1,
-        PALLET_WEIGHT: 0,
-        NET_WEIGHT: 9,
-        BAILING_WIRE_PROTOCOL: 'No',
-        HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
-        WEIGHT_OF_NON_TARGET_MATERIALS: 0,
-        RECYCLABLE_PROPORTION_PERCENTAGE: 100,
-        TONNAGE_RECEIVED_FOR_RECYCLING: 9
-      }
-    })
+  it('returns included:true and empty reasons when record is included', () => {
     expect(
-      isIncludedInWasteBalance(record, accreditation, ORS_VALIDATION_DISABLED)
-    ).toBe(true)
+      getWasteBalanceClassification(
+        fullyFilledReprocessorRecord,
+        accreditation,
+        ORS_VALIDATION_DISABLED
+      )
+    ).toEqual({ included: true, reasons: [] })
   })
 
-  it('returns false when classifyForWasteBalance returns EXCLUDED (PRN already issued)', () => {
-    const record = buildWasteRecord({
-      type: WASTE_RECORD_TYPE.EXPORTED,
-      data: {
-        processingType: PROCESSING_TYPES.EXPORTER,
-        ROW_ID: '1001',
-        DATE_RECEIVED_FOR_EXPORT: '2026-02-01',
-        EWC_CODE: '15 01 02',
-        DESCRIPTION_WASTE: 'Plastic packaging',
-        WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'Yes',
-        GROSS_WEIGHT: 10,
-        TARE_WEIGHT: 1,
-        PALLET_WEIGHT: 0,
-        NET_WEIGHT: 9,
-        BAILING_WIRE_PROTOCOL: 'No',
-        HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
-        WEIGHT_OF_NON_TARGET_MATERIALS: 0,
-        RECYCLABLE_PROPORTION_PERCENTAGE: 100,
-        TONNAGE_RECEIVED_FOR_EXPORT: 9,
-        TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 9,
-        DATE_OF_EXPORT: '2026-03-01',
-        BASEL_EXPORT_CODE: 'B3010',
-        CUSTOMS_CODES: '391510',
-        CONTAINER_NUMBER: 'CN-001',
-        DATE_RECEIVED_BY_OSR: '2026-04-01',
-        OSR_ID: '099',
-        DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE: 'No'
-      }
-    })
-    expect(
-      isIncludedInWasteBalance(record, accreditation, ORS_VALIDATION_DISABLED)
-    ).toBe(false)
+  it('returns included:false with exclusion reason when record is excluded', () => {
+    const result = getWasteBalanceClassification(
+      prnIssuedExporterRecord,
+      accreditation,
+      ORS_VALIDATION_DISABLED
+    )
+    expect(result.included).toBe(false)
+    expect(result.reasons).toContainEqual({ code: 'PRN_ISSUED' })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1662](https://eaflood.atlassian.net/browse/PAE-1662)
- Add `getWasteBalanceStatus` to return both the inclusion boolean and exclusion reason codes from the waste balance classifier
- Add `Excluded from Base Balance Reason` metadata column to the CSV export, populated with semicolon-separated reason codes (e.g. `PRN_ISSUED`, `MISSING_REQUIRED_FIELD: TONNAGE_RECEIVED_FOR_RECYCLING`) and empty for included records
- Keep `isIncludedInWasteBalance` as a thin boolean wrapper over the new function for existing callers
- Update unit tests to cover the new column and reason extraction

[PAE-1662]: https://eaflood.atlassian.net/browse/PAE-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ