### PR TITLE
PAE-1590: Backfill row states for registered-only streams

### DIFF
--- a/src/waste-records/backfill/backfill-estate-rowstates.js
+++ b/src/waste-records/backfill/backfill-estate-rowstates.js
@@ -37,7 +37,7 @@ import { backfillRegistrationRowStates } from './backfill-registration-rowstates
 /**
  * What backfilling a single registration stream contributed: either an orphaned
  * accreditation to surface, or the submission and write counts it committed.
- * `null` means the stream was skipped (no accreditation or no submitted logs).
+ * `null` means the stream was skipped (no submitted summary logs).
  *
  * @typedef {Object} StreamBackfilled
  * @property {number} submissionCount
@@ -64,11 +64,14 @@ const toOrderedSummaryLog = ({ summaryLog }) => ({
 })
 
 /**
- * Backfill one registration's stream, mirroring the live write scope: skipped
- * unless it is accredited and has at least one submitted summary log, partitioned
- * by its accreditation, classified against today's accreditation and overseas-site
- * state. A referenced accreditation missing from the organisation is surfaced as
- * orphaned rather than fatal.
+ * Backfill one registration's stream, mirroring the live write scope: every
+ * registration with at least one submitted summary log is reconstructed,
+ * partitioned by accreditation existence (`accreditationId ?? null`) and
+ * classified against today's accreditation (or null for a registered-only
+ * registration) and overseas-site state. A skip yields null only when there are
+ * no submitted summary logs. When a registration references an accreditation that
+ * is missing from the organisation, that is surfaced as orphaned rather than
+ * fatal.
  *
  * @param {Object} args
  * @param {import('#domain/organisations/model.js').Organisation} args.organisation
@@ -90,9 +93,6 @@ const backfillRegistrationStream = async ({
   rowStateRepository
 }) => {
   const { accreditationId } = registration
-  if (!accreditationId) {
-    return null
-  }
 
   const logs = await summaryLogsRepository.findAllByOrgReg(
     organisation.id,
@@ -105,22 +105,26 @@ const backfillRegistrationStream = async ({
     return null
   }
 
-  let accreditation
-  try {
-    accreditation = await organisationsRepository.findAccreditationById(
-      organisation.id,
-      accreditationId
-    )
-  } catch (error) {
-    const statusCode = Boom.isBoom(error) ? error.output.statusCode : undefined
-    if (statusCode !== StatusCodes.NOT_FOUND) {
-      throw error
-    }
-    return {
-      orphanedAccreditation: {
-        organisationId: organisation.id,
-        registrationId: registration.id,
+  let accreditation = null
+  if (accreditationId) {
+    try {
+      accreditation = await organisationsRepository.findAccreditationById(
+        organisation.id,
         accreditationId
+      )
+    } catch (error) {
+      const statusCode = Boom.isBoom(error)
+        ? error.output.statusCode
+        : undefined
+      if (statusCode !== StatusCodes.NOT_FOUND) {
+        throw error
+      }
+      return {
+        orphanedAccreditation: {
+          organisationId: organisation.id,
+          registrationId: registration.id,
+          accreditationId
+        }
       }
     }
   }
@@ -141,7 +145,7 @@ const backfillRegistrationStream = async ({
       partition: {
         organisationId: organisation.id,
         registrationId: registration.id,
-        accreditationId
+        accreditationId: accreditationId ?? null
       },
       wasteRecords,
       summaryLogs,
@@ -156,14 +160,14 @@ const backfillRegistrationStream = async ({
 /**
  * Reconstruct the waste record state collection for the whole historical estate
  * from sparse version history, mirroring the live submission path's write scope:
- * only accredited registrations contribute (registered-only streams never wrote
- * row states), only submitted summary logs are replayed, and each registration's
- * stream is partitioned by its accreditation. Accreditation validity and
- * overseas-site approval are read at today's state, so a backfilled row's
- * classification reflects current factors — the historical-reading drift
- * ADR-0037 accepts for legacy submissions. Re-runnable: every registration's
- * upserts are idempotent. An accreditation referenced by a registration but
- * missing from the organisation is surfaced and skipped, not fatal.
+ * every registration with submitted summary logs contributes — accredited and
+ * registered-only alike — partitioned by accreditation existence
+ * (`accreditationId ?? null`), and only submitted summary logs are replayed. Accreditation validity and overseas-site approval are read at today's
+ * state, so a backfilled row's classification reflects current factors — the
+ * historical-reading drift ADR-0037 accepts for legacy submissions. Re-runnable:
+ * every registration's upserts are idempotent. An accreditation referenced by a
+ * registration but missing from the organisation is surfaced and skipped, not
+ * fatal.
  *
  * @param {Object} deps
  * @param {import('#repositories/organisations/port.js').OrganisationsRepository} deps.organisationsRepository

--- a/src/waste-records/backfill/backfill-estate-rowstates.js
+++ b/src/waste-records/backfill/backfill-estate-rowstates.js
@@ -162,7 +162,8 @@ const backfillRegistrationStream = async ({
  * from sparse version history, mirroring the live submission path's write scope:
  * every registration with submitted summary logs contributes — accredited and
  * registered-only alike — partitioned by accreditation existence
- * (`accreditationId ?? null`), and only submitted summary logs are replayed. Accreditation validity and overseas-site approval are read at today's
+ * (`accreditationId ?? null`), and only submitted summary logs are replayed.
+ * Accreditation validity and overseas-site approval are read at today's
  * state, so a backfilled row's classification reflects current factors — the
  * historical-reading drift ADR-0037 accepts for legacy submissions. Re-runnable:
  * every registration's upserts are idempotent. An accreditation referenced by a

--- a/src/waste-records/backfill/backfill-estate-rowstates.test.js
+++ b/src/waste-records/backfill/backfill-estate-rowstates.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
 import { logger } from '#common/helpers/logging/logger.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
@@ -121,7 +122,7 @@ describe('backfillEstateRowStates', () => {
     })
   })
 
-  it('does not backfill a registered-only registration with no accreditation', async () => {
+  it('backfills a registered-only registration under a null-accreditation partition', async () => {
     const registration = reprocessorRegistration({ id: 'reg-ro' })
     delete registration.accreditationId
     const organisation = buildOrganisation({
@@ -142,11 +143,50 @@ describe('backfillEstateRowStates', () => {
 
     const summary = await backfillEstateRowStates(deps)
 
-    expect(
-      await deps.rowStateRepository.findBySummaryLogId(fileId('sl-1'))
-    ).toEqual([])
-    expect(summary.streamsBackfilled).toBe(0)
-    expect(summary.submissionsBackfilled).toBe(0)
+    const docs = await deps.rowStateRepository.findBySummaryLogId(
+      fileId('sl-1')
+    )
+    expect(docs.map((d) => d.rowId)).toEqual(['row-1'])
+    expect(docs[0].accreditationId).toBeNull()
+    expect(summary.streamsBackfilled).toBe(1)
+    expect(summary.submissionsBackfilled).toBe(1)
+    expect(summary.orphanedAccreditations).toEqual([])
+  })
+
+  it('backfills a registered-only processing-type stream rather than dropping it', async () => {
+    const registration = reprocessorRegistration({ id: 'reg-ro-pt' })
+    delete registration.accreditationId
+    const organisation = buildOrganisation({
+      registrations: [registration],
+      accreditations: []
+    })
+    const wasteRecords = [
+      receivedRecord(organisation.id, 'reg-ro-pt', 'row-1', [
+        {
+          summaryLog: { id: fileId('sl-1') },
+          data: {
+            processingType: PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY,
+            supplierName: 'Acme'
+          }
+        }
+      ])
+    ]
+    const deps = inMemoryDeps({ organisations: [organisation], wasteRecords })
+    await insertLog(deps.summaryLogsRepository, 'sl-1', {
+      organisationId: organisation.id,
+      registrationId: 'reg-ro-pt',
+      submittedAt: '2025-01-01T00:00:00.000Z'
+    })
+
+    const summary = await backfillEstateRowStates(deps)
+
+    const docs = await deps.rowStateRepository.findBySummaryLogId(
+      fileId('sl-1')
+    )
+    expect(docs.map((d) => d.rowId)).toEqual(['row-1'])
+    expect(docs[0].accreditationId).toBeNull()
+    expect(summary.streamsBackfilled).toBe(1)
+    expect(summary.submissionsBackfilled).toBe(1)
   })
 
   it('replays only submitted logs and skips streams whose logs are all unsubmitted', async () => {


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)
## What

The estate row-state backfill now reconstructs row states for registered-only registrations (those with no accreditation), partitioned under `accreditationId: null` — the full population the forward path writes. Previously it reconstructed only accredited balance-type streams.

Orphaned-accreditation handling (an `accreditationId` present but missing from the organisation) and the reconstruction function signatures are unchanged.

## Why

The forward path already writes row states for every submission, partitioned by accreditation existence (`accreditationId ?? null`), but the backfill still mirrored the old scope and skipped any registration without an `accreditationId`. Registered-only streams were therefore never reconstructed, so the reconciliation diagnostic would report them as absent on both sides rather than reconciling.

## Scope

This reconstructs the row-state collection only. It does not emit `SUMMARY_LOG_SUBMITTED` committed-head events for registered-only partitions, so the committed-head-gated read path still returns nothing for them. Resolving the registered-only read head is tracked separately and is out of scope here.


[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ