### PR TITLE
PAE-1686: Route summary-log report reads through a reports facade

### DIFF
--- a/src/application/summary-logs/classify-and-persist.js
+++ b/src/application/summary-logs/classify-and-persist.js
@@ -26,7 +26,7 @@ import {
 /** @typedef {import('./load-counts.js').Loads} Loads */
 /** @typedef {import('./period-status.js').LoadsByReportingPeriod} LoadsByReportingPeriod */
 /** @typedef {string} ProcessingType */
-/** @typedef {import('#reports/repository/port.js').ReportsRepository} ReportsRepository */
+/** @typedef {import('#reports/application/report-service.js').ReportsService} ReportsService */
 
 /**
  * Filters waste records to only those from tables that participate in waste balance.
@@ -127,17 +127,17 @@ export const classifyLoads = ({
  * @param {Registration} [params.registration]
  * @param {string} params.status
  * @param {SubmittedSummaryLog} params.summaryLog
- * @param {ReportsRepository} params.reportsRepository
+ * @param {ReportsService} params.reportsService
  * @returns {Promise<import('#reports/repository/port.js').PeriodicReport[]>}
  */
 export const fetchPeriodicReports = async ({
   registration,
   status,
   summaryLog,
-  reportsRepository
+  reportsService
 }) => {
   if (registration && status === SUMMARY_LOG_STATUS.VALIDATED) {
-    return reportsRepository.findPeriodicReports({
+    return reportsService.findPeriodicReports({
       organisationId: summaryLog.organisationId,
       registrationId: summaryLog.registrationId
     })

--- a/src/application/summary-logs/submit.integration.test.js
+++ b/src/application/summary-logs/submit.integration.test.js
@@ -13,6 +13,7 @@ import {
   createAndSubmitReport
 } from '#reports/repository/contract/test-data.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
+import { createReportsService } from '#reports/application/report-service.js'
 import {
   REPROCESSOR_RECEIVED_HEADERS,
   createReprocessorReceivedRowValues,
@@ -134,7 +135,7 @@ const setupSubmit = async ({ reportsRepository, createdAt }) => {
     featureFlags: createInMemoryFeatureFlags(),
     summaryLogExtractor,
     overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
-    reportsRepository,
+    reportsService: createReportsService(reportsRepository),
     user: SUBMIT_USER,
     onSummaryLogUploaded: vi.fn().mockResolvedValue(undefined)
   }

--- a/src/application/summary-logs/submit.js
+++ b/src/application/summary-logs/submit.js
@@ -24,7 +24,7 @@ import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
  * @property {import('#waste-records/repository/port.js').RowStateRepository} wasteRecordStatesRepository
  * @property {ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>} wasteBalanceService
  * @property {import('#feature-flags/feature-flags.port.js').FeatureFlags} featureFlags
- * @property {import('#reports/repository/port.js').ReportsRepository} reportsRepository
+ * @property {import('#reports/application/report-service.js').ReportsService} reportsService
  * @property {object} summaryLogExtractor
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
  * @property {import('#domain/summary-logs/worker/port.js').SubmitUser} user
@@ -39,16 +39,16 @@ import { summaryLogMetrics } from '#common/helpers/metrics/summary-logs.js'
  *
  * @param {object} summaryLog
  * @param {string} summaryLogId
- * @param {import('#reports/repository/port.js').ReportsRepository} reportsRepository
+ * @param {import('#reports/application/report-service.js').ReportsService} reportsService
  * @returns {Promise<void>}
  */
 const assertNoReportSubmittedSinceCreation = async (
   summaryLog,
   summaryLogId,
-  reportsRepository
+  reportsService
 ) => {
   const reportSubmittedSinceCreation =
-    await reportsRepository.hasReportSubmittedSince(
+    await reportsService.hasReportSubmittedSince(
       summaryLog.organisationId,
       summaryLog.registrationId,
       summaryLog.createdAt
@@ -157,7 +157,7 @@ const syncAndFinalise = async (summaryLogId, version, summaryLog, deps) => {
  * @returns {Promise<void>}
  */
 export const submitSummaryLog = async (summaryLogId, deps) => {
-  const { summaryLogsRepository, reportsRepository } = deps
+  const { summaryLogsRepository, reportsService } = deps
 
   const existing = await summaryLogsRepository.findById(summaryLogId)
 
@@ -176,7 +176,7 @@ export const submitSummaryLog = async (summaryLogId, deps) => {
   await assertNoReportSubmittedSinceCreation(
     summaryLog,
     summaryLogId,
-    reportsRepository
+    reportsService
   )
 
   await syncAndFinalise(summaryLogId, version, summaryLog, deps)

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -126,7 +126,7 @@ describe('SummaryLogsValidator integration', () => {
       summaryLogsRepository,
       organisationsRepository,
       wasteRecordsRepository,
-      reportsRepository: /** @type {any} */ ({
+      reportsService: /** @type {any} */ ({
         findPeriodicReports: async () => []
       }),
       overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -53,7 +53,7 @@ export { MAX_ACTUAL_LENGTH } from './cap-issues-for-storage.js'
 /** @import {SummaryLogExtractor} from './extractor.js' */
 /** @import {Loads} from './load-counts.js' */
 /** @import {LoadsByReportingPeriod} from './period-status.js' */
-/** @import {ReportsRepository} from '#reports/repository/port.js' */
+/** @import {ReportsService} from '#reports/application/report-service.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
 
 /**
@@ -565,7 +565,7 @@ const classifyAndPersistResult = async ({
   summaryLog,
   summaryLogsRepository,
   version,
-  reportsRepository,
+  reportsService,
   organisationsRepository,
   overseasSitesRepository
 }) => {
@@ -573,7 +573,7 @@ const classifyAndPersistResult = async ({
     registration,
     status,
     summaryLog,
-    reportsRepository
+    reportsService
   })
 
   const overseasSites = await resolveOverseasSitesContext({
@@ -618,7 +618,7 @@ const classifyAndPersistResult = async ({
  *   summaryLogsRepository: SummaryLogsRepository,
  *   organisationsRepository: OrganisationsRepository,
  *   wasteRecordsRepository: WasteRecordsRepository,
- *   reportsRepository: ReportsRepository,
+ *   reportsService: ReportsService,
  *   overseasSitesRepository: OverseasSitesRepository,
  *   summaryLogExtractor: SummaryLogExtractor
  * }} params
@@ -629,7 +629,7 @@ export const createSummaryLogsValidator = ({
   summaryLogsRepository,
   organisationsRepository,
   wasteRecordsRepository,
-  reportsRepository,
+  reportsService,
   overseasSitesRepository,
   summaryLogExtractor
 }) => {
@@ -698,7 +698,7 @@ export const createSummaryLogsValidator = ({
       summaryLog,
       summaryLogsRepository,
       version,
-      reportsRepository,
+      reportsService,
       organisationsRepository,
       overseasSitesRepository
     })

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -250,7 +250,7 @@ describe('SummaryLogsValidator', () => {
       summaryLogsRepository: /** @type {any} */ (summaryLogsRepository),
       organisationsRepository: /** @type {any} */ (organisationsRepository),
       wasteRecordsRepository: /** @type {any} */ (wasteRecordsRepository),
-      reportsRepository: /** @type {any} */ ({
+      reportsService: /** @type {any} */ ({
         findPeriodicReports: vi.fn().mockResolvedValue([])
       }),
       overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
@@ -677,7 +677,7 @@ describe('SummaryLogsValidator', () => {
       summaryLogsRepository: brokenRepository,
       organisationsRepository: /** @type {any} */ (organisationsRepository),
       wasteRecordsRepository: /** @type {any} */ (wasteRecordsRepository),
-      reportsRepository: /** @type {any} */ ({
+      reportsService: /** @type {any} */ ({
         findPeriodicReports: vi.fn().mockResolvedValue([])
       }),
       overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
@@ -722,7 +722,7 @@ describe('SummaryLogsValidator', () => {
       summaryLogsRepository: /** @type {any} */ (summaryLogsRepository),
       organisationsRepository: /** @type {any} */ (organisationsRepository),
       wasteRecordsRepository: /** @type {any} */ (wasteRecordsRepository),
-      reportsRepository: /** @type {any} */ ({
+      reportsService: /** @type {any} */ ({
         findPeriodicReports: vi.fn().mockRejectedValue(fetchError)
       }),
       overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),

--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -13,6 +13,31 @@ import { errorCodes } from '#reports/enums/error-codes.js'
  */
 
 /**
+ * Application-layer facade over the reports repository for cross-module reads.
+ * Consumers outside the reports module (for example summary-logs) depend on this
+ * service rather than the repository port directly. See PAE-1686.
+ *
+ * @typedef {object} ReportsService
+ * @property {(organisationId: string, registrationId: string, since: string) => Promise<boolean>} hasReportSubmittedSince
+ * @property {(params: import('#reports/repository/port.js').FindPeriodicReportsParams) => Promise<PeriodicReport[]>} findPeriodicReports
+ */
+
+/**
+ * @param {import('#reports/repository/port.js').ReportsRepository} reportsRepository
+ * @returns {ReportsService}
+ */
+export const createReportsService = (reportsRepository) => ({
+  hasReportSubmittedSince: (organisationId, registrationId, since) =>
+    reportsRepository.hasReportSubmittedSince(
+      organisationId,
+      registrationId,
+      since
+    ),
+
+  findPeriodicReports: (params) => reportsRepository.findPeriodicReports(params)
+})
+
+/**
  * Finds the report ID for a specific submission number within periodic reports,
  * checking both the current slot and previous submissions.
  * @param {PeriodicReport[]} periodicReports

--- a/src/reports/application/report-service.test.js
+++ b/src/reports/application/report-service.test.js
@@ -12,7 +12,8 @@ import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repositor
 import {
   fetchOrGenerateReportForPeriod,
   createReportForPeriod,
-  fetchReportBySubmissionNumber
+  fetchReportBySubmissionNumber,
+  createReportsService
 } from './report-service.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
@@ -87,7 +88,9 @@ const defaultParams = () => {
     registrationId: registration.id,
     registration,
     year: 2024,
-    cadence: 'monthly',
+    cadence: /** @type {import('#reports/domain/cadence.js').Cadence} */ (
+      'monthly'
+    ),
     period: 1,
     submissionNumber: 1,
     overseasSitesRepository: createInMemoryOverseasSitesRepository()()
@@ -507,5 +510,45 @@ describe('report-service', () => {
         expect(report.prn?.issuedTonnage).toBe(50)
       })
     })
+  })
+})
+
+describe('createReportsService', () => {
+  it('delegates hasReportSubmittedSince to the repository and returns its result', async () => {
+    const reportsRepository = /** @type {any} */ ({
+      hasReportSubmittedSince: vi.fn().mockResolvedValue(true),
+      findPeriodicReports: vi.fn()
+    })
+    const service = createReportsService(reportsRepository)
+
+    const result = await service.hasReportSubmittedSince(
+      'org-1',
+      'reg-1',
+      '2026-07-01T00:00:00.000Z'
+    )
+
+    expect(reportsRepository.hasReportSubmittedSince).toHaveBeenCalledWith(
+      'org-1',
+      'reg-1',
+      '2026-07-01T00:00:00.000Z'
+    )
+    expect(result).toBe(true)
+  })
+
+  it('delegates findPeriodicReports to the repository and returns its result', async () => {
+    const periodicReports = [
+      { organisationId: 'org-1', registrationId: 'reg-1' }
+    ]
+    const reportsRepository = /** @type {any} */ ({
+      hasReportSubmittedSince: vi.fn(),
+      findPeriodicReports: vi.fn().mockResolvedValue(periodicReports)
+    })
+    const service = createReportsService(reportsRepository)
+
+    const params = { organisationId: 'org-1', registrationId: 'reg-1' }
+    const result = await service.findPeriodicReports(params)
+
+    expect(reportsRepository.findPeriodicReports).toHaveBeenCalledWith(params)
+    expect(result).toBe(periodicReports)
   })
 })

--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -18,6 +18,7 @@ import { createInMemoryRowStateRepository } from '#waste-records/repository/inme
 import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
+import { createReportsService } from '#reports/application/report-service.js'
 
 import { createTestServer } from '#test/create-test-server.js'
 import { createMockLogger } from '#test/mock-logger.js'
@@ -480,7 +481,7 @@ export const createTestInfrastructure = async (
     summaryLogsRepository,
     organisationsRepository,
     wasteRecordsRepository,
-    reportsRepository: /** @type {any} */ ({
+    reportsService: /** @type {any} */ ({
       findPeriodicReports: async () => []
     }),
     overseasSitesRepository,
@@ -598,7 +599,7 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
     summaryLogsRepository,
     organisationsRepository,
     wasteRecordsRepository,
-    reportsRepository,
+    reportsService: createReportsService(reportsRepository),
     overseasSitesRepository,
     summaryLogExtractor: dynamicExtractor,
     logger: mockLogger

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
@@ -244,7 +244,7 @@ describe('Repeated uploads of identical data', () => {
         wasteRecordsRepository,
         summaryLogExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({
+        reportsService: /** @type {any} */ ({
           findPeriodicReports: async () => []
         }),
         overseasSitesRepository: createMockOverseasSitesRepository({

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -18,6 +18,7 @@ import { buildReadOrganisation } from '#repositories/organisations/contract/test
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
+import { createReportsService } from '#reports/application/report-service.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
 import { createInMemoryWasteRecordsRepository } from '#repositories/waste-records/inmemory.js'
@@ -356,7 +357,9 @@ describe('Submission and placeholder tests', () => {
         wasteRecordsRepository,
         summaryLogExtractor: validationExtractor,
         logger: mockLogger,
-        reportsRepository: createInMemoryReportsRepository()(),
+        reportsService: createReportsService(
+          createInMemoryReportsRepository()()
+        ),
         overseasSitesRepository: createInMemoryOverseasSitesRepository()()
       })
 
@@ -813,7 +816,9 @@ describe('Submission and placeholder tests', () => {
         wasteRecordsRepository,
         summaryLogExtractor,
         logger: mockLogger,
-        reportsRepository: createInMemoryReportsRepository()(),
+        reportsService: createReportsService(
+          createInMemoryReportsRepository()()
+        ),
         overseasSitesRepository: createInMemoryOverseasSitesRepository()()
       })
       const featureFlags = createInMemoryFeatureFlags()

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
@@ -390,7 +390,7 @@ describe('Advanced validation scenarios', () => {
         overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
         summaryLogExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({
+        reportsService: /** @type {any} */ ({
           findPeriodicReports: async () => []
         })
       })
@@ -576,7 +576,7 @@ describe('Advanced validation scenarios', () => {
         overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
         summaryLogExtractor,
         logger: mockLogger,
-        reportsRepository: /** @type {any} */ ({
+        reportsService: /** @type {any} */ ({
           findPeriodicReports: async () => []
         })
       })

--- a/src/server/queue-consumer/consumer.test.js
+++ b/src/server/queue-consumer/consumer.test.js
@@ -14,6 +14,7 @@ import {
 } from '#common/enums/index.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
+import { createReportsService } from '#reports/application/report-service.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
 import { waitForVersion } from '#common/helpers/polling/wait-for-version.js'
 import { createMockLogger } from '#test/mock-logger.js'
@@ -127,7 +128,7 @@ describe('createCommandQueueConsumer', () => {
         organisationsRepository,
         wasteRecordsRepository,
         wasteBalanceService,
-        reportsRepository,
+        reportsService: createReportsService(reportsRepository),
         summaryLogExtractor,
         onSummaryLogUploaded
       },

--- a/src/server/queue-consumer/queue-consumer.plugin.js
+++ b/src/server/queue-consumer/queue-consumer.plugin.js
@@ -5,6 +5,7 @@ import {
 import { createSqsClient } from '#common/helpers/sqs/sqs-client.js'
 import { createSummaryLogExtractor } from '#application/summary-logs/extractor.js'
 import { createOnSummaryLogUploaded } from '#reports/application/summary-log-events.js'
+import { createReportsService } from '#reports/application/report-service.js'
 import { createCommandQueueConsumer } from './consumer.js'
 import { summaryLogCommandHandlers } from './summary-log-commands.js'
 import { orsImportCommandHandlers } from './ors-import-commands.js'
@@ -66,7 +67,7 @@ function buildConsumerDeps(server, { config }) {
     wasteRecordStatesRepository,
     wasteBalanceService,
     featureFlags,
-    reportsRepository,
+    reportsService: createReportsService(reportsRepository),
     summaryLogExtractor: createSummaryLogExtractor({ uploadsRepository }),
     onSummaryLogUploaded
   }

--- a/src/server/queue-consumer/queue-consumer.plugin.test.js
+++ b/src/server/queue-consumer/queue-consumer.plugin.test.js
@@ -177,7 +177,10 @@ describe('commandQueueConsumerPlugin', () => {
           organisationsRepository: server.app.organisationsRepository,
           wasteRecordsRepository: server.app.wasteRecordsRepository,
           wasteBalanceService: server.app.wasteBalanceService,
-          reportsRepository: server.app.reportsRepository,
+          reportsService: expect.objectContaining({
+            hasReportSubmittedSince: expect.any(Function),
+            findPeriodicReports: expect.any(Function)
+          }),
           summaryLogExtractor: expect.any(Object),
           onSummaryLogUploaded: expect.any(Function)
         },

--- a/src/server/queue-consumer/summary-log-commands.js
+++ b/src/server/queue-consumer/summary-log-commands.js
@@ -20,8 +20,8 @@ import { submitSummaryLog } from '#application/summary-logs/submit.js'
 /** @typedef {ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>} WasteBalanceService */
 /** @typedef {import('#feature-flags/feature-flags.port.js').FeatureFlags} FeatureFlags */
 /** @typedef {import('#domain/summary-logs/extractor/port.js').SummaryLogExtractor} SummaryLogExtractor */
-/** @typedef {import('#reports/repository/port.js').ReportsRepository} ReportsRepository */
 /** @typedef {import('#reports/domain/period-key.js').PeriodRef} PeriodRef */
+/** @typedef {import('#reports/application/report-service.js').ReportsService} ReportsService */
 
 /**
  * @typedef {object} SummaryLogHandlerDeps
@@ -32,7 +32,7 @@ import { submitSummaryLog } from '#application/summary-logs/submit.js'
  * @property {RowStateRepository} wasteRecordStatesRepository
  * @property {WasteBalanceService} wasteBalanceService
  * @property {FeatureFlags} featureFlags
- * @property {ReportsRepository} reportsRepository
+ * @property {ReportsService} reportsService
  * @property {SummaryLogExtractor} summaryLogExtractor
  * @property {import('#overseas-sites/repository/port.js').OverseasSitesRepository} overseasSitesRepository
  * @property {OnSummaryLogUploaded} onSummaryLogUploaded
@@ -72,7 +72,7 @@ export const summaryLogCommandHandlers = [
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
-        reportsRepository,
+        reportsService,
         overseasSitesRepository,
         summaryLogExtractor
       } = deps
@@ -82,7 +82,7 @@ export const summaryLogCommandHandlers = [
         summaryLogsRepository,
         organisationsRepository,
         wasteRecordsRepository,
-        reportsRepository,
+        reportsService,
         overseasSitesRepository,
         summaryLogExtractor
       })

--- a/src/server/queue-consumer/summary-log-commands.test.js
+++ b/src/server/queue-consumer/summary-log-commands.test.js
@@ -44,6 +44,10 @@ describe('summaryLogCommandHandlers', () => {
       organisationsRepository: {},
       wasteRecordsRepository: {},
       wasteBalanceService: {},
+      reportsService: {
+        hasReportSubmittedSince: vi.fn(),
+        findPeriodicReports: vi.fn()
+      },
       summaryLogExtractor: {}
     }
   })
@@ -102,6 +106,7 @@ describe('summaryLogCommandHandlers', () => {
           summaryLogsRepository: deps.summaryLogsRepository,
           organisationsRepository: deps.organisationsRepository,
           wasteRecordsRepository: deps.wasteRecordsRepository,
+          reportsService: deps.reportsService,
           summaryLogExtractor: deps.summaryLogExtractor
         })
         expect(mockValidator).toHaveBeenCalledWith('log-123')


### PR DESCRIPTION
Ticket: [PAE-1686](https://eaflood.atlassian.net/browse/PAE-1686)
## What

Routes the summary-logs application layer's cross-module reads of report data through a reports application-layer facade, so summary-logs no longer calls the reports repository port directly.

A `createReportsService(reportsRepository)` factory (added to `src/reports/application/report-service.js`) exposes the two reads summary-logs needs, `hasReportSubmittedSince` and `findPeriodicReports`. The queue-consumer plugin builds the service once at wiring time and injects it into the validate and submit command handlers. The consumers (`submit.js`, `classify-and-persist.js`, `validate.js`) now depend on the service rather than the repository port.

## Why

Follow-up to reviewer feedback on #1413 (PAE-1686). That PR added the submit-time staleness guard but called `reportsRepository` directly, matching the existing pattern in the validate and classify paths. Those direct calls couple summary-logs to a reports-internal detail. Routing them through a service keeps the reports repository port out of the summary-logs paths specifically, consistent with how other cross-module dependencies (for example the waste-balance service) are injected.

This does not make the port fully private to the reports module: other consumers (for example public-register) still use it directly. The change is scoped to the three summary-logs call sites, which is what the reviewer flagged. It covers all three together rather than piecemeal.

## Scope

- Summary-logs cross-module reads only. The reports module's own routes continue to use their repository directly, which is legitimate within-module access.
- No behaviour change: the facade is a thin pass-through seam.


[PAE-1686]: https://eaflood.atlassian.net/browse/PAE-1686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ