### PR TITLE
PAE-1669: Read balance display via the waste-balance service

### DIFF
--- a/src/waste-balances/application/waste-balance-service.js
+++ b/src/waste-balances/application/waste-balance-service.js
@@ -127,6 +127,17 @@ export const createWasteBalanceService = (streamRepository) => {
 
   return {
     /**
+     * The current balance folded from the ledger, or `null` when the ledger
+     * has no events yet. This is the read side of the same fold the commands
+     * decide against; the partition key is all it needs.
+     *
+     * @param {{ registrationId: string, accreditationId: string | null }} ledgerId
+     * @returns {Promise<import('../domain/model.js').WasteBalance | null>}
+     */
+    currentBalance: (ledgerId) =>
+      currentWasteBalance(streamRepository, ledgerId),
+
+    /**
      * Record a summary-log submission against the ledger.
      *
      * @param {import('../repository/stream-schema.js').WasteBalanceLedgerId} ledgerId

--- a/src/waste-balances/application/waste-balance-service.test.js
+++ b/src/waste-balances/application/waste-balance-service.test.js
@@ -321,4 +321,32 @@ describe('createWasteBalanceService', () => {
       })
     })
   })
+
+  describe('currentBalance', () => {
+    it('resolves to null for a ledger with no events', async () => {
+      expect(await service.currentBalance(ledgerId)).toBeNull()
+    })
+
+    it('folds the ledger into its current balance', async () => {
+      await service.submitSummaryLog(
+        ledgerId,
+        { summaryLogId: 'log-A', creditTotal: 150 },
+        createdBy
+      )
+      await service.createPrn(
+        ledgerId,
+        { prnId: 'prn-1', amount: 40 },
+        createdBy
+      )
+
+      const balance = await service.currentBalance(ledgerId)
+
+      expect(balance).toMatchObject({
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1',
+        amount: 150,
+        availableAmount: 110
+      })
+    })
+  })
 })

--- a/src/waste-balances/routes/get.js
+++ b/src/waste-balances/routes/get.js
@@ -2,8 +2,9 @@ import { StatusCodes } from 'http-status-codes'
 import { ROLES, SCOPES } from '#common/helpers/auth/constants.js'
 import Joi from 'joi'
 import { wasteBalanceResponseSchema } from './response.schema.js'
+import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
 
-/** @typedef {import('#waste-balances/repository/port.js').WasteBalancesRepository} WasteBalancesRepository */
+/** @typedef {import('#waste-balances/repository/stream-port.js').WasteBalanceStreamRepository} WasteBalanceStreamRepository */
 /** @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository */
 
 export const wasteBalanceGetPath =
@@ -42,18 +43,19 @@ export const wasteBalanceGet = {
     }
   },
   /**
-   * @param {import('#common/hapi-types.js').HapiRequest & {wasteBalancesRepository: WasteBalancesRepository, organisationsRepository: OrganisationsRepository}} request
+   * @param {import('#common/hapi-types.js').HapiRequest & {streamRepository: WasteBalanceStreamRepository, organisationsRepository: OrganisationsRepository}} request
    * @param {import('#common/hapi-types.js').HapiResponseToolkit} h
    * @returns {Promise<import('#common/hapi-types.js').HapiResponseObject>}
    */
   handler: async (
-    { wasteBalancesRepository, organisationsRepository, query, params },
+    { streamRepository, organisationsRepository, query, params },
     h
   ) => {
     const { organisationId } = params
     const accreditationIds = new Set(
       /** @type {string} */ (query.accreditationIds).split(',')
     )
+    const service = createWasteBalanceService(streamRepository)
 
     const [organisation] = await organisationsRepository.findByIds([
       organisationId
@@ -74,7 +76,7 @@ export const wasteBalanceGet = {
           return null
         }
 
-        const balance = await wasteBalancesRepository.findBalance({
+        const balance = await service.currentBalance({
           registrationId,
           accreditationId
         })

--- a/src/waste-balances/routes/get.test.js
+++ b/src/waste-balances/routes/get.test.js
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { StatusCodes } from 'http-status-codes'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import { createInMemoryStreamRepository } from '#waste-balances/repository/stream-inmemory.js'
-import { createWasteBalancesRepository } from '#waste-balances/repository/repository.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import {
   buildOrganisation,
@@ -26,10 +25,10 @@ describe('GET /v1/organisations/{organisationId}/waste-balances', () => {
   const registrationId2 = 'reg-2'
 
   /**
-   * Build an in-memory waste balances repository whose balances resolve their
-   * amounts from a stream seeded with the given closing balances.
+   * Build an in-memory event stream seeded with the given closing balances, so
+   * the route's service folds them into the balances it returns.
    */
-  const buildBalancesRepository = async (balances) => {
+  const buildStreamRepository = async (balances) => {
     const streamRepository = createInMemoryStreamRepository()()
     for (const {
       accreditationId,
@@ -48,7 +47,7 @@ describe('GET /v1/organisations/{organisationId}/waste-balances', () => {
         })
       )
     }
-    return createWasteBalancesRepository({ streamRepository })
+    return streamRepository
   }
 
   /**
@@ -71,7 +70,7 @@ describe('GET /v1/organisations/{organisationId}/waste-balances', () => {
   const buildServer = async ({ balances, organisations }) =>
     createTestServer({
       repositories: {
-        wasteBalancesRepository: await buildBalancesRepository(balances),
+        streamRepository: await buildStreamRepository(balances),
         organisationsRepository: buildOrganisationsRepository(organisations)
       },
       featureFlags: createInMemoryFeatureFlags({})


### PR DESCRIPTION
Ticket: [PAE-1669](https://eaflood.atlassian.net/browse/PAE-1669)

Points the waste-balance display read at the waste-balance application service, so balances are resolved by the same ledger fold the write path decides against rather than through the `WasteBalancesRepository` port.

## What changed

- The balance display route (`GET /v1/organisations/{organisationId}/waste-balances`) now folds each accreditation's balance through the waste-balance service instead of calling `WasteBalancesRepository.findBalance`; the route takes the event stream as its dependency and constructs the service locally, the same way the PRN status routes do.
- The service gains a `currentBalance` read — the read side of the fold its commands already decide against — returning the folded balance or `null` for a ledger with no events.
- The route test seeds an in-memory event stream directly and shares it with the route, replacing the repository wrapper.

## Why

Continues the PAE-1669 migration of waste-balance consumers onto the single application service over the event store, so the `WasteBalancesRepository` port can be retired once every read and write goes through the service. Builds on the PRN status-transition migration in [#1397](https://github.com/DEFRA/epr-backend/pull/1397).


[PAE-1669]: https://eaflood.atlassian.net/browse/PAE-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ