### PR TITLE
PAE-1662: Add Waste Balance Tonnage column to WB record export

### DIFF
--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -449,6 +449,7 @@ describe('streamCsvExport', () => {
     expect(cells[5]).toBe('Yes') // Accredited column
     expect(cells[9]).toBe('false')
     expect(cells[10]).toContain('OUTSIDE_ACCREDITATION_PERIOD')
+    expect(cells[11]).toBe('') // Waste Balance Tonnage empty when excluded
   })
 
   it('emits empty Waste Balance Exclusion Reason when the record is included', async () => {
@@ -483,7 +484,8 @@ describe('streamCsvExport', () => {
     const out = await collect(streamCsvExport(deps))
     const cells = out[1].trim().split(',')
     expect(cells[9]).toBe('true')
-    expect(cells[10]).toBe('')
+    expect(cells[10]).toBe('') // Waste Balance Exclusion Reason empty when included
+    expect(Number(cells[11])).toBeGreaterThan(0) // Waste Balance Tonnage populated when included
   })
 
   it('reads Accredited "Yes" with the number for a suspended accreditation', async () => {
@@ -560,9 +562,9 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(3)
-    // Within the same type, lower rowId emits first (Row ID is metadata col 11)
-    expect(out[1].trim().split(',')[11]).toBe('1001')
-    expect(out[2].trim().split(',')[11]).toBe('2002')
+    // Within the same type, lower rowId emits first (Row ID is metadata col 12)
+    expect(out[1].trim().split(',')[12]).toBe('1001')
+    expect(out[2].trim().split(',')[12]).toBe('2002')
   })
 
   it('orders rowIds naturally so "9" comes before "10"', async () => {
@@ -578,8 +580,8 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(3)
-    expect(out[1].trim().split(',')[11]).toBe('9')
-    expect(out[2].trim().split(',')[11]).toBe('10')
+    expect(out[1].trim().split(',')[12]).toBe('9')
+    expect(out[2].trim().split(',')[12]).toBe('10')
   })
 
   it('treats a missing accreditation as registered-only', async () => {

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -41,6 +41,7 @@ export const METADATA_COLUMNS = Object.freeze([
   'Submitted At',
   'Included in Waste Balance',
   'Waste Balance Exclusion Reason',
+  'Waste Balance Tonnage',
   'Row ID'
 ])
 
@@ -157,6 +158,7 @@ export const buildDataRow = ({
     wasteBalanceClassification.reasons
       .map((r) => (r.field ? `${r.code}: ${r.field}` : r.code))
       .join('; '),
+    wasteBalanceClassification.tonnage ?? '',
     String(record.rowId)
   ]
 

--- a/src/waste-records-export/domain/csv-columns.test.js
+++ b/src/waste-records-export/domain/csv-columns.test.js
@@ -28,6 +28,7 @@ describe('csv-columns', () => {
         'Submitted At',
         'Included in Waste Balance',
         'Waste Balance Exclusion Reason',
+        'Waste Balance Tonnage',
         'Row ID'
       ])
     })
@@ -205,7 +206,7 @@ describe('csv-columns', () => {
       summaryLogEntry: {
         submittedAt: '2026-04-15T09:00:00Z'
       },
-      wasteBalanceClassification: { included: true, reasons: [] },
+      wasteBalanceClassification: { included: true, reasons: [], tonnage: 9 },
       dataFieldColumns
     }
 
@@ -227,7 +228,8 @@ describe('csv-columns', () => {
       expect(row[8]).toBe('2026-04-15T09:00:00Z') // Submitted At
       expect(row[9]).toBe('true') // Included in Waste Balance
       expect(row[10]).toBe('') // Waste Balance Exclusion Reason
-      expect(row[11]).toBe('1001') // Row ID
+      expect(row[11]).toBe(9) // Waste Balance Tonnage
+      expect(row[12]).toBe('1001') // Row ID
     })
 
     it('emits the glass recycling process in place of "glass" for the Material column', () => {
@@ -353,11 +355,24 @@ describe('csv-columns', () => {
           reasons: [
             { code: 'PRN_ISSUED' },
             { code: 'MISSING_REQUIRED_FIELD', field: 'EWC_CODE' }
-          ]
+          ],
+          tonnage: null
         }
       })
       expect(excluded[9]).toBe('false') // Included in Waste Balance
       expect(excluded[10]).toBe('PRN_ISSUED; MISSING_REQUIRED_FIELD: EWC_CODE') // Exclusion Reason
+      expect(excluded[11]).toBe('') // Waste Balance Tonnage (empty when excluded)
+
+      const included = buildDataRow({
+        ...baseInput,
+        wasteBalanceClassification: {
+          included: true,
+          reasons: [],
+          tonnage: -5.25
+        }
+      })
+      expect(included[9]).toBe('true') // Included in Waste Balance
+      expect(included[11]).toBe(-5.25) // Waste Balance Tonnage (numeric, can be negative)
     })
   })
 })

--- a/src/waste-records-export/domain/is-included-in-waste-balance.js
+++ b/src/waste-records-export/domain/is-included-in-waste-balance.js
@@ -10,6 +10,7 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
  * @typedef {Object} WasteBalanceClassification
  * @property {boolean} included - Whether the record is included in the waste balance
  * @property {WasteBalanceClassificationReason[]} reasons - Exclusion reasons; empty when included
+ * @property {number | null} tonnage - Rounded waste balance tonnage; null when excluded
  */
 
 /**
@@ -27,7 +28,7 @@ export const getWasteBalanceClassification = (
   overseasSites
 ) => {
   if (record.excludedFromWasteBalance) {
-    return { included: false, reasons: [] }
+    return { included: false, reasons: [], tonnage: null }
   }
 
   const schema = findSchemaForProcessingType(
@@ -36,7 +37,7 @@ export const getWasteBalanceClassification = (
   )
 
   if (!schema?.classifyForWasteBalance) {
-    return { included: false, reasons: [] }
+    return { included: false, reasons: [], tonnage: null }
   }
 
   const result = schema.classifyForWasteBalance(record.data, {
@@ -45,8 +46,8 @@ export const getWasteBalanceClassification = (
   })
 
   if (result.outcome === ROW_OUTCOME.INCLUDED) {
-    return { included: true, reasons: [] }
+    return { included: true, reasons: [], tonnage: result.transactionAmount }
   }
 
-  return { included: false, reasons: result.reasons }
+  return { included: false, reasons: result.reasons, tonnage: null }
 }

--- a/src/waste-records-export/domain/is-included-in-waste-balance.test.js
+++ b/src/waste-records-export/domain/is-included-in-waste-balance.test.js
@@ -80,7 +80,7 @@ describe('getWasteBalanceClassification', () => {
         accreditation,
         ORS_VALIDATION_DISABLED
       )
-    ).toEqual({ included: false, reasons: [] })
+    ).toEqual({ included: false, reasons: [], tonnage: null })
   })
 
   it('returns included:false and empty reasons when no schema or classifyForWasteBalance exists', () => {
@@ -94,7 +94,7 @@ describe('getWasteBalanceClassification', () => {
         accreditation,
         ORS_VALIDATION_DISABLED
       )
-    ).toEqual({ included: false, reasons: [] })
+    ).toEqual({ included: false, reasons: [], tonnage: null })
 
     const noClassifyRecord = buildWasteRecord({
       type: WASTE_RECORD_TYPE.SENT_ON,
@@ -106,17 +106,16 @@ describe('getWasteBalanceClassification', () => {
         accreditation,
         ORS_VALIDATION_DISABLED
       )
-    ).toEqual({ included: false, reasons: [] })
+    ).toEqual({ included: false, reasons: [], tonnage: null })
   })
 
-  it('returns included:true and empty reasons when record is included', () => {
-    expect(
-      getWasteBalanceClassification(
-        fullyFilledReprocessorRecord,
-        accreditation,
-        ORS_VALIDATION_DISABLED
-      )
-    ).toEqual({ included: true, reasons: [] })
+  it('returns included:true with tonnage when record is included', () => {
+    const result = getWasteBalanceClassification(
+      fullyFilledReprocessorRecord,
+      accreditation,
+      ORS_VALIDATION_DISABLED
+    )
+    expect(result).toEqual({ included: true, reasons: [], tonnage: 9 })
   })
 
   it('returns included:false with exclusion reason when record is excluded', () => {


### PR DESCRIPTION
Ticket: [PAE-1662](https://eaflood.atlassian.net/browse/PAE-1662)
- Add `Waste Balance Tonnage`  column to the WB record CSV export
- Populate from `transactionAmount` returned by `classifyForWasteBalance`; empty when excluded
- Tonnage can be negative (sent-on loads subtract from the balance)
- Extend `WasteBalanceClassification` typedef with `tonnage: number | null`

[PAE-1662]: https://eaflood.atlassian.net/browse/PAE-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ