### PR TITLE
PAE-1590: register mongo row-state repository and flag-gated estate backfill

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -375,6 +375,12 @@ const baseConfig = {
       format: Boolean,
       default: false,
       env: 'FEATURE_FLAG_SUMMARY_LOG_ROW_STATES'
+    },
+    wasteRecordStatesBackfill: {
+      doc: 'Feature Flag: Run the estate-wide waste-record-state reconstruction backfill on startup (ADR-0037)',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_FLAG_WASTE_RECORD_STATES_BACKFILL'
     }
   },
   formSubmissionOverrides: {

--- a/src/config.js
+++ b/src/config.js
@@ -380,7 +380,7 @@ const baseConfig = {
       doc: 'Feature Flag: Run the estate-wide waste-record-state reconstruction backfill on startup (ADR-0037)',
       format: Boolean,
       default: false,
-      env: 'FEATURE_FLAG_WASTE_RECORD_STATES_BACKFILL'
+      env: 'FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL'
     }
   },
   formSubmissionOverrides: {

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -13,5 +13,8 @@ export const createConfigFeatureFlags = (config) => ({
   },
   isWasteRecordStatesEnabled() {
     return config.get('featureFlags.wasteRecordStates')
+  },
+  isWasteRecordStatesBackfillEnabled() {
+    return config.get('featureFlags.wasteRecordStatesBackfill')
   }
 })

--- a/src/feature-flags/feature-flags.config.test.js
+++ b/src/feature-flags/feature-flags.config.test.js
@@ -29,4 +29,13 @@ describe('createConfigFeatureFlags', () => {
     expect(flags.isWasteRecordStatesEnabled()).toBe(true)
     expect(config.get).toHaveBeenCalledWith('featureFlags.wasteRecordStates')
   })
+
+  it('returns true when wasteRecordStatesBackfill flag is enabled', () => {
+    const config = { get: vi.fn().mockReturnValue(true) }
+    const flags = createConfigFeatureFlags(config)
+    expect(flags.isWasteRecordStatesBackfillEnabled()).toBe(true)
+    expect(config.get).toHaveBeenCalledWith(
+      'featureFlags.wasteRecordStatesBackfill'
+    )
+  })
 })

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -14,5 +14,8 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   },
   isWasteRecordStatesEnabled() {
     return flags.wasteRecordStates ?? false
+  },
+  isWasteRecordStatesBackfillEnabled() {
+    return flags.wasteRecordStatesBackfill ?? false
   }
 })

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -65,4 +65,23 @@ describe('createInMemoryFeatureFlags', () => {
     const flags = createInMemoryFeatureFlags({})
     expect(flags.isWasteRecordStatesEnabled()).toBe(false)
   })
+
+  it('returns true when wasteRecordStatesBackfill flag is enabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      wasteRecordStatesBackfill: true
+    })
+    expect(flags.isWasteRecordStatesBackfillEnabled()).toBe(true)
+  })
+
+  it('returns false when wasteRecordStatesBackfill flag is disabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      wasteRecordStatesBackfill: false
+    })
+    expect(flags.isWasteRecordStatesBackfillEnabled()).toBe(false)
+  })
+
+  it('returns false when wasteRecordStatesBackfill flag is not provided', () => {
+    const flags = createInMemoryFeatureFlags({})
+    expect(flags.isWasteRecordStatesBackfillEnabled()).toBe(false)
+  })
 })

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -4,6 +4,7 @@
  * @property {() => boolean} isCopyFormFilesToS3Enabled
  * @property {() => boolean} isFixDuplicateAccreditationLinksEnabled
  * @property {() => boolean} isWasteRecordStatesEnabled
+ * @property {() => boolean} isWasteRecordStatesBackfillEnabled
  */
 
 /**
@@ -12,6 +13,7 @@
  * @property {boolean} [copyFormFilesToS3]
  * @property {boolean} [fixDuplicateAccreditationLinks]
  * @property {boolean} [wasteRecordStates]
+ * @property {boolean} [wasteRecordStatesBackfill]
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/server/run-backfill-waste-record-states.js
+++ b/src/server/run-backfill-waste-record-states.js
@@ -1,0 +1,75 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import { backfillEstateRowStates } from '#waste-records/backfill/backfill-estate-rowstates.js'
+
+/** @import { OrphanedAccreditation } from '#waste-records/backfill/backfill-estate-rowstates.js' */
+
+const LOCK_NAME = 'waste-record-states-backfill'
+
+/**
+ * @param {OrphanedAccreditation} orphan
+ */
+const formatOrphan = (orphan) =>
+  `Waste-record-state backfill orphaned accreditation: organisationId=${orphan.organisationId} registrationId=${orphan.registrationId} accreditationId=${orphan.accreditationId}`
+
+/**
+ * @param {Object} server - Hapi server instance
+ */
+const runBackfill = async (server) => {
+  const summary = await backfillEstateRowStates({
+    organisationsRepository: server.app.organisationsRepository,
+    wasteRecordsRepository: server.app.wasteRecordsRepository,
+    summaryLogsRepository: server.app.summaryLogsRepository,
+    overseasSitesRepository: server.app.overseasSitesRepository,
+    rowStateRepository: server.app.wasteRecordStatesRepository
+  })
+
+  for (const orphan of summary.orphanedAccreditations) {
+    logger.warn({ message: formatOrphan(orphan) })
+  }
+
+  logger.info({
+    message: `Waste-record-state backfill complete: organisationsScanned=${summary.organisationsScanned} streamsBackfilled=${summary.streamsBackfilled} submissionsBackfilled=${summary.submissionsBackfilled} rowStateWrites=${summary.rowStateWrites} orphanedAccreditations=${summary.orphanedAccreditations.length}`
+  })
+}
+
+/**
+ * Reconstructs the historical waste-record-state estate by replaying every
+ * registration's submitted summary logs through the guarded, content-addressed
+ * upsert. The whole mechanism is gated by the waste-record-states-backfill
+ * feature flag: with it off this returns before touching the locker or any
+ * repository, so the mongodb row-state adapter is never invoked at rest and the
+ * write-gate invariant holds. The deliberate run is authorised by flipping the
+ * flag at rollout time, after the dry-run diagnostic has been reviewed.
+ *
+ * Runs under a cross-instance lock so a single pod per deploy executes the
+ * sweep. Idempotent: the upsert dedups through the unique row-state identity
+ * index, so a re-run writes nothing new. This is the sanctioned prod route —
+ * there is no ad-hoc production command.
+ *
+ * @param {Object} server - Hapi server instance
+ */
+export const runBackfillWasteRecordStates = async (server) => {
+  if (!server.featureFlags.isWasteRecordStatesBackfillEnabled()) {
+    return
+  }
+
+  try {
+    const lock = await server.locker.lock(LOCK_NAME)
+    if (!lock) {
+      logger.info({
+        message: 'Unable to obtain lock, skipping waste-record-state backfill'
+      })
+      return
+    }
+    try {
+      await runBackfill(server)
+    } finally {
+      await lock.free()
+    }
+  } catch (error) {
+    logger.error({
+      err: error,
+      message: 'Failed to run waste-record-state backfill'
+    })
+  }
+}

--- a/src/server/run-backfill-waste-record-states.test.js
+++ b/src/server/run-backfill-waste-record-states.test.js
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { logger } from '#common/helpers/logging/logger.js'
+import { backfillEstateRowStates } from '#waste-records/backfill/backfill-estate-rowstates.js'
+
+import { runBackfillWasteRecordStates } from './run-backfill-waste-record-states.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+vi.mock('#waste-records/backfill/backfill-estate-rowstates.js', () => ({
+  backfillEstateRowStates: vi.fn()
+}))
+
+/**
+ * @param {Partial<import('#waste-records/backfill/backfill-estate-rowstates.js').EstateBackfillSummary>} [summary]
+ */
+const seedSummary = (summary = {}) => {
+  vi.mocked(backfillEstateRowStates).mockResolvedValue({
+    organisationsScanned: 0,
+    streamsBackfilled: 0,
+    submissionsBackfilled: 0,
+    rowStateWrites: 0,
+    orphanedAccreditations: [],
+    ...summary
+  })
+}
+
+describe('runBackfillWasteRecordStates', () => {
+  let mockServer
+  let mockLock
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockLock = { free: vi.fn().mockResolvedValue(undefined) }
+    mockServer = {
+      featureFlags: {
+        isWasteRecordStatesBackfillEnabled: () => true
+      },
+      locker: {
+        lock: vi.fn().mockResolvedValue(mockLock)
+      },
+      app: {
+        organisationsRepository: { name: 'organisations' },
+        wasteRecordsRepository: { name: 'wasteRecords' },
+        summaryLogsRepository: { name: 'summaryLogs' },
+        overseasSitesRepository: { name: 'overseasSites' },
+        wasteRecordStatesRepository: { name: 'wasteRecordStates' }
+      }
+    }
+  })
+
+  it('does nothing when the backfill flag is off — no lock, no adapter invocation', async () => {
+    mockServer.featureFlags.isWasteRecordStatesBackfillEnabled = () => false
+
+    await runBackfillWasteRecordStates(mockServer)
+
+    expect(mockServer.locker.lock).not.toHaveBeenCalled()
+    expect(backfillEstateRowStates).not.toHaveBeenCalled()
+    expect(logger.info).not.toHaveBeenCalled()
+  })
+
+  it('acquires a lock scoped to the backfill and releases it afterwards', async () => {
+    seedSummary()
+
+    await runBackfillWasteRecordStates(mockServer)
+
+    expect(mockServer.locker.lock).toHaveBeenCalledWith(
+      'waste-record-states-backfill'
+    )
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('runs the estate backfill wired to the registered mongodb adapters', async () => {
+    seedSummary()
+
+    await runBackfillWasteRecordStates(mockServer)
+
+    expect(backfillEstateRowStates).toHaveBeenCalledWith({
+      organisationsRepository: mockServer.app.organisationsRepository,
+      wasteRecordsRepository: mockServer.app.wasteRecordsRepository,
+      summaryLogsRepository: mockServer.app.summaryLogsRepository,
+      overseasSitesRepository: mockServer.app.overseasSitesRepository,
+      rowStateRepository: mockServer.app.wasteRecordStatesRepository
+    })
+  })
+
+  it('skips the backfill when the lock is held by another instance', async () => {
+    mockServer.locker.lock.mockResolvedValue(null)
+
+    await runBackfillWasteRecordStates(mockServer)
+
+    expect(backfillEstateRowStates).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Unable to obtain lock, skipping waste-record-state backfill'
+    })
+  })
+
+  it('logs the backfill summary counts', async () => {
+    seedSummary({
+      organisationsScanned: 12,
+      streamsBackfilled: 8,
+      submissionsBackfilled: 20,
+      rowStateWrites: 140
+    })
+
+    await runBackfillWasteRecordStates(mockServer)
+
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-record-state backfill complete: organisationsScanned=12 streamsBackfilled=8 submissionsBackfilled=20 rowStateWrites=140 orphanedAccreditations=0'
+    })
+  })
+
+  it('logs each orphaned accreditation at warn', async () => {
+    seedSummary({
+      organisationsScanned: 1,
+      orphanedAccreditations: [
+        {
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          accreditationId: 'acc-1'
+        }
+      ]
+    })
+
+    await runBackfillWasteRecordStates(mockServer)
+
+    expect(logger.warn).toHaveBeenCalledWith({
+      message:
+        'Waste-record-state backfill orphaned accreditation: organisationId=org-1 registrationId=reg-1 accreditationId=acc-1'
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-record-state backfill complete: organisationsScanned=1 streamsBackfilled=0 submissionsBackfilled=0 rowStateWrites=0 orphanedAccreditations=1'
+    })
+  })
+
+  it('releases the lock and logs an error when the backfill throws', async () => {
+    const error = new Error('mongo unavailable')
+    vi.mocked(backfillEstateRowStates).mockRejectedValue(error)
+
+    await runBackfillWasteRecordStates(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run waste-record-state backfill'
+    })
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('tolerates the locker itself throwing', async () => {
+    const error = new Error('locker unavailable')
+    mockServer.locker.lock.mockRejectedValue(error)
+
+    await runBackfillWasteRecordStates(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run waste-record-state backfill'
+    })
+  })
+})

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -111,6 +111,10 @@ function getSwaggerPlugins() {
   ]
 }
 
+export const shouldRegisterWasteRecordStates = (config) =>
+  config.get('featureFlags.wasteRecordStates') ||
+  config.get('featureFlags.wasteRecordStatesBackfill')
+
 function getProductionPlugins(config) {
   const eventualConsistency = config.get('mongo.eventualConsistency')
 
@@ -126,7 +130,6 @@ function getProductionPlugins(config) {
     mongoSummaryLogsRepositoryPlugin,
     mongoFormSubmissionsRepositoryPlugin,
     mongoWasteRecordsRepositoryPlugin,
-    mongoWasteRecordStatesRepositoryPlugin,
     mongoStreamRepositoryPlugin,
     mongoWasteBalanceServicePlugin,
     mongoSystemLogsRepositoryPlugin,
@@ -137,6 +140,16 @@ function getProductionPlugins(config) {
     overseasSitesRepositoryPlugin,
     orsImportsRepositoryPlugin
   ]
+
+  // Defer row-state repository construction (and thus ensureRowStatesCollection
+  // creating the collection + indexes) until a row-state flag is on, so nothing
+  // is built ahead of the ADR-0037 switch-on. Register for either flag: the
+  // backfill sweep and the forward-write path both need the repository, and the
+  // flip choreography can leave the backfill flag off by the time forward writes
+  // begin.
+  if (shouldRegisterWasteRecordStates(config)) {
+    plugins.push(mongoWasteRecordStatesRepositoryPlugin)
+  }
 
   plugins.push(mongoReportsRepositoryPlugin)
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -38,6 +38,7 @@ import { mongoSystemLogsRepositoryPlugin } from '#repositories/system-logs/mongo
 import { mongoStreamRepositoryPlugin } from '#waste-balances/repository/stream-mongodb.plugin.js'
 import { mongoWasteBalanceServicePlugin } from '#waste-balances/repository/mongodb.plugin.js'
 import { mongoWasteRecordsRepositoryPlugin } from '#repositories/waste-records/mongodb.plugin.js'
+import { mongoWasteRecordStatesRepositoryPlugin } from '#waste-records/repository/mongodb.plugin.js'
 import { mongoReportsRepositoryPlugin } from '#reports/repository/mongodb.plugin.js'
 import { getConfig } from '#root/config.js'
 import { commandQueueConsumerPlugin } from '#server/queue-consumer/queue-consumer.plugin.js'
@@ -45,6 +46,7 @@ import { runFormsDataMigration } from '#server/run-forms-data-migration.js'
 import { copyFormFilesToS3 } from '#server/copy-form-files-to-s3.js'
 import { runOrganisationValidationSweep } from '#server/run-organisation-validation-sweep.js'
 import { runDuplicateAccreditationLinkMigration } from '#server/run-duplicate-accreditation-link-migration.js'
+import { runBackfillWasteRecordStates } from '#server/run-backfill-waste-record-states.js'
 
 /** @import { Lifecycle } from '@hapi/hapi' */
 
@@ -124,6 +126,7 @@ function getProductionPlugins(config) {
     mongoSummaryLogsRepositoryPlugin,
     mongoFormSubmissionsRepositoryPlugin,
     mongoWasteRecordsRepositoryPlugin,
+    mongoWasteRecordStatesRepositoryPlugin,
     mongoStreamRepositoryPlugin,
     mongoWasteBalanceServicePlugin,
     mongoSystemLogsRepositoryPlugin,
@@ -223,6 +226,7 @@ async function createServer(options = {}) {
     copyFormFilesToS3(server)
     runOrganisationValidationSweep(server)
     runDuplicateAccreditationLinkMigration(server)
+    runBackfillWasteRecordStates(server)
   })
 
   return server

--- a/src/server/server.test.js
+++ b/src/server/server.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+
+import { getConfig } from '#root/config.js'
+
+import { shouldRegisterWasteRecordStates } from './server.js'
+
+describe('shouldRegisterWasteRecordStates', () => {
+  it('defers registration while both row-state flags are off', () => {
+    const config = getConfig({
+      featureFlags: {
+        wasteRecordStates: false,
+        wasteRecordStatesBackfill: false
+      }
+    })
+
+    expect(shouldRegisterWasteRecordStates(config)).toBe(false)
+  })
+
+  it('registers once the write flag is on', () => {
+    const config = getConfig({
+      featureFlags: {
+        wasteRecordStates: true,
+        wasteRecordStatesBackfill: false
+      }
+    })
+
+    expect(shouldRegisterWasteRecordStates(config)).toBe(true)
+  })
+
+  it('registers once the backfill flag is on', () => {
+    const config = getConfig({
+      featureFlags: {
+        wasteRecordStates: false,
+        wasteRecordStatesBackfill: true
+      }
+    })
+
+    expect(shouldRegisterWasteRecordStates(config)).toBe(true)
+  })
+})

--- a/src/server/waste-record-states-registration.integration.test.js
+++ b/src/server/waste-record-states-registration.integration.test.js
@@ -51,7 +51,7 @@ describe('waste-record-states repository registration', () => {
 
     beforeAll(async () => {
       delete process.env.FEATURE_FLAG_WASTE_RECORD_STATES
-      delete process.env.FEATURE_FLAG_WASTE_RECORD_STATES_BACKFILL
+      delete process.env.FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL
       server = await bootServer()
     })
 
@@ -78,7 +78,7 @@ describe('waste-record-states repository registration', () => {
 
     beforeAll(async () => {
       process.env.FEATURE_FLAG_WASTE_RECORD_STATES = 'true'
-      delete process.env.FEATURE_FLAG_WASTE_RECORD_STATES_BACKFILL
+      delete process.env.FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL
       server = await bootServer()
     })
 

--- a/src/server/waste-record-states-registration.integration.test.js
+++ b/src/server/waste-record-states-registration.integration.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { setup as setupMongo, teardown as teardownMongo } from 'vitest-mongodb'
+import { randomUUID } from 'node:crypto'
+
+import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+import { WASTE_BALANCE_ROW_STATES_COLLECTION_NAME } from '#waste-records/repository/mongodb.js'
+
+vi.mock(
+  '#adapters/sqs-command-executor/sqs-command-executor.plugin.js',
+  async () => import('#adapters/sqs-command-executor/mock.plugin.js')
+)
+vi.mock(
+  '#plugins/dlq-admin.js',
+  async () => import('#plugins/dlq-admin.mock.plugin.js')
+)
+
+const startMongo = async () => {
+  await setupMongo(
+    /** @type {*} */ ({
+      binary: { version: 'latest' },
+      serverOptions: {},
+      autoStart: false
+    })
+  )
+  process.env.MONGO_URI = globalThis.__MONGO_URI__
+}
+
+const bootServer = async () => {
+  process.env.MONGO_DATABASE = `epr-backend-test-${randomUUID()}`
+  const { createServer } = await import('#server/server.js')
+  const server = await createServer()
+  await server.initialize()
+  // The mongoDb plugin decorates `db` and repository plugins decorate `app`;
+  // neither is on Hapi's Server type, so project to the test's dynamic shape.
+  return /** @type {*} */ (server)
+}
+
+describe('waste-record-states repository registration', () => {
+  setupAuthContext()
+
+  beforeAll(async () => {
+    await startMongo()
+  })
+
+  afterAll(async () => {
+    await teardownMongo()
+  })
+
+  describe('while every row-state flag is off', () => {
+    let server
+
+    beforeAll(async () => {
+      delete process.env.FEATURE_FLAG_WASTE_RECORD_STATES
+      delete process.env.FEATURE_FLAG_WASTE_RECORD_STATES_BACKFILL
+      server = await bootServer()
+    })
+
+    afterAll(async () => {
+      await server.db.dropDatabase()
+      await server.stop()
+    })
+
+    it('constructs no row-state repository', () => {
+      expect(server.app.wasteRecordStatesRepository).toBeUndefined()
+    })
+
+    it('creates no row-state collection or indexes', async () => {
+      const collections = await server.db
+        .listCollections({ name: WASTE_BALANCE_ROW_STATES_COLLECTION_NAME })
+        .toArray()
+
+      expect(collections).toHaveLength(0)
+    })
+  })
+
+  describe('once the switch-on flag is flipped', () => {
+    let server
+
+    beforeAll(async () => {
+      process.env.FEATURE_FLAG_WASTE_RECORD_STATES = 'true'
+      delete process.env.FEATURE_FLAG_WASTE_RECORD_STATES_BACKFILL
+      server = await bootServer()
+    })
+
+    afterAll(async () => {
+      await server.db.dropDatabase()
+      await server.stop()
+      delete process.env.FEATURE_FLAG_WASTE_RECORD_STATES
+    })
+
+    it('constructs the row-state repository', () => {
+      expect(server.app.wasteRecordStatesRepository).toBeDefined()
+    })
+
+    it('creates the empty collection with its three indexes', async () => {
+      const indexes = await server.db
+        .collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME)
+        .listIndexes()
+        .toArray()
+
+      const indexesByName = Object.fromEntries(
+        indexes.map((index) => [index.name, index])
+      )
+
+      expect(indexesByName).toHaveProperty('membership')
+      expect(indexesByName).toHaveProperty('row_history')
+      expect(indexesByName.waste_record_state_identity.unique).toBe(true)
+
+      const documentCount = await server.db
+        .collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME)
+        .countDocuments()
+
+      expect(documentCount).toBe(0)
+    })
+  })
+})

--- a/src/server/waste-record-states-registration.integration.test.js
+++ b/src/server/waste-record-states-registration.integration.test.js
@@ -3,7 +3,7 @@ import { setup as setupMongo, teardown as teardownMongo } from 'vitest-mongodb'
 import { randomUUID } from 'node:crypto'
 
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
-import { WASTE_BALANCE_ROW_STATES_COLLECTION_NAME } from '#waste-records/repository/mongodb.js'
+import { SUMMARY_LOG_ROW_STATES_COLLECTION_NAME } from '#waste-records/repository/mongodb.js'
 
 vi.mock(
   '#adapters/sqs-command-executor/sqs-command-executor.plugin.js',
@@ -50,7 +50,7 @@ describe('waste-record-states repository registration', () => {
     let server
 
     beforeAll(async () => {
-      delete process.env.FEATURE_FLAG_WASTE_RECORD_STATES
+      delete process.env.FEATURE_FLAG_SUMMARY_LOG_ROW_STATES
       delete process.env.FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL
       server = await bootServer()
     })
@@ -66,7 +66,7 @@ describe('waste-record-states repository registration', () => {
 
     it('creates no row-state collection or indexes', async () => {
       const collections = await server.db
-        .listCollections({ name: WASTE_BALANCE_ROW_STATES_COLLECTION_NAME })
+        .listCollections({ name: SUMMARY_LOG_ROW_STATES_COLLECTION_NAME })
         .toArray()
 
       expect(collections).toHaveLength(0)
@@ -77,7 +77,7 @@ describe('waste-record-states repository registration', () => {
     let server
 
     beforeAll(async () => {
-      process.env.FEATURE_FLAG_WASTE_RECORD_STATES = 'true'
+      process.env.FEATURE_FLAG_SUMMARY_LOG_ROW_STATES = 'true'
       delete process.env.FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL
       server = await bootServer()
     })
@@ -85,7 +85,7 @@ describe('waste-record-states repository registration', () => {
     afterAll(async () => {
       await server.db.dropDatabase()
       await server.stop()
-      delete process.env.FEATURE_FLAG_WASTE_RECORD_STATES
+      delete process.env.FEATURE_FLAG_SUMMARY_LOG_ROW_STATES
     })
 
     it('constructs the row-state repository', () => {
@@ -94,7 +94,7 @@ describe('waste-record-states repository registration', () => {
 
     it('creates the empty collection with its three indexes', async () => {
       const indexes = await server.db
-        .collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME)
+        .collection(SUMMARY_LOG_ROW_STATES_COLLECTION_NAME)
         .listIndexes()
         .toArray()
 
@@ -102,12 +102,12 @@ describe('waste-record-states repository registration', () => {
         indexes.map((index) => [index.name, index])
       )
 
-      expect(indexesByName).toHaveProperty('membership')
+      expect(indexesByName).toHaveProperty('summary_log_membership')
       expect(indexesByName).toHaveProperty('row_history')
-      expect(indexesByName.waste_record_state_identity.unique).toBe(true)
+      expect(indexesByName.summary_log_row_state_identity.unique).toBe(true)
 
       const documentCount = await server.db
-        .collection(WASTE_BALANCE_ROW_STATES_COLLECTION_NAME)
+        .collection(SUMMARY_LOG_ROW_STATES_COLLECTION_NAME)
         .countDocuments()
 
       expect(documentCount).toBe(0)


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)

Replaces #1419, which could not be reopened after this branch was brought current onto today's `main` (the rebase orphaned the recorded head SHA). Same work, brought current.

Pre-flip enablement for the ADR-0037 committed row-state rollout. Nothing here changes runtime behaviour with the flags off — it makes the eventual flip executable in production without ad-hoc access.

## Register the mongo row-state repository in production

`getProductionPlugins` registered only the legacy `mongoWasteRecordsRepositoryPlugin`; `mongoWasteRecordStatesRepositoryPlugin` was imported nowhere, so `ensureRowStatesCollection` never ran and the `summary-log-row-states` collection and its three indexes did not exist in production. This registers it — gated behind the row-state feature flags — so when the feature is switched on the collection is created empty with its indexes, including the unique `summary_log_row_state_identity` dedup guard. The unique index must build over an empty collection, so this lands before any writes. Registration only builds the collection and indexes; it does not invoke the adapter's write methods. While every row-state flag is off nothing is constructed — no repository, no collection, no indexes.

## Flag-gated, idempotent estate backfill

Reconstructing the historical estate needs a prod-operable mechanism: `scripts/` never runs on CDP, and the rollout gate must not carry code work. This adds a startup extension wired via `onPostStart` under a cross-instance lock (one pod per deploy), reusing the registered mongodb adapters to run the estate reconstruction sweep. The upsert dedups through the unique identity index, so the sweep is safely re-runnable: a re-run persists no new state, though each entry still runs a no-op `$addToSet` and a couple of reads.

It is gated by a dedicated `wasteRecordStatesBackfill` feature flag (`FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL`), independent of the `wasteRecordStates` write flag. Two independent gates let the estate be backfilled and verified before forward writes begin. With the flag off the mechanism returns before touching the locker or any repository, so the row-state adapter is never invoked at rest and the write-gate invariant holds. The deliberate run is authorised later by flipping the flag, after the dry-run diagnostic has been reviewed — not in this change.

Both feature flags default off; this change is inert on deploy.


[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590
