### PR TITLE
PAE-1677: Return empty WB columns when accreditation is null

### DIFF
--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -286,8 +286,19 @@ describe('streamCsvExport', () => {
   it('builds the ORS context once per registration from the pre-loaded sites map', async () => {
     const validFrom = new Date('2026-01-01')
     const org = baseOrg({
+      accreditations: [
+        {
+          id: 'acc-1',
+          status: 'approved',
+          validFrom: '2026-01-01',
+          validTo: '2026-12-31',
+          statusHistory: []
+        }
+      ],
       registrations: [
         baseRegistration({
+          accreditation: null,
+          accreditationId: 'acc-1',
           overseasSites: {
             '001': { overseasSiteId: 'site-a' }
           }
@@ -645,6 +656,38 @@ describe('streamCsvExport', () => {
     expect(out).toHaveLength(3)
     expect(out[1].trim().split(',')[12]).toBe('9')
     expect(out[2].trim().split(',')[12]).toBe('10')
+  })
+
+  it('emits empty WB columns for an operator with a cancelled accreditation', async () => {
+    const cancelledAccreditation = {
+      id: 'acc-1',
+      status: 'cancelled',
+      accreditationNumber: 'ACC-CAN-1',
+      validFrom: '2026-01-01',
+      validTo: '2026-12-31',
+      statusHistory: []
+    }
+    const org = baseOrg({
+      accreditations: [cancelledAccreditation],
+      registrations: [
+        baseRegistration({ accreditation: null, accreditationId: 'acc-1' })
+      ]
+    })
+    const deps = baseDeps({
+      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
+      wasteRecordsRepository: {
+        findByRegistration: vi
+          .fn()
+          .mockResolvedValue([reprocessorReceivedRecord()])
+      }
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const cells = out[1].trim().split(',')
+    expect(cells[5]).toBe('No') // Accredited
+    expect(cells[9]).toBe('') // Included in Waste Balance
+    expect(cells[10]).toBe('') // Waste Balance Exclusion Reason
+    expect(cells[11]).toBe('') // Waste Balance Tonnage
   })
 
   it('treats a missing accreditation as registered-only', async () => {

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -521,7 +521,9 @@ describe('streamCsvExport', () => {
     const cells = out[1].trim().split(',')
     expect(cells[METADATA_COL_INDEX['Accredited']]).toBe('Yes')
     expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('false')
-    expect(cells[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toContain('OUTSIDE_ACCREDITATION_PERIOD')
+    expect(
+      cells[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]
+    ).toContain('OUTSIDE_ACCREDITATION_PERIOD')
     expect(cells[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe('')
   })
 
@@ -558,7 +560,9 @@ describe('streamCsvExport', () => {
     const cells = out[1].trim().split(',')
     expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('true')
     expect(cells[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toBe('')
-    expect(Number(cells[METADATA_COL_INDEX['Waste Balance Tonnage']])).toBeGreaterThan(0)
+    expect(
+      Number(cells[METADATA_COL_INDEX['Waste Balance Tonnage']])
+    ).toBeGreaterThan(0)
   })
 
   it('reads Accredited "Yes" with the number for a suspended accreditation', async () => {

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -4,6 +4,7 @@ import {
 } from './stream-csv-export.js'
 import {
   METADATA_COLUMNS,
+  METADATA_COL_INDEX,
   OSR_COUNTRY_REVISED,
   OSR_NAME_REVISED,
   buildDataFieldColumns,
@@ -165,10 +166,10 @@ describe('streamCsvExport', () => {
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(2)
     const cells = out[1].trim().split(',')
-    expect(cells[2]).toBe('REG-555') // Registration Number
-    expect(cells[3]).toBe('glass_re_melt') // Material (detailed)
-    expect(cells[5]).toBe('Yes') // Accredited
-    expect(cells[6]).toBe('ACC-777') // Accreditation Number
+    expect(cells[METADATA_COL_INDEX['Registration Number']]).toBe('REG-555')
+    expect(cells[METADATA_COL_INDEX['Material']]).toBe('glass_re_melt')
+    expect(cells[METADATA_COL_INDEX['Accredited']]).toBe('Yes')
+    expect(cells[METADATA_COL_INDEX['Accreditation Number']]).toBe('ACC-777')
   })
 
   it('serialises a numeric data field bare so it is a real number in the CSV', async () => {
@@ -232,9 +233,8 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(2)
-    // The Submitted At column (index 8) is empty and serialises bare
     const cells = out[1].trim().split(',')
-    expect(cells[8]).toBe('')
+    expect(cells[METADATA_COL_INDEX['Submitted At']]).toBe('')
   })
 
   it('processes received, processed, sentOn and exported records on the same registration', async () => {
@@ -350,9 +350,8 @@ describe('streamCsvExport', () => {
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(2)
     expect(deps.overseasSitesRepository.findAll).toHaveBeenCalledTimes(1)
-    // "Included in Waste Balance" is the 10th metadata column (index 9) → true
     const cells = out[1].trim().split(',')
-    expect(cells[9]).toBe('true')
+    expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('true')
   })
 
   it('populates the derived OSR columns from the approved overseas site matched by OSR_ID', async () => {
@@ -485,8 +484,8 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     const cells = out[1].trim().split(',')
-    expect(cells[5]).toBe('Yes') // Accredited column
-    expect(cells[9]).toBe('true')
+    expect(cells[METADATA_COL_INDEX['Accredited']]).toBe('Yes')
+    expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('true')
   })
 
   it('marks accredited exporter row as not included when DATE_OF_EXPORT is outside accreditation period', async () => {
@@ -520,10 +519,10 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     const cells = out[1].trim().split(',')
-    expect(cells[5]).toBe('Yes') // Accredited column
-    expect(cells[9]).toBe('false')
-    expect(cells[10]).toContain('OUTSIDE_ACCREDITATION_PERIOD')
-    expect(cells[11]).toBe('') // Waste Balance Tonnage empty when excluded
+    expect(cells[METADATA_COL_INDEX['Accredited']]).toBe('Yes')
+    expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('false')
+    expect(cells[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toContain('OUTSIDE_ACCREDITATION_PERIOD')
+    expect(cells[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe('')
   })
 
   it('emits empty Waste Balance Exclusion Reason when the record is included', async () => {
@@ -557,9 +556,9 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     const cells = out[1].trim().split(',')
-    expect(cells[9]).toBe('true')
-    expect(cells[10]).toBe('') // Waste Balance Exclusion Reason empty when included
-    expect(Number(cells[11])).toBeGreaterThan(0) // Waste Balance Tonnage populated when included
+    expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('true')
+    expect(cells[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toBe('')
+    expect(Number(cells[METADATA_COL_INDEX['Waste Balance Tonnage']])).toBeGreaterThan(0)
   })
 
   it('reads Accredited "Yes" with the number for a suspended accreditation', async () => {
@@ -588,8 +587,8 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     const cells = out[1].trim().split(',')
-    expect(cells[5]).toBe('Yes') // Accredited
-    expect(cells[6]).toBe('ACC-SUS-1') // Accreditation Number
+    expect(cells[METADATA_COL_INDEX['Accredited']]).toBe('Yes')
+    expect(cells[METADATA_COL_INDEX['Accreditation Number']]).toBe('ACC-SUS-1')
   })
 
   it('iterates organisations and registrations sorted by id for deterministic output', async () => {
@@ -636,9 +635,8 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(3)
-    // Within the same type, lower rowId emits first (Row ID is metadata col 12)
-    expect(out[1].trim().split(',')[12]).toBe('1001')
-    expect(out[2].trim().split(',')[12]).toBe('2002')
+    expect(out[1].trim().split(',')[METADATA_COL_INDEX['Row ID']]).toBe('1001')
+    expect(out[2].trim().split(',')[METADATA_COL_INDEX['Row ID']]).toBe('2002')
   })
 
   it('orders rowIds naturally so "9" comes before "10"', async () => {
@@ -654,8 +652,8 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(3)
-    expect(out[1].trim().split(',')[12]).toBe('9')
-    expect(out[2].trim().split(',')[12]).toBe('10')
+    expect(out[1].trim().split(',')[METADATA_COL_INDEX['Row ID']]).toBe('9')
+    expect(out[2].trim().split(',')[METADATA_COL_INDEX['Row ID']]).toBe('10')
   })
 
   it('emits empty WB columns for an operator with a cancelled accreditation', async () => {
@@ -684,10 +682,10 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     const cells = out[1].trim().split(',')
-    expect(cells[5]).toBe('No') // Accredited
-    expect(cells[9]).toBe('') // Included in Waste Balance
-    expect(cells[10]).toBe('') // Waste Balance Exclusion Reason
-    expect(cells[11]).toBe('') // Waste Balance Tonnage
+    expect(cells[METADATA_COL_INDEX['Accredited']]).toBe('No')
+    expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('')
+    expect(cells[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toBe('')
+    expect(cells[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe('')
   })
 
   it('treats a missing accreditation as registered-only', async () => {
@@ -705,7 +703,7 @@ describe('streamCsvExport', () => {
     const out = await collect(streamCsvExport(deps))
     expect(out).toHaveLength(2)
     const cells = out[1].trim().split(',')
-    expect(cells[5]).toBe('No') // Accredited column
+    expect(cells[METADATA_COL_INDEX['Accredited']]).toBe('No')
   })
 
   it('skips organisations that have no registrations array', async () => {

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -145,7 +145,7 @@ export const buildHeaderRow = (dataFieldColumns) => [
  * @property {Accreditation | null} accreditation
  * @property {WasteRecord} record
  * @property {{ submittedAt: string } | null | undefined} summaryLogEntry
- * @property {WasteBalanceClassification} wasteBalanceClassification
+ * @property {WasteBalanceClassification | null} wasteBalanceClassification
  * @property {Record<string, import('./overseas-sites-context.js').OverseasSiteContextEntry>} [overseasSites]
  * @property {string[]} dataFieldColumns
  */
@@ -193,11 +193,15 @@ export const buildDataRow = ({
     accreditation?.accreditationNumber ?? '',
     record.type,
     summaryLogEntry?.submittedAt ?? '',
-    wasteBalanceClassification.included ? 'true' : 'false',
-    wasteBalanceClassification.reasons
-      .map((r) => (r.field ? `${r.code}: ${r.field}` : r.code))
-      .join('; '),
-    wasteBalanceClassification.tonnage ?? '',
+    wasteBalanceClassification
+      ? String(wasteBalanceClassification.included)
+      : '',
+    wasteBalanceClassification
+      ? wasteBalanceClassification.reasons
+          .map((r) => (r.field ? `${r.code}: ${r.field}` : r.code))
+          .join('; ')
+      : '',
+    wasteBalanceClassification?.tonnage ?? '',
     String(record.rowId),
     orsDetails?.country ?? '',
     orsDetails?.siteName ?? ''

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -142,6 +142,19 @@ export const buildHeaderRow = (dataFieldColumns) => [
   ...dataFieldColumns
 ]
 
+const formatReason = (r) => (r.field ? `${r.code}: ${r.field}` : r.code)
+
+const buildWasteBalanceCells = (classification) => {
+  if (!classification) {
+    return ['', '', '']
+  }
+  return [
+    String(classification.included),
+    classification.reasons.map(formatReason).join('; '),
+    classification.tonnage ?? ''
+  ]
+}
+
 /**
  * @typedef {Object} BuildDataRowInput
  * @property {Organisation} org
@@ -197,15 +210,7 @@ export const buildDataRow = ({
     accreditation?.accreditationNumber ?? '',
     record.type,
     summaryLogEntry?.submittedAt ?? '',
-    wasteBalanceClassification
-      ? String(wasteBalanceClassification.included)
-      : '',
-    wasteBalanceClassification
-      ? wasteBalanceClassification.reasons
-          .map((r) => (r.field ? `${r.code}: ${r.field}` : r.code))
-          .join('; ')
-      : '',
-    wasteBalanceClassification?.tonnage ?? '',
+    ...buildWasteBalanceCells(wasteBalanceClassification),
     String(record.rowId),
     orsDetails?.country ?? '',
     orsDetails?.siteName ?? ''

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -70,6 +70,10 @@ export const METADATA_COLUMNS = Object.freeze([
   OSR_NAME_REVISED
 ])
 
+export const METADATA_COL_INDEX = Object.freeze(
+  Object.fromEntries(METADATA_COLUMNS.map((name, i) => [name, i]))
+)
+
 // Both fields are already rendered in the metadata prefix:
 //   ROW_ID            -> 'Row ID'
 //   processingType    -> 'Operator Processing Type'

--- a/src/waste-records-export/domain/csv-columns.test.js
+++ b/src/waste-records-export/domain/csv-columns.test.js
@@ -358,6 +358,16 @@ describe('csv-columns', () => {
       expect(row[8]).toBe('')
     })
 
+    it('emits empty WB columns when wasteBalanceClassification is null', () => {
+      const row = buildDataRow({
+        ...baseInput,
+        wasteBalanceClassification: null
+      })
+      expect(row[9]).toBe('') // Included in Waste Balance
+      expect(row[10]).toBe('') // Waste Balance Exclusion Reason
+      expect(row[11]).toBe('') // Waste Balance Tonnage
+    })
+
     it('emits waste balance columns from the classification', () => {
       const excluded = buildDataRow({
         ...baseInput,

--- a/src/waste-records-export/domain/csv-columns.test.js
+++ b/src/waste-records-export/domain/csv-columns.test.js
@@ -114,7 +114,8 @@ describe('csv-columns', () => {
 
   describe('buildDataRow', () => {
     const dataFieldColumns = buildDataFieldColumns([])
-    const dataCol = (name) => METADATA_COLUMNS.length + dataFieldColumns.indexOf(name)
+    const dataCol = (name) =>
+      METADATA_COLUMNS.length + dataFieldColumns.indexOf(name)
 
     const userFixture = {
       fullName: 'Test User',
@@ -234,11 +235,15 @@ describe('csv-columns', () => {
       expect(row[METADATA_COL_INDEX['Organisation Name']]).toBe('Acme Ltd')
       expect(row[METADATA_COL_INDEX['Registration Number']]).toBe('REG-001')
       expect(row[METADATA_COL_INDEX['Material']]).toBe('plastic')
-      expect(row[METADATA_COL_INDEX['Operator Processing Type']]).toBe('REPROCESSOR_INPUT')
+      expect(row[METADATA_COL_INDEX['Operator Processing Type']]).toBe(
+        'REPROCESSOR_INPUT'
+      )
       expect(row[METADATA_COL_INDEX['Accredited']]).toBe('Yes')
       expect(row[METADATA_COL_INDEX['Accreditation Number']]).toBe('ACC-001')
       expect(row[METADATA_COL_INDEX['Waste Record Type']]).toBe('received')
-      expect(row[METADATA_COL_INDEX['Submitted At']]).toBe('2026-04-15T09:00:00Z')
+      expect(row[METADATA_COL_INDEX['Submitted At']]).toBe(
+        '2026-04-15T09:00:00Z'
+      )
       expect(row[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('true')
       expect(row[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toBe('')
       expect(row[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe(9)
@@ -370,8 +375,12 @@ describe('csv-columns', () => {
           tonnage: null
         }
       })
-      expect(excluded[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('false')
-      expect(excluded[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toBe('PRN_ISSUED; MISSING_REQUIRED_FIELD: EWC_CODE')
+      expect(excluded[METADATA_COL_INDEX['Included in Waste Balance']]).toBe(
+        'false'
+      )
+      expect(
+        excluded[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]
+      ).toBe('PRN_ISSUED; MISSING_REQUIRED_FIELD: EWC_CODE')
       expect(excluded[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe('')
 
       const included = buildDataRow({
@@ -382,7 +391,9 @@ describe('csv-columns', () => {
           tonnage: -5.25
         }
       })
-      expect(included[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('true')
+      expect(included[METADATA_COL_INDEX['Included in Waste Balance']]).toBe(
+        'true'
+      )
       expect(included[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe(-5.25)
     })
 

--- a/src/waste-records-export/domain/csv-columns.test.js
+++ b/src/waste-records-export/domain/csv-columns.test.js
@@ -1,5 +1,6 @@
 import {
   METADATA_COLUMNS,
+  METADATA_COL_INDEX,
   SCHEMA_FIELD_NAMES,
   OSR_COUNTRY_REVISED,
   OSR_NAME_REVISED,
@@ -113,6 +114,7 @@ describe('csv-columns', () => {
 
   describe('buildDataRow', () => {
     const dataFieldColumns = buildDataFieldColumns([])
+    const dataCol = (name) => METADATA_COLUMNS.length + dataFieldColumns.indexOf(name)
 
     const userFixture = {
       fullName: 'Test User',
@@ -228,19 +230,19 @@ describe('csv-columns', () => {
 
     it('formats the metadata prefix correctly', () => {
       const row = buildDataRow(baseInput)
-      expect(row[0]).toBe('EA') // Regulator
-      expect(row[1]).toBe('Acme Ltd') // Organisation Name
-      expect(row[2]).toBe('REG-001') // Registration Number
-      expect(row[3]).toBe('plastic') // Material
-      expect(row[4]).toBe('REPROCESSOR_INPUT') // Operator Processing Type
-      expect(row[5]).toBe('Yes') // Accredited
-      expect(row[6]).toBe('ACC-001') // Accreditation Number
-      expect(row[7]).toBe('received') // Waste Record Type
-      expect(row[8]).toBe('2026-04-15T09:00:00Z') // Submitted At
-      expect(row[9]).toBe('true') // Included in Waste Balance
-      expect(row[10]).toBe('') // Waste Balance Exclusion Reason
-      expect(row[11]).toBe(9) // Waste Balance Tonnage
-      expect(row[12]).toBe('1001') // Row ID
+      expect(row[METADATA_COL_INDEX['Regulator']]).toBe('EA')
+      expect(row[METADATA_COL_INDEX['Organisation Name']]).toBe('Acme Ltd')
+      expect(row[METADATA_COL_INDEX['Registration Number']]).toBe('REG-001')
+      expect(row[METADATA_COL_INDEX['Material']]).toBe('plastic')
+      expect(row[METADATA_COL_INDEX['Operator Processing Type']]).toBe('REPROCESSOR_INPUT')
+      expect(row[METADATA_COL_INDEX['Accredited']]).toBe('Yes')
+      expect(row[METADATA_COL_INDEX['Accreditation Number']]).toBe('ACC-001')
+      expect(row[METADATA_COL_INDEX['Waste Record Type']]).toBe('received')
+      expect(row[METADATA_COL_INDEX['Submitted At']]).toBe('2026-04-15T09:00:00Z')
+      expect(row[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('true')
+      expect(row[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toBe('')
+      expect(row[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe(9)
+      expect(row[METADATA_COL_INDEX['Row ID']]).toBe('1001')
     })
 
     it('emits the glass recycling process in place of "glass" for the Material column', () => {
@@ -251,7 +253,7 @@ describe('csv-columns', () => {
           glassRecyclingProcess: ['glass_re_melt']
         })
       })
-      expect(row[3]).toBe('glass_re_melt') // Material
+      expect(row[METADATA_COL_INDEX['Material']]).toBe('glass_re_melt')
     })
 
     it('emits an empty Registration Number when the registration has none', () => {
@@ -259,27 +261,23 @@ describe('csv-columns', () => {
         ...baseInput,
         registration: buildReg({ registrationNumber: undefined })
       })
-      expect(row[2]).toBe('')
+      expect(row[METADATA_COL_INDEX['Registration Number']]).toBe('')
     })
 
     it('emits an empty Accreditation Number when the row has no accreditation', () => {
       const row = buildDataRow({ ...baseInput, accreditation: null })
-      expect(row[5]).toBe('No') // Accredited
-      expect(row[6]).toBe('') // Accreditation Number
+      expect(row[METADATA_COL_INDEX['Accredited']]).toBe('No')
+      expect(row[METADATA_COL_INDEX['Accreditation Number']]).toBe('')
     })
 
     it('emits empty string when a data field is absent on the record', () => {
       const row = buildDataRow(baseInput)
-      const containerNumberIdx =
-        METADATA_COLUMNS.length + dataFieldColumns.indexOf('CONTAINER_NUMBER')
-      expect(row[containerNumberIdx]).toBe('')
+      expect(row[dataCol('CONTAINER_NUMBER')]).toBe('')
     })
 
     it('passes a numeric data field through as a real number', () => {
       const row = buildDataRow(baseInput)
-      const grossIdx =
-        METADATA_COLUMNS.length + dataFieldColumns.indexOf('GROSS_WEIGHT')
-      expect(row[grossIdx]).toBe(10)
+      expect(row[dataCol('GROSS_WEIGHT')]).toBe(10)
     })
 
     it('apostrophe-prefixes a string data cell that begins with a formula trigger', () => {
@@ -289,10 +287,7 @@ describe('csv-columns', () => {
           data: { ...recordFixture.data, PRODUCT_DESCRIPTION: '=SUM(A1:A2)' }
         })
       })
-      const idx =
-        METADATA_COLUMNS.length +
-        dataFieldColumns.indexOf('PRODUCT_DESCRIPTION')
-      expect(row[idx]).toBe("'=SUM(A1:A2)")
+      expect(row[dataCol('PRODUCT_DESCRIPTION')]).toBe("'=SUM(A1:A2)")
     })
 
     it.each(['+1', '-1', '@cmd'])(
@@ -304,10 +299,7 @@ describe('csv-columns', () => {
             data: { ...recordFixture.data, PRODUCT_DESCRIPTION: value }
           })
         })
-        const idx =
-          METADATA_COLUMNS.length +
-          dataFieldColumns.indexOf('PRODUCT_DESCRIPTION')
-        expect(row[idx]).toBe(`'${value}`)
+        expect(row[dataCol('PRODUCT_DESCRIPTION')]).toBe(`'${value}`)
       }
     )
 
@@ -316,14 +308,12 @@ describe('csv-columns', () => {
         ...baseInput,
         org: { ...orgFixture, companyDetails: { name: '=cmd|calc' } }
       })
-      expect(row[1]).toBe("'=cmd|calc")
+      expect(row[METADATA_COL_INDEX['Organisation Name']]).toBe("'=cmd|calc")
     })
 
     it('does not prefix a numeric cell even though numbers are not strings', () => {
       const row = buildDataRow(baseInput)
-      const grossIdx =
-        METADATA_COLUMNS.length + dataFieldColumns.indexOf('GROSS_WEIGHT')
-      expect(row[grossIdx]).toBe(10)
+      expect(row[dataCol('GROSS_WEIGHT')]).toBe(10)
     })
 
     it('emits values for runtime-observed columns not in any schema', () => {
@@ -350,12 +340,12 @@ describe('csv-columns', () => {
         ...baseInput,
         accreditation: null
       })
-      expect(row[5]).toBe('No')
+      expect(row[METADATA_COL_INDEX['Accredited']]).toBe('No')
     })
 
     it('emits empty Submitted At when no summary log entry is found', () => {
       const row = buildDataRow({ ...baseInput, summaryLogEntry: null })
-      expect(row[8]).toBe('')
+      expect(row[METADATA_COL_INDEX['Submitted At']]).toBe('')
     })
 
     it('emits empty WB columns when wasteBalanceClassification is null', () => {
@@ -363,9 +353,9 @@ describe('csv-columns', () => {
         ...baseInput,
         wasteBalanceClassification: null
       })
-      expect(row[9]).toBe('') // Included in Waste Balance
-      expect(row[10]).toBe('') // Waste Balance Exclusion Reason
-      expect(row[11]).toBe('') // Waste Balance Tonnage
+      expect(row[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('')
+      expect(row[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toBe('')
+      expect(row[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe('')
     })
 
     it('emits waste balance columns from the classification', () => {
@@ -380,9 +370,9 @@ describe('csv-columns', () => {
           tonnage: null
         }
       })
-      expect(excluded[9]).toBe('false') // Included in Waste Balance
-      expect(excluded[10]).toBe('PRN_ISSUED; MISSING_REQUIRED_FIELD: EWC_CODE') // Exclusion Reason
-      expect(excluded[11]).toBe('') // Waste Balance Tonnage (empty when excluded)
+      expect(excluded[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('false')
+      expect(excluded[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toBe('PRN_ISSUED; MISSING_REQUIRED_FIELD: EWC_CODE')
+      expect(excluded[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe('')
 
       const included = buildDataRow({
         ...baseInput,
@@ -392,8 +382,8 @@ describe('csv-columns', () => {
           tonnage: -5.25
         }
       })
-      expect(included[9]).toBe('true') // Included in Waste Balance
-      expect(included[11]).toBe(-5.25) // Waste Balance Tonnage (numeric, can be negative)
+      expect(included[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('true')
+      expect(included[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe(-5.25)
     })
 
     describe('derived OSR columns', () => {

--- a/src/waste-records-export/domain/is-included-in-waste-balance.js
+++ b/src/waste-records-export/domain/is-included-in-waste-balance.js
@@ -20,13 +20,17 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
  * @param {WasteRecord} record
  * @param {Accreditation | null} accreditation
  * @param {OverseasSitesContext} overseasSites
- * @returns {WasteBalanceClassification}
+ * @returns {WasteBalanceClassification | null} null when waste balance is not applicable (no accreditation)
  */
 export const getWasteBalanceClassification = (
   record,
   accreditation,
   overseasSites
 ) => {
+  if (accreditation === null) {
+    return null
+  }
+
   if (record.excludedFromWasteBalance) {
     return { included: false, reasons: [], tonnage: null }
   }

--- a/src/waste-records-export/domain/is-included-in-waste-balance.test.js
+++ b/src/waste-records-export/domain/is-included-in-waste-balance.test.js
@@ -68,6 +68,16 @@ const prnIssuedExporterRecord = buildWasteRecord({
 })
 
 describe('getWasteBalanceClassification', () => {
+  it('returns null when accreditation is null (e.g. cancelled or reg-only)', () => {
+    const record = buildWasteRecord({
+      type: WASTE_RECORD_TYPE.RECEIVED,
+      data: { processingType: PROCESSING_TYPES.REPROCESSOR_INPUT }
+    })
+    expect(
+      getWasteBalanceClassification(record, null, ORS_VALIDATION_DISABLED)
+    ).toBeNull()
+  })
+
   it('returns included:false and empty reasons when record is manually excluded', () => {
     const record = buildWasteRecord({
       type: WASTE_RECORD_TYPE.RECEIVED,
@@ -124,7 +134,8 @@ describe('getWasteBalanceClassification', () => {
       accreditation,
       ORS_VALIDATION_DISABLED
     )
-    expect(result.included).toBe(false)
-    expect(result.reasons).toContainEqual({ code: 'PRN_ISSUED' })
+    expect(result).not.toBeNull()
+    expect(result?.included).toBe(false)
+    expect(result?.reasons).toContainEqual({ code: 'PRN_ISSUED' })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1677](https://eaflood.atlassian.net/browse/PAE-1677)
- Fix waste record export showing WB column values for operators with cancelled accreditations or reg-only processing types
- Short-circuit `getWasteBalanceClassification` to return null when `accreditation === null`, avoiding incorrect INCLUDED classification
- Render Included in Waste Balance, Waste Balance Exclusion Reason, and Waste Balance Tonnage as empty when classification is null
- Add unit and integration tests covering cancelled accreditation and null classification scenarios

[PAE-1677]: https://eaflood.atlassian.net/browse/PAE-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ