### PR TITLE
PAE-000: use caret node engine range for lts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "vitest-mongodb": "1.0.3"
       },
       "engines": {
-        "node": ">=24.17.0 <25"
+        "node": "^24.17.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "#waste-records-export/*": "./src/waste-records-export/*"
   },
   "engines": {
-    "node": ">=24.17.0 <25"
+    "node": "^24.17.0"
   },
   "scripts": {
     "docker:dev": "NODE_ENV=development npm run server:watch",


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
follows the shared preset change (epr-re-ex-service#297). switch the node engines constraint to a single `^x.y.z` token — semantically identical to `>=x <25` (same `engine-strict` guardrail against 25/26) but a single renovate-managed token that advances cleanly to the next lts. node base image is unaffected (defradigital, managed separately).

- engines: `>=24.17.0 <25` -> `^24.17.0`