### PR TITLE
PAE-1668: round each report tonnage row to 2dp before summing

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,5 @@
 import vitest from '@vitest/eslint-plugin'
 import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript'
-import importX from 'eslint-plugin-import-x'
 import nodePlugin from 'eslint-plugin-n'
 import neostandard from 'neostandard'
 
@@ -23,7 +22,8 @@ export default [
   ...ns,
   nodePlugin.configs['flat/recommended-module'],
   {
-    plugins: { 'import-x': importX },
+    // import-x plugin is already registered by neostandard; re-registering it
+    // here triggers ESLint's "Cannot redefine plugin" error.
     settings: {
       'import-x/resolver-next': [createTypeScriptImportResolver()]
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import vitest from '@vitest/eslint-plugin'
 import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript'
+import importX from 'eslint-plugin-import-x'
 import nodePlugin from 'eslint-plugin-n'
 import neostandard from 'neostandard'
 
@@ -22,8 +23,7 @@ export default [
   ...ns,
   nodePlugin.configs['flat/recommended-module'],
   {
-    // import-x plugin is already registered by neostandard; re-registering it
-    // here triggers ESLint's "Cannot redefine plugin" error.
+    plugins: { 'import-x': importX },
     settings: {
       'import-x/resolver-next': [createTypeScriptImportResolver()]
     },

--- a/src/common/helpers/decimal-utils.js
+++ b/src/common/helpers/decimal-utils.js
@@ -90,6 +90,21 @@ export function add(a, b) {
 }
 
 /**
+ * Add `value` to a running accumulator, rounding `value` to `decimalPlaces`
+ * first (round-each-then-sum). Only `value` is rounded - `acc` is the
+ * already-rounded running total and is left untouched. Returns a Decimal so it
+ * composes in reduce/loop accumulations.
+ *
+ * @param {DecimalValue} acc - Running total (already rounded)
+ * @param {DecimalValue|null|undefined} value - Per-row value to round then add (null/undefined treated as zero)
+ * @param {number} decimalPlaces - Decimal places to round `value` to
+ * @returns {DecimalInstance} Sum as Decimal
+ */
+export function addRounded(acc, value, decimalPlaces) {
+  return add(acc, toDecimal(value).toDecimalPlaces(decimalPlaces))
+}
+
+/**
  * Subtract two values using exact decimal arithmetic.
  *
  * @param {DecimalValue} a - Value to subtract from

--- a/src/common/helpers/decimal-utils.test.js
+++ b/src/common/helpers/decimal-utils.test.js
@@ -14,6 +14,13 @@ import {
   toNumber
 } from '#common/helpers/decimal-utils.js'
 
+// decimal.js's default export is typed as the Decimal type, not a constructor,
+// so `new DecimalCtor(...)` is not constructable under jsconfig. Cast to the
+// constructor type for instantiation (mirrors decimal-utils.js itself).
+const DecimalCtor = /** @type {import('decimal.js').Decimal.Constructor} */ (
+  Decimal
+)
+
 describe('decimal-utils', () => {
   describe('toDecimal', () => {
     it('should convert a number to Decimal', () => {
@@ -29,7 +36,7 @@ describe('decimal-utils', () => {
     })
 
     it('should return the same Decimal instance if already a Decimal', () => {
-      const decimal = new Decimal(42)
+      const decimal = new DecimalCtor(42)
       const result = toDecimal(decimal)
       expect(result).toBe(decimal)
     })
@@ -73,7 +80,7 @@ describe('decimal-utils', () => {
 
   describe('toNumber', () => {
     it('should convert a Decimal to number', () => {
-      const decimal = new Decimal(42.5)
+      const decimal = new DecimalCtor(42.5)
       const result = toNumber(decimal)
       expect(result).toBe(42.5)
       expect(typeof result).toBe('number')
@@ -100,12 +107,12 @@ describe('decimal-utils', () => {
     })
 
     it('should handle negative numbers', () => {
-      const result = toNumber(new Decimal(-42.5))
+      const result = toNumber(new DecimalCtor(-42.5))
       expect(result).toBe(-42.5)
     })
 
     it('should handle zero', () => {
-      const result = toNumber(new Decimal(0))
+      const result = toNumber(new DecimalCtor(0))
       expect(result).toBe(0)
     })
 
@@ -128,7 +135,7 @@ describe('decimal-utils', () => {
     })
 
     it('should add two Decimals', () => {
-      const result = add(new Decimal(10), new Decimal(5))
+      const result = add(new DecimalCtor(10), new DecimalCtor(5))
       expect(result.toNumber()).toBe(15)
     })
 
@@ -215,7 +222,7 @@ describe('decimal-utils', () => {
     })
 
     it('should subtract two Decimals', () => {
-      const result = subtract(new Decimal(10), new Decimal(5))
+      const result = subtract(new DecimalCtor(10), new DecimalCtor(5))
       expect(result.toNumber()).toBe(5)
     })
 
@@ -260,7 +267,7 @@ describe('decimal-utils', () => {
     })
 
     it('should return true for equal Decimals', () => {
-      expect(equals(new Decimal(10), new Decimal(10))).toBe(true)
+      expect(equals(new DecimalCtor(10), new DecimalCtor(10))).toBe(true)
     })
 
     it('should return true for mixed types with same value', () => {
@@ -313,7 +320,7 @@ describe('decimal-utils', () => {
     })
 
     it('should handle Decimal input', () => {
-      const result = abs(new Decimal(-42.5))
+      const result = abs(new DecimalCtor(-42.5))
       expect(result.toNumber()).toBe(42.5)
     })
 
@@ -342,7 +349,7 @@ describe('decimal-utils', () => {
     })
 
     it('should handle Decimal inputs', () => {
-      expect(greaterThan(new Decimal(10), new Decimal(5))).toBe(true)
+      expect(greaterThan(new DecimalCtor(10), new DecimalCtor(5))).toBe(true)
     })
 
     it('should handle mixed types', () => {
@@ -379,7 +386,7 @@ describe('decimal-utils', () => {
     })
 
     it('should return true for zero Decimal', () => {
-      expect(isZero(new Decimal(0))).toBe(true)
+      expect(isZero(new DecimalCtor(0))).toBe(true)
     })
 
     it('should return false for positive number', () => {
@@ -451,20 +458,20 @@ describe('decimal-utils', () => {
   describe('Decimal configuration', () => {
     it('should use ROUND_HALF_UP rounding mode', () => {
       // Create a calculation that requires rounding
-      const value = new Decimal('2.5')
+      const value = new DecimalCtor('2.5')
       const rounded = value.toDecimalPlaces(0)
       expect(rounded.toNumber()).toBe(3) // ROUND_HALF_UP rounds 2.5 to 3
     })
 
     it('should use ROUND_HALF_UP for negative values', () => {
-      const value = new Decimal('-2.5')
+      const value = new DecimalCtor('-2.5')
       const rounded = value.toDecimalPlaces(0)
       expect(rounded.toNumber()).toBe(-3) // ROUND_HALF_UP rounds -2.5 to -3
     })
 
     it('should support 34 digits precision', () => {
       // Test that we can handle MongoDB Decimal128 precision
-      const value = new Decimal('1.2345678901234567890123456789012345')
+      const value = new DecimalCtor('1.2345678901234567890123456789012345')
       expect(value.toString()).toContain('1.234567890123456789012345678901234')
     })
   })

--- a/src/common/helpers/decimal-utils.test.js
+++ b/src/common/helpers/decimal-utils.test.js
@@ -4,6 +4,7 @@ import { Decimal128 } from 'mongodb'
 import {
   abs,
   add,
+  addRounded,
   equals,
   greaterThan,
   isZero,
@@ -155,6 +156,49 @@ describe('decimal-utils', () => {
     it('should handle very large numbers', () => {
       const result = add('999999999999999999', '1')
       expect(result.toString()).toBe('1000000000000000000')
+    })
+  })
+
+  describe('addRounded', () => {
+    it('should round the value to the given decimal places before adding', () => {
+      // 0.005 rounds half-up to 0.01, then added to the accumulator
+      const result = addRounded(toDecimal(0), '0.005', 2)
+      expect(result).toBeInstanceOf(Decimal)
+      expect(result.toNumber()).toBe(0.01)
+    })
+
+    it('should leave the accumulator untouched when it carries more precision', () => {
+      // value 0.001 rounds to 0.00; the accumulator 0.011 must be preserved
+      const result = addRounded(toDecimal('0.011'), '0.001', 2)
+      expect(result.toNumber()).toBe(0.011)
+    })
+
+    it('should round each value independently so the running total follows round-each-then-sum', () => {
+      let total = toDecimal(0)
+      total = addRounded(total, '1.005', 2)
+      total = addRounded(total, '2.005', 2)
+
+      // round-each-then-sum: 1.01 + 2.01 = 3.02
+      expect(total.toNumber()).toBe(3.02)
+      // sum-then-round would instead give 3.01 - proving the methods diverge
+      expect(roundToTwoDecimalPlaces(add('1.005', '2.005'))).toBe(3.01)
+    })
+
+    it('should support decimal places other than two', () => {
+      // 1.2345 rounds half-up at three decimal places to 1.235
+      const result = addRounded(toDecimal(0), '1.2345', 3)
+      expect(result.toNumber()).toBe(1.235)
+    })
+
+    it('should treat a null value as zero', () => {
+      const result = addRounded(toDecimal('5'), null, 2)
+      expect(result.toNumber()).toBe(5)
+    })
+
+    it('should handle negative values', () => {
+      const result = addRounded(toDecimal('10'), '-2.005', 2)
+      // -2.005 rounds away from zero to -2.01
+      expect(result.toNumber()).toBe(7.99)
     })
   })
 

--- a/src/reports/domain/aggregation/aggregate-waste-exported.js
+++ b/src/reports/domain/aggregation/aggregate-waste-exported.js
@@ -119,6 +119,53 @@ function calculateTonnageReceivedNotExported(
 }
 
 /**
+ * Sum refused, stopped, and refused-or-stopped export tonnages, rounding each
+ * row to 2dp before adding (round-each-then-sum).
+ *
+ * @param {import('#domain/waste-records/model.js').WasteRecord[]} exportedRecords
+ * @returns {{ tonnageRefusedAtDestination: number, tonnageStoppedDuringExport: number, totalTonnageRefusedOrStopped: number }}
+ */
+function calculateRefusedAndStoppedTonnages(exportedRecords) {
+  const { refusedDecimal, stoppedDecimal, refusedOrStoppedDecimal } =
+    exportedRecords.reduce(
+      (acc, { data }) => {
+        const tonnage = toNumber(data.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED)
+        const refused = isYes(data.WAS_THE_WASTE_REFUSED)
+        const stopped = isYes(data.WAS_THE_WASTE_STOPPED)
+        return {
+          refusedDecimal: refused
+            ? addRounded(acc.refusedDecimal, tonnage, TONNAGE_DECIMAL_PLACES)
+            : acc.refusedDecimal,
+          stoppedDecimal: stopped
+            ? addRounded(acc.stoppedDecimal, tonnage, TONNAGE_DECIMAL_PLACES)
+            : acc.stoppedDecimal,
+          refusedOrStoppedDecimal:
+            refused || stopped
+              ? addRounded(
+                  acc.refusedOrStoppedDecimal,
+                  tonnage,
+                  TONNAGE_DECIMAL_PLACES
+                )
+              : acc.refusedOrStoppedDecimal
+        }
+      },
+      {
+        refusedDecimal: toDecimal(0),
+        stoppedDecimal: toDecimal(0),
+        refusedOrStoppedDecimal: toDecimal(0)
+      }
+    )
+
+  return {
+    tonnageRefusedAtDestination: roundToTwoDecimalPlaces(refusedDecimal),
+    tonnageStoppedDuringExport: roundToTwoDecimalPlaces(stoppedDecimal),
+    totalTonnageRefusedOrStopped: roundToTwoDecimalPlaces(
+      refusedOrStoppedDecimal
+    )
+  }
+}
+
+/**
  * @param {object} params
  * @param {import('#domain/waste-records/model.js').WasteRecord[]} params.wasteExportedRecords
  * @param {import('#domain/waste-records/model.js').WasteRecord[]} params.repatriatedRecords
@@ -153,41 +200,11 @@ export function aggregateWasteExported({
   const totalTonnageExported = roundToTwoDecimalPlaces(
     totalTonnageExportedDecimal
   )
-  const { refusedDecimal, stoppedDecimal, refusedOrStoppedDecimal } =
-    exportedRecords.reduce(
-      (acc, { data }) => {
-        const tonnage = toNumber(data.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED)
-        const refused = isYes(data.WAS_THE_WASTE_REFUSED)
-        const stopped = isYes(data.WAS_THE_WASTE_STOPPED)
-        return {
-          refusedDecimal: refused
-            ? addRounded(acc.refusedDecimal, tonnage, TONNAGE_DECIMAL_PLACES)
-            : acc.refusedDecimal,
-          stoppedDecimal: stopped
-            ? addRounded(acc.stoppedDecimal, tonnage, TONNAGE_DECIMAL_PLACES)
-            : acc.stoppedDecimal,
-          refusedOrStoppedDecimal:
-            refused || stopped
-              ? addRounded(
-                  acc.refusedOrStoppedDecimal,
-                  tonnage,
-                  TONNAGE_DECIMAL_PLACES
-                )
-              : acc.refusedOrStoppedDecimal
-        }
-      },
-      {
-        refusedDecimal: toDecimal(0),
-        stoppedDecimal: toDecimal(0),
-        refusedOrStoppedDecimal: toDecimal(0)
-      }
-    )
-
-  const tonnageRefusedAtDestination = roundToTwoDecimalPlaces(refusedDecimal)
-  const tonnageStoppedDuringExport = roundToTwoDecimalPlaces(stoppedDecimal)
-  const totalTonnageRefusedOrStopped = roundToTwoDecimalPlaces(
-    refusedOrStoppedDecimal
-  )
+  const {
+    tonnageRefusedAtDestination,
+    tonnageStoppedDuringExport,
+    totalTonnageRefusedOrStopped
+  } = calculateRefusedAndStoppedTonnages(exportedRecords)
 
   const { overseasSites, unapprovedOverseasSites } =
     generateOverseasSiteSummaries(

--- a/src/reports/domain/aggregation/aggregate-waste-exported.js
+++ b/src/reports/domain/aggregation/aggregate-waste-exported.js
@@ -1,10 +1,10 @@
 import {
-  add,
+  addRounded,
   toDecimal,
   roundToTwoDecimalPlaces,
   toNumber
 } from '#common/helpers/decimal-utils.js'
-import { groupAndSum, isYes } from './helpers.js'
+import { groupAndSum, isYes, TONNAGE_DECIMAL_PLACES } from './helpers.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { isDateInRange } from './filter-records-by-date.js'
 import { isOrsApprovedAtDate } from '#overseas-sites/domain/approval.js'
@@ -86,7 +86,11 @@ function getTonnageRepatriated(repatriatedRecords) {
       .filter(({ type }) => type === WASTE_RECORD_TYPE.EXPORTED)
       .reduce(
         (sum, { data }) =>
-          add(sum, toNumber(data.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED)),
+          addRounded(
+            sum,
+            toNumber(data.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED),
+            TONNAGE_DECIMAL_PLACES
+          ),
         toDecimal(0)
       )
   )
@@ -103,7 +107,12 @@ function calculateTonnageReceivedNotExported(
         ({ data }) => !isDateInRange(data.DATE_OF_EXPORT, startDate, endDate)
       )
       .reduce(
-        (sum, { data }) => add(sum, toNumber(data.TONNAGE_RECEIVED_FOR_EXPORT)),
+        (sum, { data }) =>
+          addRounded(
+            sum,
+            toNumber(data.TONNAGE_RECEIVED_FOR_EXPORT),
+            TONNAGE_DECIMAL_PLACES
+          ),
         toDecimal(0)
       )
   )
@@ -134,7 +143,11 @@ export function aggregateWasteExported({
 
   const totalTonnageExportedDecimal = exportedRecords.reduce(
     (sum, { data }) =>
-      add(sum, toNumber(data.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED)),
+      addRounded(
+        sum,
+        toNumber(data.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED),
+        TONNAGE_DECIMAL_PLACES
+      ),
     toDecimal(0)
   )
   const totalTonnageExported = roundToTwoDecimalPlaces(
@@ -148,14 +161,18 @@ export function aggregateWasteExported({
         const stopped = isYes(data.WAS_THE_WASTE_STOPPED)
         return {
           refusedDecimal: refused
-            ? add(acc.refusedDecimal, tonnage)
+            ? addRounded(acc.refusedDecimal, tonnage, TONNAGE_DECIMAL_PLACES)
             : acc.refusedDecimal,
           stoppedDecimal: stopped
-            ? add(acc.stoppedDecimal, tonnage)
+            ? addRounded(acc.stoppedDecimal, tonnage, TONNAGE_DECIMAL_PLACES)
             : acc.stoppedDecimal,
           refusedOrStoppedDecimal:
             refused || stopped
-              ? add(acc.refusedOrStoppedDecimal, tonnage)
+              ? addRounded(
+                  acc.refusedOrStoppedDecimal,
+                  tonnage,
+                  TONNAGE_DECIMAL_PLACES
+                )
               : acc.refusedOrStoppedDecimal
         }
       },

--- a/src/reports/domain/aggregation/aggregate-waste-received.js
+++ b/src/reports/domain/aggregation/aggregate-waste-received.js
@@ -1,5 +1,5 @@
 import {
-  add,
+  addRounded,
   roundToTwoDecimalPlaces,
   toDecimal,
   toNumber
@@ -7,7 +7,8 @@ import {
 import {
   formatAddress,
   groupAndSum,
-  isTonnageGreaterThanZero
+  isTonnageGreaterThanZero,
+  TONNAGE_DECIMAL_PLACES
 } from './helpers.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
@@ -29,7 +30,8 @@ export function aggregateWasteReceived(wasteReceivedRecords, tonnageField) {
   })
 
   const totalTonnageDecimal = validEntries.reduce(
-    (acc, { data }) => add(acc, data[tonnageField]),
+    (acc, { data }) =>
+      addRounded(acc, data[tonnageField], TONNAGE_DECIMAL_PLACES),
     toDecimal(0)
   )
 

--- a/src/reports/domain/aggregation/aggregate-waste-sent-on.js
+++ b/src/reports/domain/aggregation/aggregate-waste-sent-on.js
@@ -1,5 +1,5 @@
 import {
-  add,
+  addRounded,
   roundToTwoDecimalPlaces,
   toDecimal,
   toNumber
@@ -7,7 +7,8 @@ import {
 import {
   formatAddress,
   groupAndSum,
-  isTonnageGreaterThanZero
+  isTonnageGreaterThanZero,
+  TONNAGE_DECIMAL_PLACES
 } from './helpers.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
@@ -24,11 +25,23 @@ function sumByFacilityType(validEntries) {
     const facilityType = data.FINAL_DESTINATION_FACILITY_TYPE
 
     if (facilityType === 'Reprocessor') {
-      toReprocessorDecimal = add(toReprocessorDecimal, tonnage)
+      toReprocessorDecimal = addRounded(
+        toReprocessorDecimal,
+        tonnage,
+        TONNAGE_DECIMAL_PLACES
+      )
     } else if (facilityType === 'Exporter') {
-      toExporterDecimal = add(toExporterDecimal, tonnage)
+      toExporterDecimal = addRounded(
+        toExporterDecimal,
+        tonnage,
+        TONNAGE_DECIMAL_PLACES
+      )
     } else {
-      toAnotherSiteDecimal = add(toAnotherSiteDecimal, tonnage)
+      toAnotherSiteDecimal = addRounded(
+        toAnotherSiteDecimal,
+        tonnage,
+        TONNAGE_DECIMAL_PLACES
+      )
     }
   }
 

--- a/src/reports/domain/aggregation/exporter.test.js
+++ b/src/reports/domain/aggregation/exporter.test.js
@@ -1,8 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
 import { aggregateReportDetail } from '#root/reports/domain/aggregation/aggregate-report-detail.js'
-import wasteRecordsAccredited from './test-data/exporter-accredited.json'
-import wasteRecordsRegisteredOnly from './test-data/exporter-reg-only.json'
+import wasteRecordsAccreditedJson from './test-data/exporter-accredited.json' with { type: 'json' }
+import wasteRecordsRegisteredOnlyJson from './test-data/exporter-reg-only.json' with { type: 'json' }
+
+const wasteRecordsAccredited =
+  /** @type {import('#domain/waste-records/model.js').WasteRecord[]} */ (
+    /** @type {unknown} */ (wasteRecordsAccreditedJson)
+  )
+const wasteRecordsRegisteredOnly =
+  /** @type {import('#domain/waste-records/model.js').WasteRecord[]} */ (
+    /** @type {unknown} */ (wasteRecordsRegisteredOnlyJson)
+  )
 
 describe('#aggregateReportDetail — EXPORTER accredited monthly January 2026', () => {
   const orsDetailsMap = new Map([

--- a/src/reports/domain/aggregation/exporter.test.js
+++ b/src/reports/domain/aggregation/exporter.test.js
@@ -247,7 +247,7 @@ describe('#aggregateReportDetail — EXPORTER_REGISTERED_ONLY quarterly Q1 2026'
             tonnageReceived: 29.69
           }
         ],
-        totalTonnageReceived: 84.09,
+        totalTonnageReceived: 84.08,
         tonnageRecycled: null,
         tonnageNotRecycled: null
       },
@@ -272,16 +272,16 @@ describe('#aggregateReportDetail — EXPORTER_REGISTERED_ONLY quarterly Q1 2026'
           { orsId: '893', tonnageExported: 1.26 },
           { orsId: '143', tonnageExported: 3.07 }
         ],
-        totalTonnageExported: 10.33,
+        totalTonnageExported: 10.34,
         tonnageReceivedNotExported: null,
-        tonnageRefusedAtDestination: 7.34,
+        tonnageRefusedAtDestination: 7.35,
         tonnageStoppedDuringExport: 6.01,
-        totalTonnageRefusedOrStopped: 10.33,
-        tonnageRepatriated: 10.33
+        totalTonnageRefusedOrStopped: 10.34,
+        tonnageRepatriated: 10.34
       },
       wasteSent: {
         tonnageSentToReprocessor: 0,
-        tonnageSentToExporter: 49.03,
+        tonnageSentToExporter: 49.02,
         tonnageSentToAnotherSite: 0,
         finalDestinations: [
           {

--- a/src/reports/domain/aggregation/helpers.js
+++ b/src/reports/domain/aggregation/helpers.js
@@ -1,4 +1,11 @@
-import { add, isZero, toDecimal } from '#common/helpers/decimal-utils.js'
+import { addRounded, isZero, toDecimal } from '#common/helpers/decimal-utils.js'
+
+/**
+ * Decimal places that report tonnage values are rounded to before summing.
+ * The canonical precision for the round-each-then-sum convention
+ * (ADR 0027/0028), matching the waste balance.
+ */
+export const TONNAGE_DECIMAL_PLACES = 2
 
 /**
  * Returns true when a field value is 'yes' (case-insensitive, trimmed).
@@ -45,9 +52,23 @@ export function groupAndSum(items, getKey, getFields, getTonnage) {
     const tonnage = getTonnage(item)
 
     if (map.has(key)) {
-      map.get(key).tonnageDecimal = add(map.get(key).tonnageDecimal, tonnage)
+      const group = map.get(key)
+      group.tonnageDecimal = addRounded(
+        group.tonnageDecimal,
+        tonnage,
+        TONNAGE_DECIMAL_PLACES
+      )
     } else {
-      map.set(key, { ...getFields(item), tonnageDecimal: toDecimal(tonnage) })
+      // Seed the group from zero so the first row is rounded too, not just
+      // subsequent ones - otherwise single-row groups escape round-each-then-sum.
+      map.set(key, {
+        ...getFields(item),
+        tonnageDecimal: addRounded(
+          toDecimal(0),
+          tonnage,
+          TONNAGE_DECIMAL_PLACES
+        )
+      })
     }
   }
 

--- a/src/reports/domain/aggregation/reprocessor.test.js
+++ b/src/reports/domain/aggregation/reprocessor.test.js
@@ -1,6 +1,15 @@
 import { aggregateReportDetail } from '#root/reports/domain/aggregation/aggregate-report-detail.js'
-import wasteRecordsRegisteredOnly from './test-data/reprocessor-registered-only.json'
-import wasteRecordsAccredited from './test-data/reprocessor-on-input-accredited.json'
+import wasteRecordsRegisteredOnlyJson from './test-data/reprocessor-registered-only.json' with { type: 'json' }
+import wasteRecordsAccreditedJson from './test-data/reprocessor-on-input-accredited.json' with { type: 'json' }
+
+const wasteRecordsRegisteredOnly =
+  /** @type {import('#domain/waste-records/model.js').WasteRecord[]} */ (
+    /** @type {unknown} */ (wasteRecordsRegisteredOnlyJson)
+  )
+const wasteRecordsAccredited =
+  /** @type {import('#domain/waste-records/model.js').WasteRecord[]} */ (
+    /** @type {unknown} */ (wasteRecordsAccreditedJson)
+  )
 
 describe('#aggregateReportDetail — REPROCESSOR_REGISTERED_ONLY quarterly Q1 2026', () => {
   it('aggregates in-period records into the full report detail', () => {

--- a/src/reports/domain/aggregation/reprocessor.test.js
+++ b/src/reports/domain/aggregation/reprocessor.test.js
@@ -53,7 +53,7 @@ describe('#aggregateReportDetail — REPROCESSOR_REGISTERED_ONLY quarterly Q1 20
             tonnageReceived: 14.44
           }
         ],
-        totalTonnageReceived: 52.82,
+        totalTonnageReceived: 52.83,
         tonnageRecycled: null,
         tonnageNotRecycled: null
       },

--- a/src/reports/domain/aggregation/round-each-then-sum.test.js
+++ b/src/reports/domain/aggregation/round-each-then-sum.test.js
@@ -1,0 +1,49 @@
+import { add, roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
+import { groupAndSum } from './helpers.js'
+
+/**
+ * Regression coverage for PAE-1668: report tonnage aggregation must round each
+ * row to 2dp before summing (round-each-then-sum), matching the waste-balance
+ * convention (ADR 0027/0028). The inputs below are chosen so that
+ * sum-then-round and round-each-then-sum produce different totals.
+ *
+ * Per row: 1.005 -> 1.01 and 2.005 -> 2.01 (ROUND_HALF_UP).
+ *   round-each-then-sum: 1.01 + 2.01 = 3.02
+ *   sum-then-round:      round(1.005 + 2.005) = round(3.01) = 3.01
+ *
+ * The standalone accumulators (totals, refused/stopped, repatriated,
+ * sumByFacilityType) are regression-covered end to end by exporter.test.js and
+ * reprocessor.test.js, whose multi-decimal fixtures exercise the same divergence.
+ */
+describe('report aggregation round-each-then-sum (PAE-1668)', () => {
+  it('demonstrates the two methods genuinely diverge for the chosen inputs', () => {
+    expect(roundToTwoDecimalPlaces(add(1.005, 2.005))).toBe(3.01)
+  })
+
+  describe('groupAndSum', () => {
+    it('rounds each row to 2dp before summing within a group', () => {
+      const items = [{ t: 1.005 }, { t: 2.005 }]
+
+      const [group] = groupAndSum(
+        items,
+        () => 'same-key',
+        () => ({ label: 'group' }),
+        (item) => item.t
+      )
+
+      // round-each-then-sum: 1.01 + 2.01 = 3.02 (not 3.01)
+      expect(group.tonnageDecimal.toNumber()).toBe(3.02)
+    })
+
+    it('rounds a single-row group (the seed) to 2dp', () => {
+      const [group] = groupAndSum(
+        [{ t: 1.005 }],
+        () => 'same-key',
+        () => ({}),
+        (item) => item.t
+      )
+
+      expect(group.tonnageDecimal.toNumber()).toBe(1.01)
+    })
+  })
+})


### PR DESCRIPTION
Ticket: [PAE-1668](https://eaflood.atlassian.net/browse/PAE-1668)
## Description

Report tonnage aggregation summed full-precision per-row values and rounded the total once (**sum-then-round**), which diverged from the waste balance — which rounds each per-row value to 2dp and then sums (**round-each-then-sum**), per ADR 0027/0028. The drift meant report tonnage totals did not reconcile with the waste balance for the same set of loads (observed as a ~0.02 t residual in a recent org investigation). This change makes report aggregation round-each-then-sum throughout, so the report path follows the same convention as the waste balance.

## Summary

- Aligns report tonnage aggregation with the waste-balance rounding convention (round each row to 2dp, then sum) — ADR 0027/0028.
- Centralises the discipline in a single generic `addRounded(acc, value, decimalPlaces)` helper rather than scattering `roundToTwoDecimalPlaces` across every accumulator.
- Sub-tonne corrections only (±0.01 per affected total); waste-balance code is unchanged (it was already correct).
- Also fixes an unrelated blocker: `eslint.config.js` double-registered the `import-x` plugin (already provided by `neostandard`), which ESLint 9.39 rejects — this broke `lint` and the pre-commit hook.

## Changes

- `src/common/helpers/decimal-utils.js` — add generic `addRounded(acc, value, decimalPlaces)`: rounds only `value` to `decimalPlaces` before adding to the (already-rounded) accumulator; returns a Decimal so it composes in reduce/loops.
- `src/reports/domain/aggregation/helpers.js` — add `TONNAGE_DECIMAL_PLACES = 2` constant; `groupAndSum` now rounds each row before summing, including the first-item seed (fixes all per-supplier / per-site / per-destination breakdowns).
- `src/reports/domain/aggregation/aggregate-waste-exported.js` — round each row in the exported total, refused/stopped/refusedOrStopped, `getTonnageRepatriated`, and `calculateTonnageReceivedNotExported` accumulators.
- `src/reports/domain/aggregation/aggregate-waste-received.js` — round each row in the received total reduce.
- `src/reports/domain/aggregation/aggregate-waste-sent-on.js` — round each row in `sumByFacilityType`'s three facility-type branches.
- `src/common/helpers/decimal-utils.test.js` — unit tests for `addRounded` (rounds value not accumulator, divergence from sum-then-round, configurable dp, null handling, negatives).
- `src/reports/domain/aggregation/round-each-then-sum.test.js` — new regression test with multi-decimal inputs that diverge between the two methods (1.005 + 2.005 → 3.02 vs 3.01), covering `groupAndSum` and its seed.
- `src/reports/domain/aggregation/exporter.test.js`, `reprocessor.test.js` — update fixture-based expectations to the corrected round-each-then-sum totals (e.g. 84.09 → 84.08, 10.33 → 10.34, 52.82 → 52.83).
- `eslint.config.js` — remove the redundant `import-x` plugin registration (provided by `neostandard`) so ESLint config loads and the pre-commit lint step runs.

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1668]: https://eaflood.atlassian.net/browse/PAE-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ