### PR TITLE
PAE-1669: Add startup diagnostic for duplicate waste-balance events

### DIFF
--- a/src/server/run-waste-balance-duplicate-events-report.js
+++ b/src/server/run-waste-balance-duplicate-events-report.js
@@ -13,7 +13,10 @@ const formatFinding = (group) => {
   const identity = Object.entries(group._id)
     .map(([field, value]) => `${field}=${value}`)
     .join(' ')
-  return `Duplicate waste-balance event: ${identity} count=${group.count} numbers=[${group.numbers.join(',')}]`
+  const createdAt = group.createdAt
+    .map((/** @type {Date} */ at) => new Date(at).toISOString())
+    .join(',')
+  return `Duplicate waste-balance event: ${identity} count=${group.count} numbers=[${group.numbers.join(',')}] createdAt=[${createdAt}]`
 }
 
 /**

--- a/src/server/run-waste-balance-duplicate-events-report.js
+++ b/src/server/run-waste-balance-duplicate-events-report.js
@@ -1,0 +1,72 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import { findDuplicateBusinessEvents } from '#waste-balances/monitoring/duplicate-business-events.js'
+import { WASTE_BALANCE_EVENTS_COLLECTION_NAME } from '#waste-balances/repository/stream-mongodb.js'
+
+/** @import { Document } from 'mongodb' */
+
+const LOCK_NAME = 'waste-balance-duplicate-events-report'
+
+/**
+ * @param {Document} group - a {@link import('#waste-balances/monitoring/duplicate-business-events.js').DuplicateGroup}
+ */
+const formatFinding = (group) => {
+  const identity = Object.entries(group._id)
+    .map(([field, value]) => `${field}=${value}`)
+    .join(' ')
+  return `Duplicate waste-balance event: ${identity} count=${group.count} numbers=[${group.numbers.join(',')}]`
+}
+
+/**
+ * @param {Object} server - Hapi server instance
+ */
+const runReport = async (server) => {
+  const collection = server.db.collection(WASTE_BALANCE_EVENTS_COLLECTION_NAME)
+  const { prn, summaryLog } = await findDuplicateBusinessEvents(collection)
+
+  for (const group of [...prn, ...summaryLog]) {
+    logger.info({ message: formatFinding(group) })
+  }
+
+  logger.info({
+    message: `Waste-balance duplicate events report: prnDuplicates=${prn.length} summaryLogDuplicates=${summaryLog.length}`
+  })
+}
+
+/**
+ * One-shot startup diagnostic that scans the waste-balance event stream for
+ * duplicate business events — two events written for a single action, the
+ * signature of the pre-optimistic-concurrency append path. Each duplicate group
+ * is logged on its own line, followed by a single summary line. Everything is
+ * logged at info: these are findings to read and confirm, not failures to alarm
+ * on, so info keeps them queryable without tripping the warn/error OpenSearch
+ * alerts. There is no pass/fail gate and no remediation.
+ *
+ * This is the sanctioned route to production data — there is no ad-hoc
+ * production query. Read-only, safe under live traffic. Runs under a
+ * cross-instance lock so a single pod per deploy executes the scan; the
+ * aggregations run server-side so only the duplicate groups are returned.
+ *
+ * @param {Object} server - Hapi server instance
+ */
+export const runWasteBalanceDuplicateEventsReport = async (server) => {
+  try {
+    const lock = await server.locker.lock(LOCK_NAME)
+    if (!lock) {
+      logger.info({
+        message:
+          'Unable to obtain lock, skipping waste-balance duplicate events report'
+      })
+      return
+    }
+    try {
+      await runReport(server)
+    } finally {
+      await lock.free()
+    }
+  } catch (error) {
+    logger.error({
+      err: error,
+      message: 'Failed to run waste-balance duplicate events report'
+    })
+  }
+}

--- a/src/server/run-waste-balance-duplicate-events-report.test.js
+++ b/src/server/run-waste-balance-duplicate-events-report.test.js
@@ -96,7 +96,11 @@ describe('runWasteBalanceDuplicateEventsReport', () => {
             kind: 'prn-created'
           },
           count: 2,
-          numbers: [1, 2]
+          numbers: [1, 2],
+          createdAt: [
+            new Date('2026-01-15T10:00:00.000Z'),
+            new Date('2026-01-15T10:00:00.050Z')
+          ]
         }
       ]
     })
@@ -106,7 +110,7 @@ describe('runWasteBalanceDuplicateEventsReport', () => {
     expect(logger.warn).not.toHaveBeenCalled()
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Duplicate waste-balance event: registrationId=reg-1 accreditationId=acc-1 prnId=prn-1 kind=prn-created count=2 numbers=[1,2]'
+        'Duplicate waste-balance event: registrationId=reg-1 accreditationId=acc-1 prnId=prn-1 kind=prn-created count=2 numbers=[1,2] createdAt=[2026-01-15T10:00:00.000Z,2026-01-15T10:00:00.050Z]'
     })
     expect(logger.info).toHaveBeenCalledWith({
       message:
@@ -124,7 +128,12 @@ describe('runWasteBalanceDuplicateEventsReport', () => {
             summaryLogId: 'log-1'
           },
           count: 3,
-          numbers: [1, 2, 3]
+          numbers: [1, 2, 3],
+          createdAt: [
+            new Date('2026-01-15T10:00:00.000Z'),
+            new Date('2026-01-15T10:00:00.020Z'),
+            new Date('2026-01-15T10:00:00.040Z')
+          ]
         }
       ]
     })
@@ -133,7 +142,7 @@ describe('runWasteBalanceDuplicateEventsReport', () => {
 
     expect(logger.info).toHaveBeenCalledWith({
       message:
-        'Duplicate waste-balance event: registrationId=reg-1 accreditationId=null summaryLogId=log-1 count=3 numbers=[1,2,3]'
+        'Duplicate waste-balance event: registrationId=reg-1 accreditationId=null summaryLogId=log-1 count=3 numbers=[1,2,3] createdAt=[2026-01-15T10:00:00.000Z,2026-01-15T10:00:00.020Z,2026-01-15T10:00:00.040Z]'
     })
     expect(logger.info).toHaveBeenCalledWith({
       message:

--- a/src/server/run-waste-balance-duplicate-events-report.test.js
+++ b/src/server/run-waste-balance-duplicate-events-report.test.js
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { logger } from '#common/helpers/logging/logger.js'
+import { findDuplicateBusinessEvents } from '#waste-balances/monitoring/duplicate-business-events.js'
+
+import { runWasteBalanceDuplicateEventsReport } from './run-waste-balance-duplicate-events-report.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+vi.mock('#waste-balances/monitoring/duplicate-business-events.js', () => ({
+  findDuplicateBusinessEvents: vi.fn()
+}))
+
+/**
+ * @param {{ prn?: import('mongodb').Document[], summaryLog?: import('mongodb').Document[] }} [findings]
+ */
+const seedFindings = ({ prn = [], summaryLog = [] } = {}) => {
+  vi.mocked(findDuplicateBusinessEvents).mockResolvedValue({ prn, summaryLog })
+}
+
+describe('runWasteBalanceDuplicateEventsReport', () => {
+  let mockServer
+  let mockLock
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockLock = { free: vi.fn().mockResolvedValue(undefined) }
+    mockServer = {
+      db: { collection: vi.fn().mockReturnValue({}) },
+      locker: {
+        lock: vi.fn().mockResolvedValue(mockLock)
+      }
+    }
+  })
+
+  it('acquires a lock scoped to the report and releases it afterwards', async () => {
+    seedFindings()
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(mockServer.locker.lock).toHaveBeenCalledWith(
+      'waste-balance-duplicate-events-report'
+    )
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('reads the waste-balance-events collection', async () => {
+    seedFindings()
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(mockServer.db.collection).toHaveBeenCalledWith(
+      'waste-balance-events'
+    )
+  })
+
+  it('skips the report when the lock is held by another instance', async () => {
+    mockServer.locker.lock.mockResolvedValue(null)
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(findDuplicateBusinessEvents).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Unable to obtain lock, skipping waste-balance duplicate events report'
+    })
+  })
+
+  it('logs a zero-duplicate summary for a clean stream', async () => {
+    seedFindings()
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledTimes(1)
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-balance duplicate events report: prnDuplicates=0 summaryLogDuplicates=0'
+    })
+  })
+
+  it('logs a PRN duplicate finding at info with its identity, count and slot numbers', async () => {
+    seedFindings({
+      prn: [
+        {
+          _id: {
+            registrationId: 'reg-1',
+            accreditationId: 'acc-1',
+            prnId: 'prn-1',
+            kind: 'prn-created'
+          },
+          count: 2,
+          numbers: [1, 2]
+        }
+      ]
+    })
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Duplicate waste-balance event: registrationId=reg-1 accreditationId=acc-1 prnId=prn-1 kind=prn-created count=2 numbers=[1,2]'
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-balance duplicate events report: prnDuplicates=1 summaryLogDuplicates=0'
+    })
+  })
+
+  it('logs a summary-log duplicate finding for a registered-only (null accreditation) partition', async () => {
+    seedFindings({
+      summaryLog: [
+        {
+          _id: {
+            registrationId: 'reg-1',
+            accreditationId: null,
+            summaryLogId: 'log-1'
+          },
+          count: 3,
+          numbers: [1, 2, 3]
+        }
+      ]
+    })
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Duplicate waste-balance event: registrationId=reg-1 accreditationId=null summaryLogId=log-1 count=3 numbers=[1,2,3]'
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-balance duplicate events report: prnDuplicates=0 summaryLogDuplicates=1'
+    })
+  })
+
+  it('releases the lock and logs an error when the scan throws', async () => {
+    const error = new Error('mongo unavailable')
+    vi.mocked(findDuplicateBusinessEvents).mockRejectedValue(error)
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run waste-balance duplicate events report'
+    })
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('tolerates the locker itself throwing', async () => {
+    const error = new Error('locker unavailable')
+    mockServer.locker.lock.mockRejectedValue(error)
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run waste-balance duplicate events report'
+    })
+  })
+})

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -44,6 +44,7 @@ import { runFormsDataMigration } from '#server/run-forms-data-migration.js'
 import { copyFormFilesToS3 } from '#server/copy-form-files-to-s3.js'
 import { runOrganisationValidationSweep } from '#server/run-organisation-validation-sweep.js'
 import { runDuplicateAccreditationLinkMigration } from '#server/run-duplicate-accreditation-link-migration.js'
+import { runWasteBalanceDuplicateEventsReport } from '#server/run-waste-balance-duplicate-events-report.js'
 
 /** @import { Lifecycle } from '@hapi/hapi' */
 
@@ -224,6 +225,7 @@ async function createServer(options = {}) {
     copyFormFilesToS3(server)
     runOrganisationValidationSweep(server)
     runDuplicateAccreditationLinkMigration(server)
+    runWasteBalanceDuplicateEventsReport(server)
   })
 
   return server

--- a/src/waste-balances/monitoring/duplicate-business-events.js
+++ b/src/waste-balances/monitoring/duplicate-business-events.js
@@ -20,9 +20,8 @@ const DUPLICATE_THRESHOLD = 1
  * @typedef {Object} DuplicateGroup
  * @property {Record<string, string | null>} _id - the business identity that repeated
  * @property {number} count - how many slots carry that identity
- * @property {number[]} numbers - the partition slot numbers of the repeated events
- * @property {import('mongodb').ObjectId[]} eventIds - storage ids, to locate each event
- * @property {Date[]} createdAt - when each duplicate was written
+ * @property {number[]} numbers - the partition slot numbers of the repeated events, which (with the identity) locate them
+ * @property {Date[]} createdAt - when each duplicate was written; near-simultaneous times confirm one action written twice
  */
 
 const groupByIdentityStages = (
@@ -33,7 +32,6 @@ const groupByIdentityStages = (
       _id: identity,
       count: { $sum: 1 },
       numbers: { $push: '$number' },
-      eventIds: { $push: '$_id' },
       createdAt: { $push: '$createdAt' }
     }
   },
@@ -81,15 +79,20 @@ export const duplicateSummaryLogEventsPipeline = () => [
  * findings for review. That is the sanctioned route to production data — there
  * is no ad-hoc production query.
  *
+ * `allowDiskUse` is set because the stream grows without bound and the `$group`
+ * must accumulate every distinct identity before the count filter — the peak
+ * would otherwise risk the in-memory aggregation limit on a large collection.
+ *
  * Each result row has the shape of a {@link DuplicateGroup}.
  *
  * @param {Pick<import('mongodb').Collection, 'aggregate'>} collection - the waste-balance-events collection
  * @returns {Promise<{ prn: import('mongodb').Document[], summaryLog: import('mongodb').Document[] }>}
  */
 export const findDuplicateBusinessEvents = async (collection) => {
+  const options = { allowDiskUse: true }
   const [prn, summaryLog] = await Promise.all([
-    collection.aggregate(duplicatePrnEventsPipeline()).toArray(),
-    collection.aggregate(duplicateSummaryLogEventsPipeline()).toArray()
+    collection.aggregate(duplicatePrnEventsPipeline(), options).toArray(),
+    collection.aggregate(duplicateSummaryLogEventsPipeline(), options).toArray()
   ])
   return { prn, summaryLog }
 }

--- a/src/waste-balances/monitoring/duplicate-business-events.js
+++ b/src/waste-balances/monitoring/duplicate-business-events.js
@@ -72,11 +72,14 @@ export const duplicateSummaryLogEventsPipeline = () => [
 /**
  * Read-only sweep of the waste-balance event stream for duplicate business
  * events — the signature of the pre-optimistic-concurrency append path writing
- * two events for one action. Runs both pipelines against the given collection.
+ * two events for one action. Runs both pipelines against the given collection
+ * and returns the flagged groups. The aggregations run server-side, so only the
+ * duplicate groups come back rather than the whole collection.
  *
- * To run through the CDP terminal (`/query-cdp-mongodb`), paste each pipeline
- * into mongosh:
- *   db.getCollection("waste-balance-events").aggregate(<pipeline>)
+ * The startup diagnostic `run-waste-balance-duplicate-events-report` is the
+ * caller: it runs this against each environment's live data and logs the
+ * findings for review. That is the sanctioned route to production data — there
+ * is no ad-hoc production query.
  *
  * Each result row has the shape of a {@link DuplicateGroup}.
  *

--- a/src/waste-balances/monitoring/duplicate-business-events.js
+++ b/src/waste-balances/monitoring/duplicate-business-events.js
@@ -1,0 +1,92 @@
+import {
+  PRN_KINDS,
+  STREAM_EVENT_KIND
+} from '#waste-balances/repository/stream-schema.js'
+
+/**
+ * A business event should occupy exactly one slot in its partition: the PRN
+ * status machine is an acyclic DAG with terminal states, so each `(prnId, kind)`
+ * arises at most once, and a summary-log submission carries a distinct id. More
+ * than one slot for the same business identity is a duplicate — two events
+ * written for a single action.
+ */
+const DUPLICATE_THRESHOLD = 1
+
+/**
+ * Shape of each aggregation result row (documentation of what the pipelines
+ * produce — aggregation output is dynamically typed, so the functions return
+ * the driver's `Document`).
+ *
+ * @typedef {Object} DuplicateGroup
+ * @property {Record<string, string | null>} _id - the business identity that repeated
+ * @property {number} count - how many slots carry that identity
+ * @property {number[]} numbers - the partition slot numbers of the repeated events
+ * @property {import('mongodb').ObjectId[]} eventIds - storage ids, to locate each event
+ * @property {Date[]} createdAt - when each duplicate was written
+ */
+
+const groupByIdentityStages = (
+  /** @type {Record<string, string>} */ identity
+) => [
+  {
+    $group: {
+      _id: identity,
+      count: { $sum: 1 },
+      numbers: { $push: '$number' },
+      eventIds: { $push: '$_id' },
+      createdAt: { $push: '$createdAt' }
+    }
+  },
+  { $match: { count: { $gt: DUPLICATE_THRESHOLD } } },
+  { $sort: { count: -1 } }
+]
+
+/**
+ * Aggregation pipeline flagging PRN business events (`prn-created`, `prn-issued`,
+ * …) that occupy more than one slot for the same
+ * `(registrationId, accreditationId, prnId, kind)`.
+ */
+export const duplicatePrnEventsPipeline = () => [
+  { $match: { kind: { $in: [...PRN_KINDS] } } },
+  ...groupByIdentityStages({
+    registrationId: '$registrationId',
+    accreditationId: '$accreditationId',
+    prnId: '$payload.prnId',
+    kind: '$kind'
+  })
+]
+
+/**
+ * Aggregation pipeline flagging summary-log submissions that occupy more than
+ * one slot for the same `(registrationId, accreditationId, summaryLogId)`.
+ */
+export const duplicateSummaryLogEventsPipeline = () => [
+  { $match: { kind: STREAM_EVENT_KIND.SUMMARY_LOG_SUBMITTED } },
+  ...groupByIdentityStages({
+    registrationId: '$registrationId',
+    accreditationId: '$accreditationId',
+    summaryLogId: '$payload.summaryLogId'
+  })
+]
+
+/**
+ * Read-only sweep of the waste-balance event stream for duplicate business
+ * events — the signature of the pre-optimistic-concurrency append path writing
+ * two events for one action. Runs both pipelines against the given collection.
+ *
+ * To run through the CDP terminal (`/query-cdp-mongodb`), paste each pipeline
+ * into mongosh:
+ *   db.getCollection("waste-balance-events").aggregate(<pipeline>)
+ *
+ * Each result row has the shape of a {@link DuplicateGroup}.
+ *
+ * @param {Pick<import('mongodb').Collection, 'aggregate'>} collection - the waste-balance-events collection
+ * @returns {Promise<{ prn: import('mongodb').Document[], summaryLog: import('mongodb').Document[] }>}
+ */
+export const findDuplicateBusinessEvents = async (collection) => {
+  const [prn, summaryLog] = await Promise.all([
+    collection.aggregate(duplicatePrnEventsPipeline()).toArray(),
+    collection.aggregate(duplicateSummaryLogEventsPipeline()).toArray()
+  ])
+  return { prn, summaryLog }
+}

--- a/src/waste-balances/monitoring/duplicate-business-events.test.js
+++ b/src/waste-balances/monitoring/duplicate-business-events.test.js
@@ -1,0 +1,191 @@
+import { describe, beforeEach, expect } from 'vitest'
+import { it as mongoIt } from '#vite/fixtures/mongo.js'
+import { MongoClient } from 'mongodb'
+
+import {
+  ensureStreamCollection,
+  WASTE_BALANCE_EVENTS_COLLECTION_NAME
+} from '#waste-balances/repository/stream-mongodb.js'
+import {
+  buildStreamEvent,
+  buildPrnCreatedEvent,
+  buildPrnIssuedEvent
+} from '#waste-balances/repository/stream-test-data.js'
+
+import { findDuplicateBusinessEvents } from './duplicate-business-events.js'
+
+const DATABASE_NAME = 'epr-backend'
+
+const it = mongoIt.extend({
+  mongoClient: async (/** @type {*} */ { db }, use) => {
+    const client = await MongoClient.connect(db)
+    await use(client)
+    await client.close()
+  },
+
+  streamCollection: async (/** @type {*} */ { mongoClient }, use) => {
+    const database = mongoClient.db(DATABASE_NAME)
+    await ensureStreamCollection(database)
+    await use(database.collection(WASTE_BALANCE_EVENTS_COLLECTION_NAME))
+  }
+})
+
+describe('findDuplicateBusinessEvents', () => {
+  beforeEach(async (/** @type {*} */ { streamCollection }) => {
+    await streamCollection.deleteMany({})
+  })
+
+  it('flags a PRN business event that appears more than once in a partition', async (/** @type {*} */ {
+    streamCollection
+  }) => {
+    await streamCollection.insertMany([
+      buildPrnCreatedEvent({
+        number: 1,
+        payload: { prnId: 'prn-1', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        number: 2,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    ])
+
+    const { prn } = await findDuplicateBusinessEvents(streamCollection)
+
+    expect(prn).toHaveLength(1)
+    expect(prn[0]._id).toEqual({
+      registrationId: 'reg-1',
+      accreditationId: 'acc-1',
+      prnId: 'prn-1',
+      kind: 'prn-created'
+    })
+    expect(prn[0].count).toBe(2)
+    expect(prn[0].numbers).toEqual([1, 2])
+  })
+
+  it('does not flag a single occurrence of a PRN business event', async (/** @type {*} */ {
+    streamCollection
+  }) => {
+    await streamCollection.insertOne(
+      buildPrnCreatedEvent({
+        number: 1,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    )
+
+    const { prn } = await findDuplicateBusinessEvents(streamCollection)
+
+    expect(prn).toHaveLength(0)
+  })
+
+  it('does not conflate different lifecycle kinds for the same PRN', async (/** @type {*} */ {
+    streamCollection
+  }) => {
+    await streamCollection.insertMany([
+      buildPrnCreatedEvent({
+        number: 1,
+        payload: { prnId: 'prn-1', amount: 50 }
+      }),
+      buildPrnIssuedEvent({
+        number: 2,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    ])
+
+    const { prn } = await findDuplicateBusinessEvents(streamCollection)
+
+    expect(prn).toHaveLength(0)
+  })
+
+  it('flags a summary-log submission that appears more than once in a partition', async (/** @type {*} */ {
+    streamCollection
+  }) => {
+    await streamCollection.insertMany([
+      buildStreamEvent({
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      }),
+      buildStreamEvent({
+        number: 2,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      })
+    ])
+
+    const { summaryLog } = await findDuplicateBusinessEvents(streamCollection)
+
+    expect(summaryLog).toHaveLength(1)
+    expect(summaryLog[0]._id).toEqual({
+      registrationId: 'reg-1',
+      accreditationId: 'acc-1',
+      summaryLogId: 'log-1'
+    })
+    expect(summaryLog[0].count).toBe(2)
+  })
+
+  it('flags duplicate summary-log submissions in a registered-only (null accreditation) partition', async (/** @type {*} */ {
+    streamCollection
+  }) => {
+    await streamCollection.insertMany([
+      buildStreamEvent({
+        accreditationId: null,
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      }),
+      buildStreamEvent({
+        accreditationId: null,
+        number: 2,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      })
+    ])
+
+    const { summaryLog } = await findDuplicateBusinessEvents(streamCollection)
+
+    expect(summaryLog).toHaveLength(1)
+    expect(summaryLog[0]._id.accreditationId).toBeNull()
+  })
+
+  it('does not flag the same summary-log id across different partitions', async (/** @type {*} */ {
+    streamCollection
+  }) => {
+    await streamCollection.insertMany([
+      buildStreamEvent({
+        registrationId: 'reg-1',
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      }),
+      buildStreamEvent({
+        registrationId: 'reg-2',
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      })
+    ])
+
+    const { summaryLog } = await findDuplicateBusinessEvents(streamCollection)
+
+    expect(summaryLog).toHaveLength(0)
+  })
+
+  it('returns no findings for a clean stream', async (/** @type {*} */ {
+    streamCollection
+  }) => {
+    await streamCollection.insertMany([
+      buildStreamEvent({
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      }),
+      buildPrnCreatedEvent({
+        number: 2,
+        payload: { prnId: 'prn-1', amount: 50 }
+      }),
+      buildPrnIssuedEvent({
+        number: 3,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    ])
+
+    const { prn, summaryLog } =
+      await findDuplicateBusinessEvents(streamCollection)
+
+    expect(prn).toHaveLength(0)
+    expect(summaryLog).toHaveLength(0)
+  })
+})

--- a/src/waste-balances/monitoring/duplicate-business-events.test.js
+++ b/src/waste-balances/monitoring/duplicate-business-events.test.js
@@ -96,6 +96,59 @@ describe('findDuplicateBusinessEvents', () => {
     expect(prn).toHaveLength(0)
   })
 
+  it('does not flag the same PRN event kind across different partitions', async (/** @type {*} */ {
+    streamCollection
+  }) => {
+    await streamCollection.insertMany([
+      buildPrnCreatedEvent({
+        registrationId: 'reg-1',
+        number: 1,
+        payload: { prnId: 'prn-1', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        registrationId: 'reg-2',
+        number: 1,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    ])
+
+    const { prn } = await findDuplicateBusinessEvents(streamCollection)
+
+    expect(prn).toHaveLength(0)
+  })
+
+  it('sorts findings by descending count so the worst duplication surfaces first', async (/** @type {*} */ {
+    streamCollection
+  }) => {
+    await streamCollection.insertMany([
+      buildPrnCreatedEvent({
+        number: 1,
+        payload: { prnId: 'prn-twice', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        number: 2,
+        payload: { prnId: 'prn-twice', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        number: 3,
+        payload: { prnId: 'prn-thrice', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        number: 4,
+        payload: { prnId: 'prn-thrice', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        number: 5,
+        payload: { prnId: 'prn-thrice', amount: 50 }
+      })
+    ])
+
+    const { prn } = await findDuplicateBusinessEvents(streamCollection)
+
+    expect(prn.map((group) => group.count)).toEqual([3, 2])
+    expect(prn[0]._id.prnId).toBe('prn-thrice')
+  })
+
   it('flags a summary-log submission that appears more than once in a partition', async (/** @type {*} */ {
     streamCollection
   }) => {

--- a/src/waste-balances/repository/stream-schema.js
+++ b/src/waste-balances/repository/stream-schema.js
@@ -16,7 +16,7 @@ export const STREAM_EVENT_KIND = Object.freeze({
 
 const kindValues = Object.values(STREAM_EVENT_KIND)
 
-const PRN_KINDS = new Set([
+export const PRN_KINDS = new Set([
   STREAM_EVENT_KIND.PRN_CREATED,
   STREAM_EVENT_KIND.PRN_ISSUED,
   STREAM_EVENT_KIND.PRN_CREATION_CANCELLED,


### PR DESCRIPTION
Ticket: [PAE-1669](https://eaflood.atlassian.net/browse/PAE-1669)
Adds a read-only startup diagnostic that detects duplicate business events in the waste-balance event stream — two events written for a single action. This is the signature of the pre-optimistic-concurrency append path: before the OCC work on this ticket, two writers processing the same action could each chain onto the head they read and both commit at a distinct slot. The now-unique `partition_number` index prevents this going forward, so any duplicate that exists is a clean pre-fix signature worth surfacing for review.

Detection runs as two server-side aggregations over `waste-balance-events`: PRN events grouped by `(registrationId, accreditationId, payload.prnId, kind)`, and summary-log submissions by `(registrationId, accreditationId, payload.summaryLogId)`, flagging any business identity carrying more than one event. Business identity is the only reliable detector — the two duplicate events differ on both their slot number and their storage `_id`, so neither identifies the duplication. Each `(prnId, kind)` legitimately occurs at most once because the PRN status machine is acyclic with terminal states, so a count above one is genuine corruption rather than a normal recurrence.

The diagnostic is delivered as an on-startup report following the existing `run-*.js` pattern (organisation validation sweep and siblings): it runs once per deploy under a cross-instance lock, and logs each duplicate group plus a summary line at info so findings stay queryable without tripping the warn/error log alerts. Running on startup is deliberate — there is no ad-hoc production database query available, so a locked, logged startup scan is the sanctioned route to production data. It is read-only with no remediation and no pass/fail gate; the logged findings are read and confirmed by a human. `allowDiskUse` guards the aggregation because the stream grows without bound. Each finding logs the partition identity, the slot numbers and the event timestamps, where near-simultaneous times confirm one action was written twice.

`PRN_KINDS` is now exported from the stream schema so the diagnostic reuses the canonical kind list rather than re-listing it.


[PAE-1669]: https://eaflood.atlassian.net/browse/PAE-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ