### PR TITLE
PAE-1590: Gate the waste-record-state discrepancy diagnostic behind a default-off flag

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -382,6 +382,12 @@ const baseConfig = {
       default: false,
       env: 'FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL'
     },
+    summaryLogRowStatesDiscrepancyReport: {
+      doc: 'Feature Flag: Run the estate-wide summary-log-row-state reconciliation discrepancy diagnostic on startup (ADR-0037)',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_DISCREPANCY_REPORT'
+    },
     registeredOnlySubmittedEvents: {
       doc: 'Feature Flag: Emit zero-delta summary-log-submitted events for registered-only (null-accreditation) streams (ADR-0031)',
       format: Boolean,

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -17,6 +17,9 @@ export const createConfigFeatureFlags = (config) => ({
   isSummaryLogRowStatesBackfillEnabled() {
     return config.get('featureFlags.summaryLogRowStatesBackfill')
   },
+  isSummaryLogRowStatesDiscrepancyReportEnabled() {
+    return config.get('featureFlags.summaryLogRowStatesDiscrepancyReport')
+  },
   isRegisteredOnlySubmittedEventsEnabled() {
     return config.get('featureFlags.registeredOnlySubmittedEvents')
   }

--- a/src/feature-flags/feature-flags.config.test.js
+++ b/src/feature-flags/feature-flags.config.test.js
@@ -47,4 +47,13 @@ describe('createConfigFeatureFlags', () => {
       'featureFlags.registeredOnlySubmittedEvents'
     )
   })
+
+  it('returns true when summaryLogRowStatesDiscrepancyReport flag is enabled', () => {
+    const config = { get: vi.fn().mockReturnValue(true) }
+    const flags = createConfigFeatureFlags(config)
+    expect(flags.isSummaryLogRowStatesDiscrepancyReportEnabled()).toBe(true)
+    expect(config.get).toHaveBeenCalledWith(
+      'featureFlags.summaryLogRowStatesDiscrepancyReport'
+    )
+  })
 })

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -18,6 +18,9 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   isSummaryLogRowStatesBackfillEnabled() {
     return flags.summaryLogRowStatesBackfill ?? false
   },
+  isSummaryLogRowStatesDiscrepancyReportEnabled() {
+    return flags.summaryLogRowStatesDiscrepancyReport ?? false
+  },
   isRegisteredOnlySubmittedEventsEnabled() {
     return flags.registeredOnlySubmittedEvents ?? false
   }

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -103,4 +103,23 @@ describe('createInMemoryFeatureFlags', () => {
     const flags = createInMemoryFeatureFlags({})
     expect(flags.isRegisteredOnlySubmittedEventsEnabled()).toBe(false)
   })
+
+  it('returns true when summaryLogRowStatesDiscrepancyReport flag is enabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      summaryLogRowStatesDiscrepancyReport: true
+    })
+    expect(flags.isSummaryLogRowStatesDiscrepancyReportEnabled()).toBe(true)
+  })
+
+  it('returns false when summaryLogRowStatesDiscrepancyReport flag is disabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      summaryLogRowStatesDiscrepancyReport: false
+    })
+    expect(flags.isSummaryLogRowStatesDiscrepancyReportEnabled()).toBe(false)
+  })
+
+  it('returns false when summaryLogRowStatesDiscrepancyReport flag is not provided', () => {
+    const flags = createInMemoryFeatureFlags({})
+    expect(flags.isSummaryLogRowStatesDiscrepancyReportEnabled()).toBe(false)
+  })
 })

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -5,6 +5,7 @@
  * @property {() => boolean} isFixDuplicateAccreditationLinksEnabled
  * @property {() => boolean} isSummaryLogRowStatesEnabled
  * @property {() => boolean} isSummaryLogRowStatesBackfillEnabled
+ * @property {() => boolean} isSummaryLogRowStatesDiscrepancyReportEnabled
  * @property {() => boolean} isRegisteredOnlySubmittedEventsEnabled
  */
 
@@ -15,6 +16,7 @@
  * @property {boolean} [fixDuplicateAccreditationLinks]
  * @property {boolean} [summaryLogRowStates]
  * @property {boolean} [summaryLogRowStatesBackfill]
+ * @property {boolean} [summaryLogRowStatesDiscrepancyReport]
  * @property {boolean} [registeredOnlySubmittedEvents]
  */
 

--- a/src/server/run-waste-record-state-discrepancy-report.js
+++ b/src/server/run-waste-record-state-discrepancy-report.js
@@ -91,9 +91,18 @@ const runReport = async (server) => {
  * cross-instance lock so a single pod per deploy executes and logs it.
  * Read-only, safe under live traffic.
  *
+ * Gated by the summary-log-row-states-discrepancy-report feature flag: with it
+ * off this returns before touching the locker or any repository. The walk is
+ * superseded by the watermark migration and persisted-state inspection, so it
+ * stays off by default until that replacement lands.
+ *
  * @param {Object} server - Hapi server instance
  */
 export const runWasteRecordStateDiscrepancyReport = async (server) => {
+  if (!server.featureFlags.isSummaryLogRowStatesDiscrepancyReportEnabled()) {
+    return
+  }
+
   try {
     const lock = await server.locker.lock(LOCK_NAME)
     if (!lock) {

--- a/src/server/run-waste-record-state-discrepancy-report.test.js
+++ b/src/server/run-waste-record-state-discrepancy-report.test.js
@@ -83,12 +83,14 @@ const buildServer = (
   app,
   {
     lock = { free: vi.fn().mockResolvedValue(undefined) },
-    backfillEnabled = true
+    backfillEnabled = true,
+    reportEnabled = true
   } = {}
 ) => ({
   app,
   featureFlags: {
-    isSummaryLogRowStatesBackfillEnabled: () => backfillEnabled
+    isSummaryLogRowStatesBackfillEnabled: () => backfillEnabled,
+    isSummaryLogRowStatesDiscrepancyReportEnabled: () => reportEnabled
   },
   locker: { lock: vi.fn().mockResolvedValue(lock) }
 })
@@ -249,6 +251,23 @@ describe('runWasteRecordStateDiscrepancyReport', () => {
     vi.clearAllMocks()
   })
 
+  it('does not run and touches nothing when the discrepancy-report flag is off', async () => {
+    const organisationsRepository = {
+      findAll: vi.fn().mockResolvedValue([])
+    }
+    const server = buildServer(
+      { ...emptyEstate(), organisationsRepository },
+      { reportEnabled: false }
+    )
+
+    await runWasteRecordStateDiscrepancyReport(server)
+
+    expect(server.locker.lock).not.toHaveBeenCalled()
+    expect(organisationsRepository.findAll).not.toHaveBeenCalled()
+    expect(logger.info).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
   it('acquires a lock scoped to the report and releases it afterwards', async () => {
     const lock = { free: vi.fn().mockResolvedValue(undefined) }
     const server = buildServer(emptyEstate(), { lock })
@@ -267,6 +286,9 @@ describe('runWasteRecordStateDiscrepancyReport', () => {
     }
     const server = {
       app: { ...emptyEstate(), organisationsRepository },
+      featureFlags: {
+        isSummaryLogRowStatesDiscrepancyReportEnabled: () => true
+      },
       locker: { lock: vi.fn().mockResolvedValue(null) }
     }
 
@@ -343,6 +365,9 @@ describe('runWasteRecordStateDiscrepancyReport', () => {
     const error = new Error('locker unavailable')
     const server = {
       app: emptyEstate(),
+      featureFlags: {
+        isSummaryLogRowStatesDiscrepancyReportEnabled: () => true
+      },
       locker: { lock: vi.fn().mockRejectedValue(error) }
     }
 


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)
## What

The startup waste-record-state reconciliation **discrepancy diagnostic** (`runWasteRecordStateDiscrepancyReport`, run at `onPostStart`) previously ran **unconditionally in every environment**. This gates it behind a new `summaryLogRowStatesDiscrepancyReport` feature flag that **defaults off**, so the diagnostic no longer runs at rest — including in production — with no environment-config change required.

## Why

The walk this diagnostic performs is **superseded** by the row-state watermark migration and the persisted-state inspection that follows it. It also cannot complete in production:

- A rolling deploy cycles the single lock-holding pod partway through an estate-long **serial** Mongo walk (fire-and-forget, no retry), so it never finishes.
- Its estate-long **in-memory accumulation on one pod** is a needless production-load / slow-response vector.

Since it does not work and is retired, it should not run in production while the replacement is built.

## Approach

Gate rather than remove — a **reversible stop-gap**, not a teardown. The gate mirrors the sibling backfill migration (`runBackfillSummaryLogRowStates`), which is likewise called unconditionally at `onPostStart` and self-guards with an early return on its own flag. The runner and its reconciliation helpers are left intact so the future persisted-state inspection work can reuse them, and the disable is reversible by flipping the flag.

The flag defaults off everywhere, so this repository change alone achieves the production disable — no coupled app-config change is needed.

Part of the ADR-0037 row-state rollout (PAE-1590).

[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ