### PR TITLE
PAE-1669: Route PRN status transitions through the waste-balance service

### DIFF
--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -5,205 +5,15 @@ import {
   LOGGING_EVENT_ACTIONS,
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/event.js'
-import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+import {
+  PRN_COMMAND_STATUS,
+  PRN_COMMAND_REJECTION
+} from '#waste-balances/domain/commands.js'
 
 /**
- * @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository
+ * @typedef {ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>} WasteBalanceService
  * @typedef {import('#packaging-recycling-notes/domain/model.js').PrnStatus} PrnStatus
- * @typedef {import('#waste-balances/repository/stream-schema.js').StreamEventKind} StreamEventKind
  */
-
-/**
- * Payload carried by a balance event — what the stream append needs and what
- * the logger needs for ops correlation. `currentStatus`/`newStatus` are
- * transition metadata preserved for logging only.
- *
- * @typedef {Object} BalanceEventParams
- * @property {PrnStatus} currentStatus
- * @property {PrnStatus} newStatus
- * @property {string} accreditationId
- * @property {string} registrationId
- * @property {string} organisationId
- * @property {string} prnId
- * @property {number} tonnage
- * @property {import('#waste-balances/repository/stream-schema.js').StreamUserSummary} createdBy
- */
-
-/**
- * @typedef {Object} BalanceEvent
- * @property {StreamEventKind} kind
- * @property {BalanceEventParams} params
- */
-
-/**
- * Deducts available waste balance when creating a PRN.
- *
- * @param {WasteBalancesRepository} wasteBalancesRepository
- * @param {Object} params
- */
-export async function deductWasteBalanceIfNeeded(
-  wasteBalancesRepository,
-  params
-) {
-  const {
-    accreditationId,
-    registrationId,
-    organisationId,
-    prnId,
-    tonnage,
-    createdBy
-  } = params
-  const balance = await wasteBalancesRepository.findBalance({
-    registrationId,
-    accreditationId
-  })
-
-  if (balance) {
-    if ((balance.availableAmount ?? 0) < tonnage) {
-      throw Boom.conflict('Insufficient available waste balance')
-    }
-
-    return wasteBalancesRepository.deductAvailableBalanceForPrnCreation({
-      accreditationId,
-      registrationId,
-      organisationId,
-      prnId,
-      tonnage,
-      createdBy,
-      expectedHead: balance.eventNumber
-    })
-  } else {
-    throw Boom.badRequest(
-      `No waste balance found for accreditation: ${accreditationId}`
-    )
-  }
-}
-
-/**
- * Deducts total waste balance when issuing a PRN.
- *
- * @param {WasteBalancesRepository} wasteBalancesRepository
- * @param {Object} params
- */
-export async function deductTotalBalanceIfNeeded(
-  wasteBalancesRepository,
-  params
-) {
-  const {
-    accreditationId,
-    registrationId,
-    organisationId,
-    prnId,
-    tonnage,
-    createdBy
-  } = params
-  const balance = await wasteBalancesRepository.findBalance({
-    registrationId,
-    accreditationId
-  })
-
-  if (balance) {
-    if ((balance.amount ?? 0) < tonnage) {
-      throw Boom.conflict('Insufficient total waste balance')
-    }
-
-    return wasteBalancesRepository.deductTotalBalanceForPrnIssue({
-      accreditationId,
-      registrationId,
-      organisationId,
-      prnId,
-      tonnage,
-      createdBy,
-      expectedHead: balance.eventNumber
-    })
-  } else {
-    throw Boom.badRequest(
-      `No waste balance found for accreditation: ${accreditationId}`
-    )
-  }
-}
-
-/**
- * Credits available waste balance when cancelling a PRN from awaiting_authorisation.
- * Reverses the ringfencing that occurred when the PRN was created.
- *
- * @param {WasteBalancesRepository} wasteBalancesRepository
- * @param {Object} params
- */
-export async function creditWasteBalanceIfNeeded(
-  wasteBalancesRepository,
-  params
-) {
-  const {
-    accreditationId,
-    registrationId,
-    organisationId,
-    prnId,
-    tonnage,
-    createdBy
-  } = params
-  const balance = await wasteBalancesRepository.findBalance({
-    registrationId,
-    accreditationId
-  })
-
-  if (balance) {
-    return wasteBalancesRepository.creditAvailableBalanceForPrnCancellation({
-      accreditationId,
-      registrationId,
-      organisationId,
-      prnId,
-      tonnage,
-      createdBy,
-      expectedHead: balance.eventNumber
-    })
-  } else {
-    throw Boom.badRequest(
-      `No waste balance found for accreditation: ${accreditationId}`
-    )
-  }
-}
-
-/**
- * Credits both amount and availableAmount when cancelling an issued PRN.
- * Reverses both the creation ringfence and the issue deduction.
- *
- * @param {WasteBalancesRepository} wasteBalancesRepository
- * @param {Object} params
- */
-export async function creditFullBalanceIfNeeded(
-  wasteBalancesRepository,
-  params
-) {
-  const {
-    accreditationId,
-    registrationId,
-    organisationId,
-    prnId,
-    tonnage,
-    createdBy
-  } = params
-  const balance = await wasteBalancesRepository.findBalance({
-    registrationId,
-    accreditationId
-  })
-
-  if (balance) {
-    return wasteBalancesRepository.creditFullBalanceForIssuedPrnCancellation({
-      accreditationId,
-      registrationId,
-      organisationId,
-      prnId,
-      tonnage,
-      createdBy,
-      expectedHead: balance.eventNumber
-    })
-  } else {
-    throw Boom.badRequest(
-      `No waste balance found for accreditation: ${accreditationId}`
-    )
-  }
-}
 
 /**
  * Operational system log capturing that a waste balance write committed.
@@ -234,124 +44,112 @@ export function logWasteBalanceUpdate(
 }
 
 /**
- * Transition table keyed by `${currentStatus}|${newStatus}`. Each entry names
- * the stream event kind the transition writes. Transitions without an entry
- * have no balance effect. Keys must be transitions the state machine
+ * Maps a permitted status transition to the waste-balance service command it
+ * runs and the operation label its system log carries. Transitions without an
+ * entry have no balance effect. Keys must be transitions the state machine
  * (`PRN_STATUS_TRANSITIONS`) actually permits.
  *
- * @type {Record<string, StreamEventKind>}
+ * @type {Record<string, { method: 'createPrn' | 'issuePrn' | 'cancelPrnCreation' | 'cancelIssuedPrn' | 'acceptPrn' | 'rejectPrn', logOperation: string }>}
  */
-const TRANSITION_TO_EVENT_KIND = Object.freeze({
-  [`${PRN_STATUS.DRAFT}|${PRN_STATUS.AWAITING_AUTHORISATION}`]:
-    STREAM_EVENT_KIND.PRN_CREATED,
-  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.AWAITING_ACCEPTANCE}`]:
-    STREAM_EVENT_KIND.PRN_ISSUED,
-  [`${PRN_STATUS.AWAITING_ACCEPTANCE}|${PRN_STATUS.ACCEPTED}`]:
-    STREAM_EVENT_KIND.PRN_ACCEPTED,
-  [`${PRN_STATUS.AWAITING_ACCEPTANCE}|${PRN_STATUS.AWAITING_CANCELLATION}`]:
-    STREAM_EVENT_KIND.PRN_REJECTED,
-  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.DELETED}`]:
-    STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
-  [`${PRN_STATUS.AWAITING_CANCELLATION}|${PRN_STATUS.CANCELLED}`]:
-    STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE
-})
-
-/**
- * Derives the balance events a status transition would write. An empty array
- * means the transition has no balance effect — callers use that to skip the
- * stream-write decision read entirely. The kinds align with `STREAM_EVENT_KIND`
- * so the live-write path, backfill, and the stream itself share one vocabulary.
- *
- * @param {PrnStatus} currentStatus
- * @param {PrnStatus} newStatus
- * @param {BalanceEventParams} params
- * @returns {BalanceEvent[]}
- */
-export function balanceEventsFor(currentStatus, newStatus, params) {
-  const kind = TRANSITION_TO_EVENT_KIND[`${currentStatus}|${newStatus}`]
-  return kind ? [{ kind, params }] : []
-}
-
-/**
- * Append a status-only stream event (PRN_ACCEPTED, PRN_REJECTED). No balance
- * change; the repository method throws loudly if no balance exists.
- *
- * @param {import('#waste-balances/repository/stream-schema.js').StreamEventKind} streamKind
- */
-const appendStatusOnlyStreamEvent =
-  (streamKind) => async (wasteBalancesRepository, params) =>
-    wasteBalancesRepository.appendStreamEvent({
-      ...params,
-      streamKind
-    })
-
-/**
- * Per-kind dispatch: each kind pairs an effect handler with its log-operation
- * label. Balance-affecting kinds append a balance movement to the stream;
- * status-only kinds (PRN_ACCEPTED, PRN_REJECTED) append a status event with no
- * balance change.
- */
-const EFFECT_HANDLERS = Object.freeze({
-  [STREAM_EVENT_KIND.PRN_CREATED]: {
-    apply: deductWasteBalanceIfNeeded,
+const TRANSITION_TO_COMMAND = Object.freeze({
+  [`${PRN_STATUS.DRAFT}|${PRN_STATUS.AWAITING_AUTHORISATION}`]: {
+    method: 'createPrn',
     logOperation: 'deduct_available'
   },
-  [STREAM_EVENT_KIND.PRN_ISSUED]: {
-    apply: deductTotalBalanceIfNeeded,
+  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.AWAITING_ACCEPTANCE}`]: {
+    method: 'issuePrn',
     logOperation: 'deduct_total'
   },
-  [STREAM_EVENT_KIND.PRN_ACCEPTED]: {
-    apply: appendStatusOnlyStreamEvent(STREAM_EVENT_KIND.PRN_ACCEPTED),
+  [`${PRN_STATUS.AWAITING_ACCEPTANCE}|${PRN_STATUS.ACCEPTED}`]: {
+    method: 'acceptPrn',
     logOperation: 'append_accepted'
   },
-  [STREAM_EVENT_KIND.PRN_REJECTED]: {
-    apply: appendStatusOnlyStreamEvent(STREAM_EVENT_KIND.PRN_REJECTED),
+  [`${PRN_STATUS.AWAITING_ACCEPTANCE}|${PRN_STATUS.AWAITING_CANCELLATION}`]: {
+    method: 'rejectPrn',
     logOperation: 'append_rejected'
   },
-  [STREAM_EVENT_KIND.PRN_CREATION_CANCELLED]: {
-    apply: creditWasteBalanceIfNeeded,
+  [`${PRN_STATUS.AWAITING_AUTHORISATION}|${PRN_STATUS.DELETED}`]: {
+    method: 'cancelPrnCreation',
     logOperation: 'credit_available'
   },
-  [STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE]: {
-    apply: creditFullBalanceIfNeeded,
+  [`${PRN_STATUS.AWAITING_CANCELLATION}|${PRN_STATUS.CANCELLED}`]: {
+    method: 'cancelIssuedPrn',
     logOperation: 'credit_full'
   }
 })
 
 /**
- * Applies the balance events for a status transition, appending one stream
- * event per input event and returning them in order. Each handler reads the
- * balance, then appends at the head it read; a competing write that advanced
- * the head in between surfaces as a slot/sequence conflict and propagates to
- * the caller (ADR-0036), failing the transition.
+ * The waste-balance command a status transition runs, or `undefined` when the
+ * transition has no balance effect.
  *
- * @param {WasteBalancesRepository} wasteBalancesRepository
+ * @param {PrnStatus} currentStatus
+ * @param {PrnStatus} newStatus
+ */
+export const prnCommandFor = (currentStatus, newStatus) =>
+  TRANSITION_TO_COMMAND[`${currentStatus}|${newStatus}`]
+
+/**
+ * Turn a command rejection into the error its callers expect. The domain
+ * decider reports the rejection as data; the contextual HTTP-shaped error is
+ * built here, where the ledger identity is in hand.
+ *
+ * @type {Record<import('#waste-balances/domain/commands.js').PrnCommandRejection, (accreditationId: string) => Error>}
+ */
+const REJECTION_TO_ERROR = Object.freeze({
+  [PRN_COMMAND_REJECTION.NO_LEDGER]: (accreditationId) =>
+    Boom.badRequest(
+      `No waste balance found for accreditation: ${accreditationId}`
+    ),
+  [PRN_COMMAND_REJECTION.INSUFFICIENT_AVAILABLE_BALANCE]: () =>
+    Boom.conflict('Insufficient available waste balance'),
+  [PRN_COMMAND_REJECTION.INSUFFICIENT_TOTAL_BALANCE]: () =>
+    Boom.conflict('Insufficient total waste balance')
+})
+
+/**
+ * Run the waste-balance command for a status transition through the service,
+ * folding once and appending the decided events. A rejection becomes the
+ * caller-facing error; a commit is logged and its appended stream events
+ * returned for the projection fold. The slot index is the optimistic-concurrency
+ * guard: a head that moved after the fold surfaces as a slot conflict and
+ * propagates to the caller (ADR-0036).
+ *
+ * @param {WasteBalanceService} service
  * @param {import('#common/hapi-types.js').TypedLogger} logger
- * @param {BalanceEvent[]} events
+ * @param {Object} command
+ * @param {PrnStatus} command.currentStatus
+ * @param {PrnStatus} command.newStatus
+ * @param {import('#waste-balances/repository/stream-schema.js').WasteBalanceLedgerId & { accreditationId: string }} command.ledgerId
+ * @param {string} command.prnId
+ * @param {number} command.tonnage
+ * @param {import('#waste-balances/repository/stream-schema.js').StreamUserSummary} command.createdBy
  * @returns {Promise<Array<import('#waste-balances/repository/stream-port.js').StreamEvent>>}
  */
-export async function applyWasteBalanceEffects(
-  wasteBalancesRepository,
+export async function applyPrnBalanceCommand(
+  service,
   logger,
-  events
+  { currentStatus, newStatus, ledgerId, prnId, tonnage, createdBy }
 ) {
-  const applied = []
-  for (const event of events) {
-    const handler = EFFECT_HANDLERS[event.kind]
-    const { currentStatus, newStatus, ...balanceParams } = event.params
-    const streamEvent = await handler.apply(
-      wasteBalancesRepository,
-      balanceParams
-    )
-    applied.push(streamEvent)
-    logWasteBalanceUpdate(
-      logger,
-      handler.logOperation,
-      balanceParams.prnId,
-      balanceParams.tonnage,
-      currentStatus,
-      newStatus
-    )
+  const command = prnCommandFor(currentStatus, newStatus)
+
+  const result = await service[command.method](
+    ledgerId,
+    { prnId, amount: tonnage },
+    createdBy
+  )
+
+  if (result.status === PRN_COMMAND_STATUS.REJECTED) {
+    throw REJECTION_TO_ERROR[result.reason](ledgerId.accreditationId)
   }
-  return applied
+
+  logWasteBalanceUpdate(
+    logger,
+    command.logOperation,
+    prnId,
+    tonnage,
+    currentStatus,
+    newStatus
+  )
+
+  return result.events
 }

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -107,6 +107,18 @@ const REJECTION_TO_ERROR = Object.freeze({
 })
 
 /**
+ * Commands that act on a PRN already created and issued. Both transitions only
+ * follow ones that opened the ledger, so a missing ledger here is not a client
+ * error but a broken invariant — surfaced as a 500 rather than the contextual
+ * 400 the reachable commands return.
+ *
+ * @type {ReadonlySet<string>}
+ */
+const COMMANDS_REQUIRING_OPEN_LEDGER = Object.freeze(
+  new Set(['acceptPrn', 'rejectPrn'])
+)
+
+/**
  * Run the waste-balance command for a status transition through the service,
  * folding once and appending the decided events. A rejection becomes the
  * caller-facing error; a commit is logged and its appended stream events
@@ -139,6 +151,14 @@ export async function applyPrnBalanceCommand(
   )
 
   if (result.status === PRN_COMMAND_STATUS.REJECTED) {
+    if (
+      result.reason === PRN_COMMAND_REJECTION.NO_LEDGER &&
+      COMMANDS_REQUIRING_OPEN_LEDGER.has(command.method)
+    ) {
+      throw Boom.badImplementation(
+        `${command.method} reached a missing waste balance ledger for accreditation ${ledgerId.accreditationId}; a created and issued PRN must have an open ledger`
+      )
+    }
     throw REJECTION_TO_ERROR[result.reason](ledgerId.accreditationId)
   }
 

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
@@ -1,21 +1,29 @@
 import { describe, it, expect, vi } from 'vitest'
 
 import {
-  applyWasteBalanceEffects,
-  balanceEventsFor
+  applyPrnBalanceCommand,
+  prnCommandFor
 } from './update-status-balance-effects.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
-import { createWasteBalancesRepository } from '#waste-balances/repository/repository.js'
 import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
+import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
 import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
-import { StreamSlotConflictError } from '#waste-balances/repository/stream-port.js'
 import { buildStreamEvent } from '#waste-balances/repository/stream-test-data.js'
 
 const REGISTRATION_ID = 'reg-1'
 const ACCREDITATION_ID = 'acc-1'
 const ORGANISATION_ID = 'org-1'
-const SEEDED_EVENT_NUMBER = 1
-const APPENDED_EVENT_NUMBER = 2
+const PRN_ID = 'prn-1'
+const TONNAGE = 10
+const SEED_NUMBER = 1
+const APPENDED_NUMBER = 2
+
+const ledgerId = {
+  organisationId: ORGANISATION_ID,
+  registrationId: REGISTRATION_ID,
+  accreditationId: ACCREDITATION_ID
+}
+const createdBy = { id: 'user-1' }
 
 const buildLogger = () => ({
   info: vi.fn(),
@@ -28,316 +36,182 @@ const buildLogger = () => ({
 })
 
 /**
- * An in-memory repository seeded with one stream event so the read resolves a
- * non-zero balance. The next balance effect appends a second event, so the
- * returned watermark is APPENDED_EVENT_NUMBER.
+ * A service over an in-memory stream. With a closing balance the ledger is
+ * seeded with one summary-log event so commands resolve a balance; without one
+ * the ledger is empty and commands reject with NO_LEDGER.
  */
-const setupLedgerRepository = async () => {
-  const streamRepository = createInMemoryStreamRepository()()
-  await streamRepository.appendEvent(
-    buildStreamEvent({
-      registrationId: REGISTRATION_ID,
-      accreditationId: ACCREDITATION_ID,
-      number: SEEDED_EVENT_NUMBER,
-      closingBalance: { amount: 100, availableAmount: 100 }
-    })
-  )
-
-  const wasteBalancesRepository = createWasteBalancesRepository({
-    streamRepository
-  })()
-
-  return { wasteBalancesRepository, streamRepository }
+const serviceWithBalance = (closingBalance) => {
+  const events = closingBalance
+    ? [
+        buildStreamEvent({
+          registrationId: REGISTRATION_ID,
+          accreditationId: ACCREDITATION_ID,
+          organisationId: ORGANISATION_ID,
+          number: SEED_NUMBER,
+          closingBalance
+        })
+      ]
+    : []
+  return createWasteBalanceService(createInMemoryStreamRepository(events)())
 }
 
-const balanceParamsFor = (overrides) => ({
-  prnId: 'prn-1',
-  tonnage: 10,
-  accreditationId: ACCREDITATION_ID,
-  registrationId: REGISTRATION_ID,
-  organisationId: ORGANISATION_ID,
-  createdBy: { id: 'user-1' },
-  ...overrides
-})
-
-const eventsForTransition = (currentStatus, newStatus) =>
-  balanceEventsFor(
+const applyTransition = (service, logger, currentStatus, newStatus) =>
+  applyPrnBalanceCommand(service, logger, {
     currentStatus,
     newStatus,
-    balanceParamsFor({ currentStatus, newStatus })
-  )
-
-describe('applyWasteBalanceEffects appended events return', () => {
-  it('returns the appended event from the deduct-available branch', async () => {
-    const { wasteBalancesRepository, streamRepository } =
-      await setupLedgerRepository()
-
-    const applied = await applyWasteBalanceEffects(
-      wasteBalancesRepository,
-      buildLogger(),
-      eventsForTransition(PRN_STATUS.DRAFT, PRN_STATUS.AWAITING_AUTHORISATION)
-    )
-
-    const latest = await streamRepository.findLatestByPartition(
-      REGISTRATION_ID,
-      ACCREDITATION_ID
-    )
-    expect(applied).toHaveLength(1)
-    expect(applied[0]?.number).toBe(latest?.number)
-    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
+    ledgerId,
+    prnId: PRN_ID,
+    tonnage: TONNAGE,
+    createdBy
   })
 
-  it('returns the appended event from the deduct-total branch', async () => {
-    const { wasteBalancesRepository, streamRepository } =
-      await setupLedgerRepository()
+describe('prnCommandFor', () => {
+  it.each([
+    [
+      PRN_STATUS.DRAFT,
+      PRN_STATUS.AWAITING_AUTHORISATION,
+      'createPrn',
+      'deduct_available'
+    ],
+    [
+      PRN_STATUS.AWAITING_AUTHORISATION,
+      PRN_STATUS.AWAITING_ACCEPTANCE,
+      'issuePrn',
+      'deduct_total'
+    ],
+    [
+      PRN_STATUS.AWAITING_ACCEPTANCE,
+      PRN_STATUS.ACCEPTED,
+      'acceptPrn',
+      'append_accepted'
+    ],
+    [
+      PRN_STATUS.AWAITING_ACCEPTANCE,
+      PRN_STATUS.AWAITING_CANCELLATION,
+      'rejectPrn',
+      'append_rejected'
+    ],
+    [
+      PRN_STATUS.AWAITING_AUTHORISATION,
+      PRN_STATUS.DELETED,
+      'cancelPrnCreation',
+      'credit_available'
+    ],
+    [
+      PRN_STATUS.AWAITING_CANCELLATION,
+      PRN_STATUS.CANCELLED,
+      'cancelIssuedPrn',
+      'credit_full'
+    ]
+  ])(
+    'maps %s -> %s to the %s command',
+    (currentStatus, newStatus, method, logOperation) => {
+      expect(prnCommandFor(currentStatus, newStatus)).toEqual({
+        method,
+        logOperation
+      })
+    }
+  )
 
-    const applied = await applyWasteBalanceEffects(
-      wasteBalancesRepository,
+  it('has no command for a transition with no balance effect', () => {
+    expect(
+      prnCommandFor(PRN_STATUS.DRAFT, PRN_STATUS.DISCARDED)
+    ).toBeUndefined()
+  })
+})
+
+describe('applyPrnBalanceCommand on commit', () => {
+  it('appends the decided event and returns it', async () => {
+    const service = serviceWithBalance({ amount: 1000, availableAmount: 1000 })
+
+    const events = await applyTransition(
+      service,
       buildLogger(),
-      eventsForTransition(
+      PRN_STATUS.DRAFT,
+      PRN_STATUS.AWAITING_AUTHORISATION
+    )
+
+    expect(events).toHaveLength(1)
+    expect(events[0]?.kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+    expect(events[0]?.number).toBe(APPENDED_NUMBER)
+  })
+
+  it('logs the operation against the PRN', async () => {
+    const service = serviceWithBalance({ amount: 1000, availableAmount: 1000 })
+    const logger = buildLogger()
+
+    await applyTransition(
+      service,
+      logger,
+      PRN_STATUS.DRAFT,
+      PRN_STATUS.AWAITING_AUTHORISATION
+    )
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('deduct_available'),
+        event: expect.objectContaining({
+          action: 'waste_balance_updated',
+          category: 'database',
+          reference: PRN_ID
+        })
+      })
+    )
+    const [entry] = logger.info.mock.calls[0]
+    expect(entry.message).toContain(PRN_ID)
+    expect(entry.message).toContain(String(TONNAGE))
+  })
+})
+
+describe('applyPrnBalanceCommand on rejection', () => {
+  it('throws a 400 naming the accreditation when no ledger exists', async () => {
+    const service = serviceWithBalance(null)
+
+    await expect(
+      applyTransition(
+        service,
+        buildLogger(),
+        PRN_STATUS.DRAFT,
+        PRN_STATUS.AWAITING_AUTHORISATION
+      )
+    ).rejects.toMatchObject({
+      isBoom: true,
+      output: { statusCode: 400 },
+      message: `No waste balance found for accreditation: ${ACCREDITATION_ID}`
+    })
+  })
+
+  it('throws a 409 when the available balance is exhausted on creation', async () => {
+    const service = serviceWithBalance({ amount: 500, availableAmount: 0 })
+
+    await expect(
+      applyTransition(
+        service,
+        buildLogger(),
+        PRN_STATUS.DRAFT,
+        PRN_STATUS.AWAITING_AUTHORISATION
+      )
+    ).rejects.toMatchObject({
+      isBoom: true,
+      output: { statusCode: 409 },
+      message: 'Insufficient available waste balance'
+    })
+  })
+
+  it('throws a 409 when the total balance is exhausted on issuance', async () => {
+    const service = serviceWithBalance({ amount: 0, availableAmount: 500 })
+
+    await expect(
+      applyTransition(
+        service,
+        buildLogger(),
         PRN_STATUS.AWAITING_AUTHORISATION,
         PRN_STATUS.AWAITING_ACCEPTANCE
       )
-    )
-
-    const latest = await streamRepository.findLatestByPartition(
-      REGISTRATION_ID,
-      ACCREDITATION_ID
-    )
-    expect(applied[0]?.number).toBe(latest?.number)
-    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
-  })
-
-  it('returns the appended event from the credit-available branch', async () => {
-    const { wasteBalancesRepository, streamRepository } =
-      await setupLedgerRepository()
-
-    const applied = await applyWasteBalanceEffects(
-      wasteBalancesRepository,
-      buildLogger(),
-      eventsForTransition(PRN_STATUS.AWAITING_AUTHORISATION, PRN_STATUS.DELETED)
-    )
-
-    const latest = await streamRepository.findLatestByPartition(
-      REGISTRATION_ID,
-      ACCREDITATION_ID
-    )
-    expect(applied[0]?.number).toBe(latest?.number)
-    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
-  })
-
-  it('returns the appended event from the prn-accepted branch', async () => {
-    const { wasteBalancesRepository, streamRepository } =
-      await setupLedgerRepository()
-
-    const applied = await applyWasteBalanceEffects(
-      wasteBalancesRepository,
-      buildLogger(),
-      eventsForTransition(PRN_STATUS.AWAITING_ACCEPTANCE, PRN_STATUS.ACCEPTED)
-    )
-
-    const latest = await streamRepository.findLatestByPartition(
-      REGISTRATION_ID,
-      ACCREDITATION_ID
-    )
-    expect(applied[0]?.kind).toBe(STREAM_EVENT_KIND.PRN_ACCEPTED)
-    expect(applied[0]?.number).toBe(latest?.number)
-    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
-  })
-
-  it('returns the appended event from the prn-rejected branch', async () => {
-    const { wasteBalancesRepository, streamRepository } =
-      await setupLedgerRepository()
-
-    const applied = await applyWasteBalanceEffects(
-      wasteBalancesRepository,
-      buildLogger(),
-      eventsForTransition(
-        PRN_STATUS.AWAITING_ACCEPTANCE,
-        PRN_STATUS.AWAITING_CANCELLATION
-      )
-    )
-
-    const latest = await streamRepository.findLatestByPartition(
-      REGISTRATION_ID,
-      ACCREDITATION_ID
-    )
-    expect(applied[0]?.kind).toBe(STREAM_EVENT_KIND.PRN_REJECTED)
-    expect(applied[0]?.number).toBe(latest?.number)
-    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
-  })
-
-  it('returns the appended event from the credit-full branch', async () => {
-    const { wasteBalancesRepository, streamRepository } =
-      await setupLedgerRepository()
-
-    const applied = await applyWasteBalanceEffects(
-      wasteBalancesRepository,
-      buildLogger(),
-      eventsForTransition(
-        PRN_STATUS.AWAITING_CANCELLATION,
-        PRN_STATUS.CANCELLED
-      )
-    )
-
-    const latest = await streamRepository.findLatestByPartition(
-      REGISTRATION_ID,
-      ACCREDITATION_ID
-    )
-    expect(applied[0]?.number).toBe(latest?.number)
-    expect(applied[0]?.number).toBe(APPENDED_EVENT_NUMBER)
-  })
-
-  it('returns an empty array when the events array is empty', async () => {
-    const { wasteBalancesRepository } = await setupLedgerRepository()
-
-    const applied = await applyWasteBalanceEffects(
-      wasteBalancesRepository,
-      buildLogger(),
-      []
-    )
-
-    expect(applied).toEqual([])
-  })
-})
-
-/**
- * Replace the repository's append with one that lands a single competing event
- * the first time it is called, then delegates. This makes the effect's append
- * collide on the slot the competing writer has taken, exercising the
- * optimistic-concurrency guard.
- *
- * @param {import('#waste-balances/repository/stream-port.js').WasteBalanceStreamRepository} streamRepository
- * @param {object} competingEvent
- */
-const landCompetingEventOnFirstAppend = (streamRepository, competingEvent) => {
-  const realAppend = streamRepository.appendEvent.bind(streamRepository)
-  let landed = false
-  streamRepository.appendEvent = async (event) => {
-    if (!landed) {
-      landed = true
-      await realAppend(buildStreamEvent(competingEvent))
-    }
-    return realAppend(event)
-  }
-}
-
-describe('applyWasteBalanceEffects optimistic concurrency', () => {
-  it('surfaces a slot conflict when a competing event takes the targeted slot', async () => {
-    const { wasteBalancesRepository, streamRepository } =
-      await setupLedgerRepository()
-
-    landCompetingEventOnFirstAppend(streamRepository, {
-      registrationId: REGISTRATION_ID,
-      accreditationId: ACCREDITATION_ID,
-      number: 2,
-      kind: STREAM_EVENT_KIND.PRN_CREATED,
-      payload: { prnId: 'competing-prn', amount: 70 },
-      openingBalance: { amount: 100, availableAmount: 100 },
-      closingBalance: { amount: 100, availableAmount: 30 }
+    ).rejects.toMatchObject({
+      isBoom: true,
+      output: { statusCode: 409 },
+      message: 'Insufficient total waste balance'
     })
-
-    const events = balanceEventsFor(
-      PRN_STATUS.DRAFT,
-      PRN_STATUS.AWAITING_AUTHORISATION,
-      balanceParamsFor({
-        tonnage: 80,
-        currentStatus: PRN_STATUS.DRAFT,
-        newStatus: PRN_STATUS.AWAITING_AUTHORISATION
-      })
-    )
-
-    await expect(
-      applyWasteBalanceEffects(wasteBalancesRepository, buildLogger(), events)
-    ).rejects.toBeInstanceOf(StreamSlotConflictError)
-
-    const all = await streamRepository.findAllByPartition(
-      REGISTRATION_ID,
-      ACCREDITATION_ID
-    )
-    expect(all).toHaveLength(2)
-  })
-})
-
-describe('balanceEventsFor', () => {
-  const params = balanceParamsFor({
-    currentStatus: PRN_STATUS.DRAFT,
-    newStatus: PRN_STATUS.AWAITING_AUTHORISATION
-  })
-
-  it('emits a prn-created event for PRN creation', () => {
-    expect(
-      balanceEventsFor(
-        PRN_STATUS.DRAFT,
-        PRN_STATUS.AWAITING_AUTHORISATION,
-        params
-      )
-    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_CREATED, params }])
-  })
-
-  it('emits a prn-issued event for PRN issuance', () => {
-    expect(
-      balanceEventsFor(
-        PRN_STATUS.AWAITING_AUTHORISATION,
-        PRN_STATUS.AWAITING_ACCEPTANCE,
-        params
-      )
-    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_ISSUED, params }])
-  })
-
-  it('emits a prn-creation-cancelled event for deleting a PRN awaiting authorisation', () => {
-    expect(
-      balanceEventsFor(
-        PRN_STATUS.AWAITING_AUTHORISATION,
-        PRN_STATUS.DELETED,
-        params
-      )
-    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED, params }])
-  })
-
-  it('emits a prn-cancelled-after-issue event for cancelling an issued PRN', () => {
-    expect(
-      balanceEventsFor(
-        PRN_STATUS.AWAITING_CANCELLATION,
-        PRN_STATUS.CANCELLED,
-        params
-      )
-    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE, params }])
-  })
-
-  it('emits a prn-accepted event for accepting an issued PRN', () => {
-    expect(
-      balanceEventsFor(
-        PRN_STATUS.AWAITING_ACCEPTANCE,
-        PRN_STATUS.ACCEPTED,
-        params
-      )
-    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_ACCEPTED, params }])
-  })
-
-  it('emits a prn-rejected event for requesting cancellation of an issued PRN', () => {
-    expect(
-      balanceEventsFor(
-        PRN_STATUS.AWAITING_ACCEPTANCE,
-        PRN_STATUS.AWAITING_CANCELLATION,
-        params
-      )
-    ).toEqual([{ kind: STREAM_EVENT_KIND.PRN_REJECTED, params }])
-  })
-
-  it('emits no events when discarding a draft PRN', () => {
-    expect(
-      balanceEventsFor(PRN_STATUS.DRAFT, PRN_STATUS.DISCARDED, params)
-    ).toEqual([])
-  })
-
-  it('emits no events for an awaiting-authorisation to cancelled move the state machine forbids', () => {
-    expect(
-      balanceEventsFor(
-        PRN_STATUS.AWAITING_AUTHORISATION,
-        PRN_STATUS.CANCELLED,
-        params
-      )
-    ).toEqual([])
   })
 })

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
@@ -214,4 +214,25 @@ describe('applyPrnBalanceCommand on rejection', () => {
       message: 'Insufficient total waste balance'
     })
   })
+
+  it.each([
+    ['acceptance', PRN_STATUS.AWAITING_ACCEPTANCE, PRN_STATUS.ACCEPTED],
+    [
+      'rejection',
+      PRN_STATUS.AWAITING_ACCEPTANCE,
+      PRN_STATUS.AWAITING_CANCELLATION
+    ]
+  ])(
+    'throws a 500 on %s when the ledger is missing, as that state is unreachable',
+    async (_label, currentStatus, newStatus) => {
+      const service = serviceWithBalance(null)
+
+      await expect(
+        applyTransition(service, buildLogger(), currentStatus, newStatus)
+      ).rejects.toMatchObject({
+        isBoom: true,
+        output: { statusCode: 500 }
+      })
+    }
+  )
 })

--- a/src/packaging-recycling-notes/application/update-status-compensation.test.js
+++ b/src/packaging-recycling-notes/application/update-status-compensation.test.js
@@ -6,7 +6,6 @@ import {
 } from '#packaging-recycling-notes/domain/model.js'
 import { REGULATOR } from '#domain/organisations/model.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
-import { createWasteBalancesRepository } from '#waste-balances/repository/repository.js'
 import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
 import {
   buildAwaitingAuthorisationPrn,
@@ -110,17 +109,12 @@ const setupRepositories = async ({ prnSeed, balanceSeed }) => {
     })
   )
 
-  const wasteFactory = createWasteBalancesRepository({
-    streamRepository
-  })
-  const wasteBalancesRepository = wasteFactory()
-
   const organisationsRepository = buildOrganisationsRepository()
 
   return {
     logger,
     prnRepository,
-    wasteBalancesRepository,
+    streamRepository,
     organisationsRepository
   }
 }
@@ -150,19 +144,15 @@ const expectWasteBalanceLog = (
 
 describe('updatePrnStatus system logging on successful balance update', () => {
   it('logs deduct_available when a PRN is created from draft', async () => {
-    const {
-      logger,
-      prnRepository,
-      wasteBalancesRepository,
-      organisationsRepository
-    } = await setupRepositories({
-      prnSeed: buildDraftPrn(PRN_BASE),
-      balanceSeed: buildBalanceSeed()
-    })
+    const { logger, prnRepository, streamRepository, organisationsRepository } =
+      await setupRepositories({
+        prnSeed: buildDraftPrn(PRN_BASE),
+        balanceSeed: buildBalanceSeed()
+      })
 
     await updatePrnStatus({
       prnRepository,
-      wasteBalancesRepository,
+      streamRepository,
       organisationsRepository,
       logger,
       id: PRN_ID,
@@ -185,21 +175,17 @@ describe('updatePrnStatus system logging on successful balance update', () => {
   })
 
   it('logs deduct_total when a PRN is issued', async () => {
-    const {
-      logger,
-      prnRepository,
-      wasteBalancesRepository,
-      organisationsRepository
-    } = await setupRepositories({
-      prnSeed: buildAwaitingAuthorisationPrn(PRN_BASE),
-      balanceSeed: buildBalanceSeed({
-        availableAmount: POST_DEDUCTION_AVAILABLE
+    const { logger, prnRepository, streamRepository, organisationsRepository } =
+      await setupRepositories({
+        prnSeed: buildAwaitingAuthorisationPrn(PRN_BASE),
+        balanceSeed: buildBalanceSeed({
+          availableAmount: POST_DEDUCTION_AVAILABLE
+        })
       })
-    })
 
     await updatePrnStatus({
       prnRepository,
-      wasteBalancesRepository,
+      streamRepository,
       organisationsRepository,
       logger,
       id: PRN_ID,
@@ -222,21 +208,17 @@ describe('updatePrnStatus system logging on successful balance update', () => {
   })
 
   it('logs credit_available when a pending PRN is deleted', async () => {
-    const {
-      logger,
-      prnRepository,
-      wasteBalancesRepository,
-      organisationsRepository
-    } = await setupRepositories({
-      prnSeed: buildAwaitingAuthorisationPrn(PRN_BASE),
-      balanceSeed: buildBalanceSeed({
-        availableAmount: POST_DEDUCTION_AVAILABLE
+    const { logger, prnRepository, streamRepository, organisationsRepository } =
+      await setupRepositories({
+        prnSeed: buildAwaitingAuthorisationPrn(PRN_BASE),
+        balanceSeed: buildBalanceSeed({
+          availableAmount: POST_DEDUCTION_AVAILABLE
+        })
       })
-    })
 
     await updatePrnStatus({
       prnRepository,
-      wasteBalancesRepository,
+      streamRepository,
       organisationsRepository,
       logger,
       id: PRN_ID,
@@ -266,22 +248,18 @@ describe('updatePrnStatus system logging on successful balance update', () => {
           currentStatus: PRN_STATUS.AWAITING_CANCELLATION
         })
     })
-    const {
-      logger,
-      prnRepository,
-      wasteBalancesRepository,
-      organisationsRepository
-    } = await setupRepositories({
-      prnSeed: awaitingCancellationSeed,
-      balanceSeed: buildBalanceSeed({
-        availableAmount: POST_DEDUCTION_AVAILABLE,
-        amount: POST_DEDUCTION_AVAILABLE
+    const { logger, prnRepository, streamRepository, organisationsRepository } =
+      await setupRepositories({
+        prnSeed: awaitingCancellationSeed,
+        balanceSeed: buildBalanceSeed({
+          availableAmount: POST_DEDUCTION_AVAILABLE,
+          amount: POST_DEDUCTION_AVAILABLE
+        })
       })
-    })
 
     await updatePrnStatus({
       prnRepository,
-      wasteBalancesRepository,
+      streamRepository,
       organisationsRepository,
       logger,
       id: PRN_ID,
@@ -304,19 +282,15 @@ describe('updatePrnStatus system logging on successful balance update', () => {
   })
 
   it('does not log a balance update for a discard write with no balance effect', async () => {
-    const {
-      logger,
-      prnRepository,
-      wasteBalancesRepository,
-      organisationsRepository
-    } = await setupRepositories({
-      prnSeed: buildDraftPrn(PRN_BASE),
-      balanceSeed: buildBalanceSeed()
-    })
+    const { logger, prnRepository, streamRepository, organisationsRepository } =
+      await setupRepositories({
+        prnSeed: buildDraftPrn(PRN_BASE),
+        balanceSeed: buildBalanceSeed()
+      })
 
     await updatePrnStatus({
       prnRepository,
-      wasteBalancesRepository,
+      streamRepository,
       organisationsRepository,
       logger,
       id: PRN_ID,

--- a/src/packaging-recycling-notes/application/update-status-concurrency.test.js
+++ b/src/packaging-recycling-notes/application/update-status-concurrency.test.js
@@ -6,7 +6,6 @@ import {
 } from '#packaging-recycling-notes/domain/model.js'
 import { REGULATOR } from '#domain/organisations/model.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
-import { createWasteBalancesRepository } from '#waste-balances/repository/repository.js'
 import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
 import { StreamSlotConflictError } from '#waste-balances/repository/stream-port.js'
 import {
@@ -169,17 +168,12 @@ describe('updatePrnStatus concurrency', () => {
     const balanceSeed = buildBalanceSeed()
     const streamRepository = createInMemoryStreamRepository()()
     await seedClosingBalance(streamRepository, balanceSeed)
-    const wasteFactory = createWasteBalancesRepository({
-      streamRepository
-    })
-    const wasteBalancesRepository = wasteFactory()
-
     const organisationsRepository = buildOrganisationsRepository()
 
     const issue = () =>
       updatePrnStatus({
         prnRepository,
-        wasteBalancesRepository,
+        streamRepository,
         organisationsRepository,
         logger: noopLogger(),
         id: PRN_ID,
@@ -212,17 +206,12 @@ describe('updatePrnStatus concurrency', () => {
     })
     const streamRepository = createInMemoryStreamRepository()()
     await seedClosingBalance(streamRepository, balanceSeed)
-    const wasteFactory = createWasteBalancesRepository({
-      streamRepository
-    })
-    const wasteBalancesRepository = wasteFactory()
-
     const organisationsRepository = buildOrganisationsRepository()
 
     const cancel = () =>
       updatePrnStatus({
         prnRepository,
-        wasteBalancesRepository,
+        streamRepository,
         organisationsRepository,
         logger: noopLogger(),
         id: PRN_ID,
@@ -256,17 +245,12 @@ describe('updatePrnStatus concurrency', () => {
     })
     const streamRepository = createInMemoryStreamRepository()()
     await seedClosingBalance(streamRepository, balanceSeed)
-    const wasteFactory = createWasteBalancesRepository({
-      streamRepository
-    })
-    const wasteBalancesRepository = wasteFactory()
-
     const organisationsRepository = buildOrganisationsRepository()
 
     const cancel = () =>
       updatePrnStatus({
         prnRepository,
-        wasteBalancesRepository,
+        streamRepository,
         organisationsRepository,
         logger: noopLogger(),
         id: PRN_ID,

--- a/src/packaging-recycling-notes/application/update-status-stream.test.js
+++ b/src/packaging-recycling-notes/application/update-status-stream.test.js
@@ -26,7 +26,8 @@ const REG_ID = 'reg-789'
 const PRN_ID = '507f1f77bcf86cd799439011'
 const PRN_NUMBER = 'ER2600001'
 const TONNAGE = 50
-const APPENDED_WATERMARK = 5
+const SEED_NUMBER = 1
+const APPENDED_WATERMARK = 2
 const USER = { id: 'user-789', name: 'Test User' }
 const EVENT_AT = new Date('2026-02-01T12:00:00.000Z')
 
@@ -38,13 +39,6 @@ const buildLogger = () => ({
   trace: vi.fn(),
   fatal: vi.fn(),
   child: vi.fn()
-})
-
-const buildLedgerBalance = (overrides = {}) => ({
-  accreditationId: ACC_ID,
-  amount: 1000,
-  availableAmount: 1000,
-  ...overrides
 })
 
 /**
@@ -93,6 +87,28 @@ const buildStreamEvent = (kind, number = APPENDED_WATERMARK) => ({
   createdBy: USER
 })
 
+/**
+ * Seed the ledger with a summary-log submission so the read fold resolves a
+ * non-zero balance with room to spare. The first PRN command then appends at
+ * APPENDED_WATERMARK.
+ */
+const buildSeededStreamRepository = () =>
+  createInMemoryStreamRepository([
+    {
+      id: 'seed-1',
+      registrationId: REG_ID,
+      accreditationId: ACC_ID,
+      organisationId: ORG_ID,
+      number: SEED_NUMBER,
+      kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+      payload: { summaryLogId: 'seed', creditTotal: 1000 },
+      openingBalance: { amount: 0, availableAmount: 0 },
+      closingBalance: { amount: 1000, availableAmount: 1000 },
+      createdAt: EVENT_AT,
+      createdBy: USER
+    }
+  ])()
+
 const buildOrganisationsRepository = (accreditation = {}) => ({
   findAccreditationById: vi.fn().mockResolvedValue({
     submittedToRegulator: REGULATOR.EA,
@@ -107,7 +123,11 @@ const buildLedgerRepositories = (storedPrn, events = []) => {
   const wasteBalancesRepository = createWasteBalancesRepository({
     streamRepository
   })()
-  return { packagingRecyclingNotesRepository, wasteBalancesRepository }
+  return {
+    packagingRecyclingNotesRepository,
+    wasteBalancesRepository,
+    streamRepository
+  }
 }
 
 const callUpdate = (overrides) =>
@@ -135,16 +155,11 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       createInMemoryPackagingRecyclingNotesRepository([storedPrn])(
         buildLogger()
       )
-    const wasteBalancesRepository = {
-      findBalance: vi.fn().mockResolvedValue(buildLedgerBalance()),
-      deductAvailableBalanceForPrnCreation: vi
-        .fn()
-        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_CREATED))
-    }
+    const streamRepository = buildSeededStreamRepository()
 
     await callUpdate({
       prnRepository: packagingRecyclingNotesRepository,
-      wasteBalancesRepository,
+      streamRepository,
       organisationsRepository: buildOrganisationsRepository(),
       providedPrn: storedPrn,
       newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
@@ -162,17 +177,12 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       .fn()
       .mockImplementation(async ({ projection }) => projection)
     const prnRepository = { findById: vi.fn(), persistProjection }
-    const deductTotalBalanceForPrnIssue = vi
-      .fn()
-      .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED))
-    const wasteBalancesRepository = {
-      findBalance: vi.fn().mockResolvedValue(buildLedgerBalance()),
-      deductTotalBalanceForPrnIssue
-    }
+    const streamRepository = buildSeededStreamRepository()
+    const appendEvents = vi.spyOn(streamRepository, 'bulkAppendEvents')
 
     await callUpdate({
       prnRepository,
-      wasteBalancesRepository,
+      streamRepository,
       organisationsRepository: buildOrganisationsRepository(),
       providedPrn: buildPrn({
         status: {
@@ -184,9 +194,9 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       actor: PRN_ACTOR.SIGNATORY
     })
 
-    expect(
-      deductTotalBalanceForPrnIssue.mock.invocationCallOrder[0]
-    ).toBeLessThan(persistProjection.mock.invocationCallOrder[0])
+    expect(appendEvents.mock.invocationCallOrder[0]).toBeLessThan(
+      persistProjection.mock.invocationCallOrder[0]
+    )
     expect(persistProjection).toHaveBeenCalledWith(
       expect.objectContaining({
         projection: expect.objectContaining({
@@ -199,16 +209,13 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
   it('rejects issuance on a suspended accreditation before appending any event', async () => {
     const persistProjection = vi.fn()
     const prnRepository = { findById: vi.fn(), persistProjection }
-    const deductTotalBalanceForPrnIssue = vi.fn()
-    const wasteBalancesRepository = {
-      findBalance: vi.fn().mockResolvedValue(buildLedgerBalance()),
-      deductTotalBalanceForPrnIssue
-    }
+    const streamRepository = buildSeededStreamRepository()
+    const appendEvents = vi.spyOn(streamRepository, 'bulkAppendEvents')
 
     await expect(
       callUpdate({
         prnRepository,
-        wasteBalancesRepository,
+        streamRepository,
         organisationsRepository: buildOrganisationsRepository({
           status: 'suspended'
         }),
@@ -223,7 +230,7 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       })
     ).rejects.toThrow(SuspendedAccreditationError)
 
-    expect(deductTotalBalanceForPrnIssue).not.toHaveBeenCalled()
+    expect(appendEvents).not.toHaveBeenCalled()
     expect(persistProjection).not.toHaveBeenCalled()
   })
 
@@ -232,34 +239,27 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       .fn()
       .mockImplementation(async ({ projection }) => projection)
     const prnRepository = { findById: vi.fn(), persistProjection }
-    const creditFullBalanceForIssuedPrnCancellation = vi
-      .fn()
-      .mockResolvedValue(
-        buildStreamEvent(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE)
-      )
-    const wasteBalancesRepository = {
-      findBalance: vi.fn().mockResolvedValue(buildLedgerBalance()),
-      creditFullBalanceForIssuedPrnCancellation
-    }
+    const streamRepository = buildSeededStreamRepository()
+    const appendEvents = vi.spyOn(streamRepository, 'bulkAppendEvents')
 
     await callUpdate({
       prnRepository,
-      wasteBalancesRepository,
+      streamRepository,
       organisationsRepository: buildOrganisationsRepository(),
       providedPrn: buildPrn({
         status: {
           currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
           history: []
         },
-        lastAppliedEventNumber: 2
+        lastAppliedEventNumber: SEED_NUMBER
       }),
       newStatus: PRN_STATUS.CANCELLED,
       actor: PRN_ACTOR.SIGNATORY
     })
 
-    expect(
-      creditFullBalanceForIssuedPrnCancellation.mock.invocationCallOrder[0]
-    ).toBeLessThan(persistProjection.mock.invocationCallOrder[0])
+    expect(appendEvents.mock.invocationCallOrder[0]).toBeLessThan(
+      persistProjection.mock.invocationCallOrder[0]
+    )
     expect(persistProjection).toHaveBeenCalledWith(
       expect.objectContaining({
         projection: expect.objectContaining({
@@ -269,24 +269,17 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
     )
   })
 
-  it('does not credit the balance back when persistProjection fails on creation', async () => {
+  it('leaves the appended event in place when persistProjection fails on creation', async () => {
     const persistProjection = vi
       .fn()
       .mockRejectedValue(new Error('doc write failed'))
     const prnRepository = { findById: vi.fn(), persistProjection }
-    const creditAvailableBalanceForPrnCancellation = vi.fn()
-    const wasteBalancesRepository = {
-      findBalance: vi.fn().mockResolvedValue(buildLedgerBalance()),
-      deductAvailableBalanceForPrnCreation: vi
-        .fn()
-        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_CREATED)),
-      creditAvailableBalanceForPrnCancellation
-    }
+    const streamRepository = buildSeededStreamRepository()
 
     await expect(
       callUpdate({
         prnRepository,
-        wasteBalancesRepository,
+        streamRepository,
         organisationsRepository: buildOrganisationsRepository(),
         providedPrn: buildPrn({
           status: { currentStatus: PRN_STATUS.DRAFT, history: [] }
@@ -296,7 +289,9 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       })
     ).rejects.toThrow('doc write failed')
 
-    expect(creditAvailableBalanceForPrnCancellation).not.toHaveBeenCalled()
+    const all = await streamRepository.findAllByPartition(REG_ID, ACC_ID)
+    expect(all).toHaveLength(2)
+    expect(all.at(-1)?.kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
   })
 
   it('retries issuance on a PrnNumberConflictError and persists on the second attempt', async () => {
@@ -309,16 +304,11 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       })
       .mockImplementation(async ({ projection }) => projection)
     const prnRepository = { findById: vi.fn(), persistProjection }
-    const wasteBalancesRepository = {
-      findBalance: vi.fn().mockResolvedValue(buildLedgerBalance()),
-      deductTotalBalanceForPrnIssue: vi
-        .fn()
-        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED))
-    }
+    const streamRepository = buildSeededStreamRepository()
 
     await callUpdate({
       prnRepository,
-      wasteBalancesRepository,
+      streamRepository,
       organisationsRepository: buildOrganisationsRepository(),
       providedPrn: buildPrn({
         status: {
@@ -340,17 +330,12 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       .fn()
       .mockRejectedValue(new PrnNumberConflictError('ER2600001'))
     const prnRepository = { findById: vi.fn(), persistProjection }
-    const wasteBalancesRepository = {
-      findBalance: vi.fn().mockResolvedValue(buildLedgerBalance()),
-      deductTotalBalanceForPrnIssue: vi
-        .fn()
-        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED))
-    }
+    const streamRepository = buildSeededStreamRepository()
 
     await expect(
       callUpdate({
         prnRepository,
-        wasteBalancesRepository,
+        streamRepository,
         organisationsRepository: buildOrganisationsRepository(),
         providedPrn: buildPrn({
           status: {
@@ -367,17 +352,12 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
   it('throws Boom.badImplementation when persistProjection returns null on issuance', async () => {
     const persistProjection = vi.fn().mockResolvedValue(null)
     const prnRepository = { findById: vi.fn(), persistProjection }
-    const wasteBalancesRepository = {
-      findBalance: vi.fn().mockResolvedValue(buildLedgerBalance()),
-      deductTotalBalanceForPrnIssue: vi
-        .fn()
-        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED))
-    }
+    const streamRepository = buildSeededStreamRepository()
 
     await expect(
       callUpdate({
         prnRepository,
-        wasteBalancesRepository,
+        streamRepository,
         organisationsRepository: buildOrganisationsRepository(),
         providedPrn: buildPrn({
           status: {
@@ -394,19 +374,12 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
   it('throws Boom.badImplementation when persistProjection returns null on a non-issuance ledger write', async () => {
     const persistProjection = vi.fn().mockResolvedValue(null)
     const prnRepository = { findById: vi.fn(), persistProjection }
-    const wasteBalancesRepository = {
-      findBalance: vi.fn().mockResolvedValue(buildLedgerBalance()),
-      creditFullBalanceForIssuedPrnCancellation: vi
-        .fn()
-        .mockResolvedValue(
-          buildStreamEvent(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE)
-        )
-    }
+    const streamRepository = buildSeededStreamRepository()
 
     await expect(
       callUpdate({
         prnRepository,
-        wasteBalancesRepository,
+        streamRepository,
         organisationsRepository: buildOrganisationsRepository(),
         providedPrn: buildPrn({
           status: {
@@ -420,24 +393,17 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
     ).rejects.toThrow(/Failed to persist PRN projection/)
   })
 
-  it('does not roll back the balance when persistProjection fails on issuance', async () => {
+  it('leaves the appended event in place when persistProjection fails on issuance', async () => {
     const persistProjection = vi
       .fn()
       .mockRejectedValue(new Error('doc write failed'))
     const prnRepository = { findById: vi.fn(), persistProjection }
-    const creditFullBalanceForIssuedPrnCancellation = vi.fn()
-    const wasteBalancesRepository = {
-      findBalance: vi.fn().mockResolvedValue(buildLedgerBalance()),
-      deductTotalBalanceForPrnIssue: vi
-        .fn()
-        .mockResolvedValue(buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED)),
-      creditFullBalanceForIssuedPrnCancellation
-    }
+    const streamRepository = buildSeededStreamRepository()
 
     await expect(
       callUpdate({
         prnRepository,
-        wasteBalancesRepository,
+        streamRepository,
         organisationsRepository: buildOrganisationsRepository(),
         providedPrn: buildPrn({
           status: {
@@ -450,7 +416,9 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       })
     ).rejects.toThrow('doc write failed')
 
-    expect(creditFullBalanceForIssuedPrnCancellation).not.toHaveBeenCalled()
+    const all = await streamRepository.findAllByPartition(REG_ID, ACC_ID)
+    expect(all).toHaveLength(2)
+    expect(all.at(-1)?.kind).toBe(STREAM_EVENT_KIND.PRN_ISSUED)
   })
 })
 
@@ -467,11 +435,14 @@ describe('updatePrnStatus composes the read fold with the real CAS-enforcing rep
         history: []
       }
     })
-    const { packagingRecyclingNotesRepository, wasteBalancesRepository } =
-      buildLedgerRepositories(storedPrn, [
-        buildStreamEvent(STREAM_EVENT_KIND.PRN_CREATED, 1),
-        buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED, 2)
-      ])
+    const {
+      packagingRecyclingNotesRepository,
+      wasteBalancesRepository,
+      streamRepository
+    } = buildLedgerRepositories(storedPrn, [
+      buildStreamEvent(STREAM_EVENT_KIND.PRN_CREATED, 1),
+      buildStreamEvent(STREAM_EVENT_KIND.PRN_ISSUED, 2)
+    ])
 
     const projected = await getProjectedPrnByNumber({
       packagingRecyclingNotesRepository,
@@ -482,7 +453,7 @@ describe('updatePrnStatus composes the read fold with the real CAS-enforcing rep
 
     const accepted = await callUpdate({
       prnRepository: packagingRecyclingNotesRepository,
-      wasteBalancesRepository,
+      streamRepository,
       organisationsRepository: buildOrganisationsRepository(),
       providedPrn: projected,
       newStatus: PRN_STATUS.ACCEPTED,

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -2,8 +2,8 @@ import Boom from '@hapi/boom'
 
 import { prnMetrics } from './metrics.js'
 import {
-  applyWasteBalanceEffects,
-  balanceEventsFor
+  applyPrnBalanceCommand,
+  prnCommandFor
 } from './update-status-balance-effects.js'
 import {
   PRN_STATUS,
@@ -12,6 +12,7 @@ import {
 } from '#packaging-recycling-notes/domain/model.js'
 import { generatePrnNumber } from '#packaging-recycling-notes/domain/prn-number-generator.js'
 import { PrnNumberConflictError } from '#packaging-recycling-notes/repository/port.js'
+import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
 import { foldPrnFromTailEvents } from './fold-prn-from-tail-events.js'
 
 /** Suffixes A-Z for PRN-number collision avoidance on issuance */
@@ -19,7 +20,7 @@ const COLLISION_SUFFIXES = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
 
 /**
  * @typedef {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} PackagingRecyclingNotesRepository
- * @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository
+ * @typedef {ReturnType<typeof createWasteBalanceService>} WasteBalanceService
  * @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository
  * @typedef {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} PackagingRecyclingNote
  * @typedef {import('#packaging-recycling-notes/domain/model.js').PrnStatus} PrnStatus
@@ -32,7 +33,7 @@ const COLLISION_SUFFIXES = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
  * @typedef {Object} PrnWriteContext
  * @property {PackagingRecyclingNotesRepository} prnRepository
  * @property {OrganisationsRepository} organisationsRepository
- * @property {WasteBalancesRepository} wasteBalancesRepository
+ * @property {WasteBalanceService} service
  * @property {import('#common/hapi-types.js').TypedLogger} logger
  * @property {PackagingRecyclingNote} prn
  * @property {import('#packaging-recycling-notes/repository/port.js').UpdateStatusParams} updateParams
@@ -100,13 +101,16 @@ async function persistProjectionWithIssuanceRetry({
 async function performStreamWrite({
   prnRepository,
   organisationsRepository,
-  wasteBalancesRepository,
+  service,
   logger,
   prn,
-  events,
+  currentStatus,
   newStatus,
   organisationId,
-  accreditationId
+  registrationId,
+  accreditationId,
+  id,
+  user
 }) {
   // The suspension check is hoisted ahead of the stream append so a suspended
   // accreditation is never debited. The fetched accreditation is reused to
@@ -120,11 +124,14 @@ async function performStreamWrite({
     assertAccreditationNotSuspended(accreditation)
   }
 
-  const streamEvents = await applyWasteBalanceEffects(
-    wasteBalancesRepository,
-    logger,
-    events
-  )
+  const streamEvents = await applyPrnBalanceCommand(service, logger, {
+    currentStatus,
+    newStatus,
+    ledgerId: { organisationId, registrationId, accreditationId },
+    prnId: id,
+    tonnage: prn.tonnage,
+    createdBy: user
+  })
 
   const projection = foldPrnFromTailEvents(prn, streamEvents)
 
@@ -159,49 +166,17 @@ async function performStreamWrite({
  * unrecoverable doc/stream divergence. Pre-creation transitions
  * (DRAFT→DISCARDED) are filtered out before this branch is reached.
  */
-async function performLedgerWrite({
-  prnRepository,
-  organisationsRepository,
-  wasteBalancesRepository,
-  logger,
-  prn,
-  newStatus,
-  organisationId,
-  registrationId,
-  accreditationId,
-  user,
-  currentStatus,
-  id
-}) {
-  const events = balanceEventsFor(currentStatus, newStatus, {
-    currentStatus,
-    newStatus,
-    accreditationId,
-    registrationId,
-    organisationId,
-    prnId: id,
-    tonnage: prn.tonnage,
-    createdBy: user
-  })
+async function performLedgerWrite(ctx) {
+  const { currentStatus, newStatus, accreditationId } = ctx
 
-  /* c8 ignore next 5 - defensive: the only legal transition with no balance events (DRAFT→DISCARDED) is handled before this branch */
-  if (events.length === 0) {
+  /* c8 ignore next 5 - defensive: the only legal transition with no balance command (DRAFT→DISCARDED) is handled before this branch */
+  if (!prnCommandFor(currentStatus, newStatus)) {
     throw Boom.badImplementation(
       `No stream events for transition ${currentStatus} -> ${newStatus} on ledger accreditation ${accreditationId}`
     )
   }
 
-  return performStreamWrite({
-    prnRepository,
-    organisationsRepository,
-    wasteBalancesRepository,
-    logger,
-    prn,
-    events,
-    newStatus,
-    organisationId,
-    accreditationId
-  })
+  return performStreamWrite(ctx)
 }
 
 /**
@@ -225,7 +200,7 @@ const performDiscardWrite = async ({ prnRepository, updateParams }) => {
  *
  * @param {Object} params
  * @param {PackagingRecyclingNotesRepository} params.prnRepository
- * @param {WasteBalancesRepository} params.wasteBalancesRepository
+ * @param {import('#waste-balances/repository/stream-port.js').WasteBalanceStreamRepository} params.streamRepository
  * @param {OrganisationsRepository} params.organisationsRepository
  * @param {import('#common/hapi-types.js').TypedLogger} params.logger
  * @param {string} params.id
@@ -241,7 +216,7 @@ const performDiscardWrite = async ({ prnRepository, updateParams }) => {
  */
 export async function updatePrnStatus({
   prnRepository,
-  wasteBalancesRepository,
+  streamRepository,
   organisationsRepository,
   logger,
   id,
@@ -280,7 +255,7 @@ export async function updatePrnStatus({
   const ctx = {
     prnRepository,
     organisationsRepository,
-    wasteBalancesRepository,
+    service: createWasteBalanceService(streamRepository),
     logger,
     prn,
     updateParams,

--- a/src/packaging-recycling-notes/application/update-status.test.js
+++ b/src/packaging-recycling-notes/application/update-status.test.js
@@ -148,7 +148,12 @@ const seedRepositories = ({
   const organisationsRepository = createInMemoryOrganisationsRepository([
     buildOrgWithAccreditation({ accreditation, withAccreditation })
   ])()
-  return { prnRepository, wasteBalancesRepository, organisationsRepository }
+  return {
+    prnRepository,
+    streamRepository,
+    wasteBalancesRepository,
+    organisationsRepository
+  }
 }
 
 const readBalance = (wasteBalancesRepository) =>
@@ -341,24 +346,18 @@ describe('updatePrnStatus', () => {
       ).rejects.toThrow('No waste balance found for accreditation: acc-456')
     })
 
-    it('treats an absent available amount as zero when creating', async () => {
+    it('rejects creation when the available balance is exhausted', async () => {
       const repositories = seedRepositories({
         prn: buildPrn({
           tonnage: 1,
           status: { currentStatus: PRN_STATUS.DRAFT, history: [] }
-        })
+        }),
+        balance: { amount: 500, availableAmount: 0 }
       })
 
       await expect(
         callUpdate({
           ...repositories,
-          // The stream-backed balance always carries both amounts; a partial
-          // balance only arises from a hand-built double, exercising the guard.
-          wasteBalancesRepository: {
-            findBalance: vi
-              .fn()
-              .mockResolvedValue({ accreditationId: ACC_ID, amount: 500 })
-          },
           newStatus: PRN_STATUS.AWAITING_AUTHORISATION,
           actor: PRN_ACTOR.REPROCESSOR_EXPORTER
         })
@@ -438,7 +437,7 @@ describe('updatePrnStatus', () => {
       ).rejects.toThrow('No waste balance found for accreditation: acc-456')
     })
 
-    it('treats an absent total amount as zero when issuing', async () => {
+    it('rejects issuance when the total balance is exhausted', async () => {
       const repositories = seedRepositories({
         prn: buildPrn({
           tonnage: 1,
@@ -446,20 +445,13 @@ describe('updatePrnStatus', () => {
             currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
             history: []
           }
-        })
+        }),
+        balance: { amount: 0, availableAmount: 200 }
       })
 
       await expect(
         callUpdate({
           ...repositories,
-          // The stream-backed balance always carries both amounts; a partial
-          // balance only arises from a hand-built double, exercising the guard.
-          wasteBalancesRepository: {
-            findBalance: vi.fn().mockResolvedValue({
-              accreditationId: ACC_ID,
-              availableAmount: 200
-            })
-          },
           newStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
           actor: PRN_ACTOR.SIGNATORY
         })

--- a/src/packaging-recycling-notes/routes/accept.test.js
+++ b/src/packaging-recycling-notes/routes/accept.test.js
@@ -80,6 +80,7 @@ const startServer = async (prn) => {
     },
     repositories: {
       packagingRecyclingNotesRepository: prnRepositoryFactory,
+      streamRepository: () => streamRepository,
       wasteBalancesRepository: createWasteBalancesRepository({
         streamRepository
       }),

--- a/src/packaging-recycling-notes/routes/external-transition-handler.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.js
@@ -20,6 +20,7 @@ import { getProjectedPrnByNumber } from '#packaging-recycling-notes/application/
  * @import { PrnStatus } from '#packaging-recycling-notes/domain/model.js'
  * @import { PackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/port.js'
  * @import { WasteBalancesRepository } from '#waste-balances/repository/port.js'
+ * @import { WasteBalanceStreamRepository } from '#waste-balances/repository/stream-port.js'
  * @import { OrganisationsRepository } from '#repositories/organisations/port.js'
  * @import { SystemLogsRepository } from '#repositories/system-logs/port.js'
  */
@@ -28,6 +29,7 @@ import { getProjectedPrnByNumber } from '#packaging-recycling-notes/application/
  * @typedef {HapiRequest & {
  *   packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository,
  *   wasteBalancesRepository: WasteBalancesRepository,
+ *   streamRepository: WasteBalanceStreamRepository,
  *   organisationsRepository: OrganisationsRepository,
  *   systemLogsRepository: SystemLogsRepository
  * }} ExternalTransitionRequest
@@ -58,6 +60,7 @@ export function createExternalTransitionHandler({
       const {
         packagingRecyclingNotesRepository,
         wasteBalancesRepository,
+        streamRepository,
         organisationsRepository,
         params,
         payload,
@@ -89,7 +92,7 @@ export function createExternalTransitionHandler({
 
         const updatedPrn = await updatePrnStatus({
           prnRepository: packagingRecyclingNotesRepository,
-          wasteBalancesRepository,
+          streamRepository,
           organisationsRepository,
           logger,
           id: prn.id,

--- a/src/packaging-recycling-notes/routes/external-transition-handler.test.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.test.js
@@ -124,6 +124,7 @@ const startServer = async ({ currentStatus, events }) => {
         createInMemoryPackagingRecyclingNotesRepository([
           buildPrn(currentStatus)
         ]),
+      streamRepository: () => streamRepository,
       wasteBalancesRepository: createWasteBalancesRepository({
         streamRepository
       }),

--- a/src/packaging-recycling-notes/routes/reject.test.js
+++ b/src/packaging-recycling-notes/routes/reject.test.js
@@ -80,6 +80,7 @@ const startServer = async (prn) => {
     },
     repositories: {
       packagingRecyclingNotesRepository: prnRepositoryFactory,
+      streamRepository: () => streamRepository,
       wasteBalancesRepository: createWasteBalancesRepository({
         streamRepository
       }),

--- a/src/packaging-recycling-notes/routes/status.js
+++ b/src/packaging-recycling-notes/routes/status.js
@@ -21,7 +21,7 @@ import { auditPrnStatusTransition } from '#packaging-recycling-notes/application
 /**
  * @import { PackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/port.js'
  * @import { PrnStatus } from '#packaging-recycling-notes/domain/model.js'
- * @import { WasteBalancesRepository } from '#waste-balances/repository/port.js'
+ * @import { WasteBalanceStreamRepository } from '#waste-balances/repository/stream-port.js'
  * @import { SystemLogsRepository } from '#repositories/system-logs/port.js'
  * @import { OrganisationsRepository } from '#repositories/organisations/port.js'
  * @import { HapiRequest } from '#common/hapi-types.js'
@@ -87,7 +87,7 @@ export const packagingRecyclingNotesUpdateStatus = {
   /**
    * @param {HapiRequest<{ status: PrnStatus }> & {
    *   packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository,
-   *   wasteBalancesRepository: WasteBalancesRepository,
+   *   streamRepository: WasteBalanceStreamRepository,
    *   organisationsRepository: OrganisationsRepository,
    *   systemLogsRepository: SystemLogsRepository
    * }} request
@@ -96,7 +96,7 @@ export const packagingRecyclingNotesUpdateStatus = {
   handler: async (request, h) => {
     const {
       packagingRecyclingNotesRepository,
-      wasteBalancesRepository,
+      streamRepository,
       organisationsRepository,
       params,
       payload,
@@ -126,7 +126,7 @@ export const packagingRecyclingNotesUpdateStatus = {
 
       const updatedPrn = await updatePrnStatus({
         prnRepository: packagingRecyclingNotesRepository,
-        wasteBalancesRepository,
+        streamRepository,
         organisationsRepository,
         logger,
         id,

--- a/src/packaging-recycling-notes/routes/status.test.js
+++ b/src/packaging-recycling-notes/routes/status.test.js
@@ -22,6 +22,8 @@ import {
 } from '#domain/organisations/model.js'
 import { PrnNumberConflictError } from '#packaging-recycling-notes/repository/port.js'
 import { STREAM_EVENT_KIND } from '#waste-balances/repository/stream-schema.js'
+import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
+import { buildStreamEvent } from '#waste-balances/repository/stream-test-data.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
 import { packagingRecyclingNotesUpdateStatusPath } from './status.js'
 
@@ -30,26 +32,35 @@ const registrationId = 'reg-456'
 const accreditationId = 'acc-789'
 const prnId = '507f1f77bcf86cd799439011'
 
+const SEED_BALANCE = { amount: 500, availableAmount: 500 }
+
 /**
- * A valid appended stream event, as the ledger-path balance effects return one.
- * The read-side fold reads `kind`, `number`, `createdAt` and `createdBy` off it.
+ * An in-memory stream seeded with one summary-log submission, opening the
+ * partition's ledger at the given balance so PRN commands resolve against it.
+ * Passing `null` leaves the ledger absent, which the commands reject as
+ * `NO_LEDGER`.
  *
- * @param {import('#waste-balances/repository/stream-schema.js').StreamEventKind} kind
- * @param {number} [number]
+ * @param {{ amount: number, availableAmount: number } | null} [closingBalance]
  */
-const buildAppendedEvent = (kind, number = 2) => ({
-  id: `event-${number}`,
-  registrationId,
-  accreditationId,
-  organisationId,
-  number,
-  kind,
-  payload: { prnId, amount: 100 },
-  openingBalance: { amount: 500, availableAmount: 500 },
-  closingBalance: { amount: 500, availableAmount: 400 },
-  createdAt: new Date('2026-02-03T10:00:00.000Z'),
-  createdBy: { id: 'test-user-id', name: 'Ada Lovelace' }
-})
+const seedStream = (closingBalance = SEED_BALANCE) =>
+  createInMemoryStreamRepository(
+    closingBalance
+      ? [
+          buildStreamEvent({
+            registrationId,
+            accreditationId,
+            organisationId,
+            number: 1,
+            payload: {
+              summaryLogId: 'log-1',
+              creditTotal: closingBalance.amount
+            },
+            openingBalance: { amount: 0, availableAmount: 0 },
+            closingBalance
+          })
+        ]
+      : []
+  )()
 
 const createMockPrn = (overrides = {}) => ({
   id: prnId,
@@ -93,37 +104,14 @@ const createMockPrn = (overrides = {}) => ({
 describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
   setupAuthContext()
 
-  describe('when feature flag is enabled', () => {
+  describe('writing a status transition', () => {
     let server
     let packagingRecyclingNotesRepository
-    let wasteBalancesRepository
+    let streamRepository
     let organisationsRepository
     const mockPrn = createMockPrn()
 
-    const createMockWasteBalance = (overrides = {}) => ({
-      id: 'balance-123',
-      organisationId,
-      accreditationId,
-      amount: 500,
-      availableAmount: 500,
-      version: 1,
-      schemaVersion: 1,
-      ...overrides
-    })
-
     beforeAll(async () => {
-      wasteBalancesRepository = {
-        findBalance: vi.fn().mockResolvedValue(createMockWasteBalance()),
-        getPrnCatchupEvents: vi.fn().mockResolvedValue([]),
-        appendStreamEvent: vi.fn(),
-        deductAvailableBalanceForPrnCreation: vi
-          .fn()
-          .mockResolvedValue(buildAppendedEvent(STREAM_EVENT_KIND.PRN_CREATED)),
-        deductTotalBalanceForPrnIssue: vi
-          .fn()
-          .mockResolvedValue(buildAppendedEvent(STREAM_EVENT_KIND.PRN_ISSUED))
-      }
-
       organisationsRepository = {
         findAccreditationById: vi.fn(async () => ({
           wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
@@ -135,7 +123,7 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
         repositories: {
           packagingRecyclingNotesRepository: () =>
             packagingRecyclingNotesRepository,
-          wasteBalancesRepository: () => wasteBalancesRepository,
+          streamRepository: () => streamRepository,
           organisationsRepository: () => organisationsRepository
         },
         featureFlags: createInMemoryFeatureFlags()
@@ -145,6 +133,7 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
     })
 
     beforeEach(() => {
+      streamRepository = seedStream()
       packagingRecyclingNotesRepository =
         createInMemoryPackagingRecyclingNotesRepository([mockPrn])({
           info: vi.fn(),
@@ -523,7 +512,7 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
         ).toHaveBeenCalledTimes(2)
       })
 
-      it('sets updatedBy to the authenticated user', async () => {
+      it('attributes the appended event to the authenticated user', async () => {
         const userId = 'specific-test-user-id'
         const userName = 'Test User Name'
 
@@ -547,12 +536,13 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
           payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
         })
 
-        expect(
-          wasteBalancesRepository.deductAvailableBalanceForPrnCreation
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            createdBy: expect.objectContaining({ id: userId, name: userName })
-          })
+        const events = await streamRepository.findAllByPartition(
+          registrationId,
+          accreditationId
+        )
+        expect(events.at(-1)?.kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+        expect(events.at(-1)?.createdBy).toEqual(
+          expect.objectContaining({ id: userId, name: userName })
         )
       })
 
@@ -574,15 +564,12 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
           payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
         })
 
-        expect(
-          wasteBalancesRepository.deductAvailableBalanceForPrnCreation
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            createdBy: expect.objectContaining({
-              id: 'unknown',
-              name: 'unknown'
-            })
-          })
+        const events = await streamRepository.findAllByPartition(
+          registrationId,
+          accreditationId
+        )
+        expect(events.at(-1)?.createdBy).toEqual(
+          expect.objectContaining({ id: 'unknown', name: 'unknown' })
         )
       })
     })
@@ -807,6 +794,23 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
 
         expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
       })
+
+      it('returns 400 when the accreditation has no waste balance ledger', async () => {
+        streamRepository = seedStream(null)
+        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
+          createMockPrn()
+        )
+
+        const response = await server.inject({
+          method: 'POST',
+          url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${prnId}/status`,
+          ...asStandardUser({ linkedOrgId: organisationId }),
+          payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+        expect(response.payload).toContain('No waste balance found')
+      })
     })
 
     describe('actor enforcement', () => {
@@ -839,7 +843,7 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
         expect(response.payload).toContain('is not permitted to transition')
       })
 
-      it('does not trigger waste balance changes for blocked transitions', async () => {
+      it('appends no balance event for blocked transitions', async () => {
         const awaitingAcceptancePrn = createMockPrn({
           prnNumber: 'ER2600001',
           status: {
@@ -865,199 +869,13 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
         })
 
         expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
-        expect(
-          wasteBalancesRepository.deductAvailableBalanceForPrnCreation
-        ).not.toHaveBeenCalled()
-        expect(
-          wasteBalancesRepository.deductTotalBalanceForPrnIssue
-        ).not.toHaveBeenCalled()
+        const events = await streamRepository.findAllByPartition(
+          registrationId,
+          accreditationId
+        )
+        expect(events).toHaveLength(1)
+        expect(events[0]?.kind).toBe(STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
       })
-    })
-  })
-
-  describe('waste balance deduction on PRN creation', () => {
-    let server
-    let packagingRecyclingNotesRepository
-    let wasteBalancesRepository
-    let organisationsRepository
-    const mockPrn = createMockPrn({ tonnage: 50.5 })
-
-    const createMockWasteBalance = (overrides = {}) => ({
-      id: 'balance-123',
-      organisationId,
-      accreditationId,
-      amount: 500,
-      availableAmount: 500,
-      version: 1,
-      schemaVersion: 1,
-      ...overrides
-    })
-
-    beforeAll(async () => {
-      wasteBalancesRepository = {
-        findBalance: vi.fn().mockResolvedValue(createMockWasteBalance()),
-        getPrnCatchupEvents: vi.fn().mockResolvedValue([]),
-        appendStreamEvent: vi.fn(),
-        deductAvailableBalanceForPrnCreation: vi
-          .fn()
-          .mockResolvedValue(buildAppendedEvent(STREAM_EVENT_KIND.PRN_CREATED)),
-        deductTotalBalanceForPrnIssue: vi
-          .fn()
-          .mockResolvedValue(buildAppendedEvent(STREAM_EVENT_KIND.PRN_ISSUED))
-      }
-
-      organisationsRepository = {
-        findAccreditationById: vi.fn(async () => ({
-          wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
-          submittedToRegulator: REGULATOR.EA
-        }))
-      }
-
-      server = await createTestServer({
-        repositories: {
-          packagingRecyclingNotesRepository: () =>
-            packagingRecyclingNotesRepository,
-          wasteBalancesRepository: () => wasteBalancesRepository,
-          organisationsRepository: () => organisationsRepository
-        },
-        featureFlags: createInMemoryFeatureFlags()
-      })
-
-      await server.initialize()
-    })
-
-    beforeEach(() => {
-      packagingRecyclingNotesRepository =
-        createInMemoryPackagingRecyclingNotesRepository([mockPrn])({
-          info: vi.fn(),
-          error: vi.fn(),
-          warn: vi.fn(),
-          debug: vi.fn(),
-          trace: vi.fn(),
-          fatal: vi.fn(),
-          child: vi.fn()
-        })
-      vi.spyOn(packagingRecyclingNotesRepository, 'findById')
-      vi.spyOn(packagingRecyclingNotesRepository, 'updateStatus')
-      vi.spyOn(packagingRecyclingNotesRepository, 'persistProjection')
-    })
-
-    afterEach(() => {
-      vi.clearAllMocks()
-    })
-
-    afterAll(async () => {
-      await server.stop()
-    })
-
-    it('deducts tonnage from available balance when transitioning to awaiting_authorisation', async () => {
-      const balance = createMockWasteBalance()
-      wasteBalancesRepository.findBalance.mockResolvedValueOnce(balance)
-      wasteBalancesRepository.deductAvailableBalanceForPrnCreation.mockResolvedValueOnce(
-        buildAppendedEvent(STREAM_EVENT_KIND.PRN_CREATED)
-      )
-      packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(mockPrn)
-
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${prnId}/status`,
-        auth: {
-          strategy: 'access-token',
-          credentials: {
-            scope: ['standard_user'],
-            id: 'test-user-id',
-            name: 'Ada Lovelace',
-            email: 'ada@example.com',
-            linkedOrgId: organisationId
-          }
-        },
-        payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.OK)
-      expect(
-        wasteBalancesRepository.deductAvailableBalanceForPrnCreation
-      ).toHaveBeenCalledWith({
-        accreditationId,
-        registrationId,
-        organisationId,
-        prnId,
-        tonnage: 50.5,
-        createdBy: {
-          id: 'test-user-id',
-          name: 'Ada Lovelace',
-          email: 'ada@example.com'
-        }
-      })
-    })
-
-    it('does not deduct balance for non-creation transitions', async () => {
-      const awaitingAuthPrn = createMockPrn({
-        status: {
-          currentStatus: PRN_STATUS.AWAITING_AUTHORISATION,
-          history: [
-            {
-              status: PRN_STATUS.AWAITING_AUTHORISATION,
-              at: new Date(),
-              by: { id: 'user-123', name: 'Test User' }
-            }
-          ]
-        }
-      })
-
-      packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
-        awaitingAuthPrn
-      )
-
-      await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${prnId}/status`,
-        ...asStandardUser({ linkedOrgId: organisationId }),
-        payload: { status: PRN_STATUS.AWAITING_ACCEPTANCE }
-      })
-
-      expect(
-        wasteBalancesRepository.deductAvailableBalanceForPrnCreation
-      ).not.toHaveBeenCalled()
-    })
-
-    it('returns 400 when no waste balance exists', async () => {
-      wasteBalancesRepository.findBalance.mockResolvedValueOnce(null)
-      packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
-        createMockPrn()
-      )
-
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${prnId}/status`,
-        ...asStandardUser({ linkedOrgId: organisationId }),
-        payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
-      expect(
-        wasteBalancesRepository.deductAvailableBalanceForPrnCreation
-      ).not.toHaveBeenCalled()
-    })
-
-    it('returns 500 when waste balance deduction fails', async () => {
-      const balance = createMockWasteBalance()
-      wasteBalancesRepository.findBalance.mockResolvedValueOnce(balance)
-      wasteBalancesRepository.deductAvailableBalanceForPrnCreation.mockRejectedValueOnce(
-        new Error('Database write failed')
-      )
-      packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
-        createMockPrn()
-      )
-
-      const response = await server.inject({
-        method: 'POST',
-        url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${prnId}/status`,
-        ...asStandardUser({ linkedOrgId: organisationId }),
-        payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
     })
   })
 })

--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -629,6 +629,7 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
     repositories: {
       summaryLogsRepository: () => summaryLogsRepository,
       uploadsRepository,
+      streamRepository: () => streamRepository,
       wasteBalancesRepository: () => wasteBalancesRepository,
       wasteRecordsRepository: () => wasteRecordsRepository,
       packagingRecyclingNotesRepository: () =>

--- a/src/test/create-test-server.js
+++ b/src/test/create-test-server.js
@@ -34,6 +34,7 @@ import { createInMemoryOrganisationsRepositoryPlugin } from '#repositories/organ
 import { createInMemorySummaryLogsRepositoryPlugin } from '#repositories/summary-logs/inmemory.plugin.js'
 import { createInMemorySystemLogsRepositoryPlugin } from '#repositories/system-logs/inmemory.plugin.js'
 import { createInMemoryWasteBalancesRepositoryPlugin } from '#waste-balances/repository/inmemory.plugin.js'
+import { createInMemoryStreamRepositoryPlugin } from '#waste-balances/repository/stream-inmemory.plugin.js'
 import { createInMemoryWasteRecordsRepositoryPlugin } from '#repositories/waste-records/inmemory.plugin.js'
 import { createInMemoryWasteRecordStatesRepositoryPlugin } from '#waste-records/repository/inmemory.plugin.js'
 
@@ -107,6 +108,10 @@ const repositoryConfigs = [
   {
     name: 'wasteRecordStatesRepository',
     createDefault: createInMemoryWasteRecordStatesRepositoryPlugin
+  },
+  {
+    name: 'streamRepository',
+    createDefault: createInMemoryStreamRepositoryPlugin
   },
   {
     name: 'wasteBalancesRepository',

--- a/src/waste-balances/application/waste-balance-service.js
+++ b/src/waste-balances/application/waste-balance-service.js
@@ -1,5 +1,24 @@
-import { submitSummaryLog as decideSummaryLog } from '../domain/commands.js'
+import {
+  submitSummaryLog as decideSummaryLog,
+  createPrn as decideCreatePrn,
+  issuePrn as decideIssuePrn,
+  cancelPrnCreation as decideCancelPrnCreation,
+  cancelIssuedPrn as decideCancelIssuedPrn,
+  acceptPrn as decideAcceptPrn,
+  rejectPrn as decideRejectPrn,
+  PRN_COMMAND_STATUS,
+  PRN_COMMAND_REJECTION
+} from '../domain/commands.js'
 import { currentWasteBalance } from './current-waste-balance.js'
+
+/**
+ * The outcome of a PRN command: the appended stream events when it commits, or
+ * the reason it did not. The application layer turns a rejection into the
+ * contextual error its callers expect.
+ *
+ * @typedef {{ status: 'committed', events: import('../repository/stream-port.js').StreamEvent[] }
+ *   | { status: 'rejected', reason: import('../domain/commands.js').PrnCommandRejection }} PrnCommandResult
+ */
 
 /**
  * The single application boundary over the waste balance ledger. Each command
@@ -63,6 +82,35 @@ export const createWasteBalanceService = (streamRepository) => {
     )
   }
 
+  /**
+   * Run a PRN command: fold the ledger, reject when it does not exist yet
+   * (PRN commands always act on an open ledger), run the pure decider, and
+   * append the decided events when it commits. The no-ledger rejection lives
+   * here, in one place, rather than in each decider.
+   *
+   * @param {(balance: import('../repository/stream-schema.js').StreamBalanceSnapshot, payload: import('../repository/stream-schema.js').PrnPayload) => import('../domain/commands.js').PrnDecision} decide
+   * @returns {(ledgerId: import('../repository/stream-schema.js').WasteBalanceLedgerId, payload: import('../repository/stream-schema.js').PrnPayload, createdBy: import('../repository/stream-schema.js').StreamUserSummary) => Promise<PrnCommandResult>}
+   */
+  const runPrnCommand = (decide) => async (ledgerId, payload, createdBy) => {
+    const { state, head } = await fold(ledgerId)
+    if (!state) {
+      return {
+        status: PRN_COMMAND_STATUS.REJECTED,
+        reason: PRN_COMMAND_REJECTION.NO_LEDGER
+      }
+    }
+
+    const decision = decide(state.balance, payload)
+    if (decision.status === PRN_COMMAND_STATUS.REJECTED) {
+      return decision
+    }
+
+    return {
+      status: PRN_COMMAND_STATUS.COMMITTED,
+      events: await append(ledgerId, head, decision.events, createdBy)
+    }
+  }
+
   return {
     /**
      * Record a summary-log submission against the ledger.
@@ -80,6 +128,13 @@ export const createWasteBalanceService = (streamRepository) => {
         decideSummaryLog(state, submission),
         createdBy
       )
-    }
+    },
+
+    createPrn: runPrnCommand(decideCreatePrn),
+    issuePrn: runPrnCommand(decideIssuePrn),
+    cancelPrnCreation: runPrnCommand(decideCancelPrnCreation),
+    cancelIssuedPrn: runPrnCommand(decideCancelIssuedPrn),
+    acceptPrn: runPrnCommand(decideAcceptPrn),
+    rejectPrn: runPrnCommand(decideRejectPrn)
   }
 }

--- a/src/waste-balances/application/waste-balance-service.test.js
+++ b/src/waste-balances/application/waste-balance-service.test.js
@@ -3,6 +3,10 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { createInMemoryStreamRepository } from '../repository/stream-inmemory.js'
 import { STREAM_EVENT_KIND } from '../repository/stream-schema.js'
 import { StreamSlotConflictError } from '../repository/stream-port.js'
+import {
+  PRN_COMMAND_STATUS,
+  PRN_COMMAND_REJECTION
+} from '../domain/commands.js'
 import { createWasteBalanceService } from './waste-balance-service.js'
 
 const ledgerId = {
@@ -95,6 +99,173 @@ describe('createWasteBalanceService', () => {
 
       const all = await streamRepository.findAllByPartition('reg-1', 'acc-1')
       expect(all).toHaveLength(1)
+    })
+  })
+
+  describe('PRN commands', () => {
+    const seedLedger = (creditTotal = 1000) =>
+      service.submitSummaryLog(
+        ledgerId,
+        { summaryLogId: 'seed', creditTotal },
+        createdBy
+      )
+
+    it('createPrn commits a prn-created event ringfencing the available balance', async () => {
+      await seedLedger()
+
+      const result = await service.createPrn(
+        ledgerId,
+        { prnId: 'prn-1', amount: 100 },
+        createdBy
+      )
+
+      expect(result.status).toBe(PRN_COMMAND_STATUS.COMMITTED)
+      const [event] = result.events
+      expect(event.number).toBe(2)
+      expect(event.kind).toBe(STREAM_EVENT_KIND.PRN_CREATED)
+      expect(event.payload).toEqual({ prnId: 'prn-1', amount: 100 })
+      expect(event.closingBalance).toEqual({
+        amount: 1000,
+        availableAmount: 900
+      })
+    })
+
+    it('createPrn rejects insufficient available balance without appending', async () => {
+      await seedLedger(50)
+
+      const result = await service.createPrn(
+        ledgerId,
+        { prnId: 'prn-1', amount: 100 },
+        createdBy
+      )
+
+      expect(result).toEqual({
+        status: PRN_COMMAND_STATUS.REJECTED,
+        reason: PRN_COMMAND_REJECTION.INSUFFICIENT_AVAILABLE_BALANCE
+      })
+      const all = await streamRepository.findAllByPartition('reg-1', 'acc-1')
+      expect(all).toHaveLength(1)
+    })
+
+    it('rejects with no-ledger when the partition has no events', async () => {
+      const result = await service.createPrn(
+        ledgerId,
+        { prnId: 'prn-1', amount: 100 },
+        createdBy
+      )
+
+      expect(result).toEqual({
+        status: PRN_COMMAND_STATUS.REJECTED,
+        reason: PRN_COMMAND_REJECTION.NO_LEDGER
+      })
+    })
+
+    it('issuePrn commits a prn-issued event deducting the total balance', async () => {
+      await seedLedger()
+
+      const result = await service.issuePrn(
+        ledgerId,
+        { prnId: 'prn-1', amount: 75 },
+        createdBy
+      )
+
+      expect(result.status).toBe(PRN_COMMAND_STATUS.COMMITTED)
+      expect(result.events[0].closingBalance).toEqual({
+        amount: 925,
+        availableAmount: 1000
+      })
+    })
+
+    it('issuePrn rejects insufficient total balance', async () => {
+      await seedLedger(50)
+
+      const result = await service.issuePrn(
+        ledgerId,
+        { prnId: 'prn-1', amount: 100 },
+        createdBy
+      )
+
+      expect(result.reason).toBe(
+        PRN_COMMAND_REJECTION.INSUFFICIENT_TOTAL_BALANCE
+      )
+    })
+
+    it('cancelPrnCreation commits a credit of the available balance', async () => {
+      await seedLedger()
+      await service.createPrn(
+        ledgerId,
+        { prnId: 'prn-1', amount: 100 },
+        createdBy
+      )
+
+      const result = await service.cancelPrnCreation(
+        ledgerId,
+        { prnId: 'prn-1', amount: 100 },
+        createdBy
+      )
+
+      expect(result.events[0].kind).toBe(
+        STREAM_EVENT_KIND.PRN_CREATION_CANCELLED
+      )
+      expect(result.events[0].closingBalance).toEqual({
+        amount: 1000,
+        availableAmount: 1000
+      })
+    })
+
+    it('cancelIssuedPrn commits a credit of both balances', async () => {
+      await seedLedger()
+      await service.issuePrn(
+        ledgerId,
+        { prnId: 'prn-1', amount: 100 },
+        createdBy
+      )
+
+      const result = await service.cancelIssuedPrn(
+        ledgerId,
+        { prnId: 'prn-1', amount: 100 },
+        createdBy
+      )
+
+      expect(result.events[0].kind).toBe(
+        STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE
+      )
+      expect(result.events[0].closingBalance).toEqual({
+        amount: 1000,
+        availableAmount: 1100
+      })
+    })
+
+    it('acceptPrn commits a status-only event leaving the balance unchanged', async () => {
+      await seedLedger()
+
+      const result = await service.acceptPrn(
+        ledgerId,
+        { prnId: 'prn-1', amount: 100 },
+        createdBy
+      )
+
+      expect(result.events[0].kind).toBe(STREAM_EVENT_KIND.PRN_ACCEPTED)
+      expect(result.events[0].closingBalance).toEqual({
+        amount: 1000,
+        availableAmount: 1000
+      })
+    })
+
+    it('rejectPrn commits a status-only event leaving the balance unchanged', async () => {
+      await seedLedger()
+
+      const result = await service.rejectPrn(
+        ledgerId,
+        { prnId: 'prn-1', amount: 100 },
+        createdBy
+      )
+
+      expect(result.events[0].kind).toBe(STREAM_EVENT_KIND.PRN_REJECTED)
+      expect(result.events[0].closingBalance).toEqual({
+        amount: 1000,
+        availableAmount: 1000
+      })
     })
   })
 })

--- a/src/waste-balances/domain/commands.js
+++ b/src/waste-balances/domain/commands.js
@@ -1,5 +1,8 @@
 import { STREAM_EVENT_KIND, ZERO_BALANCE } from '../repository/stream-schema.js'
-import { closingForSummaryLogSubmitted } from './stream-closing-balance.js'
+import {
+  closingForSummaryLogSubmitted,
+  closingForPrn
+} from './stream-closing-balance.js'
 
 /**
  * The ledger state a command decides against: the resolved balance and the
@@ -20,10 +23,40 @@ import { closingForSummaryLogSubmitted } from './stream-closing-balance.js'
  *
  * @typedef {Object} BalanceEvent
  * @property {import('../repository/stream-schema.js').StreamEventKind} kind
- * @property {import('../repository/stream-schema.js').SummaryLogSubmittedPayload} payload
+ * @property {import('../repository/stream-schema.js').SummaryLogSubmittedPayload | import('../repository/stream-schema.js').PrnPayload} payload
  * @property {import('../repository/stream-schema.js').StreamBalanceSnapshot} openingBalance
  * @property {import('../repository/stream-schema.js').StreamBalanceSnapshot} closingBalance
  */
+
+/**
+ * A PRN command's outcome as data, not control flow: either the balance events
+ * to commit, or a reason the command cannot proceed. The deciders never throw —
+ * the application layer turns a rejection into the contextual error its callers
+ * expect (`reason` plus the ledger identity it holds).
+ *
+ * @typedef {{ status: 'committed', events: BalanceEvent[] }
+ *   | { status: 'rejected', reason: PrnCommandRejection }} PrnDecision
+ */
+
+/**
+ * @typedef {typeof PRN_COMMAND_REJECTION[keyof typeof PRN_COMMAND_REJECTION]} PrnCommandRejection
+ */
+
+export const PRN_COMMAND_STATUS = Object.freeze({
+  COMMITTED: 'committed',
+  REJECTED: 'rejected'
+})
+
+/**
+ * Why a PRN command did not commit. `NO_LEDGER` is raised by the service shell
+ * when the partition has no events to decide against; the sufficiency reasons
+ * are raised by the deciders below.
+ */
+export const PRN_COMMAND_REJECTION = Object.freeze({
+  NO_LEDGER: 'no-ledger',
+  INSUFFICIENT_AVAILABLE_BALANCE: 'insufficient-available-balance',
+  INSUFFICIENT_TOTAL_BALANCE: 'insufficient-total-balance'
+})
 
 /**
  * The state a summary-log submission opens a ledger from when none exists.
@@ -55,3 +88,96 @@ export const submitSummaryLog = (state, { summaryLogId, creditTotal }) => {
     }
   ]
 }
+
+/**
+ * @param {import('../repository/stream-schema.js').StreamEventKind} kind
+ * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} opening
+ * @param {import('../repository/stream-schema.js').PrnPayload} payload
+ * @returns {PrnDecision}
+ */
+const committed = (kind, opening, payload) => ({
+  status: PRN_COMMAND_STATUS.COMMITTED,
+  events: [
+    {
+      kind,
+      payload,
+      openingBalance: opening,
+      closingBalance: closingForPrn(opening, kind, payload.amount)
+    }
+  ]
+})
+
+/**
+ * @param {PrnCommandRejection} reason
+ * @returns {PrnDecision}
+ */
+const rejected = (reason) => ({
+  status: PRN_COMMAND_STATUS.REJECTED,
+  reason
+})
+
+/**
+ * Ringfence available balance for a new PRN. Rejects when the tonnage exceeds
+ * the balance available to ringfence.
+ *
+ * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} balance
+ * @param {import('../repository/stream-schema.js').PrnPayload} payload
+ * @returns {PrnDecision}
+ */
+export const createPrn = (balance, payload) =>
+  balance.availableAmount < payload.amount
+    ? rejected(PRN_COMMAND_REJECTION.INSUFFICIENT_AVAILABLE_BALANCE)
+    : committed(STREAM_EVENT_KIND.PRN_CREATED, balance, payload)
+
+/**
+ * Deduct total balance as a PRN is issued. Rejects when the tonnage exceeds the
+ * total balance.
+ *
+ * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} balance
+ * @param {import('../repository/stream-schema.js').PrnPayload} payload
+ * @returns {PrnDecision}
+ */
+export const issuePrn = (balance, payload) =>
+  balance.amount < payload.amount
+    ? rejected(PRN_COMMAND_REJECTION.INSUFFICIENT_TOTAL_BALANCE)
+    : committed(STREAM_EVENT_KIND.PRN_ISSUED, balance, payload)
+
+/**
+ * Credit the ringfenced available balance back when a pending PRN is deleted.
+ *
+ * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} balance
+ * @param {import('../repository/stream-schema.js').PrnPayload} payload
+ * @returns {PrnDecision}
+ */
+export const cancelPrnCreation = (balance, payload) =>
+  committed(STREAM_EVENT_KIND.PRN_CREATION_CANCELLED, balance, payload)
+
+/**
+ * Credit both balances back when an issued PRN's cancellation completes.
+ *
+ * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} balance
+ * @param {import('../repository/stream-schema.js').PrnPayload} payload
+ * @returns {PrnDecision}
+ */
+export const cancelIssuedPrn = (balance, payload) =>
+  committed(STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE, balance, payload)
+
+/**
+ * Record a PRN acceptance. No balance movement.
+ *
+ * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} balance
+ * @param {import('../repository/stream-schema.js').PrnPayload} payload
+ * @returns {PrnDecision}
+ */
+export const acceptPrn = (balance, payload) =>
+  committed(STREAM_EVENT_KIND.PRN_ACCEPTED, balance, payload)
+
+/**
+ * Record a PRN rejection (cancellation request). No balance movement.
+ *
+ * @param {import('../repository/stream-schema.js').StreamBalanceSnapshot} balance
+ * @param {import('../repository/stream-schema.js').PrnPayload} payload
+ * @returns {PrnDecision}
+ */
+export const rejectPrn = (balance, payload) =>
+  committed(STREAM_EVENT_KIND.PRN_REJECTED, balance, payload)

--- a/src/waste-balances/domain/commands.test.js
+++ b/src/waste-balances/domain/commands.test.js
@@ -1,7 +1,17 @@
 import { describe, it, expect } from 'vitest'
 
 import { STREAM_EVENT_KIND, ZERO_BALANCE } from '../repository/stream-schema.js'
-import { submitSummaryLog } from './commands.js'
+import {
+  submitSummaryLog,
+  createPrn,
+  issuePrn,
+  cancelPrnCreation,
+  cancelIssuedPrn,
+  acceptPrn,
+  rejectPrn,
+  PRN_COMMAND_STATUS,
+  PRN_COMMAND_REJECTION
+} from './commands.js'
 
 describe('submitSummaryLog', () => {
   it('opens a ledger from zero on the first submission', () => {
@@ -51,5 +61,201 @@ describe('submitSummaryLog', () => {
         closingBalance: { amount: 150, availableAmount: 120 }
       }
     ])
+  })
+})
+
+describe('createPrn', () => {
+  it('commits a prn-created event ringfencing the available balance', () => {
+    expect(
+      createPrn(
+        { amount: 1000, availableAmount: 1000 },
+        {
+          prnId: 'prn-1',
+          amount: 100
+        }
+      )
+    ).toEqual({
+      status: PRN_COMMAND_STATUS.COMMITTED,
+      events: [
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATED,
+          payload: { prnId: 'prn-1', amount: 100 },
+          openingBalance: { amount: 1000, availableAmount: 1000 },
+          closingBalance: { amount: 1000, availableAmount: 900 }
+        }
+      ]
+    })
+  })
+
+  it('commits when the tonnage equals the available balance exactly', () => {
+    expect(
+      createPrn(
+        { amount: 500, availableAmount: 100 },
+        {
+          prnId: 'prn-1',
+          amount: 100
+        }
+      )
+    ).toEqual({
+      status: PRN_COMMAND_STATUS.COMMITTED,
+      events: [
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATED,
+          payload: { prnId: 'prn-1', amount: 100 },
+          openingBalance: { amount: 500, availableAmount: 100 },
+          closingBalance: { amount: 500, availableAmount: 0 }
+        }
+      ]
+    })
+  })
+
+  it('rejects when the tonnage exceeds the available balance', () => {
+    expect(
+      createPrn(
+        { amount: 500, availableAmount: 50 },
+        {
+          prnId: 'prn-1',
+          amount: 100
+        }
+      )
+    ).toEqual({
+      status: PRN_COMMAND_STATUS.REJECTED,
+      reason: PRN_COMMAND_REJECTION.INSUFFICIENT_AVAILABLE_BALANCE
+    })
+  })
+})
+
+describe('issuePrn', () => {
+  it('commits a prn-issued event deducting the total balance', () => {
+    expect(
+      issuePrn(
+        { amount: 1000, availableAmount: 900 },
+        {
+          prnId: 'prn-1',
+          amount: 75
+        }
+      )
+    ).toEqual({
+      status: PRN_COMMAND_STATUS.COMMITTED,
+      events: [
+        {
+          kind: STREAM_EVENT_KIND.PRN_ISSUED,
+          payload: { prnId: 'prn-1', amount: 75 },
+          openingBalance: { amount: 1000, availableAmount: 900 },
+          closingBalance: { amount: 925, availableAmount: 900 }
+        }
+      ]
+    })
+  })
+
+  it('rejects when the tonnage exceeds the total balance', () => {
+    expect(
+      issuePrn(
+        { amount: 50, availableAmount: 200 },
+        {
+          prnId: 'prn-1',
+          amount: 100
+        }
+      )
+    ).toEqual({
+      status: PRN_COMMAND_STATUS.REJECTED,
+      reason: PRN_COMMAND_REJECTION.INSUFFICIENT_TOTAL_BALANCE
+    })
+  })
+})
+
+describe('cancelPrnCreation', () => {
+  it('commits a prn-creation-cancelled event crediting the available balance', () => {
+    expect(
+      cancelPrnCreation(
+        { amount: 1000, availableAmount: 925 },
+        {
+          prnId: 'prn-1',
+          amount: 75
+        }
+      )
+    ).toEqual({
+      status: PRN_COMMAND_STATUS.COMMITTED,
+      events: [
+        {
+          kind: STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,
+          payload: { prnId: 'prn-1', amount: 75 },
+          openingBalance: { amount: 1000, availableAmount: 925 },
+          closingBalance: { amount: 1000, availableAmount: 1000 }
+        }
+      ]
+    })
+  })
+})
+
+describe('cancelIssuedPrn', () => {
+  it('commits a prn-cancelled-after-issue event crediting both balances', () => {
+    expect(
+      cancelIssuedPrn(
+        { amount: 440, availableAmount: 940 },
+        {
+          prnId: 'prn-1',
+          amount: 60
+        }
+      )
+    ).toEqual({
+      status: PRN_COMMAND_STATUS.COMMITTED,
+      events: [
+        {
+          kind: STREAM_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+          payload: { prnId: 'prn-1', amount: 60 },
+          openingBalance: { amount: 440, availableAmount: 940 },
+          closingBalance: { amount: 500, availableAmount: 1000 }
+        }
+      ]
+    })
+  })
+})
+
+describe('acceptPrn', () => {
+  it('commits a prn-accepted event leaving the balance unchanged', () => {
+    expect(
+      acceptPrn(
+        { amount: 500, availableAmount: 400 },
+        {
+          prnId: 'prn-1',
+          amount: 50
+        }
+      )
+    ).toEqual({
+      status: PRN_COMMAND_STATUS.COMMITTED,
+      events: [
+        {
+          kind: STREAM_EVENT_KIND.PRN_ACCEPTED,
+          payload: { prnId: 'prn-1', amount: 50 },
+          openingBalance: { amount: 500, availableAmount: 400 },
+          closingBalance: { amount: 500, availableAmount: 400 }
+        }
+      ]
+    })
+  })
+})
+
+describe('rejectPrn', () => {
+  it('commits a prn-rejected event leaving the balance unchanged', () => {
+    expect(
+      rejectPrn(
+        { amount: 500, availableAmount: 400 },
+        {
+          prnId: 'prn-1',
+          amount: 50
+        }
+      )
+    ).toEqual({
+      status: PRN_COMMAND_STATUS.COMMITTED,
+      events: [
+        {
+          kind: STREAM_EVENT_KIND.PRN_REJECTED,
+          payload: { prnId: 'prn-1', amount: 50 },
+          openingBalance: { amount: 500, availableAmount: 400 },
+          closingBalance: { amount: 500, availableAmount: 400 }
+        }
+      ]
+    })
   })
 })

--- a/src/waste-balances/repository/inmemory.plugin.js
+++ b/src/waste-balances/repository/inmemory.plugin.js
@@ -1,18 +1,21 @@
 import { createWasteBalancesRepository } from './repository.js'
-import { createInMemoryStreamRepository } from './stream-inmemory.js'
 import { registerRepository } from '#plugins/register-repository.js'
 
+/**
+ * Reads the waste balance over the shared in-memory stream from
+ * `server.app.streamRepository`, so `createInMemoryStreamRepositoryPlugin` must
+ * register before this plugin.
+ */
 export function createInMemoryWasteBalancesRepositoryPlugin() {
   return {
     name: 'wasteBalancesRepository',
     register: (server) => {
-      const streamRepository = createInMemoryStreamRepository()()
-      const factory = createWasteBalancesRepository({
-        streamRepository
-      })
-      const repository = factory()
+      const streamRepository =
+        /** @type {import('./stream-port.js').WasteBalanceStreamRepository} */ (
+          server.app.streamRepository
+        )
+      const repository = createWasteBalancesRepository({ streamRepository })()
       registerRepository(server, 'wasteBalancesRepository', () => repository)
-      registerRepository(server, 'streamRepository', () => streamRepository)
     }
   }
 }

--- a/src/waste-balances/repository/stream-inmemory.plugin.js
+++ b/src/waste-balances/repository/stream-inmemory.plugin.js
@@ -1,0 +1,12 @@
+import { createInMemoryStreamRepository } from './stream-inmemory.js'
+import { registerRepository } from '#plugins/register-repository.js'
+
+export function createInMemoryStreamRepositoryPlugin() {
+  return {
+    name: 'streamRepository',
+    register: (server) => {
+      const streamRepository = createInMemoryStreamRepository()()
+      registerRepository(server, 'streamRepository', () => streamRepository)
+    }
+  }
+}


### PR DESCRIPTION
Ticket: [PAE-1669](https://eaflood.atlassian.net/browse/PAE-1669)
Migrates the PRN status-transition write path onto the waste-balance application service, so every transition resolves its balance the same way: fold the ledger once, run a pure command decider, append the decided events.

## What changed

- PRN transitions (created, issued, creation-cancelled, cancelled-after-issue, accepted, rejected) now run through the waste-balance service's commands instead of `WasteBalancesRepository`'s `deduct*`/`credit*`/`appendStreamEvent` methods; the never-issued DRAFT→DISCARDED transition keeps its direct document write.
- The PRN command deciders are pure functions returning a result as data (`committed` with events, or `rejected` with a reason); only creation and issuance can reject, on insufficient available or total balance.
- The no-ledger rejection is centralised in the service rather than repeated per command, and the application layer turns each rejection into its caller-facing error — a 400 naming the accreditation when no balance exists, a 409 when a balance is exhausted, and a 500 when accept or reject meet a missing ledger, since a created and issued PRN must already have one.
- The status and external-transition routes take the event stream for the write; optimistic-concurrency behaviour is unchanged (a head that moved after the fold surfaces as a slot conflict, with no in-process retry).
- The status, accept, reject and external-transition route tests, plus the waste-balance integration harness, now run against a real in-memory event stream seeded with an opening balance, replacing the repository-method mocks; the status route tests drop their waste-balance mock entirely since the route depends only on the stream.
- `streamRepository` is registered as a first-class in-memory test plugin so a test and the route under test share one stream.

## Why

Reshapes the waste-balance write path into a functional core / imperative shell over the append-only event store, making the optimistic-concurrency guarantee structural and removing the `expectedHead` token that previously leaked through the repository surface. Builds on the summary-log service migration in [#1394](https://github.com/DEFRA/epr-backend/pull/1394).


[PAE-1669]: https://eaflood.atlassian.net/browse/PAE-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
