### PR TITLE
PAE-1590: rename row-state collection, indexes and flag env var before first deployment

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -374,7 +374,7 @@ const baseConfig = {
       doc: 'Feature Flag: Persist waste record states on summary-log submission (ADR-0037)',
       format: Boolean,
       default: false,
-      env: 'FEATURE_FLAG_WASTE_RECORD_STATES'
+      env: 'FEATURE_FLAG_SUMMARY_LOG_ROW_STATES'
     }
   },
   formSubmissionOverrides: {

--- a/src/non-prod-data-reset/mongodb.js
+++ b/src/non-prod-data-reset/mongodb.js
@@ -22,13 +22,13 @@ const COLLECTIONS = {
   OVERSEAS_SITES: 'overseas-sites',
   SYSTEM_LOGS: 'system-logs',
   WASTE_BALANCE_EVENTS: 'waste-balance-events',
-  WASTE_BALANCE_ROW_STATES: 'waste-balance-row-states'
+  SUMMARY_LOG_ROW_STATES: 'summary-log-row-states'
 }
 
 const EMPTY_COUNTS = Object.freeze({
   'packaging-recycling-notes': 0,
   'waste-balance-events': 0,
-  'waste-balance-row-states': 0,
+  'summary-log-row-states': 0,
   reports: 0,
   'waste-records': 0,
   'summary-logs': 0,
@@ -91,8 +91,8 @@ const buildCascadeSteps = (orgId, mongoIdHex, { overseasSiteIds }) => [
     filter: { organisationId: mongoIdHex }
   },
   {
-    label: 'waste-balance-row-states',
-    collection: COLLECTIONS.WASTE_BALANCE_ROW_STATES,
+    label: 'summary-log-row-states',
+    collection: COLLECTIONS.SUMMARY_LOG_ROW_STATES,
     filter: { organisationId: mongoIdHex }
   },
   {

--- a/src/non-prod-data-reset/mongodb.test.js
+++ b/src/non-prod-data-reset/mongodb.test.js
@@ -213,7 +213,6 @@ const seedDownstreamForOrganisation = async (
   await repositories.wasteRecords.appendVersions(
     organisationId,
     registrationId,
-    // @ts-expect-error -- partial waste record map sufficient for seeding
     toWasteRecordVersions({
       received: { 'row-1': { version, data } }
     })

--- a/src/non-prod-data-reset/mongodb.test.js
+++ b/src/non-prod-data-reset/mongodb.test.js
@@ -63,7 +63,7 @@ const COLLECTIONS = [
   'summary-logs',
   'overseas-sites',
   'system-logs',
-  'waste-balance-row-states'
+  'summary-log-row-states'
 ]
 
 const mockS3Config = { s3Client: {}, preSignedUrlExpiry: 60 }
@@ -273,7 +273,7 @@ const seedStagingCollections = async (database, orgId) => {
 const EMPTY_COUNTS = {
   'packaging-recycling-notes': 0,
   'waste-balance-events': 0,
-  'waste-balance-row-states': 0,
+  'summary-log-row-states': 0,
   reports: 0,
   'waste-records': 0,
   'summary-logs': 0,
@@ -312,7 +312,7 @@ describe('non-prod data reset (mongo)', () => {
       expect(counts).toEqual({
         'packaging-recycling-notes': 2,
         'waste-balance-events': 1,
-        'waste-balance-row-states': 1,
+        'summary-log-row-states': 1,
         reports: 1,
         'waste-records': 1,
         'summary-logs': 1,
@@ -366,7 +366,7 @@ describe('non-prod data reset (mongo)', () => {
       ).toBe(1)
       expect(
         await database
-          .collection('waste-balance-row-states')
+          .collection('summary-log-row-states')
           .countDocuments({ organisationId: other.organisationId })
       ).toBe(1)
       expect(

--- a/src/waste-records/repository/mongodb.js
+++ b/src/waste-records/repository/mongodb.js
@@ -20,8 +20,7 @@ import { createHash } from 'node:crypto'
 
 import { validateRowStateInsert, validateRowStateRead } from './validation.js'
 
-export const WASTE_BALANCE_ROW_STATES_COLLECTION_NAME =
-  'waste-balance-row-states'
+export const SUMMARY_LOG_ROW_STATES_COLLECTION_NAME = 'summary-log-row-states'
 
 /**
  * Ensures the row-states collection exists with the indexes required by the
@@ -37,9 +36,12 @@ export const WASTE_BALANCE_ROW_STATES_COLLECTION_NAME =
  * @returns {Promise<Collection>}
  */
 export async function ensureRowStatesCollection(db) {
-  const collection = db.collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME)
+  const collection = db.collection(SUMMARY_LOG_ROW_STATES_COLLECTION_NAME)
 
-  await collection.createIndex({ summaryLogIds: 1 }, { name: 'membership' })
+  await collection.createIndex(
+    { summaryLogIds: 1 },
+    { name: 'summary_log_membership' }
+  )
 
   await collection.createIndex(
     {
@@ -60,7 +62,7 @@ export async function ensureRowStatesCollection(db) {
       wasteRecordType: 1,
       contentHash: 1
     },
-    { name: 'waste_record_state_identity', unique: true }
+    { name: 'summary_log_row_state_identity', unique: true }
   )
 
   return collection

--- a/src/waste-records/repository/mongodb.test.js
+++ b/src/waste-records/repository/mongodb.test.js
@@ -7,7 +7,7 @@ import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import {
   createMongoRowStateRepository,
   ensureRowStatesCollection,
-  WASTE_BALANCE_ROW_STATES_COLLECTION_NAME
+  SUMMARY_LOG_ROW_STATES_COLLECTION_NAME
 } from './mongodb.js'
 import { testRowStateRepositoryContract } from './port.contract.js'
 import { buildRowStateEntry, DEFAULT_PARTITION } from './test-data.js'
@@ -24,13 +24,13 @@ const it = mongoIt.extend({
   rowStatesCollection: async (/** @type {*} */ { mongoClient }, use) => {
     const database = mongoClient.db(DATABASE_NAME)
     await ensureRowStatesCollection(database)
-    await use(database.collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME))
+    await use(database.collection(SUMMARY_LOG_ROW_STATES_COLLECTION_NAME))
   },
 
   rowStateRepository: async (/** @type {*} */ { mongoClient }, use) => {
     const database = mongoClient.db(DATABASE_NAME)
     await database
-      .collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME)
+      .collection(SUMMARY_LOG_ROW_STATES_COLLECTION_NAME)
       .deleteMany({})
     const factory = await createMongoRowStateRepository(database)
     await use(factory)
@@ -44,7 +44,7 @@ describe('ensureRowStatesCollection', () => {
   beforeEach(async (/** @type {*} */ { mongoClient }) => {
     await mongoClient
       .db(DATABASE_NAME)
-      .collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME)
+      .collection(SUMMARY_LOG_ROW_STATES_COLLECTION_NAME)
       .deleteMany({})
   })
 
@@ -52,7 +52,9 @@ describe('ensureRowStatesCollection', () => {
     rowStatesCollection
   }) => {
     const indexes = await rowStatesCollection.indexes()
-    expect(indexKeyFor(indexes, 'membership')).toEqual({ summaryLogIds: 1 })
+    expect(indexKeyFor(indexes, 'summary_log_membership')).toEqual({
+      summaryLogIds: 1
+    })
   })
 
   it('creates the row-history index', async (/** @type {*} */ {
@@ -71,7 +73,7 @@ describe('ensureRowStatesCollection', () => {
     rowStatesCollection
   }) => {
     const indexes = await rowStatesCollection.indexes()
-    expect(indexKeyFor(indexes, 'waste_record_state_identity')).toEqual({
+    expect(indexKeyFor(indexes, 'summary_log_row_state_identity')).toEqual({
       organisationId: 1,
       registrationId: 1,
       accreditationId: 1,
@@ -80,7 +82,8 @@ describe('ensureRowStatesCollection', () => {
       contentHash: 1
     })
     expect(
-      indexes.find((idx) => idx.name === 'waste_record_state_identity')?.unique
+      indexes.find((idx) => idx.name === 'summary_log_row_state_identity')
+        ?.unique
     ).toBe(true)
   })
 


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)
## What

Renames the physical names of the committed row-state storage before anything creates them in a deployed environment:

- Collection `waste-balance-row-states` → `summary-log-row-states` (and the exported constant to match)
- Index `membership` → `summary_log_membership`
- Unique index `waste_record_state_identity` → `summary_log_row_state_identity`
- Env var `FEATURE_FLAG_WASTE_RECORD_STATES` → `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES`

## Why

The collection has never been created in a deployed environment (the repository plugin is not yet registered in production) and the feature flag is not set in any environment config, so these names can change freely today — after first use each would need a data migration or coordinated config change.

`summary-log-row-states` reflects what the collection holds: each document is one state a row has held — its content as submitted plus its classification at submission time — with `summaryLogIds` recording which submitted summary log versions contained the row in that state. The old name attributed the data to the waste balance rather than to the summary logs it decomposes.

Internal code symbols (`wasteRecordStates*` identifiers, config keys, accessor names) are deliberately unchanged — a wider vocabulary alignment is tracked separately and deferred until the in-flight PAE-1590 branches land, to avoid churning them.


[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ