### PR TITLE
Raise cdp-uploader contract hook timeout above container startup

### DIFF
--- a/src/adapters/repositories/uploads/cdp-uploader.test.js
+++ b/src/adapters/repositories/uploads/cdp-uploader.test.js
@@ -1,7 +1,13 @@
-import { describe, expect } from 'vitest'
+import { describe, expect, vi } from 'vitest'
 import { it as baseIt } from '#vite/fixtures/cdp-uploader.js'
 import { testUploadsRepositoryContract } from './port.contract.js'
 import { createUploadsRepository } from './cdp-uploader.js'
+
+// The cdpUploaderStack fixture brings up a Docker stack (Floci, Redis, an init
+// container, CDP Uploader, a Socat proxy) whose own startup timeouts reach 120s.
+// The default 60s hook timeout is shorter than that budget, so a cold image pull
+// or CPU contention can time the setup hook out before the containers are ready.
+vi.setConfig({ hookTimeout: 180_000, testTimeout: 180_000 })
 
 // Extend base fixture with contract test specific fixtures
 const it = baseIt.extend({


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
The `cdp-uploader` repository contract test (`src/adapters/repositories/uploads/cdp-uploader.test.js`) intermittently fails its setup hook with `Error: Hook timed out in 60000ms`. The hook brings up the `cdpUploaderStack` fixture — a Docker stack (Floci/localstack, Redis, a one-shot init container, the CDP Uploader image and a Socat proxy) whose own container startup timeouts reach 120s. But the hook awaiting that stack runs under Vitest's default 60s `hookTimeout`, so the budget is shorter than the startup it is waiting on.

When the machine is thermally constrained — a laptop that isn't in "leafblower mode" (fans going full pelt) — the host throttles and container startup slows past 60s, tripping the hook before the stack is ready. The same happens on a cold image pull or when another test suite is competing for CPU. The containers are nowhere near their own 120s limits; the hook just gives up first.

This scopes a 180s `hookTimeout` and `testTimeout` to that one file via `vi.setConfig`, so the gate matches the stack it waits on. `testTimeout` rises with it because the round-trip tests (`waitForCallback` over the real upload-and-scan) share the same contention sensitivity. No other file is affected.
