### PR TITLE
PAE-1648: Include loadsByReportingPeriod on submitted summary-log response

### DIFF
--- a/src/routes/v1/organisations/registrations/summary-logs/get.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/get.js
@@ -50,7 +50,8 @@ export const summaryLogsGet = {
       status: summaryLog.status,
       ...transformValidationResponse(summaryLog.validation),
       ...(summaryLog.loads && { loads: summaryLog.loads }),
-      ...(summaryLog.status === SUMMARY_LOG_STATUS.VALIDATED && {
+      ...((summaryLog.status === SUMMARY_LOG_STATUS.VALIDATED ||
+        summaryLog.status === SUMMARY_LOG_STATUS.SUBMITTED) && {
         loadsByReportingPeriod:
           summaryLog.loadsByReportingPeriod ?? emptyLoadsByReportingPeriod()
       }),

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
@@ -713,4 +713,34 @@ describe('loadsByReportingPeriod population at validate time', () => {
       loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
     ).toBe(0)
   })
+
+  it('includes loadsByReportingPeriod on the GET response after submit', async () => {
+    const env = await setupWasteBalanceIntegrationEnvironment({
+      processingType: 'exporter'
+    })
+
+    await upload(
+      env,
+      'sl-submitted-period',
+      'file-submitted-period',
+      createUploadData([{ rowId: 1001, osrId: 100, exportTonnage: 100 }])
+    )
+    await submitAndPoll(env, 'sl-submitted-period')
+
+    const { server, organisationId, registrationId } = env
+    const response = await server.inject({
+      method: 'GET',
+      url: buildGetUrl(organisationId, registrationId, 'sl-submitted-period'),
+      ...asStandardUser({ linkedOrgId: organisationId })
+    })
+    const body = JSON.parse(response.payload)
+
+    // After submit the document still carries loadsByReportingPeriod; the GET
+    // status endpoint must serialise it so the confirmation page can detect
+    // closed-period changes.
+    expect(body.status).toBe(SUMMARY_LOG_STATUS.SUBMITTED)
+    expect(
+      body.loadsByReportingPeriod.openPeriodLoads.added.balanceAffecting.count
+    ).toBe(1)
+  })
 })

--- a/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/response.schema.js
@@ -71,7 +71,7 @@ export const summaryLogResponseSchema = Joi.object({
   }).optional(),
   loads: loadsSchema.optional(),
   loadsByReportingPeriod: Joi.when('status', {
-    is: SUMMARY_LOG_STATUS.VALIDATED,
+    is: Joi.valid(SUMMARY_LOG_STATUS.VALIDATED, SUMMARY_LOG_STATUS.SUBMITTED),
     then: loadsByReportingPeriodSchema.required(),
     otherwise: loadsByReportingPeriodSchema.optional()
   }),


### PR DESCRIPTION
Ticket: [PAE-1648](https://eaflood.atlassian.net/browse/PAE-1648)
## What

The GET summary-log status endpoint now serialises `loadsByReportingPeriod` when the summary log status is `SUBMITTED`, in addition to the existing `VALIDATED` case. The response schema is widened to match: the field is required for both `VALIDATED` and `SUBMITTED`, and optional otherwise.

## Why

The waste-balance breakdown by reporting period is already stored on the document, but it was stripped from the response for every status except `VALIDATED`. The PAE-1648 confirmation page needs this data after a submit so it can detect and message closed-period changes. Widening the condition lets the frontend read the breakdown straight from the status endpoint once a submission completes.

Submitting and superseded statuses are out of scope: the change is limited to the `SUBMITTED` terminal state.

[PAE-1648]: https://eaflood.atlassian.net/browse/PAE-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ