### PR TITLE
PAE-1590: Tidy committed row-state document shape

### DIFF
--- a/.impeccable/hook.cache.json
+++ b/.impeccable/hook.cache.json
@@ -1,1 +1,14 @@
-{ "version": 1, "sessions": {} }
+{
+  "version": 1,
+  "sessions": {
+    "4a97df54-cdcd-4245-a591-b5490981c156": {
+      "updatedAt": 1783508825938,
+      "files": {
+        "/home/graeme/Development/Defra/epr-backend/PAE-1590-rowstate-doc-shape/src/server/run-waste-record-state-discrepancy-report.test.js": {
+          "editCount": 2,
+          "findings": []
+        }
+      }
+    }
+  }
+}

--- a/.impeccable/hook.cache.json
+++ b/.impeccable/hook.cache.json
@@ -1,14 +1,1 @@
-{
-  "version": 1,
-  "sessions": {
-    "4a97df54-cdcd-4245-a591-b5490981c156": {
-      "updatedAt": 1783508825938,
-      "files": {
-        "/home/graeme/Development/Defra/epr-backend/PAE-1590-rowstate-doc-shape/src/server/run-waste-record-state-discrepancy-report.test.js": {
-          "editCount": 2,
-          "findings": []
-        }
-      }
-    }
-  }
-}
+{ "version": 1, "sessions": {} }

--- a/src/server/run-waste-record-state-discrepancy-report.test.js
+++ b/src/server/run-waste-record-state-discrepancy-report.test.js
@@ -131,9 +131,12 @@ const receivedRecord = (organisationId, rowId, versionFileTag) => ({
   registrationId: 'reg-1',
   rowId,
   type: WASTE_RECORD_TYPE.RECEIVED,
-  data: { supplierName: 'Acme' },
+  data: { processingType: 'REPROCESSOR_INPUT', supplierName: 'Acme' },
   versions: [
-    { summaryLog: { id: versionFileTag }, data: { supplierName: 'Acme' } }
+    {
+      summaryLog: { id: versionFileTag },
+      data: { processingType: 'REPROCESSOR_INPUT', supplierName: 'Acme' }
+    }
   ]
 })
 
@@ -452,8 +455,13 @@ const receivedRecordFor = (
   registrationId,
   rowId,
   type: WASTE_RECORD_TYPE.RECEIVED,
-  data: { supplierName: 'Acme' },
-  versions: [{ summaryLog: { id: versionTag }, data: { supplierName: 'Acme' } }]
+  data: { processingType: 'REPROCESSOR_INPUT', supplierName: 'Acme' },
+  versions: [
+    {
+      summaryLog: { id: versionTag },
+      data: { processingType: 'REPROCESSOR_INPUT', supplierName: 'Acme' }
+    }
+  ]
 })
 
 const approvedReprocessorAccreditation = (id) =>

--- a/src/waste-records/application/project-summary-log-row-state.js
+++ b/src/waste-records/application/project-summary-log-row-state.js
@@ -2,24 +2,29 @@ import { classifyWasteRecord } from '#waste-balances/application/target-amount.j
 import { coerceStoredTonnages } from './stored-tonnage-coercion.js'
 
 /**
- * @import { ClassifiedRow } from '#waste-balances/application/target-amount.js'
+ * @import { SummaryLogRowStateEntry } from '#waste-records/repository/schema.js'
  */
 
 /**
  * Project a waste record into its committed row state: classify it for the
  * waste balance, coerce the stored tonnages to two decimal places, and hold the
- * rowId as a string. Both are properties of the row-state value itself, so they
+ * rowId as a string. These are properties of the row-state value itself, so they
  * live here in the projection rather than at each write site — every path that
- * persists a row state goes through this seam and inherits the coercion. The
+ * persists a row state goes through this seam and inherits the shape. The
  * rowId is a row reference, not a number; a string holding matches the insert
  * schema and the forward-write transformer regardless of how the source record
- * stored it. The balance path keeps `classifyWasteRecord` directly and stays at
- * full precision, which the cross-field reconciliation arithmetic requires.
+ * stored it. `processingType` is injected metadata describing the row, so it is
+ * hoisted to a top-level field alongside the record rather than kept inside the
+ * raw `data`; the redundant `ROW_ID` copy is dropped in favour of the top-level
+ * `rowId`. The hoist happens on the projection output, after `classifyWasteRecord`
+ * has read `data.processingType` to select its schema. The balance path keeps
+ * `classifyWasteRecord` directly and stays at full precision, which the
+ * cross-field reconciliation arithmetic requires.
  *
  * @param {import('#domain/waste-records/model.js').WasteRecord} record
  * @param {Object} accreditation
  * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} overseasSites
- * @returns {ClassifiedRow}
+ * @returns {SummaryLogRowStateEntry}
  */
 export const projectSummaryLogRowState = (
   record,
@@ -27,9 +32,11 @@ export const projectSummaryLogRowState = (
   overseasSites
 ) => {
   const classified = classifyWasteRecord(record, accreditation, overseasSites)
+  const { ROW_ID: _ROW_ID, processingType, ...data } = classified.data
   return {
     ...classified,
     rowId: String(classified.rowId),
-    data: coerceStoredTonnages(classified.data)
+    processingType,
+    data: coerceStoredTonnages(data)
   }
 }

--- a/src/waste-records/application/project-summary-log-row-state.test.js
+++ b/src/waste-records/application/project-summary-log-row-state.test.js
@@ -27,18 +27,57 @@ describe('projectSummaryLogRowState', () => {
     expect(projected).toMatchObject({
       rowId: '1',
       wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+      processingType: 'REPROCESSOR_REGISTERED_ONLY',
       classification: {
         outcome: ROW_OUTCOME.EXCLUDED,
         reasons: [],
         transactionAmount: 0
       },
       data: {
-        processingType: 'REPROCESSOR_REGISTERED_ONLY',
         TONNAGE_RECEIVED_FOR_RECYCLING: 1.01,
         NET_WEIGHT: 7.54,
         supplierName: 'Acme'
       }
     })
+  })
+
+  it('hoists processingType to a top-level field, leaving it out of the stored data', () => {
+    const record = {
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      rowId: '1',
+      type: WASTE_RECORD_TYPE.RECEIVED,
+      versions: [],
+      data: {
+        processingType: 'REPROCESSOR_REGISTERED_ONLY',
+        supplierName: 'Acme'
+      }
+    }
+
+    const projected = projectSummaryLogRowState(record, null, overseasSites)
+
+    expect(projected.processingType).toBe('REPROCESSOR_REGISTERED_ONLY')
+    expect(projected.data).not.toHaveProperty('processingType')
+  })
+
+  it('drops the redundant ROW_ID key from the stored data', () => {
+    const record = {
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      rowId: '1011',
+      type: WASTE_RECORD_TYPE.RECEIVED,
+      versions: [],
+      data: {
+        processingType: 'REPROCESSOR_REGISTERED_ONLY',
+        ROW_ID: 1011,
+        supplierName: 'Acme'
+      }
+    }
+
+    const projected = projectSummaryLogRowState(record, null, overseasSites)
+
+    expect(projected.data).not.toHaveProperty('ROW_ID')
+    expect(projected.rowId).toBe('1011')
   })
 
   it('stores a row state that reconciles by construction — NET equals GROSS minus TARE minus PALLET at 2dp', () => {

--- a/src/waste-records/backfill/backfill-estate-summary-log-row-states.test.js
+++ b/src/waste-records/backfill/backfill-estate-summary-log-row-states.test.js
@@ -52,14 +52,23 @@ const insertLog = (
     submittedAt
   })
 
-const receivedRecord = (organisationId, registrationId, rowId, versions) => ({
-  organisationId,
-  registrationId,
-  rowId,
-  type: WASTE_RECORD_TYPE.RECEIVED,
-  data: versions.at(-1).data,
-  versions
-})
+const receivedRecord = (organisationId, registrationId, rowId, versions) => {
+  const stamped = versions.map((version) => ({
+    ...version,
+    data: {
+      processingType: PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY,
+      ...version.data
+    }
+  }))
+  return {
+    organisationId,
+    registrationId,
+    rowId,
+    type: WASTE_RECORD_TYPE.RECEIVED,
+    data: stamped.at(-1).data,
+    versions: stamped
+  }
+}
 
 const inMemoryDeps = ({ organisations, wasteRecords }) => ({
   organisationsRepository:

--- a/src/waste-records/backfill/backfill-registration-summary-log-row-states.test.js
+++ b/src/waste-records/backfill/backfill-registration-summary-log-row-states.test.js
@@ -23,14 +23,20 @@ const submittedLog = (id, submittedAt) => ({
   submittedAt
 })
 
-const receivedRecord = (rowId, versions) => ({
-  organisationId: 'org-1',
-  registrationId: 'reg-1',
-  rowId,
-  type: WASTE_RECORD_TYPE.RECEIVED,
-  data: versions.at(-1).data,
-  versions
-})
+const receivedRecord = (rowId, versions) => {
+  const stamped = versions.map((version) => ({
+    ...version,
+    data: { processingType: 'REPROCESSOR_INPUT', ...version.data }
+  }))
+  return {
+    organisationId: 'org-1',
+    registrationId: 'reg-1',
+    rowId,
+    type: WASTE_RECORD_TYPE.RECEIVED,
+    data: stamped.at(-1).data,
+    versions: stamped
+  }
+}
 
 const rowHistory = (repository, rowId) =>
   repository.findRowHistory('org-1', 'reg-1', rowId, WASTE_RECORD_TYPE.RECEIVED)

--- a/src/waste-records/backfill/reconstruct-submission-summary-log-row-states.js
+++ b/src/waste-records/backfill/reconstruct-submission-summary-log-row-states.js
@@ -4,7 +4,7 @@ import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import { compareSubmissionOrder } from './submission-order.js'
 
 /**
- * @import { ClassifiedRow } from '#waste-balances/application/target-amount.js'
+ * @import { SummaryLogRowStateEntry } from '#waste-records/repository/schema.js'
  * @import { WasteRecord } from '#domain/waste-records/model.js'
  */
 
@@ -17,7 +17,7 @@ import { compareSubmissionOrder } from './submission-order.js'
  *
  * @typedef {Object} SubmissionSummaryLogRowStates
  * @property {string} summaryLogId
- * @property {ClassifiedRow[]} entries
+ * @property {SummaryLogRowStateEntry[]} entries
  * @property {string} submittedAt - ISO8601 timestamp
  * @property {import('#waste-balances/repository/ledger-schema.js').LedgerUserSummary} [submittedBy]
  */

--- a/src/waste-records/repository/contract/upsertSummaryLogRowStates.contract.js
+++ b/src/waste-records/repository/contract/upsertSummaryLogRowStates.contract.js
@@ -35,6 +35,8 @@ export const testUpsertSummaryLogRowStatesBehaviour = (it) => {
       expect(state.registrationId).toBe(DEFAULT_LEDGER_ID.registrationId)
       expect(state.accreditationId).toBe(DEFAULT_LEDGER_ID.accreditationId)
       expect(state.rowId).toBe('row-1')
+      expect(state.processingType).toBe('REPROCESSOR_INPUT')
+      expect(state.data).not.toHaveProperty('processingType')
       expect(state.summaryLogIds).toEqual(['log-1'])
     })
 
@@ -116,6 +118,36 @@ export const testUpsertSummaryLogRowStatesBehaviour = (it) => {
           ['log-1'],
           ['log-2']
         ])
+      })
+
+      it('inserts a new document when only the processingType changes', async () => {
+        await repository.upsertSummaryLogRowStates(
+          DEFAULT_LEDGER_ID,
+          [
+            buildSummaryLogRowStateEntry({
+              processingType: 'REPROCESSOR_INPUT'
+            })
+          ],
+          'log-1'
+        )
+        await repository.upsertSummaryLogRowStates(
+          DEFAULT_LEDGER_ID,
+          [
+            buildSummaryLogRowStateEntry({
+              processingType: 'REPROCESSOR_OUTPUT'
+            })
+          ],
+          'log-2'
+        )
+
+        expect(
+          await repository.findRowHistory(
+            'org-1',
+            'reg-1',
+            'row-1',
+            WASTE_RECORD_TYPE.RECEIVED
+          )
+        ).toHaveLength(2)
       })
 
       it('inserts a new document when only the classification changes', async () => {

--- a/src/waste-records/repository/in-memory-store.js
+++ b/src/waste-records/repository/in-memory-store.js
@@ -53,6 +53,7 @@ const matchesRowIdentity = (doc, candidate) =>
  */
 const matchesCommittedState = (doc, candidate) =>
   matchesRowIdentity(doc, candidate) &&
+  doc.processingType === candidate.processingType &&
   isDeepStrictEqual(doc.data, candidate.data) &&
   isDeepStrictEqual(doc.classification, candidate.classification)
 
@@ -70,6 +71,7 @@ const upsertOne = (storage, ledgerId, entry, summaryLogId) => {
     accreditationId: ledgerId.accreditationId,
     wasteRecordType: entry.wasteRecordType,
     rowId: entry.rowId,
+    processingType: entry.processingType,
     data: entry.data,
     classification: entry.classification,
     summaryLogIds: [summaryLogId]

--- a/src/waste-records/repository/inmemory.test.js
+++ b/src/waste-records/repository/inmemory.test.js
@@ -27,6 +27,7 @@ describe('summary-log row states repository - in-memory implementation', () => {
         accreditationId: 'acc-1',
         wasteRecordType: 'received',
         rowId: 'row-1',
+        processingType: 'REPROCESSOR_INPUT',
         data: { tonnage: 10 },
         classification: {
           outcome: 'INCLUDED',

--- a/src/waste-records/repository/mongodb.js
+++ b/src/waste-records/repository/mongodb.js
@@ -110,6 +110,7 @@ const hashSummaryLogRowState = (candidate) =>
     .update(
       JSON.stringify(
         canonicalise({
+          processingType: candidate.processingType,
           data: candidate.data,
           classification: candidate.classification
         })
@@ -162,6 +163,7 @@ const upsertOne = async (collection, ledgerId, entry, summaryLogId) => {
     accreditationId: ledgerId.accreditationId,
     wasteRecordType: entry.wasteRecordType,
     rowId: entry.rowId,
+    processingType: entry.processingType,
     data: entry.data,
     classification: entry.classification,
     summaryLogIds: [summaryLogId]

--- a/src/waste-records/repository/schema.js
+++ b/src/waste-records/repository/schema.js
@@ -39,6 +39,7 @@ import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
  * @typedef {Object} SummaryLogRowStateEntry
  * @property {string} rowId
  * @property {import('#domain/waste-records/model.js').WasteRecordType} wasteRecordType
+ * @property {string} processingType
  * @property {Record<string, any>} data
  * @property {RowClassification} classification
  */
@@ -54,6 +55,7 @@ import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
  * @property {string | null} accreditationId
  * @property {import('#domain/waste-records/model.js').WasteRecordType} wasteRecordType
  * @property {string} rowId
+ * @property {string} processingType
  * @property {Record<string, any>} data
  * @property {RowClassification} classification
  * @property {string[]} summaryLogIds
@@ -88,6 +90,7 @@ export const summaryLogRowStateInsertSchema = Joi.object({
     .valid(...Object.values(WASTE_RECORD_TYPE))
     .required(),
   rowId: Joi.string().required(),
+  processingType: Joi.string().required(),
   data: Joi.object().required(),
   classification: classificationSchema.required(),
   summaryLogIds: Joi.array().items(Joi.string().required()).min(1).required()

--- a/src/waste-records/repository/schema.test.js
+++ b/src/waste-records/repository/schema.test.js
@@ -79,6 +79,21 @@ describe('row state insert schema', () => {
     expect(error).toBeDefined()
   })
 
+  it('accepts a top-level processingType', () => {
+    const { error, value } = validate(
+      buildSummaryLogRowState({ processingType: 'REPROCESSOR_OUTPUT' })
+    )
+    expect(error).toBeUndefined()
+    expect(value.processingType).toBe('REPROCESSOR_OUTPUT')
+  })
+
+  it('rejects a missing processingType', () => {
+    const { processingType: _processingType, ...withoutProcessingType } =
+      buildSummaryLogRowState()
+    const { error } = validate(withoutProcessingType)
+    expect(error).toBeDefined()
+  })
+
   it('rejects missing required top-level fields', () => {
     const details = expectValidationError(
       summaryLogRowStateInsertSchema,
@@ -95,6 +110,7 @@ describe('row state insert schema', () => {
     expect(missing).toContain('data')
     expect(missing).toContain('classification')
     expect(missing).toContain('summaryLogIds')
+    expect(missing).toContain('processingType')
   })
 })
 

--- a/src/waste-records/repository/test-data.js
+++ b/src/waste-records/repository/test-data.js
@@ -12,6 +12,7 @@ export const buildSummaryLogRowState = (overrides = {}) => ({
   accreditationId: 'acc-1',
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   rowId: 'row-1',
+  processingType: 'REPROCESSOR_INPUT',
   data: { supplierName: 'Acme', tonnage: 10 },
   classification: {
     outcome: ROW_OUTCOME.INCLUDED,
@@ -30,6 +31,7 @@ export const buildSummaryLogRowState = (overrides = {}) => ({
 export const buildSummaryLogRowStateEntry = (overrides = {}) => ({
   rowId: 'row-1',
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+  processingType: 'REPROCESSOR_INPUT',
   data: { supplierName: 'Acme', tonnage: 10 },
   classification: {
     outcome: ROW_OUTCOME.INCLUDED,


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)
Two structural tidy-ups to the committed row-state document produced by the shared `projectSummaryLogRowState` projection, prompted by inspecting stored dev data whose `data` object held `ROW_ID` as a number and carried `processingType` inline.

**Drop the redundant `ROW_ID` from stored `data`.** It duplicated the top-level `rowId` (already narrowed to a string) and had no reader on the row-state collection.

**Hoist `processingType` to a top-level document field.** It is injected metadata describing the row, not raw row input, so it belongs alongside the record rather than inside its `data`. The move happens on the projection *output*, after `classifyWasteRecord` has read `record.data.processingType` to select its schema — so classification is unchanged. The row-state insert/read schema gains a required top-level `processingType` field.

Both changes live in the single projection seam shared by the live write path and the backfill, so both inherit the tidied shape. `processingType` stays in the MongoDB content-hash and the in-memory dedup comparison, so relocating it out of `data` preserves the committed-state document identity — a row differing only in `processingType` remains a distinct committed state, exactly as before.

The row-state collection is a pre-release rollout-window mechanism: forward writes are feature-flagged off in production and the Stage-2 read cutover that would consume this document is not built, so the shape change has no reader impact and no persisted production data depends on the previous shape.


[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ