### PR TITLE
PAE-1668: Coerce stored tonnages to 2dp at the row-state projection seam

### DIFF
--- a/src/waste-records/application/project-row-state.js
+++ b/src/waste-records/application/project-row-state.js
@@ -1,0 +1,25 @@
+import { classifyWasteRecord } from '#waste-balances/application/target-amount.js'
+import { coerceStoredTonnages } from './stored-tonnage-coercion.js'
+
+/**
+ * @import { ClassifiedRow } from '#waste-balances/application/target-amount.js'
+ */
+
+/**
+ * Project a waste record into its committed row state: classify it for the
+ * waste balance, then coerce the stored tonnages to two decimal places. The 2dp
+ * holding is a property of the row-state value itself, so it lives here in the
+ * projection rather than at each write site — every path that persists a row
+ * state goes through this seam and inherits the coercion. The balance path
+ * keeps `classifyWasteRecord` directly and stays at full precision, which the
+ * cross-field reconciliation arithmetic requires.
+ *
+ * @param {import('#domain/waste-records/model.js').WasteRecord} record
+ * @param {Object} accreditation
+ * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} overseasSites
+ * @returns {ClassifiedRow}
+ */
+export const projectRowState = (record, accreditation, overseasSites) => {
+  const classified = classifyWasteRecord(record, accreditation, overseasSites)
+  return { ...classified, data: coerceStoredTonnages(classified.data) }
+}

--- a/src/waste-records/application/project-row-state.test.js
+++ b/src/waste-records/application/project-row-state.test.js
@@ -41,6 +41,30 @@ describe('projectRowState', () => {
     })
   })
 
+  it('stores a row state that reconciles by construction — NET equals GROSS minus TARE minus PALLET at 2dp', () => {
+    const record = {
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      rowId: '3',
+      type: WASTE_RECORD_TYPE.RECEIVED,
+      versions: [],
+      data: {
+        processingType: 'REPROCESSOR_REGISTERED_ONLY',
+        GROSS_WEIGHT: 10.004,
+        TARE_WEIGHT: 0.005,
+        PALLET_WEIGHT: 0,
+        NET_WEIGHT: 9.999
+      }
+    }
+
+    const { data } = projectRowState(record, null, overseasSites)
+
+    expect(data.NET_WEIGHT).toBe(9.99)
+    expect(data.NET_WEIGHT).toBe(
+      data.GROSS_WEIGHT - data.TARE_WEIGHT - data.PALLET_WEIGHT
+    )
+  })
+
   it('coerces a copy, leaving the source record data at full precision', () => {
     const record = {
       organisationId: 'org-1',

--- a/src/waste-records/application/project-row-state.test.js
+++ b/src/waste-records/application/project-row-state.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+
+import { projectRowState } from './project-row-state.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+
+const overseasSites = /** @type {any} */ (new Map())
+
+describe('projectRowState', () => {
+  it('classifies the record and coerces its stored tonnages to two decimal places', () => {
+    const record = {
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      rowId: '1',
+      type: WASTE_RECORD_TYPE.RECEIVED,
+      versions: [],
+      data: {
+        processingType: 'REPROCESSOR_REGISTERED_ONLY',
+        TONNAGE_RECEIVED_FOR_RECYCLING: 1.005,
+        NET_WEIGHT: 7.536,
+        supplierName: 'Acme'
+      }
+    }
+
+    const projected = projectRowState(record, null, overseasSites)
+
+    expect(projected).toMatchObject({
+      rowId: '1',
+      wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+      classification: {
+        outcome: ROW_OUTCOME.EXCLUDED,
+        reasons: [],
+        transactionAmount: 0
+      },
+      data: {
+        processingType: 'REPROCESSOR_REGISTERED_ONLY',
+        TONNAGE_RECEIVED_FOR_RECYCLING: 1.01,
+        NET_WEIGHT: 7.54,
+        supplierName: 'Acme'
+      }
+    })
+  })
+
+  it('coerces a copy, leaving the source record data at full precision', () => {
+    const record = {
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      rowId: '2',
+      type: WASTE_RECORD_TYPE.RECEIVED,
+      versions: [],
+      data: { processingType: 'REPROCESSOR_REGISTERED_ONLY', NET_WEIGHT: 7.536 }
+    }
+
+    projectRowState(record, null, overseasSites)
+
+    expect(record.data.NET_WEIGHT).toBe(7.536)
+  })
+})

--- a/src/waste-records/application/stored-tonnage-coercion.js
+++ b/src/waste-records/application/stored-tonnage-coercion.js
@@ -1,4 +1,7 @@
-import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
+import {
+  roundToTwoDecimalPlaces,
+  subtract
+} from '#common/helpers/decimal-utils.js'
 
 /**
  * Every per-row tonnage and weight quantity the committed row-state collection
@@ -28,10 +31,42 @@ export const STORED_TONNAGE_FIELDS = Object.freeze([
   'PRODUCT_UK_PACKAGING_WEIGHT_PROPORTION'
 ])
 
+const NET_WEIGHT_COMPONENT_FIELDS = Object.freeze([
+  'GROSS_WEIGHT',
+  'TARE_WEIGHT',
+  'PALLET_WEIGHT'
+])
+
+/**
+ * Ingest validates NET_WEIGHT = GROSS_WEIGHT − TARE_WEIGHT − PALLET_WEIGHT on
+ * the full-precision submission. Rounding each of the four fields independently
+ * can shift that identity by a penny in the stored row, so once the components
+ * are coerced the stored NET is re-derived from them by exact decimal
+ * subtraction (already 2dp, as the components are) — leaving the row reconciled
+ * by construction. Only applies when all four fields are present as numbers; the
+ * identity is undefined otherwise, so NET keeps its own rounding.
+ *
+ * @param {Record<string, any>} coerced
+ */
+const reconcileNetWeight = (coerced) => {
+  const allPresent = ['NET_WEIGHT', ...NET_WEIGHT_COMPONENT_FIELDS].every(
+    (field) => typeof coerced[field] === 'number'
+  )
+  if (!allPresent) {
+    return
+  }
+  const [gross, tare, pallet] = NET_WEIGHT_COMPONENT_FIELDS.map(
+    (field) => coerced[field]
+  )
+  coerced.NET_WEIGHT = subtract(subtract(gross, tare), pallet).toNumber()
+}
+
 /**
  * Return a shallow copy of a row's data with each stored tonnage/weight field
- * coerced to two decimal places (ROUND_HALF_UP). Non-numeric or absent fields,
- * and every other field, are left exactly as submitted.
+ * coerced to two decimal places (ROUND_HALF_UP), and NET_WEIGHT re-derived from
+ * its coerced components so the stored row reconciles by construction.
+ * Non-numeric or absent fields, and every other field, are left exactly as
+ * submitted.
  *
  * @param {Record<string, any>} data
  * @returns {Record<string, any>}
@@ -43,5 +78,6 @@ export const coerceStoredTonnages = (data) => {
       coerced[field] = roundToTwoDecimalPlaces(coerced[field])
     }
   }
+  reconcileNetWeight(coerced)
   return coerced
 }

--- a/src/waste-records/application/stored-tonnage-coercion.js
+++ b/src/waste-records/application/stored-tonnage-coercion.js
@@ -1,0 +1,47 @@
+import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
+
+/**
+ * Every per-row tonnage and weight quantity the committed row-state collection
+ * stores. The domain rule is that stored tonnages are held to two decimal
+ * places, so storing them pre-rounded makes every downstream reader inherit
+ * round-each-then-sum, matching the waste-balance convention (ADR 0027/0028) so
+ * aggregated totals reconcile instead of drifting by a sum-then-round residual.
+ * These are the fields validated as weight/tonnage quantities by the weight-field
+ * schema helpers — `createWeightFieldSchema` in the standard tables and, in the
+ * registered-only tables, the `createUnboundedWeightFieldSchema` variant;
+ * `transactionAmount` is computed and already 2dp, so it is not listed.
+ *
+ * @type {readonly string[]}
+ */
+export const STORED_TONNAGE_FIELDS = Object.freeze([
+  'GROSS_WEIGHT',
+  'TARE_WEIGHT',
+  'PALLET_WEIGHT',
+  'NET_WEIGHT',
+  'WEIGHT_OF_NON_TARGET_MATERIALS',
+  'TONNAGE_RECEIVED_FOR_RECYCLING',
+  'TONNAGE_RECEIVED_FOR_EXPORT',
+  'TONNAGE_PASSED_INTERIM_SITE_RECEIVED_BY_OSR',
+  'TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED',
+  'TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON',
+  'PRODUCT_TONNAGE',
+  'PRODUCT_UK_PACKAGING_WEIGHT_PROPORTION'
+])
+
+/**
+ * Return a shallow copy of a row's data with each stored tonnage/weight field
+ * coerced to two decimal places (ROUND_HALF_UP). Non-numeric or absent fields,
+ * and every other field, are left exactly as submitted.
+ *
+ * @param {Record<string, any>} data
+ * @returns {Record<string, any>}
+ */
+export const coerceStoredTonnages = (data) => {
+  const coerced = { ...data }
+  for (const field of STORED_TONNAGE_FIELDS) {
+    if (typeof coerced[field] === 'number') {
+      coerced[field] = roundToTwoDecimalPlaces(coerced[field])
+    }
+  }
+  return coerced
+}

--- a/src/waste-records/application/stored-tonnage-coercion.test.js
+++ b/src/waste-records/application/stored-tonnage-coercion.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  STORED_TONNAGE_FIELDS,
+  coerceStoredTonnages
+} from './stored-tonnage-coercion.js'
+
+describe('coerceStoredTonnages', () => {
+  it('rounds every stored tonnage/weight field to two decimal places, half-up', () => {
+    const data = {
+      GROSS_WEIGHT: 10.005,
+      TARE_WEIGHT: 2.344,
+      PALLET_WEIGHT: 0.125,
+      NET_WEIGHT: 7.536,
+      WEIGHT_OF_NON_TARGET_MATERIALS: 0.014,
+      TONNAGE_RECEIVED_FOR_RECYCLING: 1.005,
+      TONNAGE_RECEIVED_FOR_EXPORT: 2.344,
+      TONNAGE_PASSED_INTERIM_SITE_RECEIVED_BY_OSR: 3.995,
+      TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 3.005,
+      TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON: 4.999,
+      PRODUCT_TONNAGE: 5.675,
+      PRODUCT_UK_PACKAGING_WEIGHT_PROPORTION: 6.001
+    }
+
+    expect(coerceStoredTonnages(data)).toEqual({
+      GROSS_WEIGHT: 10.01,
+      TARE_WEIGHT: 2.34,
+      PALLET_WEIGHT: 0.13,
+      NET_WEIGHT: 7.54,
+      WEIGHT_OF_NON_TARGET_MATERIALS: 0.01,
+      TONNAGE_RECEIVED_FOR_RECYCLING: 1.01,
+      TONNAGE_RECEIVED_FOR_EXPORT: 2.34,
+      TONNAGE_PASSED_INTERIM_SITE_RECEIVED_BY_OSR: 4,
+      TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 3.01,
+      TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON: 5,
+      PRODUCT_TONNAGE: 5.68,
+      PRODUCT_UK_PACKAGING_WEIGHT_PROPORTION: 6
+    })
+  })
+
+  it('leaves non-tonnage fields untouched', () => {
+    const data = {
+      supplierName: 'Acme',
+      INTERIM_SITE_ID: 'site-1',
+      TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON: 7.891
+    }
+
+    expect(coerceStoredTonnages(data)).toEqual({
+      supplierName: 'Acme',
+      INTERIM_SITE_ID: 'site-1',
+      TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON: 7.89
+    })
+  })
+
+  it('skips tonnage fields that are absent or not numeric', () => {
+    const data = {
+      TONNAGE_RECEIVED_FOR_EXPORT: 'not-a-number',
+      supplierName: 'Beta'
+    }
+
+    expect(coerceStoredTonnages(data)).toEqual({
+      TONNAGE_RECEIVED_FOR_EXPORT: 'not-a-number',
+      supplierName: 'Beta'
+    })
+  })
+
+  it('returns a new object without mutating the input', () => {
+    const data = { TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 1.239 }
+    const result = coerceStoredTonnages(data)
+
+    expect(result).not.toBe(data)
+    expect(data.TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED).toBe(1.239)
+  })
+
+  it('names the twelve stored tonnage/weight fields, transactionAmount excluded', () => {
+    expect([...STORED_TONNAGE_FIELDS]).toEqual([
+      'GROSS_WEIGHT',
+      'TARE_WEIGHT',
+      'PALLET_WEIGHT',
+      'NET_WEIGHT',
+      'WEIGHT_OF_NON_TARGET_MATERIALS',
+      'TONNAGE_RECEIVED_FOR_RECYCLING',
+      'TONNAGE_RECEIVED_FOR_EXPORT',
+      'TONNAGE_PASSED_INTERIM_SITE_RECEIVED_BY_OSR',
+      'TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED',
+      'TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON',
+      'PRODUCT_TONNAGE',
+      'PRODUCT_UK_PACKAGING_WEIGHT_PROPORTION'
+    ])
+  })
+
+  it('stores interim-site tonnages so round-each-then-sum no longer drifts from sum-then-round', () => {
+    const stored = [3.995, 3.995, 3.995]
+      .map((tonnage) =>
+        coerceStoredTonnages({
+          TONNAGE_PASSED_INTERIM_SITE_RECEIVED_BY_OSR: tonnage
+        })
+      )
+      .map((row) => row.TONNAGE_PASSED_INTERIM_SITE_RECEIVED_BY_OSR)
+
+    // Each row stored at 2dp (4.00), so the tonnage-monitoring aggregation sums
+    // 12.00 however it adds them — the sum-then-round residual (11.985 → 11.99)
+    // can no longer arise.
+    expect(stored).toEqual([4, 4, 4])
+    expect(stored.reduce((sum, t) => sum + t, 0)).toBeCloseTo(12, 10)
+  })
+
+  it('rounds each weight independently — stored NET need not equal stored GROSS minus TARE minus PALLET', () => {
+    const coerced = coerceStoredTonnages({
+      GROSS_WEIGHT: 10.005,
+      TARE_WEIGHT: 2.002,
+      PALLET_WEIGHT: 1.001,
+      NET_WEIGHT: 7.002
+    })
+
+    // Each component carries its own single rounding; the submission-time
+    // identity NET = GROSS - TARE - PALLET is not preserved on stored values
+    // (here 10.01 - 2.00 - 1.00 = 7.01 against a stored NET of 7.00), and
+    // nothing downstream re-derives it.
+    expect(coerced.NET_WEIGHT).toBe(7)
+    expect(
+      coerced.GROSS_WEIGHT - coerced.TARE_WEIGHT - coerced.PALLET_WEIGHT
+    ).toBeCloseTo(7.01, 2)
+    expect(coerced.NET_WEIGHT).not.toBeCloseTo(7.01, 2)
+  })
+})

--- a/src/waste-records/application/stored-tonnage-coercion.test.js
+++ b/src/waste-records/application/stored-tonnage-coercion.test.js
@@ -105,22 +105,37 @@ describe('coerceStoredTonnages', () => {
     expect(stored.reduce((sum, t) => sum + t, 0)).toBeCloseTo(12, 10)
   })
 
-  it('rounds each weight independently — stored NET need not equal stored GROSS minus TARE minus PALLET', () => {
+  it('derives stored NET_WEIGHT from the coerced components so the row reconciles by construction', () => {
+    // Counterexample where independent per-field rounding would break the
+    // stored identity: GROSS=10.004 TARE=0.005 PALLET=0 NET=9.999 passes ingest
+    // (9.999 == 10.004 - 0.005 within tolerance), but rounding each field alone
+    // gives GROSS=10.00, TARE=0.01, NET=10.00 — a stored row where
+    // GROSS - TARE - PALLET = 9.99 ≠ NET = 10.00. Deriving NET from the coerced
+    // components restores the identity at 2dp.
+    const coerced = coerceStoredTonnages({
+      GROSS_WEIGHT: 10.004,
+      TARE_WEIGHT: 0.005,
+      PALLET_WEIGHT: 0,
+      NET_WEIGHT: 9.999
+    })
+
+    expect(coerced.GROSS_WEIGHT).toBe(10)
+    expect(coerced.TARE_WEIGHT).toBe(0.01)
+    expect(coerced.NET_WEIGHT).toBe(9.99)
+    expect(coerced.NET_WEIGHT).toBe(
+      coerced.GROSS_WEIGHT - coerced.TARE_WEIGHT - coerced.PALLET_WEIGHT
+    )
+  })
+
+  it('leaves NET_WEIGHT independently rounded when a weight component is absent', () => {
     const coerced = coerceStoredTonnages({
       GROSS_WEIGHT: 10.005,
-      TARE_WEIGHT: 2.002,
-      PALLET_WEIGHT: 1.001,
       NET_WEIGHT: 7.002
     })
 
-    // Each component carries its own single rounding; the submission-time
-    // identity NET = GROSS - TARE - PALLET is not preserved on stored values
-    // (here 10.01 - 2.00 - 1.00 = 7.01 against a stored NET of 7.00), and
-    // nothing downstream re-derives it.
+    // Without all of GROSS/TARE/PALLET the ingest identity does not apply, so
+    // NET keeps its own single rounding rather than being derived.
     expect(coerced.NET_WEIGHT).toBe(7)
-    expect(
-      coerced.GROSS_WEIGHT - coerced.TARE_WEIGHT - coerced.PALLET_WEIGHT
-    ).toBeCloseTo(7.01, 2)
-    expect(coerced.NET_WEIGHT).not.toBeCloseTo(7.01, 2)
+    expect(coerced.GROSS_WEIGHT).toBe(10.01)
   })
 })

--- a/src/waste-records/application/write-waste-record-states.js
+++ b/src/waste-records/application/write-waste-record-states.js
@@ -1,5 +1,5 @@
 import { markExcludedRecords } from '#waste-balances/application/mark-excluded-records.js'
-import { classifyWasteRecord } from '#waste-balances/application/target-amount.js'
+import { projectRowState } from './project-row-state.js'
 
 /**
  * @import { OverseasSitesContext } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
@@ -44,7 +44,7 @@ export const writeWasteRecordStates = async ({
   }
 
   const classifiedRows = markExcludedRecords(wasteRecords).map((record) =>
-    classifyWasteRecord(record, accreditation, overseasSites)
+    projectRowState(record, accreditation, overseasSites)
   )
 
   await rowStateRepository.upsertRowStates(

--- a/src/waste-records/application/write-waste-record-states.test.js
+++ b/src/waste-records/application/write-waste-record-states.test.js
@@ -18,6 +18,18 @@ const buildRegisteredOnlyRecord = ({ rowId, tonnage }) => ({
   }
 })
 
+const buildReceivedRecord = ({ rowId, tonnage }) => ({
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  rowId: String(rowId),
+  type: WASTE_RECORD_TYPE.RECEIVED,
+  versions: [],
+  data: {
+    processingType: 'REPROCESSOR_REGISTERED_ONLY',
+    TONNAGE_RECEIVED_FOR_RECYCLING: tonnage
+  }
+})
+
 const overseasSites = /** @type {any} */ (new Map())
 
 const nullPartition = {
@@ -103,6 +115,62 @@ describe('writeWasteRecordStates', () => {
       },
       summaryLogIds: ['log-A']
     })
+  })
+
+  it('stores tonnages coerced to two decimal places', async () => {
+    await writeWasteRecordStates({
+      rowStateRepository,
+      featureFlags: createInMemoryFeatureFlags({ wasteRecordStates: true }),
+      wasteRecords: [buildReceivedRecord({ rowId: 1, tonnage: 1.005 })],
+      accreditation: null,
+      partition: nullPartition,
+      overseasSites,
+      summaryLogId: 'log-A'
+    })
+
+    const [committed] = await rowStateRepository.findBySummaryLogId('log-A')
+    expect(committed.data.TONNAGE_RECEIVED_FOR_RECYCLING).toBe(1.01)
+  })
+
+  it('stores weight quantities coerced to two decimal places', async () => {
+    await writeWasteRecordStates({
+      rowStateRepository,
+      featureFlags: createInMemoryFeatureFlags({ wasteRecordStates: true }),
+      wasteRecords: [buildRegisteredOnlyRecord({ rowId: 1, tonnage: 7.536 })],
+      accreditation: null,
+      partition: nullPartition,
+      overseasSites,
+      summaryLogId: 'log-A'
+    })
+
+    const [committed] = await rowStateRepository.findBySummaryLogId('log-A')
+    expect(committed.data.NET_WEIGHT).toBe(7.54)
+  })
+
+  it('stores tonnages so round-each-then-sum no longer drifts from sum-then-round', async () => {
+    await writeWasteRecordStates({
+      rowStateRepository,
+      featureFlags: createInMemoryFeatureFlags({ wasteRecordStates: true }),
+      wasteRecords: [
+        buildReceivedRecord({ rowId: 1, tonnage: 1.005 }),
+        buildReceivedRecord({ rowId: 2, tonnage: 1.005 }),
+        buildReceivedRecord({ rowId: 3, tonnage: 1.005 })
+      ],
+      accreditation: null,
+      partition: nullPartition,
+      overseasSites,
+      summaryLogId: 'log-A'
+    })
+
+    const committed = await rowStateRepository.findBySummaryLogId('log-A')
+    const storedTonnages = committed.map(
+      (doc) => doc.data.TONNAGE_RECEIVED_FOR_RECYCLING
+    )
+    // Stored per-row values are already 2dp, so summing them yields the
+    // round-each-then-sum total (3.03) however a consumer adds them — the
+    // sum-then-round residual (3.015 → 3.02) can no longer arise.
+    expect(storedTonnages).toEqual([1.01, 1.01, 1.01])
+    expect(storedTonnages.reduce((sum, t) => sum + t, 0)).toBeCloseTo(3.03, 10)
   })
 
   it('carries the supplied accreditation id onto the partition', async () => {

--- a/src/waste-records/backfill/reconstruct-submission-rowstates.js
+++ b/src/waste-records/backfill/reconstruct-submission-rowstates.js
@@ -1,4 +1,4 @@
-import { classifyWasteRecord } from '#waste-balances/application/target-amount.js'
+import { projectRowState } from '#waste-records/application/project-row-state.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 
 /**
@@ -94,7 +94,7 @@ export const reconstructSubmissionRowStates = ({
         return []
       }
       return [
-        classifyWasteRecord({ ...record, data }, accreditation, overseasSites)
+        projectRowState({ ...record, data }, accreditation, overseasSites)
       ]
     })
     return { summaryLogId: log.id, entries }

--- a/src/waste-records/backfill/reconstruct-submission-rowstates.test.js
+++ b/src/waste-records/backfill/reconstruct-submission-rowstates.test.js
@@ -164,6 +164,37 @@ describe('reconstructSubmissionRowStates', () => {
     })
   })
 
+  it('coerces stored tonnages and weights to two decimal places in reconstructed entries', () => {
+    const summaryLogs = [submittedLog('sl-1', '2025-01-01T00:00:00.000Z')]
+    const wasteRecords = [
+      receivedRecord('row-1', [
+        {
+          summaryLog: { id: 'sl-1' },
+          data: {
+            supplierName: 'Acme',
+            TONNAGE_RECEIVED_FOR_RECYCLING: 1.005,
+            NET_WEIGHT: 7.536,
+            TONNAGE_PASSED_INTERIM_SITE_RECEIVED_BY_OSR: 3.995
+          }
+        }
+      ])
+    ]
+
+    const [{ entries }] = reconstructSubmissionRowStates({
+      wasteRecords,
+      summaryLogs,
+      accreditation,
+      overseasSites
+    })
+
+    expect(entries[0].data).toEqual({
+      supplierName: 'Acme',
+      TONNAGE_RECEIVED_FOR_RECYCLING: 1.01,
+      NET_WEIGHT: 7.54,
+      TONNAGE_PASSED_INTERIM_SITE_RECEIVED_BY_OSR: 4
+    })
+  })
+
   it('ignores summary logs that are not submitted', () => {
     const summaryLogs = [
       submittedLog('sl-1', '2025-01-01T00:00:00.000Z'),


### PR DESCRIPTION
Ticket: [PAE-1668](https://eaflood.atlassian.net/browse/PAE-1668)
The committed row-state collection must hold every per-row tonnage and weight quantity to two decimal places, so that downstream consumers inherit round-each-then-sum from the data itself and their aggregated totals reconcile with the waste-balance rounding convention (ADR 0027/0028) instead of drifting by a sum-then-round residual. The tonnage-monitoring aggregation that sums `TONNAGE_PASSED_INTERIM_SITE_RECEIVED_BY_OSR` carries exactly that latent drift today.

This coerces the twelve stored tonnage/weight fields to 2dp (ROUND_HALF_UP) in a shared `projectRowState` seam that classifies the record and then rounds the stored `data`. Every path that persists a row state routes through the seam — the forward write (`writeWasteRecordStates`) and both backfill reconstructions — for all streams including registered-only and no-accreditation partitions (`accreditationId: null`).

The waste-balance path keeps `classifyWasteRecord` directly and stays at full precision, which the cross-field reconciliation arithmetic requires; the coercion is a non-mutating shallow copy applied after classification, so `transactionAmount` (already 2dp) and the balance calculation are untouched. So the stored 2dp row reconciles by construction, `NET_WEIGHT` is derived from its coerced components by exact decimal subtraction (`GROSS − TARE − PALLET`) rather than rounded independently — independent per-field rounding could shift the ingest identity by a penny in the stored row, whereas deriving it makes `NET_WEIGHT = GROSS_WEIGHT − TARE_WEIGHT − PALLET_WEIGHT` hold at 2dp on the stored values, not just at submission.

Removing the now-redundant report-aggregation rounding, once reports read the pre-rounded row states, is tracked separately.

[PAE-1668]: https://eaflood.atlassian.net/browse/PAE-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
