### PR TITLE
PAE-1684: derive OSR_COUNTRY_REVISED/OSR_NAME_REVISED export columns

### DIFF
--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -69,7 +69,7 @@ const encodeRow = async (cells) => {
  * @param {Organisation} input.org
  * @param {Registration} input.registration
  * @param {import('#domain/organisations/accreditation.js').Accreditation | null} input.accreditation
- * @param {Record<string, { validFrom: Date | null }>} input.overseasSites
+ * @param {Record<string, import('../domain/overseas-sites-context.js').OverseasSiteContextEntry>} input.overseasSites
  * @param {Map<string, { submittedAt: string }>} input.summaryLogMap
  * @param {WasteRecord} input.record
  * @param {string[]} input.dataFieldColumns
@@ -101,6 +101,7 @@ const rowForRecord = ({
       accreditation,
       overseasSites
     ),
+    overseasSites,
     dataFieldColumns
   })
 }

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -4,6 +4,8 @@ import {
 } from './stream-csv-export.js'
 import {
   METADATA_COLUMNS,
+  OSR_COUNTRY_REVISED,
+  OSR_NAME_REVISED,
   buildDataFieldColumns,
   buildHeaderRow
 } from '../domain/csv-columns.js'
@@ -340,6 +342,66 @@ describe('streamCsvExport', () => {
     // "Included in Waste Balance" is the 10th metadata column (index 9) → true
     const cells = out[1].trim().split(',')
     expect(cells[9]).toBe('true')
+  })
+
+  it('populates the derived OSR columns from the approved overseas site matched by OSR_ID', async () => {
+    const org = baseOrg({
+      registrations: [
+        baseRegistration({
+          overseasSites: { '001': { overseasSiteId: 'site-a' } }
+        })
+      ]
+    })
+    const exportedRecord = {
+      type: WASTE_RECORD_TYPE.EXPORTED,
+      rowId: '4001',
+      data: {
+        processingType: PROCESSING_TYPES.EXPORTER,
+        OSR_ID: '001',
+        DATE_OF_EXPORT: '2026-03-01'
+      },
+      versions: [{ summaryLog: { id: 'sl-1' } }]
+    }
+    const deps = baseDeps({
+      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
+      wasteRecordsRepository: {
+        findByRegistration: vi.fn().mockResolvedValue([exportedRecord])
+      },
+      overseasSitesRepository: {
+        findAll: vi.fn().mockResolvedValue([
+          {
+            id: 'site-a',
+            validFrom: new Date('2026-01-01'),
+            name: 'Acme Recycling',
+            country: 'Germany'
+          }
+        ])
+      }
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const header = buildHeaderRow(buildDataFieldColumns([]))
+    const cells = out[1].trim().split(',')
+    expect(cells[header.indexOf(OSR_COUNTRY_REVISED)]).toBe('Germany')
+    expect(cells[header.indexOf(OSR_NAME_REVISED)]).toBe('Acme Recycling')
+  })
+
+  it('leaves the derived OSR columns blank for a reprocessor row with no OSR_ID', async () => {
+    const org = baseOrg({ registrations: [baseRegistration()] })
+    const deps = baseDeps({
+      organisationsRepository: { findAll: vi.fn().mockResolvedValue([org]) },
+      wasteRecordsRepository: {
+        findByRegistration: vi
+          .fn()
+          .mockResolvedValue([reprocessorReceivedRecord()])
+      }
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const header = buildHeaderRow(buildDataFieldColumns([]))
+    const cells = out[1].trim().split(',')
+    expect(cells[header.indexOf(OSR_COUNTRY_REVISED)]).toBe('')
+    expect(cells[header.indexOf(OSR_NAME_REVISED)]).toBe('')
   })
 
   const exporterAccreditation = {

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -28,20 +28,14 @@ const ORS_ID_DIGITS = 3
  */
 const zeroPadOrsId = (orsId) => String(orsId).padStart(ORS_ID_DIGITS, '0')
 
+/**
+ * Derived export columns computed from the approved overseas-sites data
+ * (looked up by the record's OSR_ID) rather than from the unreliable
+ * user-entered summary-log values. Emitted as part of the metadata prefix
+ * (see `METADATA_COLUMNS`), the same way as the waste-balance columns.
+ */
 export const OSR_COUNTRY_REVISED = 'OSR_COUNTRY_REVISED'
 export const OSR_NAME_REVISED = 'OSR_NAME_REVISED'
-
-/**
- * Export-only columns derived from the approved overseas-sites data (looked up
- * by the record's OSR_ID) rather than from the unreliable user-entered
- * summary-log values. Appended after the dynamic data-field columns. The order
- * here defines the column order and must match the derived cells emitted by
- * `buildDataRow`.
- */
-export const DERIVED_OSR_COLUMNS = Object.freeze([
-  OSR_COUNTRY_REVISED,
-  OSR_NAME_REVISED
-])
 
 /**
  * Prefix a string cell that opens with =, +, - or @ with an apostrophe so
@@ -69,7 +63,9 @@ export const METADATA_COLUMNS = Object.freeze([
   'Included in Waste Balance',
   'Waste Balance Exclusion Reason',
   'Waste Balance Tonnage',
-  'Row ID'
+  'Row ID',
+  OSR_COUNTRY_REVISED,
+  OSR_NAME_REVISED
 ])
 
 // Both fields are already rendered in the metadata prefix:
@@ -129,16 +125,15 @@ export const buildDataFieldColumns = (observedKeys) => {
 }
 
 /**
- * Compose the full header row from the dynamic data-field columns, with the
- * derived OSR columns appended at the far right.
+ * Compose the full header row from the fixed metadata prefix and the dynamic
+ * data-field columns.
  *
  * @param {string[]} dataFieldColumns
  * @returns {string[]}
  */
 export const buildHeaderRow = (dataFieldColumns) => [
   ...METADATA_COLUMNS,
-  ...dataFieldColumns,
-  ...DERIVED_OSR_COLUMNS
+  ...dataFieldColumns
 ]
 
 /**
@@ -155,14 +150,16 @@ export const buildHeaderRow = (dataFieldColumns) => [
 
 /**
  * Build a single CSV data row in the same column order as
- * `[...METADATA_COLUMNS, ...dataFieldColumns, ...DERIVED_OSR_COLUMNS]`.
- * Numeric data cells stay numbers so they serialise unquoted; string cells
- * are formula-injection sanitised.
+ * `[...METADATA_COLUMNS, ...dataFieldColumns]`. Numeric data cells stay
+ * numbers so they serialise unquoted; string cells are formula-injection
+ * sanitised.
  *
- * The derived OSR columns are looked up from the approved overseas-sites
- * context by the record's OSR_ID. They are blank when the record has no
- * OSR_ID or no matching approved site is found — which also leaves them blank
- * for reprocessor rows, whose registrations carry no overseas sites.
+ * The derived OSR columns (OSR_COUNTRY_REVISED / OSR_NAME_REVISED) sit at the
+ * end of the metadata prefix and are looked up from the approved
+ * overseas-sites context by the record's OSR_ID. They are blank when the
+ * record has no OSR_ID or no matching approved site is found — which also
+ * leaves them blank for reprocessor rows, whose registrations carry no
+ * overseas sites.
  *
  * @param {BuildDataRowInput} input
  * @returns {(string | number)[]}
@@ -180,6 +177,10 @@ export const buildDataRow = ({
   const accredited = accreditation !== null ? 'Yes' : 'No'
   const data = record.data
 
+  const orsDetails = data.OSR_ID
+    ? overseasSites?.[zeroPadOrsId(data.OSR_ID)]
+    : undefined
+
   const metadata = [
     uppercaseString(registration.submittedToRegulator),
     org.companyDetails.name,
@@ -195,7 +196,9 @@ export const buildDataRow = ({
       .map((r) => (r.field ? `${r.code}: ${r.field}` : r.code))
       .join('; '),
     wasteBalanceClassification.tonnage ?? '',
-    String(record.rowId)
+    String(record.rowId),
+    orsDetails?.country ?? '',
+    orsDetails?.siteName ?? ''
   ]
 
   const dataCells = dataFieldColumns.map((field) => {
@@ -203,12 +206,5 @@ export const buildDataRow = ({
     return value === null || value === undefined ? '' : value
   })
 
-  const orsDetails = data.OSR_ID
-    ? overseasSites?.[zeroPadOrsId(data.OSR_ID)]
-    : undefined
-  const derivedCells = [orsDetails?.country ?? '', orsDetails?.siteName ?? '']
-
-  return [...metadata, ...dataCells, ...derivedCells].map(
-    sanitiseFormulaInjection
-  )
+  return [...metadata, ...dataCells].map(sanitiseFormulaInjection)
 }

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -32,10 +32,12 @@ const zeroPadOrsId = (orsId) => String(orsId).padStart(ORS_ID_DIGITS, '0')
  * Derived export columns computed from the approved overseas-sites data
  * (looked up by the record's OSR_ID) rather than from the unreliable
  * user-entered summary-log values. Emitted as part of the metadata prefix
- * (see `METADATA_COLUMNS`), the same way as the waste-balance columns.
+ * (see `METADATA_COLUMNS`), the same way as the waste-balance columns — hence
+ * the spaced, Title Case headers that distinguish them from the
+ * SCREAMING_SNAKE data-field columns.
  */
-export const OSR_COUNTRY_REVISED = 'OSR_COUNTRY_REVISED'
-export const OSR_NAME_REVISED = 'OSR_NAME_REVISED'
+export const OSR_COUNTRY_REVISED = 'OSR Country Revised'
+export const OSR_NAME_REVISED = 'OSR Name Revised'
 
 /**
  * Prefix a string cell that opens with =, +, - or @ with an apostrophe so

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -16,6 +16,33 @@ import * as shared from '#domain/summary-logs/table-schemas/shared/fields.js'
 
 const FORMULA_INJECTION_PREFIX = /^[=+\-@]/
 
+const ORS_ID_DIGITS = 3
+
+/**
+ * Zero-pad an OSR_ID to the 3-digit form used as the overseas-sites context
+ * key (e.g. `1` -> `'001'`). Mirrors the report aggregation lookup so both
+ * paths resolve the same site for a given record.
+ *
+ * @param {string | number} orsId
+ * @returns {string}
+ */
+const zeroPadOrsId = (orsId) => String(orsId).padStart(ORS_ID_DIGITS, '0')
+
+export const OSR_COUNTRY_REVISED = 'OSR_COUNTRY_REVISED'
+export const OSR_NAME_REVISED = 'OSR_NAME_REVISED'
+
+/**
+ * Export-only columns derived from the approved overseas-sites data (looked up
+ * by the record's OSR_ID) rather than from the unreliable user-entered
+ * summary-log values. Appended after the dynamic data-field columns. The order
+ * here defines the column order and must match the derived cells emitted by
+ * `buildDataRow`.
+ */
+export const DERIVED_OSR_COLUMNS = Object.freeze([
+  OSR_COUNTRY_REVISED,
+  OSR_NAME_REVISED
+])
+
 /**
  * Prefix a string cell that opens with =, +, - or @ with an apostrophe so
  * spreadsheet software treats it as literal text rather than a formula.
@@ -102,14 +129,16 @@ export const buildDataFieldColumns = (observedKeys) => {
 }
 
 /**
- * Compose the full header row from the dynamic data-field columns.
+ * Compose the full header row from the dynamic data-field columns, with the
+ * derived OSR columns appended at the far right.
  *
  * @param {string[]} dataFieldColumns
  * @returns {string[]}
  */
 export const buildHeaderRow = (dataFieldColumns) => [
   ...METADATA_COLUMNS,
-  ...dataFieldColumns
+  ...dataFieldColumns,
+  ...DERIVED_OSR_COLUMNS
 ]
 
 /**
@@ -120,14 +149,20 @@ export const buildHeaderRow = (dataFieldColumns) => [
  * @property {WasteRecord} record
  * @property {{ submittedAt: string } | null | undefined} summaryLogEntry
  * @property {WasteBalanceClassification} wasteBalanceClassification
+ * @property {Record<string, import('./overseas-sites-context.js').OverseasSiteContextEntry>} [overseasSites]
  * @property {string[]} dataFieldColumns
  */
 
 /**
  * Build a single CSV data row in the same column order as
- * `[...METADATA_COLUMNS, ...dataFieldColumns]`. Numeric data cells stay
- * numbers so they serialise unquoted; string cells are formula-injection
- * sanitised.
+ * `[...METADATA_COLUMNS, ...dataFieldColumns, ...DERIVED_OSR_COLUMNS]`.
+ * Numeric data cells stay numbers so they serialise unquoted; string cells
+ * are formula-injection sanitised.
+ *
+ * The derived OSR columns are looked up from the approved overseas-sites
+ * context by the record's OSR_ID. They are blank when the record has no
+ * OSR_ID or no matching approved site is found — which also leaves them blank
+ * for reprocessor rows, whose registrations carry no overseas sites.
  *
  * @param {BuildDataRowInput} input
  * @returns {(string | number)[]}
@@ -139,6 +174,7 @@ export const buildDataRow = ({
   record,
   summaryLogEntry,
   wasteBalanceClassification,
+  overseasSites,
   dataFieldColumns
 }) => {
   const accredited = accreditation !== null ? 'Yes' : 'No'
@@ -167,5 +203,12 @@ export const buildDataRow = ({
     return value === null || value === undefined ? '' : value
   })
 
-  return [...metadata, ...dataCells].map(sanitiseFormulaInjection)
+  const orsDetails = data.OSR_ID
+    ? overseasSites?.[zeroPadOrsId(data.OSR_ID)]
+    : undefined
+  const derivedCells = [orsDetails?.country ?? '', orsDetails?.siteName ?? '']
+
+  return [...metadata, ...dataCells, ...derivedCells].map(
+    sanitiseFormulaInjection
+  )
 }

--- a/src/waste-records-export/domain/csv-columns.test.js
+++ b/src/waste-records-export/domain/csv-columns.test.js
@@ -32,8 +32,8 @@ describe('csv-columns', () => {
         'Waste Balance Exclusion Reason',
         'Waste Balance Tonnage',
         'Row ID',
-        'OSR_COUNTRY_REVISED',
-        'OSR_NAME_REVISED'
+        'OSR Country Revised',
+        'OSR Name Revised'
       ])
     })
 

--- a/src/waste-records-export/domain/csv-columns.test.js
+++ b/src/waste-records-export/domain/csv-columns.test.js
@@ -1,7 +1,6 @@
 import {
   METADATA_COLUMNS,
   SCHEMA_FIELD_NAMES,
-  DERIVED_OSR_COLUMNS,
   OSR_COUNTRY_REVISED,
   OSR_NAME_REVISED,
   buildDataFieldColumns,
@@ -32,7 +31,16 @@ describe('csv-columns', () => {
         'Included in Waste Balance',
         'Waste Balance Exclusion Reason',
         'Waste Balance Tonnage',
-        'Row ID'
+        'Row ID',
+        'OSR_COUNTRY_REVISED',
+        'OSR_NAME_REVISED'
+      ])
+    })
+
+    it('ends with the derived OSR columns', () => {
+      expect(METADATA_COLUMNS.slice(-2)).toEqual([
+        OSR_COUNTRY_REVISED,
+        OSR_NAME_REVISED
       ])
     })
   })
@@ -93,19 +101,13 @@ describe('csv-columns', () => {
   })
 
   describe('buildHeaderRow', () => {
-    it('returns metadata columns, the supplied data field columns, then the derived OSR columns', () => {
+    it('returns the metadata columns followed by the supplied data field columns', () => {
       const dataFieldColumns = ['ALPHA', 'BETA']
       expect(buildHeaderRow(dataFieldColumns)).toEqual([
         ...METADATA_COLUMNS,
         'ALPHA',
-        'BETA',
-        ...DERIVED_OSR_COLUMNS
+        'BETA'
       ])
-    })
-
-    it('appends OSR_COUNTRY_REVISED then OSR_NAME_REVISED as the final columns', () => {
-      const header = buildHeaderRow([])
-      expect(header.slice(-2)).toEqual([OSR_COUNTRY_REVISED, OSR_NAME_REVISED])
     })
   })
 
@@ -219,13 +221,9 @@ describe('csv-columns', () => {
       dataFieldColumns
     }
 
-    it('produces a row whose length matches metadata + dataFieldColumns + derived OSR columns', () => {
+    it('produces a row whose length matches metadata + dataFieldColumns', () => {
       const row = buildDataRow(baseInput)
-      expect(row.length).toBe(
-        METADATA_COLUMNS.length +
-          dataFieldColumns.length +
-          DERIVED_OSR_COLUMNS.length
-      )
+      expect(row.length).toBe(METADATA_COLUMNS.length + dataFieldColumns.length)
     })
 
     it('formats the metadata prefix correctly', () => {
@@ -389,11 +387,8 @@ describe('csv-columns', () => {
     })
 
     describe('derived OSR columns', () => {
-      const derivedBase = METADATA_COLUMNS.length + dataFieldColumns.length
-      const countryIdx =
-        derivedBase + DERIVED_OSR_COLUMNS.indexOf(OSR_COUNTRY_REVISED)
-      const nameIdx =
-        derivedBase + DERIVED_OSR_COLUMNS.indexOf(OSR_NAME_REVISED)
+      const countryIdx = METADATA_COLUMNS.indexOf(OSR_COUNTRY_REVISED)
+      const nameIdx = METADATA_COLUMNS.indexOf(OSR_NAME_REVISED)
 
       const overseasSites = {
         '001': {

--- a/src/waste-records-export/domain/csv-columns.test.js
+++ b/src/waste-records-export/domain/csv-columns.test.js
@@ -1,6 +1,9 @@
 import {
   METADATA_COLUMNS,
   SCHEMA_FIELD_NAMES,
+  DERIVED_OSR_COLUMNS,
+  OSR_COUNTRY_REVISED,
+  OSR_NAME_REVISED,
   buildDataFieldColumns,
   buildHeaderRow,
   buildDataRow
@@ -90,13 +93,19 @@ describe('csv-columns', () => {
   })
 
   describe('buildHeaderRow', () => {
-    it('returns metadata columns followed by the supplied data field columns', () => {
+    it('returns metadata columns, the supplied data field columns, then the derived OSR columns', () => {
       const dataFieldColumns = ['ALPHA', 'BETA']
       expect(buildHeaderRow(dataFieldColumns)).toEqual([
         ...METADATA_COLUMNS,
         'ALPHA',
-        'BETA'
+        'BETA',
+        ...DERIVED_OSR_COLUMNS
       ])
+    })
+
+    it('appends OSR_COUNTRY_REVISED then OSR_NAME_REVISED as the final columns', () => {
+      const header = buildHeaderRow([])
+      expect(header.slice(-2)).toEqual([OSR_COUNTRY_REVISED, OSR_NAME_REVISED])
     })
   })
 
@@ -210,9 +219,13 @@ describe('csv-columns', () => {
       dataFieldColumns
     }
 
-    it('produces a row whose length matches metadata + dataFieldColumns', () => {
+    it('produces a row whose length matches metadata + dataFieldColumns + derived OSR columns', () => {
       const row = buildDataRow(baseInput)
-      expect(row.length).toBe(METADATA_COLUMNS.length + dataFieldColumns.length)
+      expect(row.length).toBe(
+        METADATA_COLUMNS.length +
+          dataFieldColumns.length +
+          DERIVED_OSR_COLUMNS.length
+      )
     })
 
     it('formats the metadata prefix correctly', () => {
@@ -373,6 +386,87 @@ describe('csv-columns', () => {
       })
       expect(included[9]).toBe('true') // Included in Waste Balance
       expect(included[11]).toBe(-5.25) // Waste Balance Tonnage (numeric, can be negative)
+    })
+
+    describe('derived OSR columns', () => {
+      const derivedBase = METADATA_COLUMNS.length + dataFieldColumns.length
+      const countryIdx =
+        derivedBase + DERIVED_OSR_COLUMNS.indexOf(OSR_COUNTRY_REVISED)
+      const nameIdx =
+        derivedBase + DERIVED_OSR_COLUMNS.indexOf(OSR_NAME_REVISED)
+
+      const overseasSites = {
+        '001': {
+          validFrom: new Date('2026-01-01'),
+          siteName: 'Acme Recycling',
+          country: 'Germany'
+        }
+      }
+
+      it('populates OSR_COUNTRY_REVISED and OSR_NAME_REVISED from the site matched by OSR_ID', () => {
+        const row = buildDataRow({
+          ...baseInput,
+          record: buildRecord({
+            data: { ...recordFixture.data, OSR_ID: '001' }
+          }),
+          overseasSites
+        })
+        expect(row[countryIdx]).toBe('Germany')
+        expect(row[nameIdx]).toBe('Acme Recycling')
+      })
+
+      it('zero-pads OSR_ID before looking up the approved site', () => {
+        const row = buildDataRow({
+          ...baseInput,
+          record: buildRecord({ data: { ...recordFixture.data, OSR_ID: 1 } }),
+          overseasSites
+        })
+        expect(row[countryIdx]).toBe('Germany')
+        expect(row[nameIdx]).toBe('Acme Recycling')
+      })
+
+      it('leaves both derived columns blank when the record has no OSR_ID', () => {
+        const row = buildDataRow({ ...baseInput, overseasSites })
+        expect(row[countryIdx]).toBe('')
+        expect(row[nameIdx]).toBe('')
+      })
+
+      it('leaves both derived columns blank when OSR_ID has no matching approved site', () => {
+        const row = buildDataRow({
+          ...baseInput,
+          record: buildRecord({
+            data: { ...recordFixture.data, OSR_ID: '999' }
+          }),
+          overseasSites
+        })
+        expect(row[countryIdx]).toBe('')
+        expect(row[nameIdx]).toBe('')
+      })
+
+      it('leaves both derived columns blank when the matched site has null name and country', () => {
+        const row = buildDataRow({
+          ...baseInput,
+          record: buildRecord({
+            data: { ...recordFixture.data, OSR_ID: '001' }
+          }),
+          overseasSites: {
+            '001': { validFrom: null, siteName: null, country: null }
+          }
+        })
+        expect(row[countryIdx]).toBe('')
+        expect(row[nameIdx]).toBe('')
+      })
+
+      it('leaves both derived columns blank when no overseas-sites context is supplied', () => {
+        const row = buildDataRow({
+          ...baseInput,
+          record: buildRecord({
+            data: { ...recordFixture.data, OSR_ID: '001' }
+          })
+        })
+        expect(row[countryIdx]).toBe('')
+        expect(row[nameIdx]).toBe('')
+      })
     })
   })
 })

--- a/src/waste-records-export/domain/overseas-sites-context.js
+++ b/src/waste-records-export/domain/overseas-sites-context.js
@@ -1,26 +1,39 @@
 /** @import {OverseasSite} from '#overseas-sites/repository/port.js' */
 
 /**
+ * @typedef {Object} OverseasSiteContextEntry
+ * @property {Date | null} validFrom - Approval date used by classifyForWasteBalance.
+ * @property {string | null} siteName - Approved site name (for OSR_NAME_REVISED).
+ * @property {string | null} country - Destination country (for OSR_COUNTRY_REVISED).
+ */
+
+/**
  * Builds an ORS context map for a single registration from a pre-loaded
  * sites-by-id Map. The returned object is keyed by the 3-digit OSR key
  * (as stored on the registration) and contains the validFrom date used
- * by classifyForWasteBalance.
+ * by classifyForWasteBalance, along with the approved site name and
+ * destination country used to populate the derived OSR_NAME_REVISED /
+ * OSR_COUNTRY_REVISED export columns.
  *
  * Pure function — no IO. Use after pre-loading all sites once via
  * `overseasSitesRepository.findAll()`.
  *
  * @param {{ overseasSites?: Record<string, { overseasSiteId: string }> | null }} registration
  * @param {Map<string, OverseasSite>} sitesById
- * @returns {Record<string, { validFrom: Date | null }>}
+ * @returns {Record<string, OverseasSiteContextEntry>}
  */
 export const buildOverseasSitesContext = (registration, sitesById) => {
   const entries = Object.entries(registration?.overseasSites ?? {})
 
-  /** @type {Record<string, { validFrom: Date | null }>} */
+  /** @type {Record<string, OverseasSiteContextEntry>} */
   const context = {}
   for (const [osrKey, { overseasSiteId }] of entries) {
     const site = sitesById.get(overseasSiteId)
-    context[osrKey] = { validFrom: site?.validFrom ?? null }
+    context[osrKey] = {
+      validFrom: site?.validFrom ?? null,
+      siteName: site?.name ?? null,
+      country: site?.country ?? null
+    }
   }
   return context
 }

--- a/src/waste-records-export/domain/overseas-sites-context.test.js
+++ b/src/waste-records-export/domain/overseas-sites-context.test.js
@@ -13,7 +13,7 @@ describe('buildOverseasSitesContext', () => {
     expect(buildOverseasSitesContext(registration, sitesById)).toEqual({})
   })
 
-  it('builds a context map keyed by 3-digit OSR key with validFrom values', () => {
+  it('builds a context map keyed by 3-digit OSR key with validFrom, site name and country', () => {
     const registration = {
       overseasSites: {
         '001': { overseasSiteId: 'site-a' },
@@ -21,16 +21,36 @@ describe('buildOverseasSitesContext', () => {
       }
     }
     const sitesById = new Map([
-      ['site-a', { id: 'site-a', validFrom: new Date('2026-01-01') }],
-      ['site-b', { id: 'site-b', validFrom: null }]
+      [
+        'site-a',
+        {
+          id: 'site-a',
+          validFrom: new Date('2026-01-01'),
+          name: 'Acme Recycling',
+          country: 'Germany'
+        }
+      ],
+      [
+        'site-b',
+        {
+          id: 'site-b',
+          validFrom: null,
+          name: 'Beta Sorting',
+          country: 'India'
+        }
+      ]
     ])
     expect(buildOverseasSitesContext(registration, sitesById)).toEqual({
-      '001': { validFrom: new Date('2026-01-01') },
-      '042': { validFrom: null }
+      '001': {
+        validFrom: new Date('2026-01-01'),
+        siteName: 'Acme Recycling',
+        country: 'Germany'
+      },
+      '042': { validFrom: null, siteName: 'Beta Sorting', country: 'India' }
     })
   })
 
-  it('emits validFrom: null when the referenced site is missing from the map', () => {
+  it('emits null validFrom, siteName and country when the referenced site is missing from the map', () => {
     const registration = {
       overseasSites: {
         '001': { overseasSiteId: 'site-missing' }
@@ -38,7 +58,7 @@ describe('buildOverseasSitesContext', () => {
     }
     const sitesById = new Map()
     expect(buildOverseasSitesContext(registration, sitesById)).toEqual({
-      '001': { validFrom: null }
+      '001': { validFrom: null, siteName: null, country: null }
     })
   })
 })

--- a/src/waste-records-export/domain/overseas-sites-context.test.js
+++ b/src/waste-records-export/domain/overseas-sites-context.test.js
@@ -1,5 +1,20 @@
 import { buildOverseasSitesContext } from './overseas-sites-context.js'
 
+/** @import {OverseasSite} from '#overseas-sites/repository/port.js' */
+
+/**
+ * @param {Partial<OverseasSite> & { id: string }} overrides
+ * @returns {OverseasSite}
+ */
+const buildSite = (overrides) => ({
+  name: 'Default Site',
+  address: { line1: '1 Test Street', townOrCity: 'Testville' },
+  country: 'Testland',
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  ...overrides
+})
+
 describe('buildOverseasSitesContext', () => {
   it('returns an empty object when registration has no overseasSites', () => {
     const registration = { overseasSites: null }
@@ -23,21 +38,17 @@ describe('buildOverseasSitesContext', () => {
     const sitesById = new Map([
       [
         'site-a',
-        {
+        buildSite({
           id: 'site-a',
           validFrom: new Date('2026-01-01'),
           name: 'Acme Recycling',
           country: 'Germany'
-        }
+        })
       ],
+      // site-b has no validFrom, so the context should surface validFrom: null
       [
         'site-b',
-        {
-          id: 'site-b',
-          validFrom: null,
-          name: 'Beta Sorting',
-          country: 'India'
-        }
+        buildSite({ id: 'site-b', name: 'Beta Sorting', country: 'India' })
       ]
     ])
     expect(buildOverseasSitesContext(registration, sitesById)).toEqual({


### PR DESCRIPTION
Ticket: [PAE-1684](https://eaflood.atlassian.net/browse/PAE-1684)
## Summary

- The user-entered `OSR_COUNTRY` and `OSR_NAME` values in the waste records export are unreliable (~7k blank `OSR_COUNTRY` in ~317k rows for the 11 Jun 2026 export), which blocks answering an FOI request about destination countries.
- Adds two derived columns, **`OSR Country Revised`** and **`OSR Name Revised`**, looked up from the approved overseas-sites data by each record's `OSR_ID` (zero-padded, scoped to the registration).
- Populated for exporter rows only; blank when `OSR_ID` is unset or has no matching approved site. The existing `OSR_COUNTRY` / `OSR_NAME` columns are left untouched.

## Design notes

- The two columns are **derived**, not raw `record.data`, so they are emitted as part of the fixed metadata prefix (`METADATA_COLUMNS`) with computed cells — the same mechanism as the existing `Waste Balance Exclusion Reason` column. `dataFieldColumns` stays a pure `record.data[field]` passthrough.
- They use spaced, Title Case headers (`OSR Country Revised` / `OSR Name Revised`) to match the other metadata-prefix headers and visually distinguish them from the SCREAMING_SNAKE data-field columns. The exported constants keep their `OSR_COUNTRY_REVISED` / `OSR_NAME_REVISED` identifiers.
- Placed at the end of the metadata prefix (after `Row ID`), so existing column positions are unaffected.

## Changes

- **`domain/overseas-sites-context.js`** — extend `buildOverseasSitesContext` so each entry also carries `siteName` and `country` (new `OverseasSiteContextEntry` typedef). The waste-balance classifier only reads `validFrom`, so the wider object stays compatible with `OverseasSitesContext`; the shared type is unchanged.
- **`domain/csv-columns.js`** — add the `OSR_COUNTRY_REVISED` / `OSR_NAME_REVISED` header constants to `METADATA_COLUMNS`, a `zeroPadOrsId` helper (mirroring the report aggregation), and populate the cells in `buildDataRow` via the per-registration overseas-sites context. Derived cells go through the same formula-injection sanitiser as every other cell.
- **`application/stream-csv-export.js`** — pass the already-built per-registration overseas-sites context into `buildDataRow`.
- **Tests** — update `overseas-sites-context.test.js` and `csv-columns.test.js` for the new context shape and columns, add a `derived OSR columns` block (matched / zero-padded / no `OSR_ID` / unmatched / null-site / no-context), and add two end-to-end cases in `stream-csv-export.test.js` (exporter row populated from DB; reprocessor row blank).

## Note

The Jira AC currently names only `OSR_COUNTRY_REVISED`; the OSR name column is added per the ticket title ("... osr country & osr name ...") and is expected to be added to the AC shortly.


[PAE-1684]: https://eaflood.atlassian.net/browse/PAE-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ