### PR TITLE
PAE-1590: Coerce row state rowId to a string in the projection

### DIFF
--- a/src/waste-records/application/project-summary-log-row-state.js
+++ b/src/waste-records/application/project-summary-log-row-state.js
@@ -7,12 +7,14 @@ import { coerceStoredTonnages } from './stored-tonnage-coercion.js'
 
 /**
  * Project a waste record into its committed row state: classify it for the
- * waste balance, then coerce the stored tonnages to two decimal places. The 2dp
- * holding is a property of the row-state value itself, so it lives here in the
- * projection rather than at each write site — every path that persists a row
- * state goes through this seam and inherits the coercion. The balance path
- * keeps `classifyWasteRecord` directly and stays at full precision, which the
- * cross-field reconciliation arithmetic requires.
+ * waste balance, coerce the stored tonnages to two decimal places, and hold the
+ * rowId as a string. Both are properties of the row-state value itself, so they
+ * live here in the projection rather than at each write site — every path that
+ * persists a row state goes through this seam and inherits the coercion. The
+ * rowId is a row reference, not a number; a string holding matches the insert
+ * schema and the forward-write transformer regardless of how the source record
+ * stored it. The balance path keeps `classifyWasteRecord` directly and stays at
+ * full precision, which the cross-field reconciliation arithmetic requires.
  *
  * @param {import('#domain/waste-records/model.js').WasteRecord} record
  * @param {Object} accreditation
@@ -25,5 +27,9 @@ export const projectSummaryLogRowState = (
   overseasSites
 ) => {
   const classified = classifyWasteRecord(record, accreditation, overseasSites)
-  return { ...classified, data: coerceStoredTonnages(classified.data) }
+  return {
+    ...classified,
+    rowId: String(classified.rowId),
+    data: coerceStoredTonnages(classified.data)
+  }
 }

--- a/src/waste-records/application/project-summary-log-row-state.test.js
+++ b/src/waste-records/application/project-summary-log-row-state.test.js
@@ -65,6 +65,25 @@ describe('projectSummaryLogRowState', () => {
     )
   })
 
+  it('coerces a numeric rowId to a string', () => {
+    const record = {
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      rowId: 1000,
+      type: WASTE_RECORD_TYPE.RECEIVED,
+      versions: [],
+      data: { processingType: 'REPROCESSOR_REGISTERED_ONLY' }
+    }
+
+    const projected = projectSummaryLogRowState(
+      /** @type {any} */ (record),
+      null,
+      overseasSites
+    )
+
+    expect(projected.rowId).toBe('1000')
+  })
+
   it('coerces a copy, leaving the source record data at full precision', () => {
     const record = {
       organisationId: 'org-1',


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)
The ADR-0037 waste-record-state reconciliation diagnostic shipped in [#1361](https://github.com/DEFRA/epr-backend/pull/1361) threw on deploy to both dev and test, producing a single "Failed to run waste record state discrepancy report" error and none of its intended output — no census, no per-ledger diagnostics — so the pre-flip review it exists to provide could not happen.

**Root cause.** The flag-off dry run reconstructs each ledger in memory and upserts the reconstructed row states, which the insert schema validates with `rowId: Joi.string().required()`. Historical `waste-records` store `rowId` as a number (in dev, 8040 of 8043 records), so the first reconstructed row failed validation and, with no per-ledger error isolation, aborted the entire estate sweep.

**Fix.** Coerce `rowId` to a string in `projectSummaryLogRowState`, the projection seam every persisted row state passes through. This mirrors the stored-tonnage coercion already performed at that seam and the `String(...)` the forward-write row transformer already applies, so both the dry-run reconstruct path and the forward-write path emit a string `rowId`. The balance path calls `classifyWasteRecord` directly and is untouched, keeping full precision. Reconcile already keys rows by string interpolation on both sides, so a numeric-versus-string `rowId` never changed its findings; the insert schema stays strict as a guard rather than being relaxed.

The complementary per-ledger error isolation in the reconciliation sweep — so a future anomaly becomes a logged finding rather than aborting the whole run — is tracked separately.

[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ