### PR TITLE
PAE-1686: Guard summary log submit against period closure

### DIFF
--- a/src/application/summary-logs/submit.integration.test.js
+++ b/src/application/summary-logs/submit.integration.test.js
@@ -24,7 +24,7 @@ import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
 import { createInMemoryRowStateRepository } from '#waste-records/repository/inmemory.js'
 import { createMockLogger } from '#test/mock-logger.js'
-import { createMockWasteBalancesRepository } from '#test/mock-repositories.js'
+import { createMockWasteBalanceService } from '#test/mock-repositories.js'
 import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 
 const VALID_FROM = '2025-01-01'
@@ -127,7 +127,7 @@ const setupSubmit = async ({ reportsRepository, createdAt }) => {
     organisationsRepository,
     wasteRecordsRepository,
     wasteRecordStatesRepository: createInMemoryRowStateRepository()(),
-    wasteBalancesRepository: createMockWasteBalancesRepository(),
+    wasteBalanceService: createMockWasteBalanceService(),
     featureFlags: createInMemoryFeatureFlags(),
     summaryLogExtractor,
     overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),

--- a/src/application/summary-logs/submit.integration.test.js
+++ b/src/application/summary-logs/submit.integration.test.js
@@ -76,6 +76,9 @@ const RECEIVED_HEADERS = [
   'CARRIER_VEHICLE_REGISTRATION_NUMBER'
 ]
 
+const TARE_WEIGHT = 100
+const PALLET_WEIGHT = 50
+
 const receivedRow = (
   rowNumber,
   rowId,
@@ -90,9 +93,9 @@ const receivedRow = (
     '03 03 08',
     'Glass - pre-sorted',
     'No',
-    netWeight + 150,
-    100,
-    50,
+    netWeight + TARE_WEIGHT + PALLET_WEIGHT,
+    TARE_WEIGHT,
+    PALLET_WEIGHT,
     netWeight,
     'Yes',
     'Actual weight (100%)',

--- a/src/application/summary-logs/submit.integration.test.js
+++ b/src/application/summary-logs/submit.integration.test.js
@@ -1,0 +1,329 @@
+import { ObjectId } from 'mongodb'
+
+import { createInMemorySummaryLogExtractor } from '#application/summary-logs/extractor-inmemory.js'
+import { submitSummaryLog } from '#application/summary-logs/submit.js'
+import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
+import { ORGANISATION_STATUS } from '#domain/organisations/model.js'
+import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
+import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
+import { buildReadOrganisation } from '#repositories/organisations/contract/test-data.js'
+import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
+import {
+  buildCreateReportParams,
+  createAndSubmitReport
+} from '#reports/repository/contract/test-data.js'
+import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
+import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
+import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
+import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
+import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
+import { createInMemoryRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createMockLogger } from '#test/mock-logger.js'
+import { createMockWasteBalancesRepository } from '#test/mock-repositories.js'
+import { PermanentError } from '#server/queue-consumer/permanent-error.js'
+
+const VALID_FROM = '2025-01-01'
+const VALID_TO = '2025-12-31'
+
+const META = {
+  REGISTRATION_NUMBER: {
+    value: 'REG-123',
+    location: { sheet: 'Data', row: 1, column: 'B' }
+  },
+  PROCESSING_TYPE: {
+    value: 'REPROCESSOR_INPUT',
+    location: { sheet: 'Data', row: 2, column: 'B' }
+  },
+  MATERIAL: {
+    value: 'Paper_and_board',
+    location: { sheet: 'Data', row: 3, column: 'B' }
+  },
+  TEMPLATE_VERSION: {
+    value: 5,
+    location: { sheet: 'Data', row: 4, column: 'B' }
+  },
+  ACCREDITATION_NUMBER: {
+    value: 'ACC-123',
+    location: { sheet: 'Data', row: 5, column: 'B' }
+  }
+}
+
+const RECEIVED_HEADERS = [
+  'ROW_ID',
+  'DATE_RECEIVED_FOR_REPROCESSING',
+  'EWC_CODE',
+  'DESCRIPTION_WASTE',
+  'WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE',
+  'GROSS_WEIGHT',
+  'TARE_WEIGHT',
+  'PALLET_WEIGHT',
+  'NET_WEIGHT',
+  'BAILING_WIRE_PROTOCOL',
+  'HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION',
+  'WEIGHT_OF_NON_TARGET_MATERIALS',
+  'RECYCLABLE_PROPORTION_PERCENTAGE',
+  'TONNAGE_RECEIVED_FOR_RECYCLING',
+  'SUPPLIER_NAME',
+  'SUPPLIER_ADDRESS',
+  'SUPPLIER_POSTCODE',
+  'SUPPLIER_EMAIL',
+  'SUPPLIER_PHONE_NUMBER',
+  'ACTIVITIES_CARRIED_OUT_BY_SUPPLIER',
+  'YOUR_REFERENCE',
+  'WEIGHBRIDGE_TICKET',
+  'CARRIER_NAME',
+  'CBD_REG_NUMBER',
+  'CARRIER_VEHICLE_REGISTRATION_NUMBER'
+]
+
+const receivedRow = (
+  rowNumber,
+  rowId,
+  netWeight,
+  nonTargetWeight,
+  tonnage
+) => ({
+  rowNumber,
+  values: [
+    rowId,
+    '2025-01-15T00:00:00.000Z',
+    '03 03 08',
+    'Glass - pre-sorted',
+    'No',
+    netWeight + 150,
+    100,
+    50,
+    netWeight,
+    'Yes',
+    'Actual weight (100%)',
+    nonTargetWeight,
+    0.85,
+    tonnage,
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    '',
+    ''
+  ]
+})
+
+const RECEIVED_DATA = {
+  RECEIVED_LOADS_FOR_REPROCESSING: {
+    location: { sheet: 'Received', row: 7, column: 'A' },
+    headers: RECEIVED_HEADERS,
+    rows: [
+      receivedRow(8, 1001, 850, 50, 678.98),
+      receivedRow(9, 1002, 765, 45, 611.028)
+    ]
+  }
+}
+
+const SUBMIT_USER = {
+  id: 'user-123',
+  email: 'operator@example.com',
+  scope: ['standard_user'],
+  role: null
+}
+
+const buildTestOrg = (organisationId, registrationId) => {
+  const accreditationId = 'acc-123'
+  const testOrg = buildReadOrganisation({
+    registrations: [
+      {
+        id: registrationId,
+        registrationNumber: 'REG-123',
+        status: 'approved',
+        material: 'paper',
+        wasteProcessingType: 'reprocessor',
+        reprocessingType: 'input',
+        submittedToRegulator: 'ea',
+        validFrom: VALID_FROM,
+        validTo: VALID_TO,
+        accreditationId
+      }
+    ],
+    accreditations: [
+      {
+        id: accreditationId,
+        accreditationNumber: 'ACC-123',
+        material: 'paper',
+        wasteProcessingType: 'reprocessor',
+        reprocessingType: 'input',
+        submittedToRegulator: 'ea',
+        validFrom: VALID_FROM,
+        validTo: VALID_TO
+      }
+    ]
+  })
+  testOrg.id = organisationId
+  return { ...testOrg, status: ORGANISATION_STATUS.ACTIVE }
+}
+
+/**
+ * Wires the real submit worker against real in-memory repositories, seeds a
+ * SUBMITTING summary log, and returns everything needed to invoke and assert.
+ *
+ * @param {object} options
+ * @param {import('#reports/repository/port.js').ReportsRepository} options.reportsRepository
+ * @param {string} [options.createdAt] - immutable creation timestamp of the log
+ */
+const setupSubmit = async ({ reportsRepository, createdAt }) => {
+  const organisationId = new ObjectId().toString()
+  const registrationId = new ObjectId().toString()
+  const logger = createMockLogger()
+
+  const summaryLogsRepository = createInMemorySummaryLogsRepository()(logger)
+  const organisationsRepository = createInMemoryOrganisationsRepository([
+    buildTestOrg(organisationId, registrationId)
+  ])()
+  const wasteRecordsRepository = createInMemoryWasteRecordsRepository()()
+
+  const summaryLog = summaryLogFactory.submitting({
+    organisationId,
+    registrationId,
+    ...(createdAt && { createdAt })
+  })
+  const summaryLogId = `submit-${organisationId}`
+  await summaryLogsRepository.insert(summaryLogId, summaryLog)
+
+  const summaryLogExtractor = createInMemorySummaryLogExtractor({
+    [summaryLog.file.id]: { meta: META, data: RECEIVED_DATA }
+  })
+
+  const deps = {
+    logger,
+    summaryLogsRepository,
+    organisationsRepository,
+    wasteRecordsRepository,
+    wasteRecordStatesRepository: createInMemoryRowStateRepository()(),
+    wasteBalancesRepository: createMockWasteBalancesRepository(),
+    featureFlags: createInMemoryFeatureFlags(),
+    summaryLogExtractor,
+    overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
+    reportsRepository,
+    user: SUBMIT_USER,
+    onSummaryLogSubmittedReportHook: vi.fn().mockResolvedValue(undefined)
+  }
+
+  return {
+    deps,
+    summaryLogId,
+    organisationId,
+    registrationId,
+    summaryLogsRepository,
+    wasteRecordsRepository
+  }
+}
+
+describe('submitSummaryLog staleness guard (period closure)', () => {
+  it('rejects when a report was submitted after the summary log was created', async () => {
+    const reportsRepository = createInMemoryReportsRepository()()
+    const {
+      deps,
+      summaryLogId,
+      organisationId,
+      registrationId,
+      wasteRecordsRepository,
+      summaryLogsRepository
+    } = await setupSubmit({
+      reportsRepository,
+      createdAt: '2024-01-01T00:00:00.000Z'
+    })
+
+    // A periodic report closes for this registration after the log was created:
+    // its SUBMITTED status.history entry is stamped "now", well after 2024.
+    await createAndSubmitReport(reportsRepository, {
+      organisationId,
+      registrationId
+    })
+
+    await expect(submitSummaryLog(summaryLogId, deps)).rejects.toBeInstanceOf(
+      PermanentError
+    )
+
+    const wasteRecords = await wasteRecordsRepository.findByRegistration(
+      organisationId,
+      registrationId
+    )
+    expect(wasteRecords).toEqual([])
+
+    // The guard throws before any write, so the log is untouched at version 1.
+    const { summaryLog, version } = await waitForVersion(
+      summaryLogsRepository,
+      summaryLogId,
+      1
+    )
+    expect(summaryLog.status).toBe(SUMMARY_LOG_STATUS.SUBMITTING)
+    expect(version).toBe(1)
+  })
+
+  it('proceeds and writes records when no report has been submitted since creation', async () => {
+    const reportsRepository = createInMemoryReportsRepository()()
+    const {
+      deps,
+      summaryLogId,
+      organisationId,
+      registrationId,
+      wasteRecordsRepository,
+      summaryLogsRepository
+    } = await setupSubmit({ reportsRepository })
+
+    // An open (never-submitted) report exists for the registration: the guard
+    // reacts only to SUBMITTED closures, so submission must still proceed.
+    await reportsRepository.createReport(
+      buildCreateReportParams({ organisationId, registrationId })
+    )
+
+    await submitSummaryLog(summaryLogId, deps)
+
+    const wasteRecords = await wasteRecordsRepository.findByRegistration(
+      organisationId,
+      registrationId
+    )
+    expect(wasteRecords).toHaveLength(2)
+    expect(wasteRecords.map((record) => record.rowId)).toEqual(['1001', '1002'])
+
+    const { summaryLog } = await waitForVersion(
+      summaryLogsRepository,
+      summaryLogId,
+      2
+    )
+    expect(summaryLog.status).toBe(SUMMARY_LOG_STATUS.SUBMITTED)
+  })
+
+  it('ignores a report last submitted before the summary log was created', async () => {
+    const reportsRepository = createInMemoryReportsRepository()()
+    // The log is created far in the future, after any real submission, so the
+    // seeded closure predates it and the guard must not fire.
+    const {
+      deps,
+      summaryLogId,
+      organisationId,
+      registrationId,
+      summaryLogsRepository
+    } = await setupSubmit({
+      reportsRepository,
+      createdAt: '2099-01-01T00:00:00.000Z'
+    })
+
+    await createAndSubmitReport(reportsRepository, {
+      organisationId,
+      registrationId
+    })
+
+    await submitSummaryLog(summaryLogId, deps)
+
+    const { summaryLog } = await waitForVersion(
+      summaryLogsRepository,
+      summaryLogId,
+      2
+    )
+    expect(summaryLog.status).toBe(SUMMARY_LOG_STATUS.SUBMITTED)
+  })
+})

--- a/src/application/summary-logs/submit.integration.test.js
+++ b/src/application/summary-logs/submit.integration.test.js
@@ -13,6 +13,11 @@ import {
   createAndSubmitReport
 } from '#reports/repository/contract/test-data.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
+import {
+  REPROCESSOR_RECEIVED_HEADERS,
+  createReprocessorReceivedRowValues,
+  createStandardMeta
+} from '#routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
@@ -25,104 +30,21 @@ import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 const VALID_FROM = '2025-01-01'
 const VALID_TO = '2025-12-31'
 
-const META = {
-  REGISTRATION_NUMBER: {
-    value: 'REG-123',
-    location: { sheet: 'Data', row: 1, column: 'B' }
-  },
-  PROCESSING_TYPE: {
-    value: 'REPROCESSOR_INPUT',
-    location: { sheet: 'Data', row: 2, column: 'B' }
-  },
-  MATERIAL: {
-    value: 'Paper_and_board',
-    location: { sheet: 'Data', row: 3, column: 'B' }
-  },
-  TEMPLATE_VERSION: {
-    value: 5,
-    location: { sheet: 'Data', row: 4, column: 'B' }
-  },
-  ACCREDITATION_NUMBER: {
-    value: 'ACC-123',
-    location: { sheet: 'Data', row: 5, column: 'B' }
-  }
-}
-
-const RECEIVED_HEADERS = [
-  'ROW_ID',
-  'DATE_RECEIVED_FOR_REPROCESSING',
-  'EWC_CODE',
-  'DESCRIPTION_WASTE',
-  'WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE',
-  'GROSS_WEIGHT',
-  'TARE_WEIGHT',
-  'PALLET_WEIGHT',
-  'NET_WEIGHT',
-  'BAILING_WIRE_PROTOCOL',
-  'HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION',
-  'WEIGHT_OF_NON_TARGET_MATERIALS',
-  'RECYCLABLE_PROPORTION_PERCENTAGE',
-  'TONNAGE_RECEIVED_FOR_RECYCLING',
-  'SUPPLIER_NAME',
-  'SUPPLIER_ADDRESS',
-  'SUPPLIER_POSTCODE',
-  'SUPPLIER_EMAIL',
-  'SUPPLIER_PHONE_NUMBER',
-  'ACTIVITIES_CARRIED_OUT_BY_SUPPLIER',
-  'YOUR_REFERENCE',
-  'WEIGHBRIDGE_TICKET',
-  'CARRIER_NAME',
-  'CBD_REG_NUMBER',
-  'CARRIER_VEHICLE_REGISTRATION_NUMBER'
-]
-
-const TARE_WEIGHT = 100
-const PALLET_WEIGHT = 50
-
-const receivedRow = (
-  rowNumber,
-  rowId,
-  netWeight,
-  nonTargetWeight,
-  tonnage
-) => ({
-  rowNumber,
-  values: [
-    rowId,
-    '2025-01-15T00:00:00.000Z',
-    '03 03 08',
-    'Glass - pre-sorted',
-    'No',
-    netWeight + TARE_WEIGHT + PALLET_WEIGHT,
-    TARE_WEIGHT,
-    PALLET_WEIGHT,
-    netWeight,
-    'Yes',
-    'Actual weight (100%)',
-    nonTargetWeight,
-    0.85,
-    tonnage,
-    '',
-    '',
-    '',
-    '',
-    '',
-    '',
-    '',
-    '',
-    '',
-    '',
-    ''
-  ]
-})
+const META = createStandardMeta('REPROCESSOR_INPUT')
 
 const RECEIVED_DATA = {
   RECEIVED_LOADS_FOR_REPROCESSING: {
     location: { sheet: 'Received', row: 7, column: 'A' },
-    headers: RECEIVED_HEADERS,
+    headers: REPROCESSOR_RECEIVED_HEADERS,
     rows: [
-      receivedRow(8, 1001, 850, 50, 678.98),
-      receivedRow(9, 1002, 765, 45, 611.028)
+      {
+        rowNumber: 8,
+        values: createReprocessorReceivedRowValues({ rowId: 1001 })
+      },
+      {
+        rowNumber: 9,
+        values: createReprocessorReceivedRowValues({ rowId: 1002 })
+      }
     ]
   }
 }

--- a/src/application/summary-logs/submit.js
+++ b/src/application/summary-logs/submit.js
@@ -28,18 +28,17 @@ import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
  */
 
 /**
- * Rejects submission when a report closed a period during the validate-to-submit
- * window. The operator confirmed a preview built from the periodic reports as
- * they stood at validate; a report submitted since (keyed on the log's immutable
- * createdAt) means that confirmed preview no longer matches what would be
- * written, so the log is failed and the operator re-uploads. See PAE-1686.
+ * Fails submission if any report for this registration was submitted since the
+ * log's createdAt, closing the validate-to-submit race where a period closes
+ * after the operator confirmed the preview. Deliberately blunt: it fires on any
+ * submission, not only periods this log touches. See PAE-1686.
  *
  * @param {object} summaryLog
  * @param {string} summaryLogId
  * @param {import('#reports/repository/port.js').ReportsRepository} reportsRepository
  * @returns {Promise<void>}
  */
-const assertNoPeriodClosedSinceCreation = async (
+const assertNoReportSubmittedSinceCreation = async (
   summaryLog,
   summaryLogId,
   reportsRepository
@@ -169,7 +168,7 @@ export const submitSummaryLog = async (summaryLogId, deps) => {
     )
   }
 
-  await assertNoPeriodClosedSinceCreation(
+  await assertNoReportSubmittedSinceCreation(
     summaryLog,
     summaryLogId,
     reportsRepository

--- a/src/application/summary-logs/submit.js
+++ b/src/application/summary-logs/submit.js
@@ -20,6 +20,7 @@ import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
  * @property {import('#waste-records/repository/port.js').RowStateRepository} wasteRecordStatesRepository
  * @property {ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>} wasteBalanceService
  * @property {import('#feature-flags/feature-flags.port.js').FeatureFlags} featureFlags
+ * @property {import('#reports/repository/port.js').ReportsRepository} reportsRepository
  * @property {object} summaryLogExtractor
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
  * @property {import('#domain/summary-logs/worker/port.js').SubmitUser} user
@@ -27,13 +28,47 @@ import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
  */
 
 /**
- * Submits a summary log by syncing its waste records and updating status.
+ * Rejects submission when a report closed a period during the validate-to-submit
+ * window. The operator confirmed a preview built from the periodic reports as
+ * they stood at validate; a report submitted since (keyed on the log's immutable
+ * createdAt) means that confirmed preview no longer matches what would be
+ * written, so the log is failed and the operator re-uploads. See PAE-1686.
+ *
+ * @param {object} summaryLog
+ * @param {string} summaryLogId
+ * @param {import('#reports/repository/port.js').ReportsRepository} reportsRepository
+ * @returns {Promise<void>}
+ */
+const assertNoPeriodClosedSinceCreation = async (
+  summaryLog,
+  summaryLogId,
+  reportsRepository
+) => {
+  const reportSubmittedSinceCreation =
+    await reportsRepository.hasReportSubmittedSince(
+      summaryLog.organisationId,
+      summaryLog.registrationId,
+      summaryLog.createdAt
+    )
+
+  if (reportSubmittedSinceCreation) {
+    throw new PermanentError(
+      `Summary log ${summaryLogId} is stale: a report was submitted for this registration after the summary log was created`
+    )
+  }
+}
+
+/**
+ * Syncs the summary log's waste records, transitions it to SUBMITTED and records
+ * the submission metrics.
  *
  * @param {string} summaryLogId
+ * @param {number} version
+ * @param {object} summaryLog
  * @param {SubmitDependencies} deps
  * @returns {Promise<void>}
  */
-export const submitSummaryLog = async (summaryLogId, deps) => {
+const syncAndFinalise = async (summaryLogId, version, summaryLog, deps) => {
   const {
     logger,
     summaryLogsRepository,
@@ -47,20 +82,6 @@ export const submitSummaryLog = async (summaryLogId, deps) => {
     user,
     onSummaryLogSubmittedReportHook
   } = deps
-
-  const existing = await summaryLogsRepository.findById(summaryLogId)
-
-  if (!existing) {
-    throw new PermanentError(`Summary log ${summaryLogId} not found`)
-  }
-
-  const { version, summaryLog } = existing
-
-  if (summaryLog.status !== SUMMARY_LOG_STATUS.SUBMITTING) {
-    throw new PermanentError(
-      `Summary log must be in submitting status. Current status: ${summaryLog.status}`
-    )
-  }
 
   const {
     file: { id: fileId, name: filename }
@@ -122,4 +143,37 @@ export const submitSummaryLog = async (summaryLogId, deps) => {
       action: LOGGING_EVENT_ACTIONS.PROCESS_SUCCESS
     }
   })
+}
+
+/**
+ * Submits a summary log by syncing its waste records and updating status.
+ *
+ * @param {string} summaryLogId
+ * @param {SubmitDependencies} deps
+ * @returns {Promise<void>}
+ */
+export const submitSummaryLog = async (summaryLogId, deps) => {
+  const { summaryLogsRepository, reportsRepository } = deps
+
+  const existing = await summaryLogsRepository.findById(summaryLogId)
+
+  if (!existing) {
+    throw new PermanentError(`Summary log ${summaryLogId} not found`)
+  }
+
+  const { version, summaryLog } = existing
+
+  if (summaryLog.status !== SUMMARY_LOG_STATUS.SUBMITTING) {
+    throw new PermanentError(
+      `Summary log must be in submitting status. Current status: ${summaryLog.status}`
+    )
+  }
+
+  await assertNoPeriodClosedSinceCreation(
+    summaryLog,
+    summaryLogId,
+    reportsRepository
+  )
+
+  await syncAndFinalise(summaryLogId, version, summaryLog, deps)
 }

--- a/src/reports/repository/contract/hasReportSubmittedSince.contract.js
+++ b/src/reports/repository/contract/hasReportSubmittedSince.contract.js
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect } from 'vitest'
+import { ObjectId } from 'mongodb'
+import { buildCreateReportParams, createAndSubmitReport } from './test-data.js'
+
+/** @import { ReportsRepositoryFactory } from '../port.js' */
+
+/** @typedef {{ reportsRepository: ReportsRepositoryFactory }} ReportsFixture */
+
+const BEFORE = '2000-01-01T00:00:00.000Z'
+const AFTER = '2100-01-01T00:00:00.000Z'
+
+export const testHasReportSubmittedSinceBehaviour = (it) => {
+  describe('hasReportSubmittedSince', () => {
+    let repository
+    let organisationId
+    let registrationId
+
+    beforeEach(
+      /** @param {ReportsFixture} fixture */ async ({ reportsRepository }) => {
+        repository = reportsRepository()
+        organisationId = new ObjectId().toString()
+        registrationId = new ObjectId().toString()
+      }
+    )
+
+    it('returns true when a report was submitted after the timestamp', async () => {
+      await createAndSubmitReport(repository, {
+        organisationId,
+        registrationId
+      })
+
+      expect(
+        await repository.hasReportSubmittedSince(
+          organisationId,
+          registrationId,
+          BEFORE
+        )
+      ).toBe(true)
+    })
+
+    it('returns false when the submission is not strictly after the timestamp', async () => {
+      const reportId = await createAndSubmitReport(repository, {
+        organisationId,
+        registrationId
+      })
+      const { status } = await repository.findReportById(reportId)
+      const submittedAt = status.submitted.at
+
+      // Boundary: `since` equal to the submission time must not match (strict >).
+      expect(
+        await repository.hasReportSubmittedSince(
+          organisationId,
+          registrationId,
+          submittedAt
+        )
+      ).toBe(false)
+
+      expect(
+        await repository.hasReportSubmittedSince(
+          organisationId,
+          registrationId,
+          AFTER
+        )
+      ).toBe(false)
+    })
+
+    it('returns false when the only report is not submitted', async () => {
+      await repository.createReport(
+        buildCreateReportParams({ organisationId, registrationId })
+      )
+
+      expect(
+        await repository.hasReportSubmittedSince(
+          organisationId,
+          registrationId,
+          BEFORE
+        )
+      ).toBe(false)
+    })
+
+    it('ignores submitted reports belonging to a different registration', async () => {
+      await createAndSubmitReport(repository, {
+        organisationId,
+        registrationId: new ObjectId().toString()
+      })
+
+      expect(
+        await repository.hasReportSubmittedSince(
+          organisationId,
+          registrationId,
+          BEFORE
+        )
+      ).toBe(false)
+    })
+  })
+}

--- a/src/reports/repository/contract/hasReportSubmittedSince.contract.js
+++ b/src/reports/repository/contract/hasReportSubmittedSince.contract.js
@@ -64,6 +64,28 @@ export const testHasReportSubmittedSinceBehaviour = (it) => {
       ).toBe(false)
     })
 
+    it('compares by instant, not raw string, across equivalent ISO forms', async () => {
+      const reportId = await createAndSubmitReport(repository, {
+        organisationId,
+        registrationId
+      })
+      const { status } = await repository.findReportById(reportId)
+      const submittedAt = status.submitted.at
+
+      // Same instant as the submission, but written with a numeric offset rather
+      // than 'Z'. A raw string compare mis-sorts this ('Z' > '+'), which would
+      // wrongly report the submission as being "after" its own timestamp.
+      const sameInstantOffsetForm = submittedAt.replace('Z', '+00:00')
+
+      expect(
+        await repository.hasReportSubmittedSince(
+          organisationId,
+          registrationId,
+          sameInstantOffsetForm
+        )
+      ).toBe(false)
+    })
+
     it('returns false when the only report is not submitted', async () => {
       await repository.createReport(
         buildCreateReportParams({ organisationId, registrationId })

--- a/src/reports/repository/contract/hasReportSubmittedSince.contract.js
+++ b/src/reports/repository/contract/hasReportSubmittedSince.contract.js
@@ -64,28 +64,6 @@ export const testHasReportSubmittedSinceBehaviour = (it) => {
       ).toBe(false)
     })
 
-    it('compares by instant, not raw string, across equivalent ISO forms', async () => {
-      const reportId = await createAndSubmitReport(repository, {
-        organisationId,
-        registrationId
-      })
-      const { status } = await repository.findReportById(reportId)
-      const submittedAt = status.submitted.at
-
-      // Same instant as the submission, but written with a numeric offset rather
-      // than 'Z'. A raw string compare mis-sorts this ('Z' > '+'), which would
-      // wrongly report the submission as being "after" its own timestamp.
-      const sameInstantOffsetForm = submittedAt.replace('Z', '+00:00')
-
-      expect(
-        await repository.hasReportSubmittedSince(
-          organisationId,
-          registrationId,
-          sameInstantOffsetForm
-        )
-      ).toBe(false)
-    })
-
     it('returns false when the only report is not submitted', async () => {
       await repository.createReport(
         buildCreateReportParams({ organisationId, registrationId })

--- a/src/reports/repository/contract/hasReportSubmittedSince.contract.js
+++ b/src/reports/repository/contract/hasReportSubmittedSince.contract.js
@@ -23,12 +23,17 @@ export const testHasReportSubmittedSinceBehaviour = (it) => {
       }
     )
 
-    it('returns true when a report was submitted after the timestamp', async () => {
-      await createAndSubmitReport(repository, {
+    it('returns true when the timestamp is before the submission instant', async () => {
+      const reportId = await createAndSubmitReport(repository, {
         organisationId,
         registrationId
       })
+      const { status } = await repository.findReportById(reportId)
+      const oneMsBefore = new Date(
+        new Date(status.submitted.at).getTime() - 1
+      ).toISOString()
 
+      // Well before the submission.
       expect(
         await repository.hasReportSubmittedSince(
           organisationId,
@@ -36,9 +41,18 @@ export const testHasReportSubmittedSinceBehaviour = (it) => {
           BEFORE
         )
       ).toBe(true)
+
+      // One millisecond before: still strictly after -> matches (lower boundary).
+      expect(
+        await repository.hasReportSubmittedSince(
+          organisationId,
+          registrationId,
+          oneMsBefore
+        )
+      ).toBe(true)
     })
 
-    it('returns false when the submission is not strictly after the timestamp', async () => {
+    it('returns false when the timestamp is at or after the submission instant', async () => {
       const reportId = await createAndSubmitReport(repository, {
         organisationId,
         registrationId
@@ -46,7 +60,7 @@ export const testHasReportSubmittedSinceBehaviour = (it) => {
       const { status } = await repository.findReportById(reportId)
       const submittedAt = status.submitted.at
 
-      // Boundary: `since` equal to the submission time must not match (strict >).
+      // Exactly at the submission instant: not strictly after (strict >).
       expect(
         await repository.hasReportSubmittedSince(
           organisationId,
@@ -55,6 +69,7 @@ export const testHasReportSubmittedSinceBehaviour = (it) => {
         )
       ).toBe(false)
 
+      // Well after the submission.
       expect(
         await repository.hasReportSubmittedSince(
           organisationId,

--- a/src/reports/repository/inmemory.js
+++ b/src/reports/repository/inmemory.js
@@ -405,6 +405,31 @@ const markSubmittedReportsRequiringResubmission = async (
 }
 
 /**
+ * Returns true when any report for the org/reg has a SUBMITTED status.history
+ * entry stamped strictly after `since`.
+ *
+ * @param {Map<string, Object>} reports
+ * @param {string} organisationId
+ * @param {string} registrationId
+ * @param {string} since - ISO timestamp
+ * @returns {Promise<boolean>}
+ */
+const hasReportSubmittedSince = async (
+  reports,
+  organisationId,
+  registrationId,
+  since
+) =>
+  [...reports.values()].some(
+    (report) =>
+      report.organisationId === organisationId &&
+      report.registrationId === registrationId &&
+      report.status.history.some(
+        (entry) => entry.status === REPORT_STATUS.SUBMITTED && entry.at > since
+      )
+  )
+
+/**
  * Create an in-memory reports repository.
  *
  * The store is used by reference so test fixtures can seed data directly.
@@ -437,6 +462,8 @@ export const createInMemoryReportsRepository = (initialReports = new Map()) => {
         uploadedAt
       ),
     markSubmittedReportsRequiringResubmission: (params) =>
-      markSubmittedReportsRequiringResubmission(reports, params)
+      markSubmittedReportsRequiringResubmission(reports, params),
+    hasReportSubmittedSince: (organisationId, registrationId, since) =>
+      hasReportSubmittedSince(reports, organisationId, registrationId, since)
   })
 }

--- a/src/reports/repository/inmemory.js
+++ b/src/reports/repository/inmemory.js
@@ -405,8 +405,9 @@ const markSubmittedReportsRequiringResubmission = async (
 }
 
 /**
- * Returns true when any report for the org/reg has a SUBMITTED status.history
- * entry stamped strictly after `since`.
+ * Returns true when any report for the org/reg was submitted strictly after
+ * `since`. SUBMITTED is terminal and each submission is a distinct document, so
+ * the denormalised `status.submitted` slot is the single submission instant.
  *
  * @param {Map<string, Object>} reports
  * @param {string} organisationId
@@ -427,9 +428,7 @@ const hasReportSubmittedSince = async (
     (report) =>
       report.organisationId === organisationId &&
       report.registrationId === registrationId &&
-      report.status.history.some(
-        (entry) => entry.status === REPORT_STATUS.SUBMITTED && entry.at > since
-      )
+      report.status.submitted?.at > since
   )
 
 /**

--- a/src/reports/repository/inmemory.js
+++ b/src/reports/repository/inmemory.js
@@ -419,15 +419,22 @@ const hasReportSubmittedSince = async (
   organisationId,
   registrationId,
   since
-) =>
-  [...reports.values()].some(
+) => {
+  // status.history `at` is always written as canonical `new Date().toISOString()`.
+  // Normalise the caller's timestamp to the same form so the lexical comparison
+  // tracks chronological order even when `since` arrives in an equivalent but
+  // different ISO form (e.g. an offset like +00:00 rather than Z).
+  const sinceIso = new Date(since).toISOString()
+  return [...reports.values()].some(
     (report) =>
       report.organisationId === organisationId &&
       report.registrationId === registrationId &&
       report.status.history.some(
-        (entry) => entry.status === REPORT_STATUS.SUBMITTED && entry.at > since
+        (entry) =>
+          entry.status === REPORT_STATUS.SUBMITTED && entry.at > sinceIso
       )
   )
+}
 
 /**
  * Create an in-memory reports repository.

--- a/src/reports/repository/inmemory.js
+++ b/src/reports/repository/inmemory.js
@@ -419,22 +419,18 @@ const hasReportSubmittedSince = async (
   organisationId,
   registrationId,
   since
-) => {
-  // status.history `at` is always written as canonical `new Date().toISOString()`.
-  // Normalise the caller's timestamp to the same form so the lexical comparison
-  // tracks chronological order even when `since` arrives in an equivalent but
-  // different ISO form (e.g. an offset like +00:00 rather than Z).
-  const sinceIso = new Date(since).toISOString()
-  return [...reports.values()].some(
+) =>
+  // Both `at` and `since` are canonical `new Date().toISOString()` values, so a
+  // lexical compare tracks chronological order (the ISO invariant this codebase
+  // relies on throughout).
+  [...reports.values()].some(
     (report) =>
       report.organisationId === organisationId &&
       report.registrationId === registrationId &&
       report.status.history.some(
-        (entry) =>
-          entry.status === REPORT_STATUS.SUBMITTED && entry.at > sinceIso
+        (entry) => entry.status === REPORT_STATUS.SUBMITTED && entry.at > since
       )
   )
-}
 
 /**
  * Create an in-memory reports repository.

--- a/src/reports/repository/mongodb.js
+++ b/src/reports/repository/mongodb.js
@@ -556,17 +556,15 @@ const performHasReportSubmittedSince = async (
   registrationId,
   since
 ) => {
-  // status.history `at` is always stored as canonical `new Date().toISOString()`.
-  // Normalise the caller's timestamp to the same form so the `$gt` string compare
-  // tracks chronological order even when `since` arrives in an equivalent but
-  // different ISO form (e.g. an offset like +00:00 rather than Z).
-  const sinceIso = new Date(since).toISOString()
+  // Both `at` and `since` are canonical `new Date().toISOString()` values, so the
+  // `$gt` string compare tracks chronological order (the ISO invariant this
+  // codebase relies on throughout).
   const match = await reportsCollection(db).findOne(
     {
       organisationId,
       registrationId,
       'status.history': {
-        $elemMatch: { status: REPORT_STATUS.SUBMITTED, at: { $gt: sinceIso } }
+        $elemMatch: { status: REPORT_STATUS.SUBMITTED, at: { $gt: since } }
       }
     },
     { projection: { _id: 1 } }

--- a/src/reports/repository/mongodb.js
+++ b/src/reports/repository/mongodb.js
@@ -541,8 +541,10 @@ const performMarkSubmittedReportsRequiringResubmission = async (
 }
 
 /**
- * Returns true when any report for the org/reg has a SUBMITTED status.history
- * entry stamped strictly after `since`.
+ * Returns true when any report for the org/reg was submitted strictly after
+ * `since`. SUBMITTED is terminal and each submission is a distinct document, so
+ * the denormalised `status.submitted` slot is the single submission instant and
+ * is directly indexable.
  *
  * @param {Db} db
  * @param {string} organisationId
@@ -563,9 +565,7 @@ const performHasReportSubmittedSince = async (
     {
       organisationId,
       registrationId,
-      'status.history': {
-        $elemMatch: { status: REPORT_STATUS.SUBMITTED, at: { $gt: since } }
-      }
+      'status.submitted.at': { $gt: since }
     },
     { projection: { _id: 1 } }
   )

--- a/src/reports/repository/mongodb.js
+++ b/src/reports/repository/mongodb.js
@@ -541,6 +541,35 @@ const performMarkSubmittedReportsRequiringResubmission = async (
 }
 
 /**
+ * Returns true when any report for the org/reg has a SUBMITTED status.history
+ * entry stamped strictly after `since`.
+ *
+ * @param {Db} db
+ * @param {string} organisationId
+ * @param {string} registrationId
+ * @param {string} since - ISO timestamp
+ * @returns {Promise<boolean>}
+ */
+const performHasReportSubmittedSince = async (
+  db,
+  organisationId,
+  registrationId,
+  since
+) => {
+  const match = await reportsCollection(db).findOne(
+    {
+      organisationId,
+      registrationId,
+      'status.history': {
+        $elemMatch: { status: REPORT_STATUS.SUBMITTED, at: { $gt: since } }
+      }
+    },
+    { projection: { _id: 1 } }
+  )
+  return match !== null
+}
+
+/**
  * Creates a MongoDB-backed reports repository.
  *
  * @param {Db} db
@@ -571,6 +600,8 @@ export const createReportsRepository = async (db) => {
         uploadedAt
       ),
     markSubmittedReportsRequiringResubmission: (params) =>
-      performMarkSubmittedReportsRequiringResubmission(db, params)
+      performMarkSubmittedReportsRequiringResubmission(db, params),
+    hasReportSubmittedSince: (organisationId, registrationId, since) =>
+      performHasReportSubmittedSince(db, organisationId, registrationId, since)
   })
 }

--- a/src/reports/repository/mongodb.js
+++ b/src/reports/repository/mongodb.js
@@ -556,12 +556,17 @@ const performHasReportSubmittedSince = async (
   registrationId,
   since
 ) => {
+  // status.history `at` is always stored as canonical `new Date().toISOString()`.
+  // Normalise the caller's timestamp to the same form so the `$gt` string compare
+  // tracks chronological order even when `since` arrives in an equivalent but
+  // different ISO form (e.g. an offset like +00:00 rather than Z).
+  const sinceIso = new Date(since).toISOString()
   const match = await reportsCollection(db).findOne(
     {
       organisationId,
       registrationId,
       'status.history': {
-        $elemMatch: { status: REPORT_STATUS.SUBMITTED, at: { $gt: since } }
+        $elemMatch: { status: REPORT_STATUS.SUBMITTED, at: { $gt: sinceIso } }
       }
     },
     { projection: { _id: 1 } }

--- a/src/reports/repository/port.contract.js
+++ b/src/reports/repository/port.contract.js
@@ -7,6 +7,7 @@ import { testFindAllPeriodicReportsBehaviour } from './contract/findAllPeriodicR
 import { testFindReportByIdBehaviour } from './contract/findReportById.contract.js'
 import { testMarkActiveReportsStaleBehaviour } from './contract/markActiveReportsStale.contract.js'
 import { testMarkSubmittedReportsRequiringResubmissionBehaviour } from './contract/markSubmittedReportsRequiringResubmission.contract.js'
+import { testHasReportSubmittedSinceBehaviour } from './contract/hasReportSubmittedSince.contract.js'
 
 export const testReportsRepositoryContract = (it) => {
   testCreateReportBehaviour(it)
@@ -18,4 +19,5 @@ export const testReportsRepositoryContract = (it) => {
   testFindReportByIdBehaviour(it)
   testMarkActiveReportsStaleBehaviour(it)
   testMarkSubmittedReportsRequiringResubmissionBehaviour(it)
+  testHasReportSubmittedSinceBehaviour(it)
 }

--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -299,8 +299,9 @@
  *   Returns the per-report details for auditing.
  * @property {(organisationId: string, registrationId: string, since: string) => Promise<boolean>} hasReportSubmittedSince
  *   Returns true when any report for the org/reg has a SUBMITTED status.history
- *   entry stamped strictly after `since` (an ISO timestamp). Used to detect a
- *   period closing during the summary log validate-to-submit window.
+ *   entry stamped strictly after `since` (an ISO timestamp). `since` is compared
+ *   by instant, not by raw string, so equivalent ISO forms sort correctly. Used
+ *   to detect a period closing during the summary log validate-to-submit window.
  */
 
 /**

--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -298,10 +298,10 @@
  *   skipping any report already flagged from `summaryLogId` or built from it.
  *   Returns the per-report details for auditing.
  * @property {(organisationId: string, registrationId: string, since: string) => Promise<boolean>} hasReportSubmittedSince
- *   Returns true when any report for the org/reg has a SUBMITTED status.history
- *   entry stamped strictly after `since` (a canonical ISO timestamp, as produced
- *   by toISOString throughout). Used to detect a period closing during the
- *   summary log validate-to-submit window.
+ *   Returns true when any report for the org/reg was submitted strictly after
+ *   `since` (a canonical ISO timestamp, as produced by toISOString throughout),
+ *   read from the denormalised `status.submitted` slot. Used to detect a period
+ *   closing during the summary log validate-to-submit window.
  */
 
 /**

--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -297,6 +297,10 @@
  *   For each given period, flags the latest submitted report as requiring resubmission,
  *   skipping any report already flagged from `summaryLogId` or built from it.
  *   Returns the per-report details for auditing.
+ * @property {(organisationId: string, registrationId: string, since: string) => Promise<boolean>} hasReportSubmittedSince
+ *   Returns true when any report for the org/reg has a SUBMITTED status.history
+ *   entry stamped strictly after `since` (an ISO timestamp). Used to detect a
+ *   period closing during the summary log validate-to-submit window.
  */
 
 /**

--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -299,9 +299,9 @@
  *   Returns the per-report details for auditing.
  * @property {(organisationId: string, registrationId: string, since: string) => Promise<boolean>} hasReportSubmittedSince
  *   Returns true when any report for the org/reg has a SUBMITTED status.history
- *   entry stamped strictly after `since` (an ISO timestamp). `since` is compared
- *   by instant, not by raw string, so equivalent ISO forms sort correctly. Used
- *   to detect a period closing during the summary log validate-to-submit window.
+ *   entry stamped strictly after `since` (a canonical ISO timestamp, as produced
+ *   by toISOString throughout). Used to detect a period closing during the
+ *   summary log validate-to-submit window.
  */
 
 /**

--- a/src/server/queue-consumer/consumer.test.js
+++ b/src/server/queue-consumer/consumer.test.js
@@ -13,6 +13,7 @@ import {
   LOGGING_EVENT_CATEGORIES
 } from '#common/enums/index.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
+import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
 import { waitForVersion } from '#common/helpers/polling/wait-for-version.js'
 import { createMockLogger } from '#test/mock-logger.js'
@@ -47,6 +48,7 @@ describe('createCommandQueueConsumer', () => {
   let organisationsRepository
   let wasteRecordsRepository
   let wasteBalanceService
+  let reportsRepository
   let summaryLogExtractor
   let onSummaryLogSubmittedReportHook
   let mockConsumer
@@ -77,6 +79,7 @@ describe('createCommandQueueConsumer', () => {
     organisationsRepository = {}
     wasteRecordsRepository = {}
     wasteBalanceService = {}
+    reportsRepository = createInMemoryReportsRepository()()
     summaryLogExtractor = {}
     onSummaryLogSubmittedReportHook = vi.fn().mockResolvedValue(undefined)
 
@@ -124,6 +127,7 @@ describe('createCommandQueueConsumer', () => {
         organisationsRepository,
         wasteRecordsRepository,
         wasteBalanceService,
+        reportsRepository,
         summaryLogExtractor,
         onSummaryLogSubmittedReportHook
       },


### PR DESCRIPTION
Ticket: [PAE-1686](https://eaflood.atlassian.net/browse/PAE-1686)
## What

Adds a submit-time guard that rejects a summary log submission when a periodic report for the same registration has been submitted since the summary log was created.

At validate time, the summary log's open/closed period classification and the check-page preview the operator confirms are computed against the periodic reports as they stood then. Those are then acted on later at submit. A period closes when an operator submits its periodic report, and that route does not touch summary logs, so the existing submit-time staleness guard (keyed on the latest submitted summary log) never fires for it. A period can therefore transition open to submitted in the validate-to-submit window, and the log would submit against a stale snapshot: the confirmed preview no longer matches what gets written, and the restated period's submitted report is silently left out of date.

## Changes

- **Reports repository:** new `hasReportSubmittedSince(organisationId, registrationId, since)` query on the port, with implementations for the in-memory and MongoDB adapters and contract-test coverage on both. It returns true when any report for the org/registration has a `SUBMITTED` status-history entry stamped strictly after the given timestamp.
- **Submit worker:** before syncing waste records, `submitSummaryLog` calls the new query using the summary log's immutable `createdAt` as the reference point. If a report has been submitted since, it throws a `PermanentError`. The existing failure path (`markAsSubmissionFailed`) then moves the log to `SUBMISSION_FAILED` and releases the lock, so the operator sees the generic error page and re-uploads against the current state. `submitSummaryLog` is split into focused helpers to keep each function within the length limit.
- **Tests:** a new application-level integration test drives the real submit worker against real in-memory repositories, covering the rejection path (no waste records written, log left untouched) and the pass-through paths (no submitted report, and a report last submitted before the log was created). The consumer test is updated to supply the reports repository the worker now depends on.

## Why this approach

The guard is deliberately blunt and fail-safe: it fires on any report submission for the registration within the window. Each false positive costs an unnecessary re-upload; none is a bad write. No schema change, no new persisted field, and no frontend work are required. The predicate can be tightened to touched-periods-only later without changing the worker wiring.

Jira: PAE-1686

[PAE-1686]: https://eaflood.atlassian.net/browse/PAE-1686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ