### PR TITLE
PAE-1669: Route summary-log writes through a waste balance application service

### DIFF
--- a/src/waste-balances/application/update-via-stream.js
+++ b/src/waste-balances/application/update-via-stream.js
@@ -2,52 +2,19 @@
 
 import { add, toNumber } from '#common/helpers/decimal-utils.js'
 
-import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
-import { appendToStream } from './append-to-stream.js'
 import { recordWasteBalanceUpdateAudit } from './audit.js'
 import { classifyWasteRecord, getTargetAmount } from './target-amount.js'
+import { createWasteBalanceService } from './waste-balance-service.js'
 
 /**
- * Append the submission event at the head this submission read. A competing
- * write that advanced the head in between surfaces as a slot/sequence conflict
- * and propagates to the caller (ADR-0036). The caller is the summary-log worker
- * job, so the conflict fails the job and the queue redelivers, recomputing the
- * submission against fresh state.
- *
- * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} repository
- * @param {import('../repository/stream-schema.js').RegistrationOrAccreditationId} partition
- * @param {{ kind: import('../repository/stream-schema.js').StreamEventKind, payload: import('../repository/stream-schema.js').SummaryLogSubmittedPayload, createdBy: import('../repository/stream-schema.js').StreamUserSummary }} event
- */
-const appendSummaryLog = async (
-  repository,
-  { registrationId, accreditationId, organisationId },
-  event
-) => {
-  const latest = await repository.findLatestByPartition(
-    registrationId,
-    accreditationId
-  )
-  const expectedHead = latest ? latest.number : 0
-
-  return appendToStream(
-    {
-      repository,
-      registrationId,
-      accreditationId,
-      organisationId,
-      expectedHead
-    },
-    event
-  )
-}
-
-/**
- * Apply a summary-log submission to the event stream.
+ * Apply a summary-log submission to the event-sourced ledger.
  *
  * Computes the aggregate `creditTotal` (sum of all row-level target amounts)
- * and appends a single `summary-log-submitted` event. The stream's delta
- * arithmetic (creditTotal minus previous creditTotal) replaces the per-row
- * delta reconciliation of the ADR-0031 ledger.
+ * and submits it through the waste balance service, which folds the ledger,
+ * decides the submission event, and appends it. A competing write that advanced
+ * the head since the fold surfaces as a slot conflict and propagates to the
+ * caller (ADR-0036): the caller is the summary-log worker job, so the conflict
+ * fails the job and the queue redelivers, recomputing against fresh state.
  *
  * @param {Object} params
  * @param {Array<import('#domain/waste-records/model.js').WasteRecord>} params.wasteRecords
@@ -84,17 +51,14 @@ export const performUpdateViaStream = async ({
     creditTotal = toNumber(add(creditTotal, getTargetAmount(classification)))
   }
 
-  const event = await appendSummaryLog(
-    streamRepository,
+  const service = createWasteBalanceService(streamRepository)
+  const [event] = await service.submitSummaryLog(
     { registrationId, accreditationId: accreditation.id, organisationId },
+    { summaryLogId, creditTotal },
     {
-      kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
-      payload: { summaryLogId, creditTotal },
-      createdBy: {
-        id: user.id,
-        ...(user.name && { name: user.name }),
-        email: user.email
-      }
+      id: user.id,
+      ...(user.name && { name: user.name }),
+      email: user.email
     }
   )
 

--- a/src/waste-balances/application/waste-balance-service.js
+++ b/src/waste-balances/application/waste-balance-service.js
@@ -6,7 +6,7 @@ import { currentWasteBalance } from './current-waste-balance.js'
  * folds the ledger once, runs the pure command core against that state, and
  * appends the returned event(s) at the next slot over the event store. The slot
  * index is the optimistic-concurrency guard: a head that moved after the fold
- * leaves the next slot occupied, so `appendEvent` rejects with a
+ * leaves the next slot occupied, so the append rejects with a
  * `StreamSlotConflictError` and the conflict surfaces to the caller — no
  * in-process retry (ADR-0036).
  *
@@ -38,8 +38,8 @@ export const createWasteBalanceService = (streamRepository) => {
   }
 
   /**
-   * Append the decided balance events to the ledger, stamping each with the
-   * ledger identity, its slot, and provenance.
+   * Append the decided balance events to the ledger as one batch, stamping
+   * each with the ledger identity, its slot, and provenance.
    *
    * @param {import('../repository/stream-schema.js').WasteBalanceLedgerId} ledgerId
    * @param {number} head
@@ -47,25 +47,20 @@ export const createWasteBalanceService = (streamRepository) => {
    * @param {import('../repository/stream-schema.js').StreamUserSummary} createdBy
    * @returns {Promise<import('../repository/stream-port.js').StreamEvent[]>}
    */
-  const append = async (ledgerId, head, events, createdBy) => {
-    const appended = []
-    let number = head
-    for (const event of events) {
-      number += 1
-      appended.push(
-        await streamRepository.appendEvent({
-          ...ledgerId,
-          number,
-          kind: event.kind,
-          payload: event.payload,
-          openingBalance: event.openingBalance,
-          closingBalance: event.closingBalance,
-          createdAt: new Date(),
-          createdBy
-        })
-      )
-    }
-    return appended
+  const append = (ledgerId, head, events, createdBy) => {
+    const createdAt = new Date()
+    return streamRepository.bulkAppendEvents(
+      events.map((event, index) => ({
+        ...ledgerId,
+        number: head + index + 1,
+        kind: event.kind,
+        payload: event.payload,
+        openingBalance: event.openingBalance,
+        closingBalance: event.closingBalance,
+        createdAt,
+        createdBy
+      }))
+    )
   }
 
   return {

--- a/src/waste-balances/application/waste-balance-service.js
+++ b/src/waste-balances/application/waste-balance-service.js
@@ -1,0 +1,90 @@
+import { submitSummaryLog as decideSummaryLog } from '../domain/commands.js'
+import { currentWasteBalance } from './current-waste-balance.js'
+
+/**
+ * The single application boundary over the waste balance ledger. Each command
+ * folds the ledger once, runs the pure command core against that state, and
+ * appends the returned event(s) at the next slot over the event store. The slot
+ * index is the optimistic-concurrency guard: a head that moved after the fold
+ * leaves the next slot occupied, so `appendEvent` rejects with a
+ * `StreamSlotConflictError` and the conflict surfaces to the caller — no
+ * in-process retry (ADR-0036).
+ *
+ * @param {import('../repository/stream-port.js').WasteBalanceStreamRepository} streamRepository
+ */
+export const createWasteBalanceService = (streamRepository) => {
+  /**
+   * Fold the ledger into the state a command decides against, plus the head the
+   * decision is made at.
+   *
+   * @param {import('../repository/stream-schema.js').WasteBalanceLedgerId} ledgerId
+   * @returns {Promise<{ state: import('../domain/commands.js').LedgerState | null, head: number }>}
+   */
+  const fold = async (ledgerId) => {
+    const balance = await currentWasteBalance(streamRepository, ledgerId)
+    if (!balance) {
+      return { state: null, head: 0 }
+    }
+    return {
+      state: {
+        balance: {
+          amount: balance.amount,
+          availableAmount: balance.availableAmount
+        },
+        creditTotal: balance.creditTotal
+      },
+      head: balance.eventNumber
+    }
+  }
+
+  /**
+   * Append the decided balance events to the ledger, stamping each with the
+   * ledger identity, its slot, and provenance.
+   *
+   * @param {import('../repository/stream-schema.js').WasteBalanceLedgerId} ledgerId
+   * @param {number} head
+   * @param {import('../domain/commands.js').BalanceEvent[]} events
+   * @param {import('../repository/stream-schema.js').StreamUserSummary} createdBy
+   * @returns {Promise<import('../repository/stream-port.js').StreamEvent[]>}
+   */
+  const append = async (ledgerId, head, events, createdBy) => {
+    const appended = []
+    let number = head
+    for (const event of events) {
+      number += 1
+      appended.push(
+        await streamRepository.appendEvent({
+          ...ledgerId,
+          number,
+          kind: event.kind,
+          payload: event.payload,
+          openingBalance: event.openingBalance,
+          closingBalance: event.closingBalance,
+          createdAt: new Date(),
+          createdBy
+        })
+      )
+    }
+    return appended
+  }
+
+  return {
+    /**
+     * Record a summary-log submission against the ledger.
+     *
+     * @param {import('../repository/stream-schema.js').WasteBalanceLedgerId} ledgerId
+     * @param {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} submission
+     * @param {import('../repository/stream-schema.js').StreamUserSummary} createdBy
+     * @returns {Promise<import('../repository/stream-port.js').StreamEvent[]>}
+     */
+    submitSummaryLog: async (ledgerId, submission, createdBy) => {
+      const { state, head } = await fold(ledgerId)
+      return append(
+        ledgerId,
+        head,
+        decideSummaryLog(state, submission),
+        createdBy
+      )
+    }
+  }
+}

--- a/src/waste-balances/application/waste-balance-service.test.js
+++ b/src/waste-balances/application/waste-balance-service.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { createInMemoryStreamRepository } from '../repository/stream-inmemory.js'
+import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
+import { StreamSlotConflictError } from '../repository/stream-port.js'
+import { createWasteBalanceService } from './waste-balance-service.js'
+
+const ledgerId = {
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  accreditationId: 'acc-1'
+}
+
+const createdBy = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'user@example.test'
+}
+
+describe('createWasteBalanceService', () => {
+  let streamRepository
+  let service
+
+  beforeEach(() => {
+    streamRepository = createInMemoryStreamRepository()()
+    service = createWasteBalanceService(streamRepository)
+  })
+
+  describe('submitSummaryLog', () => {
+    it('opens the ledger from zero on the first submission', async () => {
+      const [event] = await service.submitSummaryLog(
+        ledgerId,
+        { summaryLogId: 'log-A', creditTotal: 150 },
+        createdBy
+      )
+
+      expect(event.number).toBe(1)
+      expect(event.organisationId).toBe('org-1')
+      expect(event.registrationId).toBe('reg-1')
+      expect(event.accreditationId).toBe('acc-1')
+      expect(event.kind).toBe(STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
+      expect(event.payload).toEqual({ summaryLogId: 'log-A', creditTotal: 150 })
+      expect(event.openingBalance).toEqual({ amount: 0, availableAmount: 0 })
+      expect(event.closingBalance).toEqual({
+        amount: 150,
+        availableAmount: 150
+      })
+      expect(event.createdBy).toEqual(createdBy)
+      expect(event.createdAt).toBeInstanceOf(Date)
+    })
+
+    it('appends at the next head, moving the balance by the credit-total delta', async () => {
+      await service.submitSummaryLog(
+        ledgerId,
+        { summaryLogId: 'log-A', creditTotal: 150 },
+        createdBy
+      )
+
+      const [event] = await service.submitSummaryLog(
+        ledgerId,
+        { summaryLogId: 'log-B', creditTotal: 200 },
+        createdBy
+      )
+
+      expect(event.number).toBe(2)
+      expect(event.openingBalance).toEqual({
+        amount: 150,
+        availableAmount: 150
+      })
+      expect(event.closingBalance).toEqual({
+        amount: 200,
+        availableAmount: 200
+      })
+    })
+
+    it('lets one of two concurrent submissions win and surfaces the loser as a slot conflict', async () => {
+      const results = await Promise.allSettled([
+        service.submitSummaryLog(
+          ledgerId,
+          { summaryLogId: 'log-A', creditTotal: 150 },
+          createdBy
+        ),
+        service.submitSummaryLog(
+          ledgerId,
+          { summaryLogId: 'log-B', creditTotal: 200 },
+          createdBy
+        )
+      ])
+
+      const fulfilled = results.filter((r) => r.status === 'fulfilled')
+      const rejected = results.filter((r) => r.status === 'rejected')
+      expect(fulfilled).toHaveLength(1)
+      expect(rejected).toHaveLength(1)
+      expect(rejected[0].reason).toBeInstanceOf(StreamSlotConflictError)
+
+      const all = await streamRepository.findAllByPartition('reg-1', 'acc-1')
+      expect(all).toHaveLength(1)
+    })
+  })
+})

--- a/src/waste-balances/domain/commands.js
+++ b/src/waste-balances/domain/commands.js
@@ -1,0 +1,57 @@
+import { STREAM_EVENT_KIND, ZERO_BALANCE } from '../repository/stream-schema.js'
+import { closingForSummaryLogSubmitted } from './stream-closing-balance.js'
+
+/**
+ * The ledger state a command decides against: the resolved balance and the
+ * running summary-log credit total — the whole ledger reduced to what a command
+ * needs, with identity and head left off. `null` when the ledger has no events
+ * yet.
+ *
+ * @typedef {Object} LedgerState
+ * @property {import('../repository/stream-schema.js').StreamBalanceSnapshot} balance
+ * @property {number} creditTotal - The latest summary-log credit total, the base
+ *   the next submission's delta is measured against.
+ */
+
+/**
+ * The balance-affecting outcome a command decides: the content of an event to
+ * commit, without identity, position, or provenance. The caller stamps those and
+ * appends it to the ledger.
+ *
+ * @typedef {Object} BalanceEvent
+ * @property {import('../repository/stream-schema.js').StreamEventKind} kind
+ * @property {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} payload
+ * @property {import('../repository/stream-schema.js').StreamBalanceSnapshot} openingBalance
+ * @property {import('../repository/stream-schema.js').StreamBalanceSnapshot} closingBalance
+ */
+
+/**
+ * The state a summary-log submission opens a ledger from when none exists.
+ * @type {LedgerState}
+ */
+const EMPTY_STATE = { balance: ZERO_BALANCE, creditTotal: 0 }
+
+/**
+ * Record a summary-log submission. An empty ledger is permissible — the first
+ * submission opens it. The closing balance moves by the delta of this
+ * submission's credit total against the ledger's running total.
+ *
+ * @param {LedgerState | null} state
+ * @param {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} submission
+ * @returns {BalanceEvent[]}
+ */
+export const submitSummaryLog = (state, { summaryLogId, creditTotal }) => {
+  const { balance, creditTotal: previousCreditTotal } = state ?? EMPTY_STATE
+  return [
+    {
+      kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+      payload: { summaryLogId, creditTotal },
+      openingBalance: balance,
+      closingBalance: closingForSummaryLogSubmitted(
+        balance,
+        creditTotal,
+        previousCreditTotal
+      )
+    }
+  ]
+}

--- a/src/waste-balances/domain/commands.test.js
+++ b/src/waste-balances/domain/commands.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+
+import { STREAM_EVENT_KIND, ZERO_BALANCE } from '../repository/stream-schema.js'
+import { submitSummaryLog } from './commands.js'
+
+describe('submitSummaryLog', () => {
+  it('opens a ledger from zero on the first submission', () => {
+    expect(
+      submitSummaryLog(null, { summaryLogId: 'log-1', creditTotal: 150 })
+    ).toEqual([
+      {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-1', creditTotal: 150 },
+        openingBalance: ZERO_BALANCE,
+        closingBalance: { amount: 150, availableAmount: 150 }
+      }
+    ])
+  })
+
+  it('shifts the balance by the delta against the previous credit total', () => {
+    const state = {
+      balance: { amount: 150, availableAmount: 120 },
+      creditTotal: 150
+    }
+
+    expect(
+      submitSummaryLog(state, { summaryLogId: 'log-2', creditTotal: 200 })
+    ).toEqual([
+      {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-2', creditTotal: 200 },
+        openingBalance: { amount: 150, availableAmount: 120 },
+        closingBalance: { amount: 200, availableAmount: 170 }
+      }
+    ])
+  })
+
+  it('lowers the balance when a resubmission reduces the credit total', () => {
+    const state = {
+      balance: { amount: 200, availableAmount: 170 },
+      creditTotal: 200
+    }
+
+    expect(
+      submitSummaryLog(state, { summaryLogId: 'log-3', creditTotal: 150 })
+    ).toEqual([
+      {
+        kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+        payload: { summaryLogId: 'log-3', creditTotal: 150 },
+        openingBalance: { amount: 200, availableAmount: 170 },
+        closingBalance: { amount: 150, availableAmount: 120 }
+      }
+    ])
+  })
+})

--- a/src/waste-balances/repository/stream-contract/bulkAppendEvents.contract.js
+++ b/src/waste-balances/repository/stream-contract/bulkAppendEvents.contract.js
@@ -1,10 +1,10 @@
 import { describe, beforeEach, expect } from 'vitest'
 
 import { buildStreamEvent } from '../stream-test-data.js'
-import { StreamSequenceError } from '../stream-port.js'
+import { StreamSequenceError, StreamSlotConflictError } from '../stream-port.js'
 
 export const testBulkAppendEventsBehaviour = (it) => {
-  describe('bulkAppendEvents (@migration PAE-1382)', () => {
+  describe('bulkAppendEvents', () => {
     let repository
 
     beforeEach(
@@ -61,6 +61,43 @@ export const testBulkAppendEventsBehaviour = (it) => {
 
       await expect(repository.bulkAppendEvents(events)).rejects.toBeInstanceOf(
         StreamSequenceError
+      )
+    })
+
+    it('throws StreamSequenceError when the first event of an empty partition is not number 1', async () => {
+      const events = [
+        buildStreamEvent({
+          registrationId: 'reg-empty',
+          accreditationId: 'acc-empty',
+          number: 2
+        })
+      ]
+
+      await expect(repository.bulkAppendEvents(events)).rejects.toBeInstanceOf(
+        StreamSequenceError
+      )
+    })
+
+    it('throws StreamSlotConflictError when the starting slot is already occupied', async () => {
+      await repository.appendEvent(
+        buildStreamEvent({
+          registrationId: 'reg-occupied',
+          accreditationId: 'acc-occupied',
+          number: 1
+        })
+      )
+
+      const events = [
+        buildStreamEvent({
+          registrationId: 'reg-occupied',
+          accreditationId: 'acc-occupied',
+          number: 1,
+          payload: { summaryLogId: 'log-clash', creditTotal: 100 }
+        })
+      ]
+
+      await expect(repository.bulkAppendEvents(events)).rejects.toBeInstanceOf(
+        StreamSlotConflictError
       )
     })
 

--- a/src/waste-balances/repository/stream-inmemory.js
+++ b/src/waste-balances/repository/stream-inmemory.js
@@ -91,7 +91,8 @@ const doDeleteByPartition = (storage, registrationId, accreditationId) => {
 }
 
 /**
- * Migration PAE-1382: insert multiple events in one call.
+ * Append a contiguous batch of events. Synchronous and validated up front, so
+ * the whole batch applies or none of it does.
  *
  * @param {StreamEvent[]} storage
  * @param {StreamEventInsert[]} events
@@ -114,6 +115,13 @@ const doBulkAppend = (storage, events) => {
   const expectedStart = currentMax + 1
 
   if (first.number !== expectedStart) {
+    if (partitionEvents.some((e) => e.number === first.number)) {
+      throw new StreamSlotConflictError(
+        first.registrationId,
+        first.accreditationId,
+        first.number
+      )
+    }
     throw new StreamSequenceError(
       first.registrationId,
       first.accreditationId,

--- a/src/waste-balances/repository/stream-mongodb.js
+++ b/src/waste-balances/repository/stream-mongodb.js
@@ -240,9 +240,15 @@ const performDeleteByPartition =
   }
 
 /**
- * @migration PAE-1382 — insert multiple events in one call.
- * Validates sequence: events must be numbered sequentially, and the first
- * event's number must be currentMax + 1 (or 1 if empty partition).
+ * Append a contiguous batch of events. Validates sequence: events must be
+ * numbered sequentially, and the first event's number must be currentMax + 1
+ * (or 1 if empty partition). A starting slot occupied by a competing writer
+ * surfaces as a `StreamSlotConflictError`, whether detected on the pre-check
+ * or on the insert itself.
+ *
+ * Not a transaction: the ordered insert commits each event as it goes and is
+ * not rolled back, so a later slot conflict leaves earlier events of the same
+ * batch committed.
  * @param {Collection} collection
  * @returns {(events: import('./stream-schema.js').StreamEventInsert[]) => Promise<import('./stream-schema.js').StreamEvent[]>}
  */
@@ -266,6 +272,13 @@ const performBulkAppendEvents = (collection) => async (events) => {
   const expectedStart = (latest?.number ?? 0) + 1
 
   if (first.number !== expectedStart) {
+    if (first.number <= (latest?.number ?? 0)) {
+      throw new StreamSlotConflictError(
+        first.registrationId,
+        first.accreditationId,
+        first.number
+      )
+    }
     throw new StreamSequenceError(
       first.registrationId,
       first.accreditationId,
@@ -286,11 +299,18 @@ const performBulkAppendEvents = (collection) => async (events) => {
     }
   }
 
-  const result = await collection.insertMany(validated)
-
-  return validated.map((event, i) =>
-    toStreamEvent({ _id: result.insertedIds[i], ...event })
-  )
+  try {
+    const result = await collection.insertMany(validated)
+    return validated.map((event, i) =>
+      toStreamEvent({ _id: result.insertedIds[i], ...event })
+    )
+  } catch (error) {
+    const classified = classifyDuplicateKeyError(error, first)
+    if (classified) {
+      throw classified
+    }
+    throw error
+  }
 }
 
 /**

--- a/src/waste-balances/repository/stream-mongodb.test.js
+++ b/src/waste-balances/repository/stream-mongodb.test.js
@@ -177,4 +177,46 @@ describe('MongoDB stream repository', () => {
       })
     })
   })
+
+  describe('bulkAppendEvents error translation', () => {
+    it('rethrows non-conflict MongoDB errors unchanged', async () => {
+      const upstream = new Error('connection lost')
+      const stubCollection = {
+        createIndex: () => Promise.resolve(),
+        findOne: () => Promise.resolve(null),
+        insertMany: () => Promise.reject(upstream)
+      }
+      const stubDb = { collection: () => stubCollection }
+
+      const repository = (
+        await createMongoStreamRepository(/** @type {*} */ (stubDb))
+      )()
+
+      await expect(
+        repository.bulkAppendEvents([buildStreamEvent({ number: 1 })])
+      ).rejects.toBe(upstream)
+    })
+
+    it('classifies a slot conflict raised when inserting the batch', async () => {
+      const mongoError = Object.assign(new Error('E11000'), {
+        writeErrors: [{ code: 11000, keyPattern: { number: 1 } }]
+      })
+      const stubCollection = {
+        createIndex: () => Promise.resolve(),
+        findOne: () => Promise.resolve(null),
+        insertMany: () => Promise.reject(mongoError)
+      }
+      const stubDb = { collection: () => stubCollection }
+
+      const repository = (
+        await createMongoStreamRepository(/** @type {*} */ (stubDb))
+      )()
+
+      await expect(
+        repository.bulkAppendEvents([buildStreamEvent({ number: 1 })])
+      ).rejects.toMatchObject({
+        name: 'StreamSlotConflictError'
+      })
+    })
+  })
 })

--- a/src/waste-balances/repository/stream-port.js
+++ b/src/waste-balances/repository/stream-port.js
@@ -107,10 +107,16 @@ export class StreamSequenceError extends Error {
  *   Migration PAE-1382: delete all events for the given partition.
  *   Returns the number of deleted events. No-op on empty partition.
  * @property {(events: StreamEventInsert[]) => Promise<StreamEvent[]>} bulkAppendEvents
- *   Migration PAE-1382: insert multiple events in one call. Validates
- *   sequence: events must be numbered sequentially, and the first event's
- *   number must be `currentMax + 1` (or `1` if the partition is empty).
- *   Throws `StreamSequenceError` on failure. Empty array is a no-op.
+ *   Append a contiguous batch of events. Events must be numbered
+ *   sequentially, and the first event's number must be `currentMax + 1`
+ *   (or `1` if the partition is empty). Throws `StreamSlotConflictError` if
+ *   the starting slot is already occupied, `StreamSequenceError` on a gap or
+ *   non-sequential numbering. Empty array is a no-op.
+ *
+ *   Not isolated: the batch is not rolled back as a unit, so a later slot
+ *   conflict leaves earlier inserts of the same batch committed. A multi-event
+ *   batch is therefore only safe where nothing else writes the partition
+ *   concurrently — a single-event command append or a single-threaded load.
  */
 
 /**

--- a/src/waste-balances/repository/stream-port.js
+++ b/src/waste-balances/repository/stream-port.js
@@ -113,10 +113,14 @@ export class StreamSequenceError extends Error {
  *   the starting slot is already occupied, `StreamSequenceError` on a gap or
  *   non-sequential numbering. Empty array is a no-op.
  *
- *   Not isolated: the batch is not rolled back as a unit, so a later slot
- *   conflict leaves earlier inserts of the same batch committed. A multi-event
- *   batch is therefore only safe where nothing else writes the partition
- *   concurrently — a single-event command append or a single-threaded load.
+ *   A single-event batch is fully concurrency-safe: the slot index admits one
+ *   writer per slot and the loser appends nothing. A multi-event batch is not
+ *   isolated — it is not rolled back as a unit, so a competing writer can leave
+ *   the batch truncated to a committed prefix while the caller sees the slot
+ *   conflict. The slot index still guarantees gap-free contiguity, so the
+ *   surviving prefix folds consistently; what is lost is decision-atomicity
+ *   across the batch. A command that emits more than one event must therefore
+ *   tolerate a re-applied prefix on replay (idempotent or independent events).
  */
 
 /**


### PR DESCRIPTION
Ticket: [PAE-1669](https://eaflood.atlassian.net/browse/PAE-1669)

Introduce a waste balance application service that owns the fold → decide → append cycle over the event-sourced ledger, and route summary-log submissions through it. Balance amounts and the write outcome are unchanged — this gives the ledger fold and the balance arithmetic one home above the event store, behind a single service boundary, rather than inline in the write path.

## What changed

- **Application service** (`src/waste-balances/application/waste-balance-service.js`): a new service over the stream repository. Per command it folds the ledger once, runs the pure command core against that state, and appends the decided event(s) at the next slot through a single batch insert (`bulkAppendEvents`). The slot index stays the optimistic-concurrency guard — a head that moved after the fold leaves the slot occupied, so the append rejects with a `StreamSlotConflictError` that propagates to the caller (ADR-0036, no in-process retry). `expectedHead` is no longer part of the surface.
- **Summary-log command core** (`src/waste-balances/domain/commands.js`): the pure `submitSummaryLog(state, submission)` decider. Given the folded ledger state it returns the submission event with its opening and closing balance, shifting the balance by the credit-total delta and opening a ledger from zero on the first submission. No I/O — it sits in the domain layer alongside the closing-balance arithmetic.
- **Summary-log write path** (`src/waste-balances/application/update-via-stream.js`): submissions now go through the service instead of reading the head and recomputing the closing balance inline. The previous inline head-read and balance recomputation on this path are retired; the credit-total aggregation over the submission's rows is unchanged.


[PAE-1669]: https://eaflood.atlassian.net/browse/PAE-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ