### PR TITLE
PAE-1590: Introduce waste balance ledger identity types

### DIFF
--- a/src/waste-balances/application/append-to-stream.js
+++ b/src/waste-balances/application/append-to-stream.js
@@ -30,11 +30,8 @@ const openingBalanceFrom = (latest) =>
  *
  * Slot conflicts and idempotency conflicts surface directly to the caller.
  *
- * @param {{
+ * @param {import('../repository/stream-schema.js').RegistrationOrAccreditationId & {
  *   repository: import('../repository/stream-port.js').WasteBalanceStreamRepository,
- *   registrationId: string,
- *   accreditationId: string | null,
- *   organisationId: string,
  *   expectedHead: number
  * }} context
  * @param {{

--- a/src/waste-balances/application/update-via-stream.js
+++ b/src/waste-balances/application/update-via-stream.js
@@ -15,7 +15,7 @@ import { classifyWasteRecord, getTargetAmount } from './target-amount.js'
  * submission against fresh state.
  *
  * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} repository
- * @param {{ registrationId: string, accreditationId: string, organisationId: string }} partition
+ * @param {import('../repository/stream-schema.js').RegistrationOrAccreditationId} partition
  * @param {{ kind: import('../repository/stream-schema.js').StreamEventKind, payload: import('../repository/stream-schema.js').SummaryLogSubmittedPayload, createdBy: import('../repository/stream-schema.js').StreamUserSummary }} event
  */
 const appendSummaryLog = async (

--- a/src/waste-balances/repository/stream-schema.js
+++ b/src/waste-balances/repository/stream-schema.js
@@ -66,21 +66,51 @@ export const BACKFILL_ACTOR = Object.freeze({ id: 'system', name: 'backfill' })
  */
 
 /**
- * Shape accepted by `WasteBalanceStreamRepository.appendEvent`. Mirrors
- * `streamEventInsertSchema` — keep the two in sync; the schema is the
- * runtime gate, this typedef is the check-time gate.
+ * The identity of an accreditation, or of a registration in its registered-only
+ * phase (`accreditationId` null). `organisationId` is denormalised owner context
+ * carried for attribution — the storage uniqueness key is
+ * `(registrationId, accreditationId)`, not org — but it always travels with the
+ * id and any event can recover it. Named for what it is: a registration or
+ * accreditation identity, not a ledger-specific type. It is what we key a waste
+ * balance ledger by.
  *
- * @typedef {Object} StreamEventInsert
+ * @typedef {Object} RegistrationOrAccreditationId
+ * @property {string} organisationId
  * @property {string} registrationId
  * @property {string | null} accreditationId
- * @property {string} organisationId
- * @property {number} number
- * @property {StreamEventKind} kind
- * @property {SummaryLogSubmittedPayload | PrnPayload} payload
- * @property {StreamBalanceSnapshot} openingBalance
- * @property {StreamBalanceSnapshot} closingBalance
- * @property {Date} createdAt
- * @property {StreamUserSummary} createdBy
+ */
+
+/**
+ * The id of a waste balance ledger: a ledger is identified by the registration
+ * or accreditation whose balance it records. An alias, so ledger-layer code can
+ * name a ledger id while the value remains, honestly, a registration or
+ * accreditation identity.
+ *
+ * @typedef {RegistrationOrAccreditationId} WasteBalanceLedgerId
+ */
+
+/**
+ * A position within a waste balance ledger: the ledger id plus a sequence
+ * number. The head a decision reads at, the slot it commits to (`number + 1`),
+ * and the coordinate a slot-conflict or sequence error reports on a clash.
+ *
+ * @typedef {WasteBalanceLedgerId & { number: number }} LedgerPosition
+ */
+
+/**
+ * Shape accepted by `WasteBalanceStreamRepository.appendEvent`: the content of
+ * an event at a `LedgerPosition`. Mirrors `streamEventInsertSchema` — keep the
+ * two in sync; the schema is the runtime gate, this typedef is the check-time
+ * gate.
+ *
+ * @typedef {LedgerPosition & {
+ *   kind: StreamEventKind,
+ *   payload: SummaryLogSubmittedPayload | PrnPayload,
+ *   openingBalance: StreamBalanceSnapshot,
+ *   closingBalance: StreamBalanceSnapshot,
+ *   createdAt: Date,
+ *   createdBy: StreamUserSummary
+ * }} StreamEventInsert
  */
 
 /**


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)

The waste balance ledger code threads the same value-bundles through every write path — `{ organisationId, registrationId, accreditationId }` to identify a ledger, and that identity plus a `number` to address a position in it. They were inlined as anonymous object shapes at each site, with no name to refer to. This names them as domain types so the upcoming layering refactor and the de-jargon rename have a shared vocabulary to build on.

Three typedefs land in the ledger schema module:

`RegistrationOrAccreditationId` is the identity of an accreditation, or of a registration in its registered-only phase (`accreditationId` null). It is named for what it is — a registration or accreditation identity — rather than for the ledger it happens to key. `organisationId` is denormalised owner context carried for attribution; the storage uniqueness key is `(registrationId, accreditationId)`, but the id always travels with org and any event can recover it.

`WasteBalanceLedgerId` is an alias of that identity, so ledger-layer code can name a ledger id while the value stays, honestly, a registration or accreditation identity.

`LedgerPosition` is a ledger id plus a sequence number: the head a decision reads at, and the slot it commits to at `number + 1`.

`StreamEventInsert` is recomposed as the content of an event at a `LedgerPosition`, and the generic append path and the summary-log write path are typed with the new identity. The shapes are unchanged — this is types only, no runtime change, and the type check and full suite both pass.

The PRN write paths deliberately keep a non-null `accreditationId`: PRN events are invalid in a registered-only ledger (the runtime schema rejects them), so the nullable ledger identity does not fit there and would weaken those signatures. Renaming the remaining `Stream`/`partition` symbols to ledger language is a separate coordinated pass and is tracked separately.

[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590
