### PR TITLE
PAE-1590: Emit summary-log committed events for registered-only registrations

### DIFF
--- a/src/application/waste-records/sync-from-summary-log.js
+++ b/src/application/waste-records/sync-from-summary-log.js
@@ -240,7 +240,12 @@ const calculateMetrics = (wasteRecords) => {
  * Resolves the accreditation (when one exists, any status), commits the
  * per-row state for every submission (flag-gated, partitioned by accreditation
  * existence), and updates the waste balance only for accredited
- * balance-bearing submissions.
+ * balance-bearing submissions. A registered-only / no-accreditation submission
+ * (null partition) has no balance path, so — behind its own dedicated flag,
+ * independent of the row-state flag — it instead emits a zero-delta committed
+ * head so the head-anchored read model has a head to resolve once reg-only reads
+ * go live. The head is balance-neutral, so emitting it independently of its
+ * row-state membership is harmless before the read cutover.
  *
  * @param {object} params
  * @param {object} params.summaryLog
@@ -297,6 +302,17 @@ const commitStateAndBalance = async ({
       user,
       overseasSites,
       summaryLogId: summaryLog.file.id
+    })
+  } else if (featureFlags?.isRegisteredOnlyCommittedHeadsEnabled()) {
+    await wasteBalancesRepository.appendRegisteredOnlyHead({
+      registrationId: summaryLog.registrationId,
+      organisationId: summaryLog.organisationId,
+      summaryLogId: summaryLog.file.id,
+      createdBy: {
+        id: user.id,
+        ...(user.name && { name: user.name }),
+        email: user.email
+      }
     })
   }
 }

--- a/src/application/waste-records/sync-from-summary-log.test.js
+++ b/src/application/waste-records/sync-from-summary-log.test.js
@@ -36,7 +36,8 @@ describe('syncFromSummaryLog', () => {
   beforeEach(() => {
     wasteRecordRepository = createInMemoryWasteRecordsRepository()()
     wasteBalancesRepository = {
-      updateWasteBalanceTransactions: vi.fn()
+      updateWasteBalanceTransactions: vi.fn(),
+      appendRegisteredOnlyHead: vi.fn()
     }
     organisationsRepository = {
       findRegistrationById: vi.fn().mockResolvedValue({ overseasSites: {} }),
@@ -1770,6 +1771,128 @@ describe('syncFromSummaryLog', () => {
         'reg-1'
       )
       expect(savedRecords).toHaveLength(2)
+    })
+  })
+
+  describe('registered-only committed head (forward path)', () => {
+    const headFlagOn = createInMemoryFeatureFlags({
+      registeredOnlyCommittedHeads: true
+    })
+
+    const regOnlyData = {
+      meta: { PROCESSING_TYPE: { value: 'REPROCESSOR_INPUT' } },
+      data: {
+        RECEIVED_LOADS_FOR_REPROCESSING: {
+          location: { sheet: 'Sheet1', row: 1, column: 'A' },
+          headers: ['ROW_ID', 'DATE_RECEIVED_FOR_REPROCESSING', FIELD_GROSS_WEIGHT],
+          rows: [
+            {
+              rowNumber: 2,
+              values: ['row-123', TEST_DATE_2025_01_15, TEST_WEIGHT_100_5]
+            }
+          ]
+        }
+      }
+    }
+
+    const syncWith = (extractor, featureFlags) =>
+      /** @type {any} */ (syncFromSummaryLog)({
+        extractor,
+        wasteRecordRepository,
+        wasteBalancesRepository,
+        organisationsRepository,
+        overseasSitesRepository,
+        rowStateRepository: createInMemoryRowStateRepository()(),
+        featureFlags
+      })
+
+    it('emits a zero-delta head for a reg-only submission when the flag is on', async () => {
+      const fileId = 'file-head-on'
+      const summaryLog = {
+        file: { id: fileId, uri: 's3://bucket/head-on' },
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+      const extractor = createInMemorySummaryLogExtractor({
+        [fileId]: /** @type {any} */ (regOnlyData)
+      })
+
+      await syncWith(extractor, headFlagOn)(summaryLog, TEST_USER)
+
+      expect(
+        wasteBalancesRepository.appendRegisteredOnlyHead
+      ).toHaveBeenCalledWith({
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        summaryLogId: fileId,
+        createdBy: { id: TEST_USER.id, email: TEST_USER.email }
+      })
+      expect(
+        wasteBalancesRepository.updateWasteBalanceTransactions
+      ).not.toHaveBeenCalled()
+    })
+
+    it('does not emit a head when the dedicated flag is off', async () => {
+      const fileId = 'file-head-off'
+      const summaryLog = {
+        file: { id: fileId, uri: 's3://bucket/head-off' },
+        organisationId: 'org-1',
+        registrationId: 'reg-1'
+      }
+      const extractor = createInMemorySummaryLogExtractor({
+        [fileId]: /** @type {any} */ (regOnlyData)
+      })
+
+      await syncWith(
+        extractor,
+        createInMemoryFeatureFlags({ registeredOnlyCommittedHeads: false })
+      )(summaryLog, TEST_USER)
+
+      expect(
+        wasteBalancesRepository.appendRegisteredOnlyHead
+      ).not.toHaveBeenCalled()
+    })
+
+    it('does not emit a reg-only head for an accredited submission', async () => {
+      const fileId = 'file-head-accredited'
+      const summaryLog = {
+        file: { id: fileId, uri: 's3://bucket/head-accredited' },
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1'
+      }
+      organisationsRepository.findAccreditationById = vi.fn().mockResolvedValue({
+        id: 'acc-1',
+        validFrom: '2023-01-01',
+        validTo: '2030-12-31'
+      })
+      const extractor = createInMemorySummaryLogExtractor({
+        [fileId]: /** @type {any} */ ({
+          meta: { PROCESSING_TYPE: { value: 'EXPORTER' } },
+          data: {
+            RECEIVED_LOADS_FOR_EXPORT: {
+              location: { sheet: 'Sheet1', row: 1, column: 'A' },
+              headers: [
+                'ROW_ID',
+                'DATE_RECEIVED_FOR_REPROCESSING',
+                FIELD_GROSS_WEIGHT
+              ],
+              rows: [
+                {
+                  rowNumber: 2,
+                  values: ['row-123', TEST_DATE_2025_01_15, TEST_WEIGHT_100_5]
+                }
+              ]
+            }
+          }
+        })
+      })
+
+      await syncWith(extractor, headFlagOn)(summaryLog, TEST_USER)
+
+      expect(
+        wasteBalancesRepository.appendRegisteredOnlyHead
+      ).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/config.js
+++ b/src/config.js
@@ -369,6 +369,12 @@ const baseConfig = {
       format: Boolean,
       default: false,
       env: 'FEATURE_FLAG_WASTE_RECORD_STATES'
+    },
+    registeredOnlyCommittedHeads: {
+      doc: 'Feature Flag: Emit zero-delta summary-log-submitted committed-head events for registered-only (null-accreditation) streams (ADR-0037)',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_FLAG_REGISTERED_ONLY_COMMITTED_HEADS'
     }
   },
   formSubmissionOverrides: {

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -13,5 +13,8 @@ export const createConfigFeatureFlags = (config) => ({
   },
   isWasteRecordStatesEnabled() {
     return config.get('featureFlags.wasteRecordStates')
+  },
+  isRegisteredOnlyCommittedHeadsEnabled() {
+    return config.get('featureFlags.registeredOnlyCommittedHeads')
   }
 })

--- a/src/feature-flags/feature-flags.config.test.js
+++ b/src/feature-flags/feature-flags.config.test.js
@@ -29,4 +29,13 @@ describe('createConfigFeatureFlags', () => {
     expect(flags.isWasteRecordStatesEnabled()).toBe(true)
     expect(config.get).toHaveBeenCalledWith('featureFlags.wasteRecordStates')
   })
+
+  it('returns true when registeredOnlyCommittedHeads flag is enabled', () => {
+    const config = { get: vi.fn().mockReturnValue(true) }
+    const flags = createConfigFeatureFlags(config)
+    expect(flags.isRegisteredOnlyCommittedHeadsEnabled()).toBe(true)
+    expect(config.get).toHaveBeenCalledWith(
+      'featureFlags.registeredOnlyCommittedHeads'
+    )
+  })
 })

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -14,5 +14,8 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   },
   isWasteRecordStatesEnabled() {
     return flags.wasteRecordStates ?? false
+  },
+  isRegisteredOnlyCommittedHeadsEnabled() {
+    return flags.registeredOnlyCommittedHeads ?? false
   }
 })

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -65,4 +65,23 @@ describe('createInMemoryFeatureFlags', () => {
     const flags = createInMemoryFeatureFlags({})
     expect(flags.isWasteRecordStatesEnabled()).toBe(false)
   })
+
+  it('returns true when registeredOnlyCommittedHeads flag is enabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      registeredOnlyCommittedHeads: true
+    })
+    expect(flags.isRegisteredOnlyCommittedHeadsEnabled()).toBe(true)
+  })
+
+  it('returns false when registeredOnlyCommittedHeads flag is disabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      registeredOnlyCommittedHeads: false
+    })
+    expect(flags.isRegisteredOnlyCommittedHeadsEnabled()).toBe(false)
+  })
+
+  it('returns false when registeredOnlyCommittedHeads flag is not provided', () => {
+    const flags = createInMemoryFeatureFlags({})
+    expect(flags.isRegisteredOnlyCommittedHeadsEnabled()).toBe(false)
+  })
 })

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -4,6 +4,7 @@
  * @property {() => boolean} isCopyFormFilesToS3Enabled
  * @property {() => boolean} isFixDuplicateAccreditationLinksEnabled
  * @property {() => boolean} isWasteRecordStatesEnabled
+ * @property {() => boolean} isRegisteredOnlyCommittedHeadsEnabled
  */
 
 /**
@@ -12,6 +13,7 @@
  * @property {boolean} [copyFormFilesToS3]
  * @property {boolean} [fixDuplicateAccreditationLinks]
  * @property {boolean} [wasteRecordStates]
+ * @property {boolean} [registeredOnlyCommittedHeads]
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/test/mock-repositories.js
+++ b/src/test/mock-repositories.js
@@ -148,6 +148,7 @@ export const createMockWasteBalancesRepository = (overrides = {}) => ({
   creditFullBalanceForIssuedPrnCancellation: vi.fn(),
   appendStreamEvent: vi.fn(),
   getPrnCatchupEvents: vi.fn(),
+  appendRegisteredOnlyHead: vi.fn(),
   ...overrides
 })
 

--- a/src/waste-balances/application/append-registered-only-head.js
+++ b/src/waste-balances/application/append-registered-only-head.js
@@ -1,0 +1,41 @@
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import { appendToStream } from './append-to-stream.js'
+
+/**
+ * Append a zero-delta `summary-log-submitted` committed-head event into a
+ * registered-only (null-accreditation) stream partition.
+ *
+ * Registered-only submissions have no waste balance to contribute to — the
+ * balance is per-accreditation — so the head carries `creditTotal: 0` and the
+ * stream's closing balance equals its opening balance. The head exists purely
+ * so the uniform head-anchored read model can resolve the submission's row-state
+ * membership for the null partition, which otherwise has no head.
+ *
+ * @param {Object} params
+ * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} params.repository
+ * @param {string} params.registrationId
+ * @param {string} params.organisationId
+ * @param {string} params.summaryLogId
+ * @param {import('../repository/stream-schema.js').StreamUserSummary} params.createdBy
+ * @returns {Promise<import('../repository/stream-port.js').StreamEvent>}
+ */
+export const appendRegisteredOnlyHead = async ({
+  repository,
+  registrationId,
+  organisationId,
+  summaryLogId,
+  createdBy
+}) =>
+  appendToStream(
+    {
+      repository,
+      registrationId,
+      accreditationId: null,
+      organisationId
+    },
+    {
+      kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+      payload: { summaryLogId, creditTotal: 0 },
+      createdBy
+    }
+  )

--- a/src/waste-balances/application/append-registered-only-head.test.js
+++ b/src/waste-balances/application/append-registered-only-head.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+
+import { createInMemoryStreamRepository } from '../repository/stream-inmemory.js'
+import { STREAM_EVENT_KIND, ZERO_BALANCE } from '../repository/stream-schema.js'
+import { appendRegisteredOnlyHead } from './append-registered-only-head.js'
+
+const createdBy = { id: 'user-1', name: 'Reg User', email: 'reg@example.test' }
+
+describe('appendRegisteredOnlyHead', () => {
+  it('emits a zero-delta summary-log-submitted head into the null-accreditation partition', async () => {
+    const repository = createInMemoryStreamRepository()()
+
+    const event = await appendRegisteredOnlyHead({
+      repository,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
+      summaryLogId: 'log-1',
+      createdBy
+    })
+
+    expect(event.kind).toBe(STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
+    expect(event.accreditationId).toBeNull()
+    expect(event.payload).toEqual({ summaryLogId: 'log-1', creditTotal: 0 })
+    expect(event.openingBalance).toEqual(ZERO_BALANCE)
+    expect(event.closingBalance).toEqual(ZERO_BALANCE)
+  })
+
+  it('keeps the balance unchanged across successive reg-only heads', async () => {
+    const repository = createInMemoryStreamRepository()()
+
+    await appendRegisteredOnlyHead({
+      repository,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
+      summaryLogId: 'log-1',
+      createdBy
+    })
+    const second = await appendRegisteredOnlyHead({
+      repository,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
+      summaryLogId: 'log-2',
+      createdBy
+    })
+
+    expect(second.number).toBe(2)
+    expect(second.closingBalance).toEqual(ZERO_BALANCE)
+  })
+})

--- a/src/waste-balances/repository/contract/appendRegisteredOnlyHead.contract.js
+++ b/src/waste-balances/repository/contract/appendRegisteredOnlyHead.contract.js
@@ -1,0 +1,50 @@
+import { describe, beforeEach, expect } from 'vitest'
+import { STREAM_EVENT_KIND, ZERO_BALANCE } from '../stream-schema.js'
+
+/**
+ * @typedef {object} WasteBalanceContractContext
+ * @property {import('../port.js').WasteBalancesRepositoryFactory} wasteBalancesRepository
+ */
+
+export const testAppendRegisteredOnlyHeadBehaviour = (it) => {
+  describe('appendRegisteredOnlyHead', () => {
+    let repository
+
+    beforeEach(
+      async (
+        /** @type {WasteBalanceContractContext} */ { wasteBalancesRepository }
+      ) => {
+        repository = await wasteBalancesRepository()
+      }
+    )
+
+    it('appends a zero-delta committed head into the null-accreditation partition', async ({
+      streamRepository
+    }) => {
+      const createdBy = {
+        id: 'user-abc',
+        name: 'Ada Lovelace',
+        email: 'ada@example.com'
+      }
+
+      const appended = await repository.appendRegisteredOnlyHead({
+        registrationId: 'reg-1',
+        organisationId: 'org-1',
+        summaryLogId: 'log-1',
+        createdBy
+      })
+
+      expect(appended.kind).toBe(STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
+      expect(appended.accreditationId).toBeNull()
+      expect(appended.payload).toEqual({
+        summaryLogId: 'log-1',
+        creditTotal: 0
+      })
+      expect(appended.closingBalance).toEqual(ZERO_BALANCE)
+      expect(appended.createdBy).toEqual(createdBy)
+
+      const latest = await streamRepository.findLatestByPartition('reg-1', null)
+      expect(latest.payload).toEqual({ summaryLogId: 'log-1', creditTotal: 0 })
+    })
+  })
+}

--- a/src/waste-balances/repository/port.contract.js
+++ b/src/waste-balances/repository/port.contract.js
@@ -6,6 +6,7 @@ import { testCreditAvailableBalanceForPrnCancellationBehaviour } from './contrac
 import { testCreditFullBalanceForIssuedPrnCancellationBehaviour } from './contract/creditFullBalanceForIssuedPrnCancellation.contract.js'
 import { testAppendStreamEventBehaviour } from './contract/appendStreamEvent.contract.js'
 import { testGetPrnCatchupEventsBehaviour } from './contract/getPrnCatchupEvents.contract.js'
+import { testAppendRegisteredOnlyHeadBehaviour } from './contract/appendRegisteredOnlyHead.contract.js'
 
 export const testWasteBalancesRepositoryContract = (repositoryFactory) => {
   testFindBalanceBehaviour(repositoryFactory)
@@ -16,4 +17,5 @@ export const testWasteBalancesRepositoryContract = (repositoryFactory) => {
   testCreditFullBalanceForIssuedPrnCancellationBehaviour(repositoryFactory)
   testAppendStreamEventBehaviour(repositoryFactory)
   testGetPrnCatchupEventsBehaviour(repositoryFactory)
+  testAppendRegisteredOnlyHeadBehaviour(repositoryFactory)
 }

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -50,6 +50,14 @@
  */
 
 /**
+ * @typedef {Object} AppendRegisteredOnlyHeadParams
+ * @property {string} registrationId
+ * @property {string} organisationId
+ * @property {string} summaryLogId
+ * @property {import('./stream-schema.js').StreamUserSummary} createdBy
+ */
+
+/**
  * @typedef {Object} GetPrnCatchupEventsParams
  * @property {string} registrationId
  * @property {string} accreditationId
@@ -80,6 +88,10 @@
  * @property {(params: GetPrnCatchupEventsParams) => Promise<import('./stream-schema.js').StreamEvent[]>} getPrnCatchupEvents
  *   Return the stream tail events to project onto a PRN read. Empty array when
  *   the accreditation has no tail events for this PRN past the watermark.
+ * @property {(params: AppendRegisteredOnlyHeadParams) => Promise<import('./stream-port.js').StreamEvent>} appendRegisteredOnlyHead
+ *   Append a zero-delta `summary-log-submitted` committed head into a
+ *   registered-only (null-accreditation) partition so the head-anchored read
+ *   model can resolve its row-state membership. Balance-neutral.
  */
 
 /**

--- a/src/waste-balances/repository/repository.js
+++ b/src/waste-balances/repository/repository.js
@@ -8,6 +8,7 @@ import {
   performCreditFullBalanceForIssuedPrnCancellation
 } from './helpers-prn.js'
 import { findBalanceByPartition } from './read-balance.js'
+import { appendRegisteredOnlyHead } from '../application/append-registered-only-head.js'
 
 /**
  * Creates a waste balances repository. The event-sourced stream is the sole
@@ -70,6 +71,19 @@ export const createWasteBalancesRepository = (dependencies) => {
         appendParams,
         findBalance,
         dependencies
+      }),
+    appendRegisteredOnlyHead: async ({
+      registrationId,
+      organisationId,
+      summaryLogId,
+      createdBy
+    }) =>
+      appendRegisteredOnlyHead({
+        repository: streamRepository,
+        registrationId,
+        organisationId,
+        summaryLogId,
+        createdBy
       }),
     getPrnCatchupEvents: async ({
       registrationId,

--- a/src/waste-records/application/registered-only-head-read-through.test.js
+++ b/src/waste-records/application/registered-only-head-read-through.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+
+import { createInMemoryRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
+import { appendRegisteredOnlyHead } from '#waste-balances/application/append-registered-only-head.js'
+import { findBalanceByPartition } from '#waste-balances/repository/read-balance.js'
+import { buildStreamEvent } from '#waste-balances/repository/stream-test-data.js'
+import { buildRowStateEntry } from '#waste-records/repository/test-data.js'
+
+import { wasteRecordStatesForRegistration } from './read-waste-record-states.js'
+
+/**
+ * The reg-only committed-head migration closes the gap where registered-only
+ * (null-accreditation) submissions wrote row states no head-anchored read could
+ * return. These tests pin the closure end-to-end and guard against the head — a
+ * zero-delta balance event — surfacing a spurious balance.
+ */
+
+const nullPartition = {
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  accreditationId: null
+}
+const createdBy = { id: 'system', name: 'backfill' }
+
+const seedMembership = async (rowStateRepository, summaryLogId) =>
+  rowStateRepository.upsertRowStates(
+    nullPartition,
+    [buildRowStateEntry({ rowId: 'row-1', data: { tonnage: 10 } })],
+    summaryLogId
+  )
+
+describe('registered-only committed head — read-through', () => {
+  it('returns nothing for the null partition before a head exists (the gap)', async () => {
+    const rowStateRepository = createInMemoryRowStateRepository()()
+    await seedMembership(rowStateRepository, 'log-1')
+
+    const states = await wasteRecordStatesForRegistration({
+      streamRepository: createInMemoryStreamRepository()(),
+      rowStateRepository,
+      ...nullPartition
+    })
+
+    expect(states).toEqual([])
+  })
+
+  it('returns the membership once the reg-only head is emitted (gap closed)', async () => {
+    const rowStateRepository = createInMemoryRowStateRepository()()
+    await seedMembership(rowStateRepository, 'log-1')
+    const streamRepository = createInMemoryStreamRepository()()
+
+    await appendRegisteredOnlyHead({
+      repository: streamRepository,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
+      summaryLogId: 'log-1',
+      createdBy
+    })
+
+    const states = await wasteRecordStatesForRegistration({
+      streamRepository,
+      rowStateRepository,
+      ...nullPartition
+    })
+
+    expect(states.map((s) => s.rowId)).toEqual(['row-1'])
+    expect(states[0].data).toEqual({ tonnage: 10 })
+  })
+})
+
+describe('registered-only committed head — balance neutrality', () => {
+  it('leaves the null partition with a zero balance', async () => {
+    const streamRepository = createInMemoryStreamRepository()()
+
+    await appendRegisteredOnlyHead({
+      repository: streamRepository,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
+      summaryLogId: 'log-1',
+      createdBy
+    })
+
+    const balance = await findBalanceByPartition(
+      streamRepository,
+      /** @type {any} */ ({
+        registrationId: 'reg-1',
+        accreditationId: null
+      })
+    )
+    expect(balance).toMatchObject({ amount: 0, availableAmount: 0 })
+  })
+
+  it('does not touch an accredited balance in the same registration', async () => {
+    const streamRepository = createInMemoryStreamRepository([
+      buildStreamEvent({
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1',
+        number: 1,
+        payload: { summaryLogId: 'log-acc', creditTotal: 50 },
+        closingBalance: { amount: 50, availableAmount: 50 }
+      })
+    ])()
+
+    await appendRegisteredOnlyHead({
+      repository: streamRepository,
+      registrationId: 'reg-1',
+      organisationId: 'org-1',
+      summaryLogId: 'log-1',
+      createdBy
+    })
+
+    const accreditedBalance = await findBalanceByPartition(streamRepository, {
+      registrationId: 'reg-1',
+      accreditationId: 'acc-1'
+    })
+    expect(accreditedBalance).toMatchObject({ amount: 50, availableAmount: 50 })
+  })
+})

--- a/src/waste-records/backfill/backfill-estate-rowstates.js
+++ b/src/waste-records/backfill/backfill-estate-rowstates.js
@@ -31,6 +31,7 @@ import { backfillRegistrationRowStates } from './backfill-registration-rowstates
  * @property {number} streamsBackfilled - Registration streams that received row states
  * @property {number} submissionsBackfilled
  * @property {number} rowStateWrites
+ * @property {number} headWrites - Registered-only committed heads emitted
  * @property {OrphanedAccreditation[]} orphanedAccreditations
  */
 
@@ -42,6 +43,7 @@ import { backfillRegistrationRowStates } from './backfill-registration-rowstates
  * @typedef {Object} StreamBackfilled
  * @property {number} submissionCount
  * @property {number} rowStateWriteCount
+ * @property {number} headWriteCount
  *
  * @typedef {Object} StreamOrphaned
  * @property {OrphanedAccreditation} orphanedAccreditation
@@ -81,6 +83,7 @@ const toOrderedSummaryLog = ({ summaryLog }) => ({
  * @param {import('#repositories/summary-logs/port.js').SummaryLogsRepository} args.summaryLogsRepository
  * @param {import('#overseas-sites/repository/port.js').OverseasSitesRepository} args.overseasSitesRepository
  * @param {RowStateRepository} args.rowStateRepository
+ * @param {import('#waste-balances/repository/stream-port.js').WasteBalanceStreamRepository} args.streamRepository
  * @returns {Promise<StreamBackfilled | StreamOrphaned | null>}
  */
 const backfillRegistrationStream = async ({
@@ -90,7 +93,8 @@ const backfillRegistrationStream = async ({
   wasteRecordsRepository,
   summaryLogsRepository,
   overseasSitesRepository,
-  rowStateRepository
+  rowStateRepository,
+  streamRepository
 }) => {
   const { accreditationId } = registration
 
@@ -140,7 +144,7 @@ const backfillRegistrationStream = async ({
     registration.id
   )
 
-  const { submissionCount, rowStateWriteCount } =
+  const { submissionCount, rowStateWriteCount, headWriteCount } =
     await backfillRegistrationRowStates({
       partition: {
         organisationId: organisation.id,
@@ -151,10 +155,11 @@ const backfillRegistrationStream = async ({
       summaryLogs,
       accreditation,
       overseasSites,
-      rowStateRepository
+      rowStateRepository,
+      streamRepository
     })
 
-  return { submissionCount, rowStateWriteCount }
+  return { submissionCount, rowStateWriteCount, headWriteCount }
 }
 
 /**
@@ -166,9 +171,12 @@ const backfillRegistrationStream = async ({
  * Accreditation validity and overseas-site approval are read at today's
  * state, so a backfilled row's classification reflects current factors — the
  * historical-reading drift ADR-0037 accepts for legacy submissions. Re-runnable:
- * every registration's upserts are idempotent. An accreditation referenced by a
- * registration but missing from the organisation is surfaced and skipped, not
- * fatal.
+ * every registration's upserts are idempotent. Registered-only streams, which
+ * never formed a committed head on the live path, additionally receive a
+ * balance-neutral zero-delta head per submission so the head-anchored read model
+ * can resolve them; head emission is idempotent too. An accreditation referenced
+ * by a registration but missing from the organisation is surfaced and skipped,
+ * not fatal.
  *
  * @param {Object} deps
  * @param {import('#repositories/organisations/port.js').OrganisationsRepository} deps.organisationsRepository
@@ -176,6 +184,7 @@ const backfillRegistrationStream = async ({
  * @param {import('#repositories/summary-logs/port.js').SummaryLogsRepository} deps.summaryLogsRepository
  * @param {import('#overseas-sites/repository/port.js').OverseasSitesRepository} deps.overseasSitesRepository
  * @param {RowStateRepository} deps.rowStateRepository
+ * @param {import('#waste-balances/repository/stream-port.js').WasteBalanceStreamRepository} deps.streamRepository
  * @returns {Promise<EstateBackfillSummary>}
  */
 export const backfillEstateRowStates = async ({
@@ -183,13 +192,15 @@ export const backfillEstateRowStates = async ({
   wasteRecordsRepository,
   summaryLogsRepository,
   overseasSitesRepository,
-  rowStateRepository
+  rowStateRepository,
+  streamRepository
 }) => {
   const organisations = await organisationsRepository.findAll()
 
   let streamsBackfilled = 0
   let submissionsBackfilled = 0
   let rowStateWrites = 0
+  let headWrites = 0
   const orphanedAccreditations = []
 
   for (const organisation of organisations) {
@@ -201,7 +212,8 @@ export const backfillEstateRowStates = async ({
         wasteRecordsRepository,
         summaryLogsRepository,
         overseasSitesRepository,
-        rowStateRepository
+        rowStateRepository,
+        streamRepository
       })
       if (!result) {
         continue
@@ -212,6 +224,7 @@ export const backfillEstateRowStates = async ({
         streamsBackfilled += 1
         submissionsBackfilled += result.submissionCount
         rowStateWrites += result.rowStateWriteCount
+        headWrites += result.headWriteCount
       }
     }
   }
@@ -221,6 +234,7 @@ export const backfillEstateRowStates = async ({
     streamsBackfilled,
     submissionsBackfilled,
     rowStateWrites,
+    headWrites,
     orphanedAccreditations
   }
 }

--- a/src/waste-records/backfill/backfill-estate-rowstates.test.js
+++ b/src/waste-records/backfill/backfill-estate-rowstates.test.js
@@ -9,6 +9,8 @@ import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
 import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import { createInMemoryRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
 import {
   buildAccreditation,
   buildOrganisation,
@@ -66,7 +68,8 @@ const inMemoryDeps = ({ organisations, wasteRecords }) => ({
   wasteRecordsRepository: createInMemoryWasteRecordsRepository(wasteRecords)(),
   summaryLogsRepository: createInMemorySummaryLogsRepository()(logger),
   overseasSitesRepository: createInMemoryOverseasSitesRepository()(),
-  rowStateRepository: createInMemoryRowStateRepository()()
+  rowStateRepository: createInMemoryRowStateRepository()(),
+  streamRepository: createInMemoryStreamRepository()()
 })
 
 describe('backfillEstateRowStates', () => {
@@ -118,8 +121,50 @@ describe('backfillEstateRowStates', () => {
       streamsBackfilled: 1,
       submissionsBackfilled: 2,
       rowStateWrites: 2,
+      headWrites: 0,
       orphanedAccreditations: []
     })
+    expect(
+      await deps.streamRepository.findAllByPartition('reg-1', 'acc-1')
+    ).toEqual([])
+  })
+
+  it('emits zero-delta committed heads for a registered-only registration so its latest state reads through the head', async () => {
+    const registration = reprocessorRegistration({ id: 'reg-ro' })
+    delete registration.accreditationId
+    const organisation = buildOrganisation({
+      registrations: [registration],
+      accreditations: []
+    })
+    const wasteRecords = [
+      receivedRecord(organisation.id, 'reg-ro', 'row-1', [
+        { summaryLog: { id: fileId('sl-1') }, data: { supplierName: 'Acme' } }
+      ])
+    ]
+    const deps = inMemoryDeps({ organisations: [organisation], wasteRecords })
+    await insertLog(deps.summaryLogsRepository, 'sl-1', {
+      organisationId: organisation.id,
+      registrationId: 'reg-ro',
+      submittedAt: '2025-01-01T00:00:00.000Z'
+    })
+    await insertLog(deps.summaryLogsRepository, 'sl-2', {
+      organisationId: organisation.id,
+      registrationId: 'reg-ro',
+      submittedAt: '2025-02-01T00:00:00.000Z'
+    })
+
+    const summary = await backfillEstateRowStates(deps)
+
+    const heads = await deps.streamRepository.findAllByPartition('reg-ro', null)
+    expect(heads.map((h) => h.kind)).toEqual([
+      STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+      STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED
+    ])
+    expect(
+      heads.map((h) => /** @type {any} */ (h.payload).summaryLogId)
+    ).toEqual([fileId('sl-1'), fileId('sl-2')])
+    expect(heads.every((h) => h.closingBalance.amount === 0)).toBe(true)
+    expect(summary.headWrites).toBe(2)
   })
 
   it('backfills a registered-only registration under a null-accreditation partition', async () => {

--- a/src/waste-records/backfill/backfill-registration-rowstates.js
+++ b/src/waste-records/backfill/backfill-registration-rowstates.js
@@ -1,3 +1,6 @@
+import { appendRegisteredOnlyHead } from '#waste-balances/application/append-registered-only-head.js'
+import { BACKFILL_ACTOR, STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+
 import { reconstructSubmissionRowStates } from './reconstruct-submission-rowstates.js'
 
 /**
@@ -5,6 +8,7 @@ import { reconstructSubmissionRowStates } from './reconstruct-submission-rowstat
  * @import { RowStateRepository } from '#waste-records/repository/port.js'
  * @import { WasteRecord } from '#domain/waste-records/model.js'
  * @import { OrderedSummaryLog } from './reconstruct-submission-rowstates.js'
+ * @import { WasteBalanceStreamRepository } from '#waste-balances/repository/stream-port.js'
  */
 
 /**
@@ -13,7 +17,30 @@ import { reconstructSubmissionRowStates } from './reconstruct-submission-rowstat
  * @typedef {Object} RegistrationBackfillSummary
  * @property {number} submissionCount - Submitted summary logs replayed
  * @property {number} rowStateWriteCount - Row-state entries upserted across them
+ * @property {number} headWriteCount - Registered-only committed heads emitted
  */
+
+/**
+ * The summary-log ids of registered-only committed heads already present in a
+ * null-accreditation partition, so a re-run never double-emits a head.
+ *
+ * @param {WasteBalanceStreamRepository} streamRepository
+ * @param {string} registrationId
+ * @returns {Promise<Set<string>>}
+ */
+const existingHeadSummaryLogIds = async (streamRepository, registrationId) => {
+  const events = await streamRepository.findAllByPartition(registrationId, null)
+  return new Set(
+    events
+      .filter((event) => event.kind === STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
+      .map(
+        (event) =>
+          /** @type {import('#waste-balances/repository/stream-schema.js').SummaryLogSubmittedPayload} */ (
+            event.payload
+          ).summaryLogId
+      )
+  )
+}
 
 /**
  * Backfill one registration's waste record states from its sparse version
@@ -26,6 +53,14 @@ import { reconstructSubmissionRowStates } from './reconstruct-submission-rowstat
  * depends on an earlier submission's document already existing when a later one
  * that shares its state is written.
  *
+ * Registered-only registrations (null partition) form no committed head on the
+ * live path, so the same sweep emits a zero-delta `summary-log-submitted` head
+ * per submission, in stream order, giving the head-anchored read model
+ * something to resolve. Emission is balance-neutral and idempotent: a head is
+ * skipped when one already exists for its summary log, so a re-run emits none.
+ * Accredited partitions keep the heads their original processing wrote and emit
+ * none here.
+ *
  * @param {Object} params
  * @param {RowStatePartition} params.partition
  * @param {WasteRecord[]} params.wasteRecords
@@ -33,6 +68,7 @@ import { reconstructSubmissionRowStates } from './reconstruct-submission-rowstat
  * @param {Object} params.accreditation
  * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} params.overseasSites
  * @param {RowStateRepository} params.rowStateRepository
+ * @param {WasteBalanceStreamRepository} params.streamRepository
  * @returns {Promise<RegistrationBackfillSummary>}
  */
 export const backfillRegistrationRowStates = async ({
@@ -41,7 +77,8 @@ export const backfillRegistrationRowStates = async ({
   summaryLogs,
   accreditation,
   overseasSites,
-  rowStateRepository
+  rowStateRepository,
+  streamRepository
 }) => {
   const submissions = reconstructSubmissionRowStates({
     wasteRecords,
@@ -50,11 +87,29 @@ export const backfillRegistrationRowStates = async ({
     overseasSites
   })
 
+  const emitsHeads = partition.accreditationId === null
+  const existingHeads = emitsHeads
+    ? await existingHeadSummaryLogIds(streamRepository, partition.registrationId)
+    : new Set()
+
   let rowStateWriteCount = 0
+  let headWriteCount = 0
   for (const { summaryLogId, entries } of submissions) {
     await rowStateRepository.upsertRowStates(partition, entries, summaryLogId)
     rowStateWriteCount += entries.length
+
+    if (emitsHeads && !existingHeads.has(summaryLogId)) {
+      await appendRegisteredOnlyHead({
+        repository: streamRepository,
+        registrationId: partition.registrationId,
+        organisationId: partition.organisationId,
+        summaryLogId,
+        createdBy: BACKFILL_ACTOR
+      })
+      existingHeads.add(summaryLogId)
+      headWriteCount += 1
+    }
   }
 
-  return { submissionCount: submissions.length, rowStateWriteCount }
+  return { submissionCount: submissions.length, rowStateWriteCount, headWriteCount }
 }

--- a/src/waste-records/backfill/backfill-registration-rowstates.test.js
+++ b/src/waste-records/backfill/backfill-registration-rowstates.test.js
@@ -4,6 +4,8 @@ import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shar
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createInMemoryRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
+import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
 
 import { backfillRegistrationRowStates } from './backfill-registration-rowstates.js'
 
@@ -11,6 +13,11 @@ const partition = {
   organisationId: 'org-1',
   registrationId: 'reg-1',
   accreditationId: 'acc-1'
+}
+const nullPartition = {
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  accreditationId: null
 }
 const accreditation = { id: 'acc-1' }
 /** @type {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} */
@@ -53,7 +60,8 @@ describe('backfillRegistrationRowStates', () => {
       summaryLogs,
       accreditation,
       overseasSites,
-      rowStateRepository
+      rowStateRepository,
+      streamRepository: createInMemoryStreamRepository()()
     })
 
     expect(
@@ -82,7 +90,8 @@ describe('backfillRegistrationRowStates', () => {
       summaryLogs,
       accreditation,
       overseasSites,
-      rowStateRepository
+      rowStateRepository,
+      streamRepository: createInMemoryStreamRepository()()
     })
 
     const history = await rowHistory(rowStateRepository, 'row-1')
@@ -112,7 +121,8 @@ describe('backfillRegistrationRowStates', () => {
       summaryLogs,
       accreditation,
       overseasSites,
-      rowStateRepository
+      rowStateRepository,
+      streamRepository: createInMemoryStreamRepository()()
     })
 
     const history = await rowHistory(rowStateRepository, 'row-1')
@@ -138,7 +148,8 @@ describe('backfillRegistrationRowStates', () => {
         summaryLogs,
         accreditation,
         overseasSites,
-        rowStateRepository
+        rowStateRepository,
+        streamRepository: createInMemoryStreamRepository()()
       })
 
     await run()
@@ -170,9 +181,136 @@ describe('backfillRegistrationRowStates', () => {
       summaryLogs,
       accreditation,
       overseasSites,
-      rowStateRepository
+      rowStateRepository,
+      streamRepository: createInMemoryStreamRepository()()
     })
 
-    expect(summary).toEqual({ submissionCount: 2, rowStateWriteCount: 3 })
+    expect(summary).toEqual({
+      submissionCount: 2,
+      rowStateWriteCount: 3,
+      headWriteCount: 0
+    })
+  })
+
+  describe('registered-only committed heads', () => {
+    it('emits a zero-delta committed head per submission into the null partition', async () => {
+      const summaryLogs = [
+        submittedLog('sl-1', '2025-01-01T00:00:00.000Z'),
+        submittedLog('sl-2', '2025-02-01T00:00:00.000Z')
+      ]
+      const wasteRecords = [
+        receivedRecord('row-1', [
+          { summaryLog: { id: 'sl-1' }, data: { supplierName: 'Acme' } }
+        ])
+      ]
+      const rowStateRepository = createInMemoryRowStateRepository()()
+      const streamRepository = createInMemoryStreamRepository()()
+
+      await backfillRegistrationRowStates({
+        partition: nullPartition,
+        wasteRecords,
+        summaryLogs,
+        accreditation: null,
+        overseasSites,
+        rowStateRepository,
+        streamRepository
+      })
+
+      const heads = await streamRepository.findAllByPartition('reg-1', null)
+      expect(heads.map((h) => h.kind)).toEqual([
+        STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED
+      ])
+      expect(
+        heads.map((h) => /** @type {any} */ (h.payload).summaryLogId)
+      ).toEqual(['sl-1', 'sl-2'])
+      expect(heads.every((h) => h.closingBalance.amount === 0)).toBe(true)
+      expect(heads.every((h) => h.closingBalance.availableAmount === 0)).toBe(
+        true
+      )
+    })
+
+    it('is idempotent — a second run emits no duplicate head', async () => {
+      const summaryLogs = [
+        submittedLog('sl-1', '2025-01-01T00:00:00.000Z'),
+        submittedLog('sl-2', '2025-02-01T00:00:00.000Z')
+      ]
+      const wasteRecords = [
+        receivedRecord('row-1', [
+          { summaryLog: { id: 'sl-1' }, data: { supplierName: 'Acme' } }
+        ])
+      ]
+      const rowStateRepository = createInMemoryRowStateRepository()()
+      const streamRepository = createInMemoryStreamRepository()()
+      const run = () =>
+        backfillRegistrationRowStates({
+          partition: nullPartition,
+          wasteRecords,
+          summaryLogs,
+          accreditation: null,
+          overseasSites,
+          rowStateRepository,
+          streamRepository
+        })
+
+      await run()
+      const summary = await run()
+
+      const heads = await streamRepository.findAllByPartition('reg-1', null)
+      expect(heads).toHaveLength(2)
+      expect(summary.headWriteCount).toBe(0)
+    })
+
+    it('emits no committed head for an accredited (non-null) partition', async () => {
+      const summaryLogs = [submittedLog('sl-1', '2025-01-01T00:00:00.000Z')]
+      const wasteRecords = [
+        receivedRecord('row-1', [
+          { summaryLog: { id: 'sl-1' }, data: { supplierName: 'Acme' } }
+        ])
+      ]
+      const rowStateRepository = createInMemoryRowStateRepository()()
+      const streamRepository = createInMemoryStreamRepository()()
+
+      const summary = await backfillRegistrationRowStates({
+        partition,
+        wasteRecords,
+        summaryLogs,
+        accreditation,
+        overseasSites,
+        rowStateRepository,
+        streamRepository
+      })
+
+      expect(await streamRepository.findAllByPartition('reg-1', 'acc-1')).toEqual(
+        []
+      )
+      expect(summary.headWriteCount).toBe(0)
+    })
+
+    it('reports headWriteCount for migration logging', async () => {
+      const summaryLogs = [
+        submittedLog('sl-1', '2025-01-01T00:00:00.000Z'),
+        submittedLog('sl-2', '2025-02-01T00:00:00.000Z')
+      ]
+      const wasteRecords = [
+        receivedRecord('row-1', [
+          { summaryLog: { id: 'sl-1' }, data: { supplierName: 'Acme' } }
+        ])
+      ]
+      const rowStateRepository = createInMemoryRowStateRepository()()
+      const streamRepository = createInMemoryStreamRepository()()
+
+      const summary = await backfillRegistrationRowStates({
+        partition: nullPartition,
+        wasteRecords,
+        summaryLogs,
+        accreditation: null,
+        overseasSites,
+        rowStateRepository,
+        streamRepository
+      })
+
+      expect(summary.headWriteCount).toBe(2)
+    })
   })
 })


### PR DESCRIPTION
## What

Registered-only registrations (those with no accreditation) submit summary logs, but no summary-log committed event was being written to their waste-balance stream. The read model resolves which submissions belong to a registration from those committed events, so registered-only row states were being written but could not be read back.

This change writes a balance-neutral summary-log committed event (`creditTotal: 0`) for these registrations so their row states become readable.

## How

Behind a dedicated `FEATURE_FLAG_REGISTERED_ONLY_COMMITTED_HEADS` flag (default off), independent of the row-state write flag:

- **Forward path** — when the flag is on, a registered-only submission writes its summary-log committed event as part of committing its state.
- **Historical migration** — the backfill sweep writes one summary-log committed event per existing registered-only submission. It is idempotent: it never writes a second event for a submission that already has one, so the sweep is safe to re-run.

A registered-only registration has no accreditation and therefore no waste balance, so the event carries `creditTotal: 0` and leaves all balances unchanged. Balance calculations only consider accredited registrations, so this never surfaces a balance for a registered-only registration.

## Notes

- The flag defaults off; nothing changes in any environment until it is flipped.
- The historical migration runs as a deliberate operational step, not at runtime.
- Related row-state rollout work is tracked separately under PAE-1590.
