### PR TITLE
PAE-1669: Wire optimistic concurrency through the waste balance stream

### DIFF
--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -69,7 +69,8 @@ export async function deductWasteBalanceIfNeeded(
       organisationId,
       prnId,
       tonnage,
-      createdBy
+      createdBy,
+      expectedHead: balance.eventNumber
     })
   } else {
     throw Boom.badRequest(
@@ -112,7 +113,8 @@ export async function deductTotalBalanceIfNeeded(
       organisationId,
       prnId,
       tonnage,
-      createdBy
+      createdBy,
+      expectedHead: balance.eventNumber
     })
   } else {
     throw Boom.badRequest(
@@ -152,7 +154,8 @@ export async function creditWasteBalanceIfNeeded(
       organisationId,
       prnId,
       tonnage,
-      createdBy
+      createdBy,
+      expectedHead: balance.eventNumber
     })
   } else {
     throw Boom.badRequest(
@@ -192,7 +195,8 @@ export async function creditFullBalanceIfNeeded(
       organisationId,
       prnId,
       tonnage,
-      createdBy
+      createdBy,
+      expectedHead: balance.eventNumber
     })
   } else {
     throw Boom.badRequest(
@@ -316,8 +320,10 @@ const EFFECT_HANDLERS = Object.freeze({
 
 /**
  * Applies the balance events for a status transition, appending one stream
- * event per input event and returning them in order. Each handler appends to
- * the stream or throws.
+ * event per input event and returning them in order. Each handler reads the
+ * balance, then appends at the head it read; a competing write that advanced
+ * the head in between surfaces as a slot/sequence conflict and propagates to
+ * the caller (ADR-0036 "detection over absorption"), failing the transition.
  *
  * @param {WasteBalancesRepository} wasteBalancesRepository
  * @param {import('#common/hapi-types.js').TypedLogger} logger

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -323,7 +323,7 @@ const EFFECT_HANDLERS = Object.freeze({
  * event per input event and returning them in order. Each handler reads the
  * balance, then appends at the head it read; a competing write that advanced
  * the head in between surfaces as a slot/sequence conflict and propagates to
- * the caller (ADR-0036 "detection over absorption"), failing the transition.
+ * the caller (ADR-0036), failing the transition.
  *
  * @param {WasteBalancesRepository} wasteBalancesRepository
  * @param {import('#common/hapi-types.js').TypedLogger} logger

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
@@ -8,6 +8,7 @@ import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import { createWasteBalancesRepository } from '#waste-balances/repository/repository.js'
 import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
 import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+import { StreamSlotConflictError } from '#waste-balances/repository/stream-port.js'
 import { buildStreamEvent } from '#waste-balances/repository/stream-test-data.js'
 
 const REGISTRATION_ID = 'reg-1'
@@ -197,6 +198,64 @@ describe('applyWasteBalanceEffects appended events return', () => {
     )
 
     expect(applied).toEqual([])
+  })
+})
+
+/**
+ * Replace the repository's append with one that lands a single competing event
+ * the first time it is called, then delegates. This makes the effect's append
+ * collide on the slot the competing writer has taken, exercising the
+ * optimistic-concurrency guard.
+ *
+ * @param {import('#waste-balances/repository/stream-port.js').WasteBalanceStreamRepository} streamRepository
+ * @param {object} competingEvent
+ */
+const landCompetingEventOnFirstAppend = (streamRepository, competingEvent) => {
+  const realAppend = streamRepository.appendEvent.bind(streamRepository)
+  let landed = false
+  streamRepository.appendEvent = async (event) => {
+    if (!landed) {
+      landed = true
+      await realAppend(buildStreamEvent(competingEvent))
+    }
+    return realAppend(event)
+  }
+}
+
+describe('applyWasteBalanceEffects optimistic concurrency', () => {
+  it('surfaces a slot conflict when a competing event takes the targeted slot', async () => {
+    const { wasteBalancesRepository, streamRepository } =
+      await setupLedgerRepository()
+
+    landCompetingEventOnFirstAppend(streamRepository, {
+      registrationId: REGISTRATION_ID,
+      accreditationId: ACCREDITATION_ID,
+      number: 2,
+      kind: STREAM_EVENT_KIND.PRN_CREATED,
+      payload: { prnId: 'competing-prn', amount: 70 },
+      openingBalance: { amount: 100, availableAmount: 100 },
+      closingBalance: { amount: 100, availableAmount: 30 }
+    })
+
+    const events = balanceEventsFor(
+      PRN_STATUS.DRAFT,
+      PRN_STATUS.AWAITING_AUTHORISATION,
+      balanceParamsFor({
+        tonnage: 80,
+        currentStatus: PRN_STATUS.DRAFT,
+        newStatus: PRN_STATUS.AWAITING_AUTHORISATION
+      })
+    )
+
+    await expect(
+      applyWasteBalanceEffects(wasteBalancesRepository, buildLogger(), events)
+    ).rejects.toBeInstanceOf(StreamSlotConflictError)
+
+    const all = await streamRepository.findAllByPartition(
+      REGISTRATION_ID,
+      ACCREDITATION_ID
+    )
+    expect(all).toHaveLength(2)
   })
 })
 

--- a/src/packaging-recycling-notes/application/update-status-concurrency.test.js
+++ b/src/packaging-recycling-notes/application/update-status-concurrency.test.js
@@ -130,12 +130,21 @@ const COMMITTED_EVENT_NUMBER = 2
  * On the ledger path concurrent writers serialise at the append-only stream
  * slot: the first writer claims the next slot, the second collides with a
  * StreamSlotConflictError. Exactly one writer commits, so the stream holds a
- * single event past the seed.
+ * single event past the seed and the PRN document — persisted only by the
+ * winner, since the loser fails at the stream append before persisting —
+ * reflects that one transition.
  *
  * @param {PromiseSettledResult<unknown>[]} results
  * @param {import('#waste-balances/repository/stream-port.js').WasteBalanceStreamRepository} streamRepository
+ * @param {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} prnRepository
+ * @param {import('#packaging-recycling-notes/domain/model.js').PrnStatus} expectedStatus
  */
-const expectOneWinsOneStreamConflict = async (results, streamRepository) => {
+const expectOneWinsOneStreamConflict = async (
+  results,
+  streamRepository,
+  prnRepository,
+  expectedStatus
+) => {
   const fulfilled = results.filter((r) => r.status === 'fulfilled')
   const rejected = results.filter((r) => r.status === 'rejected')
 
@@ -145,6 +154,9 @@ const expectOneWinsOneStreamConflict = async (results, streamRepository) => {
 
   const latest = await streamRepository.findLatestByPartition(REG_ID, ACC_ID)
   expect(latest?.number).toBe(COMMITTED_EVENT_NUMBER)
+
+  const prn = await prnRepository.findById(PRN_ID)
+  expect(prn?.status.currentStatus).toBe(expectedStatus)
 }
 
 describe('updatePrnStatus concurrency', () => {
@@ -181,7 +193,12 @@ describe('updatePrnStatus concurrency', () => {
 
     const results = await Promise.allSettled([issue(), issue()])
 
-    await expectOneWinsOneStreamConflict(results, streamRepository)
+    await expectOneWinsOneStreamConflict(
+      results,
+      streamRepository,
+      prnRepository,
+      PRN_STATUS.AWAITING_ACCEPTANCE
+    )
   })
 
   it('credits the waste balance only once when two deletes race for an awaiting_authorisation PRN', async () => {
@@ -219,7 +236,12 @@ describe('updatePrnStatus concurrency', () => {
 
     const results = await Promise.allSettled([cancel(), cancel()])
 
-    await expectOneWinsOneStreamConflict(results, streamRepository)
+    await expectOneWinsOneStreamConflict(
+      results,
+      streamRepository,
+      prnRepository,
+      PRN_STATUS.DELETED
+    )
   })
 
   it('credits the waste balance only once when two cancels race for an awaiting_cancellation PRN', async () => {
@@ -258,6 +280,11 @@ describe('updatePrnStatus concurrency', () => {
 
     const results = await Promise.allSettled([cancel(), cancel()])
 
-    await expectOneWinsOneStreamConflict(results, streamRepository)
+    await expectOneWinsOneStreamConflict(
+      results,
+      streamRepository,
+      prnRepository,
+      PRN_STATUS.CANCELLED
+    )
   })
 })

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
@@ -593,7 +593,8 @@ describe('Waste balance arithmetic integration tests', () => {
         organisationId: env.organisationId,
         prnId: 'other-prn',
         tonnage: 80,
-        createdBy: { id: 'test-user' }
+        createdBy: { id: 'test-user' },
+        expectedHead: balance.eventNumber
       })
 
       balance = await getWasteBalance(
@@ -1207,13 +1208,19 @@ describe('Waste balance arithmetic integration tests', () => {
       const prn = await createPrn(env, 50)
       await transitionPrnStatus(env, prn.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
+      const headBeforeContention = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId,
+        env.registrationId
+      )
       await wasteBalancesRepository.deductTotalBalanceForPrnIssue({
         accreditationId,
         registrationId: env.registrationId,
         organisationId,
         prnId: 'other-prn',
         tonnage: 80,
-        createdBy: { id: 'test-user' }
+        createdBy: { id: 'test-user' },
+        expectedHead: headBeforeContention.eventNumber
       })
 
       const result = await transitionPrnStatus(
@@ -1259,13 +1266,19 @@ describe('Waste balance arithmetic integration tests', () => {
       const prnB = await createPrn(env, 50)
       await transitionPrnStatus(env, prnB.id, PRN_STATUS.AWAITING_AUTHORISATION)
 
+      const headBeforeContention = await getWasteBalance(
+        wasteBalancesRepository,
+        accreditationId,
+        registrationId
+      )
       await wasteBalancesRepository.deductTotalBalanceForPrnIssue({
         accreditationId,
         registrationId: env.registrationId,
         organisationId,
         prnId: 'other-prn',
         tonnage: 20,
-        createdBy: { id: 'test-user' }
+        createdBy: { id: 'test-user' },
+        expectedHead: headBeforeContention.eventNumber
       })
 
       await Promise.allSettled([

--- a/src/waste-balances/application/append-to-stream.js
+++ b/src/waste-balances/application/append-to-stream.js
@@ -11,19 +11,22 @@ const openingBalanceFrom = (latest) =>
   latest === null ? { ...ZERO_BALANCE } : { ...latest.closingBalance }
 
 /**
- * @param {import('../repository/stream-port.js').StreamEvent | null} latest
- */
-const nextNumberFrom = (latest) => (latest === null ? 1 : latest.number + 1)
-
-/**
  * Append a single event to the waste balance stream.
  *
- * Reads the latest event to determine the opening balance and next slot
- * number, computes the closing balance based on the event kind, and
- * persists the event.
+ * The event is written into the slot `expectedHead + 1`, where `expectedHead`
+ * is the stream position the caller's decision was based on (`0` for a stream
+ * the caller believes is empty). The slot index is the optimistic-concurrency
+ * guard: if a competing write has advanced the head since the caller read it,
+ * the slot is already occupied and `appendEvent` rejects with a
+ * `StreamSlotConflictError` (ADR-0036 "detection over absorption"). Deriving
+ * the slot from the caller position — rather than re-reading the head here — is
+ * what makes the guard able to fire on a stale decision.
  *
- * For `summary-log-submitted` events, also reads the latest event of
- * that kind to determine the previous `creditTotal` for delta computation.
+ * The latest event supplies the opening balance and, for
+ * `summary-log-submitted` events, the previous `creditTotal` for delta
+ * computation. On the success path the head has not moved, so the latest event
+ * is exactly the one at `expectedHead`; on a moved head the append fails before
+ * the computed balance is persisted.
  *
  * Slot conflicts and idempotency conflicts surface directly to the caller.
  *
@@ -31,7 +34,8 @@ const nextNumberFrom = (latest) => (latest === null ? 1 : latest.number + 1)
  *   repository: import('../repository/stream-port.js').WasteBalanceStreamRepository,
  *   registrationId: string,
  *   accreditationId: string | null,
- *   organisationId: string
+ *   organisationId: string,
+ *   expectedHead: number
  * }} context
  * @param {{
  *   kind: import('../repository/stream-schema.js').StreamEventKind,
@@ -41,7 +45,7 @@ const nextNumberFrom = (latest) => (latest === null ? 1 : latest.number + 1)
  * @returns {Promise<import('../repository/stream-port.js').StreamEvent>}
  */
 export const appendToStream = async (
-  { repository, registrationId, accreditationId, organisationId },
+  { repository, registrationId, accreditationId, organisationId, expectedHead },
   { kind, payload, createdBy }
 ) => {
   const latest = await repository.findLatestByPartition(
@@ -50,7 +54,7 @@ export const appendToStream = async (
   )
 
   const openingBalance = openingBalanceFrom(latest)
-  const number = nextNumberFrom(latest)
+  const number = expectedHead + 1
 
   let closingBalance
 

--- a/src/waste-balances/application/append-to-stream.test.js
+++ b/src/waste-balances/application/append-to-stream.test.js
@@ -23,11 +23,14 @@ describe('appendToStream', () => {
         ...buildContext()
       }
 
-      const result = await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-1', creditTotal: 1500 },
-        createdBy
-      })
+      const result = await appendToStream(
+        { ...context, expectedHead: 0 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-1', creditTotal: 1500 },
+          createdBy
+        }
+      )
 
       expect(result.number).toBe(1)
       expect(result.openingBalance).toEqual({ amount: 0, availableAmount: 0 })
@@ -41,17 +44,23 @@ describe('appendToStream', () => {
       const repository = createInMemoryStreamRepository()()
       const context = { repository, ...buildContext() }
 
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-1', creditTotal: 2000 },
-        createdBy
-      })
+      await appendToStream(
+        { ...context, expectedHead: 0 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-1', creditTotal: 2000 },
+          createdBy
+        }
+      )
 
-      const result = await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-2', creditTotal: 3500 },
-        createdBy
-      })
+      const result = await appendToStream(
+        { ...context, expectedHead: 1 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-2', creditTotal: 3500 },
+          createdBy
+        }
+      )
 
       expect(result.number).toBe(2)
       expect(result.openingBalance).toEqual({
@@ -68,17 +77,23 @@ describe('appendToStream', () => {
       const repository = createInMemoryStreamRepository()()
       const context = { repository, ...buildContext() }
 
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-1', creditTotal: 2000 },
-        createdBy
-      })
+      await appendToStream(
+        { ...context, expectedHead: 0 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-1', creditTotal: 2000 },
+          createdBy
+        }
+      )
 
-      const result = await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-2', creditTotal: 1000 },
-        createdBy
-      })
+      const result = await appendToStream(
+        { ...context, expectedHead: 1 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-2', creditTotal: 1000 },
+          createdBy
+        }
+      )
 
       expect(result.closingBalance).toEqual({
         amount: 1000,
@@ -90,23 +105,32 @@ describe('appendToStream', () => {
       const repository = createInMemoryStreamRepository()()
       const context = { repository, ...buildContext() }
 
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-1', creditTotal: 2000 },
-        createdBy
-      })
+      await appendToStream(
+        { ...context, expectedHead: 0 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-1', creditTotal: 2000 },
+          createdBy
+        }
+      )
 
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.PRN_CREATED,
-        payload: { prnId: 'prn-1', amount: 800 },
-        createdBy
-      })
+      await appendToStream(
+        { ...context, expectedHead: 1 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATED,
+          payload: { prnId: 'prn-1', amount: 800 },
+          createdBy
+        }
+      )
 
-      const result = await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-2', creditTotal: 3500 },
-        createdBy
-      })
+      const result = await appendToStream(
+        { ...context, expectedHead: 2 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-2', creditTotal: 3500 },
+          createdBy
+        }
+      )
 
       expect(result.number).toBe(3)
       expect(result.openingBalance).toEqual({
@@ -129,7 +153,7 @@ describe('appendToStream', () => {
 
       await expect(
         appendToStream(
-          { repository, ...buildContext() },
+          { repository, ...buildContext(), expectedHead: 0 },
           {
             kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
             payload: { summaryLogId: 'log-1', creditTotal: 100 },
@@ -145,17 +169,23 @@ describe('appendToStream', () => {
       const repository = createInMemoryStreamRepository()()
       const context = { repository, ...buildContext() }
 
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-1', creditTotal: 1000 },
-        createdBy
-      })
+      await appendToStream(
+        { ...context, expectedHead: 0 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+          createdBy
+        }
+      )
 
-      const result = await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.PRN_CREATED,
-        payload: { prnId: 'prn-1', amount: 300 },
-        createdBy
-      })
+      const result = await appendToStream(
+        { ...context, expectedHead: 1 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATED,
+          payload: { prnId: 'prn-1', amount: 300 },
+          createdBy
+        }
+      )
 
       expect(result.closingBalance).toEqual({
         amount: 1000,
@@ -167,17 +197,23 @@ describe('appendToStream', () => {
       const repository = createInMemoryStreamRepository()()
       const context = { repository, ...buildContext() }
 
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-1', creditTotal: 1000 },
-        createdBy
-      })
+      await appendToStream(
+        { ...context, expectedHead: 0 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+          createdBy
+        }
+      )
 
-      const result = await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.PRN_CREATED,
-        payload: { prnId: 'prn-1', amount: 300 },
-        createdBy
-      })
+      const result = await appendToStream(
+        { ...context, expectedHead: 1 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATED,
+          payload: { prnId: 'prn-1', amount: 300 },
+          createdBy
+        }
+      )
 
       expect(result.openingBalance).toEqual({
         amount: 1000,
@@ -191,22 +227,31 @@ describe('appendToStream', () => {
       const repository = createInMemoryStreamRepository()()
       const context = { repository, ...buildContext() }
 
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-1', creditTotal: 1000 },
-        createdBy
-      })
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.PRN_CREATED,
-        payload: { prnId: 'prn-1', amount: 300 },
-        createdBy
-      })
+      await appendToStream(
+        { ...context, expectedHead: 0 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+          createdBy
+        }
+      )
+      await appendToStream(
+        { ...context, expectedHead: 1 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATED,
+          payload: { prnId: 'prn-1', amount: 300 },
+          createdBy
+        }
+      )
 
-      const result = await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.PRN_ISSUED,
-        payload: { prnId: 'prn-1', amount: 300 },
-        createdBy
-      })
+      const result = await appendToStream(
+        { ...context, expectedHead: 2 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_ISSUED,
+          payload: { prnId: 'prn-1', amount: 300 },
+          createdBy
+        }
+      )
 
       expect(result.closingBalance).toEqual({
         amount: 700,
@@ -220,22 +265,31 @@ describe('appendToStream', () => {
       const repository = createInMemoryStreamRepository()()
       const context = { repository, ...buildContext() }
 
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-1', creditTotal: 1000 },
-        createdBy
-      })
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.PRN_CREATED,
-        payload: { prnId: 'prn-1', amount: 300 },
-        createdBy
-      })
+      await appendToStream(
+        { ...context, expectedHead: 0 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+          createdBy
+        }
+      )
+      await appendToStream(
+        { ...context, expectedHead: 1 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATED,
+          payload: { prnId: 'prn-1', amount: 300 },
+          createdBy
+        }
+      )
 
-      const result = await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
-        payload: { prnId: 'prn-1', amount: 300 },
-        createdBy
-      })
+      const result = await appendToStream(
+        { ...context, expectedHead: 2 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
+          payload: { prnId: 'prn-1', amount: 300 },
+          createdBy
+        }
+      )
 
       expect(result.closingBalance).toEqual({
         amount: 1000,
@@ -249,32 +303,105 @@ describe('appendToStream', () => {
       const repository = createInMemoryStreamRepository()()
       const context = { repository, ...buildContext() }
 
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-        payload: { summaryLogId: 'log-1', creditTotal: 1000 },
-        createdBy
-      })
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.PRN_CREATED,
-        payload: { prnId: 'prn-1', amount: 300 },
-        createdBy
-      })
-      await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.PRN_ISSUED,
-        payload: { prnId: 'prn-1', amount: 300 },
-        createdBy
-      })
+      await appendToStream(
+        { ...context, expectedHead: 0 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+          createdBy
+        }
+      )
+      await appendToStream(
+        { ...context, expectedHead: 1 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATED,
+          payload: { prnId: 'prn-1', amount: 300 },
+          createdBy
+        }
+      )
+      await appendToStream(
+        { ...context, expectedHead: 2 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_ISSUED,
+          payload: { prnId: 'prn-1', amount: 300 },
+          createdBy
+        }
+      )
 
-      const result = await appendToStream(context, {
-        kind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
-        payload: { prnId: 'prn-1', amount: 300 },
-        createdBy
-      })
+      const result = await appendToStream(
+        { ...context, expectedHead: 3 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+          payload: { prnId: 'prn-1', amount: 300 },
+          createdBy
+        }
+      )
 
       expect(result.closingBalance).toEqual({
         amount: 1000,
         availableAmount: 1000
       })
+    })
+  })
+
+  describe('optimistic concurrency (expectedHead)', () => {
+    it('rejects an append whose expectedHead is behind the live head', async () => {
+      const repository = createInMemoryStreamRepository()()
+      const context = { repository, ...buildContext() }
+
+      await appendToStream(
+        { ...context, expectedHead: 0 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+          createdBy
+        }
+      )
+
+      await appendToStream(
+        { ...context, expectedHead: 1 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATED,
+          payload: { prnId: 'prn-1', amount: 100 },
+          createdBy
+        }
+      )
+
+      await expect(
+        appendToStream(
+          { ...context, expectedHead: 1 },
+          {
+            kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+            payload: { summaryLogId: 'log-2', creditTotal: 2000 },
+            createdBy
+          }
+        )
+      ).rejects.toBeInstanceOf(StreamSlotConflictError)
+    })
+
+    it('appends at expectedHead + 1 when the head has not moved', async () => {
+      const repository = createInMemoryStreamRepository()()
+      const context = { repository, ...buildContext() }
+
+      await appendToStream(
+        { ...context, expectedHead: 0 },
+        {
+          kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+          payload: { summaryLogId: 'log-1', creditTotal: 1000 },
+          createdBy
+        }
+      )
+
+      const result = await appendToStream(
+        { ...context, expectedHead: 1 },
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATED,
+          payload: { prnId: 'prn-1', amount: 100 },
+          createdBy
+        }
+      )
+
+      expect(result.number).toBe(2)
     })
   })
 
@@ -288,7 +415,7 @@ describe('appendToStream', () => {
 
       await expect(
         appendToStream(
-          { repository, ...buildContext() },
+          { repository, ...buildContext(), expectedHead: 0 },
           {
             kind: /** @type {*} */ ('unknown-kind'),
             payload: { prnId: 'prn-1', amount: 100 },

--- a/src/waste-balances/application/update-via-stream.js
+++ b/src/waste-balances/application/update-via-stream.js
@@ -10,9 +10,9 @@ import { classifyWasteRecord, getTargetAmount } from './target-amount.js'
 /**
  * Append the submission event at the head this submission read. A competing
  * write that advanced the head in between surfaces as a slot/sequence conflict
- * and propagates to the caller (ADR-0036 "detection over absorption"). The
- * caller is the summary-log worker job, so the conflict fails the job and the
- * queue redelivers, recomputing the submission against fresh state.
+ * and propagates to the caller (ADR-0036). The caller is the summary-log worker
+ * job, so the conflict fails the job and the queue redelivers, recomputing the
+ * submission against fresh state.
  *
  * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} repository
  * @param {{ registrationId: string, accreditationId: string, organisationId: string }} partition

--- a/src/waste-balances/application/update-via-stream.js
+++ b/src/waste-balances/application/update-via-stream.js
@@ -8,6 +8,40 @@ import { recordWasteBalanceUpdateAudit } from './audit.js'
 import { classifyWasteRecord, getTargetAmount } from './target-amount.js'
 
 /**
+ * Append the submission event at the head this submission read. A competing
+ * write that advanced the head in between surfaces as a slot/sequence conflict
+ * and propagates to the caller (ADR-0036 "detection over absorption"). The
+ * caller is the summary-log worker job, so the conflict fails the job and the
+ * queue redelivers, recomputing the submission against fresh state.
+ *
+ * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} repository
+ * @param {{ registrationId: string, accreditationId: string, organisationId: string }} partition
+ * @param {{ kind: import('../repository/stream-schema.js').StreamEventKind, payload: import('../repository/stream-schema.js').SummaryLogSubmittedPayload, createdBy: import('../repository/stream-schema.js').StreamUserSummary }} event
+ */
+const appendSummaryLog = async (
+  repository,
+  { registrationId, accreditationId, organisationId },
+  event
+) => {
+  const latest = await repository.findLatestByPartition(
+    registrationId,
+    accreditationId
+  )
+  const expectedHead = latest ? latest.number : 0
+
+  return appendToStream(
+    {
+      repository,
+      registrationId,
+      accreditationId,
+      organisationId,
+      expectedHead
+    },
+    event
+  )
+}
+
+/**
  * Apply a summary-log submission to the event stream.
  *
  * Computes the aggregate `creditTotal` (sum of all row-level target amounts)
@@ -50,13 +84,9 @@ export const performUpdateViaStream = async ({
     creditTotal = toNumber(add(creditTotal, getTargetAmount(classification)))
   }
 
-  const event = await appendToStream(
-    {
-      repository: streamRepository,
-      registrationId,
-      accreditationId: accreditation.id,
-      organisationId
-    },
+  const event = await appendSummaryLog(
+    streamRepository,
+    { registrationId, accreditationId: accreditation.id, organisationId },
     {
       kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
       payload: { summaryLogId, creditTotal },

--- a/src/waste-balances/application/update-via-stream.test.js
+++ b/src/waste-balances/application/update-via-stream.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { createInMemoryStreamRepository } from '../repository/stream-inmemory.js'
 import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import { StreamSlotConflictError } from '../repository/stream-port.js'
 import { performUpdateViaStream } from './update-via-stream.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
 import { logger } from '#common/helpers/logging/logger.js'
@@ -374,6 +375,38 @@ describe('performUpdateViaStream', () => {
         id: 'user-2',
         email: 'noname@example.test'
       })
+    })
+  })
+
+  describe('optimistic concurrency', () => {
+    it('lets one of two concurrent submissions win and surfaces the loser as a slot conflict', async () => {
+      const submit = (summaryLogId, tonnage) =>
+        performUpdateViaStream({
+          wasteRecords: [buildExporterRecord({ rowId: '1', tonnage })],
+          accreditation,
+          streamRepository,
+          dependencies: { systemLogsRepository },
+          user,
+          overseasSites,
+          summaryLogId
+        })
+
+      const results = await Promise.allSettled([
+        submit('log-A', 150),
+        submit('log-B', 200)
+      ])
+
+      const fulfilled = results.filter((r) => r.status === 'fulfilled')
+      const rejected = results.filter((r) => r.status === 'rejected')
+      expect(fulfilled).toHaveLength(1)
+      expect(rejected).toHaveLength(1)
+      expect(rejected[0].reason).toBeInstanceOf(StreamSlotConflictError)
+
+      const all = await streamRepository.findAllByPartition(
+        'reg-1',
+        accreditationId
+      )
+      expect(all).toHaveLength(1)
     })
   })
 })

--- a/src/waste-balances/domain/model.js
+++ b/src/waste-balances/domain/model.js
@@ -17,6 +17,10 @@
  * @property {string} accreditationId - Accreditation ID (stream partition key)
  * @property {number} amount - Total balance (credits minus debits)
  * @property {number} availableAmount - Available balance (amount minus pending debits)
+ * @property {number} eventNumber - Stream position this balance was resolved
+ *   from: the `number` of the latest event. Callers thread it back as
+ *   `expectedHead` on a write so the slot index can reject a decision made
+ *   against a head that has since moved.
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/waste-balances/repository/contract/creditAvailableBalanceForPrnCancellation.contract.js
+++ b/src/waste-balances/repository/contract/creditAvailableBalanceForPrnCancellation.contract.js
@@ -35,7 +35,8 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-123',
         tonnage: 50,
-        createdBy: { id: 'user-abc' }
+        createdBy: { id: 'user-abc' },
+        expectedHead: 1
       })
 
       const result = await repository.findBalance({
@@ -65,7 +66,8 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-456',
           tonnage: 25.5,
-          createdBy: { id: 'user-xyz' }
+          createdBy: { id: 'user-xyz' },
+          expectedHead: 1
         })
 
       expect(appended.kind).toBe(STREAM_EVENT_KIND.PRN_CREATION_CANCELLED)
@@ -86,7 +88,8 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-789',
           tonnage: 10,
-          createdBy: { id: 'user-123' }
+          createdBy: { id: 'user-123' },
+          expectedHead: 1
         })
       ).rejects.toThrow(Boom.Boom)
     })
@@ -109,7 +112,8 @@ export const testCreditAvailableBalanceForPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-ledger',
           tonnage: 10,
-          createdBy: { id: 'user-abc' }
+          createdBy: { id: 'user-abc' },
+          expectedHead: 1
         })
 
       const latest = await streamRepository.findLatestByPartition(

--- a/src/waste-balances/repository/contract/creditFullBalanceForIssuedPrnCancellation.contract.js
+++ b/src/waste-balances/repository/contract/creditFullBalanceForIssuedPrnCancellation.contract.js
@@ -35,7 +35,8 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-123',
         tonnage: 60,
-        createdBy: { id: 'user-abc' }
+        createdBy: { id: 'user-abc' },
+        expectedHead: 1
       })
 
       const result = await repository.findBalance({
@@ -65,7 +66,8 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-456',
           tonnage: 25.5,
-          createdBy: { id: 'user-xyz' }
+          createdBy: { id: 'user-xyz' },
+          expectedHead: 1
         })
 
       expect(appended.kind).toBe(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE)
@@ -86,7 +88,8 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-789',
           tonnage: 10,
-          createdBy: { id: 'user-123' }
+          createdBy: { id: 'user-123' },
+          expectedHead: 1
         })
       ).rejects.toThrow(Boom.Boom)
     })
@@ -109,7 +112,8 @@ export const testCreditFullBalanceForIssuedPrnCancellationBehaviour = (it) => {
           organisationId: 'org-1',
           prnId: 'prn-ledger',
           tonnage: 10,
-          createdBy: { id: 'user-abc' }
+          createdBy: { id: 'user-abc' },
+          expectedHead: 1
         })
 
       const latest = await streamRepository.findLatestByPartition(

--- a/src/waste-balances/repository/contract/deductAvailableBalanceForPrnCreation.contract.js
+++ b/src/waste-balances/repository/contract/deductAvailableBalanceForPrnCreation.contract.js
@@ -34,7 +34,8 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-123',
         tonnage: 50,
-        createdBy: { id: 'user-abc' }
+        createdBy: { id: 'user-abc' },
+        expectedHead: 1
       })
 
       const result = await repository.findBalance({
@@ -63,7 +64,8 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-456',
         tonnage: 25.5,
-        createdBy: { id: 'user-xyz' }
+        createdBy: { id: 'user-xyz' },
+        expectedHead: 1
       })
 
       expect(appended.kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
@@ -83,7 +85,8 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-789',
         tonnage: 10,
-        createdBy: { id: 'user-123' }
+        createdBy: { id: 'user-123' },
+        expectedHead: 1
       })
 
       expect(appended).toBeNull()
@@ -112,7 +115,8 @@ export const testDeductAvailableBalanceForPrnCreationBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-ledger',
         tonnage: 10,
-        createdBy: { id: 'user-abc' }
+        createdBy: { id: 'user-abc' },
+        expectedHead: 1
       })
 
       const latest = await streamRepository.findLatestByPartition(

--- a/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
+++ b/src/waste-balances/repository/contract/deductTotalBalanceForPrnIssue.contract.js
@@ -36,7 +36,8 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-123',
         tonnage: 50,
-        createdBy: { id: 'user-abc' }
+        createdBy: { id: 'user-abc' },
+        expectedHead: 1
       })
 
       const result = await repository.findBalance({
@@ -65,7 +66,8 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-456',
         tonnage: 25.5,
-        createdBy: { id: 'user-xyz' }
+        createdBy: { id: 'user-xyz' },
+        expectedHead: 1
       })
 
       expect(appended.kind).toBe(STREAM_EVENT_KIND.PRN_ISSUED)
@@ -85,7 +87,8 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-999',
         tonnage: 10,
-        createdBy: { id: 'user-456' }
+        createdBy: { id: 'user-456' },
+        expectedHead: 1
       })
 
       expect(appended).toBeNull()
@@ -114,7 +117,8 @@ export const testDeductTotalBalanceForPrnIssueBehaviour = (it) => {
         organisationId: 'org-1',
         prnId: 'prn-ledger',
         tonnage: 10,
-        createdBy: { id: 'user-abc' }
+        createdBy: { id: 'user-abc' },
+        expectedHead: 1
       })
 
       const latest = await streamRepository.findLatestByPartition(

--- a/src/waste-balances/repository/contract/findBalance.contract.js
+++ b/src/waste-balances/repository/contract/findBalance.contract.js
@@ -38,7 +38,8 @@ export const testFindBalanceBehaviour = (it) => {
         registrationId: 'reg-1',
         accreditationId: 'acc-123',
         amount: 250,
-        availableAmount: 200
+        availableAmount: 200,
+        eventNumber: 1
       })
     })
 
@@ -96,6 +97,7 @@ export const testFindBalanceBehaviour = (it) => {
 
       expect(result.amount).toBe(175)
       expect(result.availableAmount).toBe(150)
+      expect(result.eventNumber).toBe(2)
     })
   })
 }

--- a/src/waste-balances/repository/helpers-prn.js
+++ b/src/waste-balances/repository/helpers-prn.js
@@ -16,6 +16,8 @@ import { STREAM_EVENT_KIND } from './stream-schema.js'
  * @param {number} params.tonnage
  * @param {import('./stream-schema.js').StreamUserSummary} params.createdBy
  * @param {import('./stream-schema.js').StreamEventKind} params.streamKind
+ * @param {number} params.expectedHead - Stream position the caller's decision
+ *   was based on; the event is written at `expectedHead + 1`.
  * @returns {Promise<import('./stream-port.js').StreamEvent>} The appended event.
  */
 const appendPrnStreamEvent = async ({
@@ -26,14 +28,16 @@ const appendPrnStreamEvent = async ({
   prnId,
   tonnage,
   createdBy,
-  streamKind
+  streamKind,
+  expectedHead
 }) =>
   appendToStream(
     {
       repository: streamRepository,
       registrationId,
       accreditationId,
-      organisationId
+      organisationId,
+      expectedHead
     },
     {
       kind: streamKind,
@@ -95,7 +99,8 @@ export const performAppendPrnStreamEvent = async ({
     prnId,
     tonnage,
     createdBy,
-    streamKind
+    streamKind,
+    expectedHead: wasteBalance.eventNumber
   })
 }
 
@@ -121,7 +126,8 @@ export const performDeductAvailableBalanceForPrnCreation = async ({
     organisationId,
     prnId,
     tonnage,
-    createdBy
+    createdBy,
+    expectedHead
   } = deductParams
   const validatedAccreditationId = validateAccreditationId(accreditationId)
 
@@ -142,7 +148,8 @@ export const performDeductAvailableBalanceForPrnCreation = async ({
     prnId,
     tonnage,
     createdBy,
-    streamKind: STREAM_EVENT_KIND.PRN_CREATED
+    streamKind: STREAM_EVENT_KIND.PRN_CREATED,
+    expectedHead
   })
 }
 
@@ -168,7 +175,8 @@ export const performDeductTotalBalanceForPrnIssue = async ({
     organisationId,
     prnId,
     tonnage,
-    createdBy
+    createdBy,
+    expectedHead
   } = deductParams
   const validatedAccreditationId = validateAccreditationId(accreditationId)
 
@@ -189,7 +197,8 @@ export const performDeductTotalBalanceForPrnIssue = async ({
     prnId,
     tonnage,
     createdBy,
-    streamKind: STREAM_EVENT_KIND.PRN_ISSUED
+    streamKind: STREAM_EVENT_KIND.PRN_ISSUED,
+    expectedHead
   })
 }
 
@@ -216,7 +225,8 @@ export const performCreditFullBalanceForIssuedPrnCancellation = async ({
     organisationId,
     prnId,
     tonnage,
-    createdBy
+    createdBy,
+    expectedHead
   } = creditParams
   const validatedAccreditationId = validateAccreditationId(accreditationId)
 
@@ -239,7 +249,8 @@ export const performCreditFullBalanceForIssuedPrnCancellation = async ({
     prnId,
     tonnage,
     createdBy,
-    streamKind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE
+    streamKind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+    expectedHead
   })
 }
 
@@ -266,7 +277,8 @@ export const performCreditAvailableBalanceForPrnCancellation = async ({
     organisationId,
     prnId,
     tonnage,
-    createdBy
+    createdBy,
+    expectedHead
   } = creditParams
   const validatedAccreditationId = validateAccreditationId(accreditationId)
 
@@ -289,6 +301,7 @@ export const performCreditAvailableBalanceForPrnCancellation = async ({
     prnId,
     tonnage,
     createdBy,
-    streamKind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED
+    streamKind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
+    expectedHead
   })
 }

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -3,8 +3,7 @@
  * balance decision (sufficiency check, reversal) was based on. The append is
  * written at `expectedHead + 1`, so a competing write that has advanced the
  * head since the caller read it makes the append fail rather than proceed from
- * a stale position (ADR-0036 "detection over absorption"). The conflict
- * surfaces to the caller.
+ * a stale position (ADR-0036). The conflict surfaces to the caller.
  */
 
 /**

--- a/src/waste-balances/repository/port.js
+++ b/src/waste-balances/repository/port.js
@@ -1,4 +1,13 @@
 /**
+ * The `expectedHead` on these params is the stream position the caller's
+ * balance decision (sufficiency check, reversal) was based on. The append is
+ * written at `expectedHead + 1`, so a competing write that has advanced the
+ * head since the caller read it makes the append fail rather than proceed from
+ * a stale position (ADR-0036 "detection over absorption"). The conflict
+ * surfaces to the caller.
+ */
+
+/**
  * @typedef {Object} DeductAvailableBalanceParams
  * @property {string} accreditationId
  * @property {string} registrationId
@@ -6,6 +15,7 @@
  * @property {string} prnId
  * @property {number} tonnage
  * @property {import('./stream-schema.js').StreamUserSummary} createdBy
+ * @property {number} expectedHead
  */
 
 /**
@@ -16,6 +26,7 @@
  * @property {string} prnId
  * @property {number} tonnage
  * @property {import('./stream-schema.js').StreamUserSummary} createdBy
+ * @property {number} expectedHead
  */
 
 /**
@@ -26,6 +37,7 @@
  * @property {string} prnId
  * @property {number} tonnage
  * @property {import('./stream-schema.js').StreamUserSummary} createdBy
+ * @property {number} expectedHead
  */
 
 /**
@@ -36,6 +48,7 @@
  * @property {string} prnId
  * @property {number} tonnage
  * @property {import('./stream-schema.js').StreamUserSummary} createdBy
+ * @property {number} expectedHead
  */
 
 /**

--- a/src/waste-balances/repository/read-balance.js
+++ b/src/waste-balances/repository/read-balance.js
@@ -26,6 +26,7 @@ export const findBalanceByPartition = async (
     registrationId,
     accreditationId,
     amount: latest.closingBalance.amount,
-    availableAmount: latest.closingBalance.availableAmount
+    availableAmount: latest.closingBalance.availableAmount,
+    eventNumber: latest.number
   }
 }


### PR DESCRIPTION
Ticket: [PAE-1669](https://eaflood.atlassian.net/browse/PAE-1669)

The waste balance stream enforces optimistic concurrency with a unique slot index on `(registrationId, accreditationId, number)`: the append primitive rejects any event whose `number` isn't `head + 1`. That guard could never fire, because `appendToStream` derived the slot number from a head it read itself immediately before writing — so the number was `head + 1` by construction on every call and a competing write could never collide. The concurrency control existed in the primitive but every caller bypassed it.

This wires the caller's read position through to the append. `findBalance` now exposes `eventNumber` (the latest event's position), the PRN and summary-log write paths thread that position back as `expectedHead`, and `appendToStream` derives the slot as `expectedHead + 1`. A write whose head moved since the caller read it now targets an occupied slot, so the append fails with a `StreamSlotConflictError` and the conflict surfaces to the caller instead of silently committing from a stale position.

The conflict propagates rather than being retried in process, because re-applying a decision the race has already invalidated — a stale sufficiency check, or a frozen summary-log `creditTotal` — is exactly the double-count this guard exists to prevent. Re-evaluation belongs at the natural boundary: a summary-log submission runs in the worker job, so the conflict fails the job and the queue redelivers against fresh state; a PRN transition surfaces the conflict to the client.

On the PRN status path the stream effect is now applied before the document write, so a losing racer fails at the slot and never persists a partial document change.

New concurrency tests drive two writes against a single partition through the application path and assert exactly one wins, the loser surfaces a `StreamSlotConflictError`, and the stream head, persisted balance, and PRN document all agree on the single committed transition.

A follow-up will move the balance business logic out of `WasteBalancesRepository` into the application layer — a pure `decide` over a folded aggregate (functional core, imperative shell) — so the concurrency guarantee holds by construction rather than resting on the slot index to catch a divergent read, and the mis-layered repository methods are retired. That refactor is tracked separately and deliberately kept out of this PR to keep the change reviewable.

[PAE-1669]: https://eaflood.atlassian.net/browse/PAE-1669
