### PR TITLE
PAE-1590: Stamp waste-balance-irrelevant rows NOT_APPLICABLE in committed row states

### DIFF
--- a/src/application/waste-records/sync-from-summary-log.test.js
+++ b/src/application/waste-records/sync-from-summary-log.test.js
@@ -13,7 +13,7 @@ import {
   toWasteRecordVersions
 } from '#repositories/waste-records/contract/test-data.js'
 import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 
 const TEST_DATE_2025_01_15 = '2025-01-15'
 const FIELD_GROSS_WEIGHT = 'GROSS_WEIGHT'
@@ -1599,7 +1599,7 @@ describe('syncFromSummaryLog', () => {
         registrationId: 'reg-1',
         wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
         classification: {
-          outcome: ROW_OUTCOME.EXCLUDED,
+          outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
           reasons: [],
           transactionAmount: 0
         },

--- a/src/waste-balances/application/target-amount.js
+++ b/src/waste-balances/application/target-amount.js
@@ -1,18 +1,10 @@
-import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/index.js'
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import {
+  WASTE_BALANCE_OUTCOME,
+  classifyRecordForWasteBalance
+} from '#waste-balances/domain/waste-balance-classification.js'
 
 /**
- * @import {RowOutcome, WasteBalanceClassificationReason} from '#domain/summary-logs/table-schemas/validation-pipeline.js'
- */
-
-/**
- * A summary-log waste record's waste-balance classification: the outcome, the
- * reasons behind it, and the tonnage it contributes (zero unless INCLUDED).
- *
- * @typedef {Object} RowClassification
- * @property {RowOutcome} outcome
- * @property {WasteBalanceClassificationReason[]} reasons
- * @property {number} transactionAmount
+ * @import {WasteBalanceClassification} from '#waste-balances/domain/waste-balance-classification.js'
  */
 
 /**
@@ -24,49 +16,15 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
  * @property {string} rowId
  * @property {import('#domain/waste-records/model.js').WasteRecordType} wasteRecordType
  * @property {Record<string, any>} data
- * @property {RowClassification} classification
+ * @property {WasteBalanceClassification} classification
  */
-
-/**
- * Classifies a single summary-log waste record for the waste balance, reusing
- * the coercion the table schema's `classifyForWasteBalance` already performs.
- * Records flagged out of the balance, or with no matching schema, are EXCLUDED
- * with no reasons and no contribution.
- *
- * @param {import('#domain/waste-records/model.js').WasteRecord} record
- * @param {Object} accreditation
- * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} overseasSites
- * @returns {RowClassification}
- */
-const classify = (record, accreditation, overseasSites) => {
-  if (record.excludedFromWasteBalance) {
-    return { outcome: ROW_OUTCOME.EXCLUDED, reasons: [], transactionAmount: 0 }
-  }
-  const schema = findSchemaForProcessingType(
-    record.data?.processingType,
-    record.type
-  )
-  if (!schema?.classifyForWasteBalance) {
-    return { outcome: ROW_OUTCOME.EXCLUDED, reasons: [], transactionAmount: 0 }
-  }
-  const result = schema.classifyForWasteBalance(record.data, {
-    accreditation,
-    overseasSites
-  })
-  return {
-    outcome: result.outcome,
-    reasons: result.reasons,
-    transactionAmount:
-      result.outcome === ROW_OUTCOME.INCLUDED ? result.transactionAmount : 0
-  }
-}
 
 /**
  * Pairs a waste record with its waste-balance classification, retaining the
  * row identity and data alongside.
  *
  * @param {import('#domain/waste-records/model.js').WasteRecord} record
- * @param {Object} accreditation
+ * @param {import('#domain/organisations/accreditation.js').Accreditation | null} accreditation
  * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} overseasSites
  * @returns {ClassifiedRow}
  */
@@ -74,7 +32,11 @@ export const classifyWasteRecord = (record, accreditation, overseasSites) => ({
   rowId: record.rowId,
   wasteRecordType: record.type,
   data: record.data,
-  classification: classify(record, accreditation, overseasSites)
+  classification: classifyRecordForWasteBalance(
+    record,
+    accreditation,
+    overseasSites
+  )
 })
 
 /**
@@ -82,10 +44,10 @@ export const classifyWasteRecord = (record, accreditation, overseasSites) => ({
  * its accreditation's balance, or zero when the row is not INCLUDED. Consumed
  * when building the ledger events for a summary-log submission.
  *
- * @param {RowClassification} classification
+ * @param {WasteBalanceClassification} classification
  * @returns {number}
  */
 export const getTargetAmount = (classification) =>
-  classification.outcome === ROW_OUTCOME.INCLUDED
+  classification.outcome === WASTE_BALANCE_OUTCOME.INCLUDED
     ? classification.transactionAmount
     : 0

--- a/src/waste-balances/application/target-amount.test.js
+++ b/src/waste-balances/application/target-amount.test.js
@@ -82,28 +82,6 @@ describe('classifyWasteRecord', () => {
       transactionAmount: 100
     })
   })
-
-  it('stamps a no-accreditation record NOT_APPLICABLE', async () => {
-    await setSchema({
-      classifyForWasteBalance: () => ({
-        outcome: ROW_OUTCOME.INCLUDED,
-        reasons: [],
-        transactionAmount: 100
-      })
-    })
-
-    const { classification } = classifyWasteRecord(
-      buildRecord(),
-      null,
-      overseasSites
-    )
-
-    expect(classification).toEqual({
-      outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
-      reasons: [],
-      transactionAmount: 0
-    })
-  })
 })
 
 describe('getTargetAmount', () => {

--- a/src/waste-balances/application/target-amount.test.js
+++ b/src/waste-balances/application/target-amount.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { classifyWasteRecord, getTargetAmount } from './target-amount.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 
@@ -8,7 +9,10 @@ vi.mock('#domain/summary-logs/table-schemas/index.js', () => ({
   findSchemaForProcessingType: vi.fn()
 }))
 
-const accreditation = { id: 'acc-1' }
+const accreditation =
+  /** @type {import('#domain/organisations/accreditation.js').Accreditation} */ (
+    /** @type {unknown} */ ({ id: 'acc-1' })
+  )
 const overseasSites = /** @type {*} */ (new Map())
 
 const buildRecord = (overrides = {}) =>
@@ -57,40 +61,7 @@ describe('classifyWasteRecord', () => {
     })
   })
 
-  it('classifies an excluded-from-waste-balance record as EXCLUDED with no amount', async () => {
-    const record = buildRecord({ excludedFromWasteBalance: true })
-
-    const { classification } = classifyWasteRecord(
-      record,
-      accreditation,
-      overseasSites
-    )
-
-    expect(classification).toEqual({
-      outcome: ROW_OUTCOME.EXCLUDED,
-      reasons: [],
-      transactionAmount: 0
-    })
-  })
-
-  it('classifies a record with no matching schema as EXCLUDED with no amount', async () => {
-    await setSchema(null)
-    const record = buildRecord()
-
-    const { classification } = classifyWasteRecord(
-      record,
-      accreditation,
-      overseasSites
-    )
-
-    expect(classification).toEqual({
-      outcome: ROW_OUTCOME.EXCLUDED,
-      reasons: [],
-      transactionAmount: 0
-    })
-  })
-
-  it('surfaces the included outcome, reasons and amount from the schema classifier', async () => {
+  it('delegates classification to the waste-balance classifier', async () => {
     await setSchema({
       classifyForWasteBalance: () => ({
         outcome: ROW_OUTCOME.INCLUDED,
@@ -98,39 +69,38 @@ describe('classifyWasteRecord', () => {
         transactionAmount: 100
       })
     })
-    const record = buildRecord()
 
     const { classification } = classifyWasteRecord(
-      record,
+      buildRecord(),
       accreditation,
       overseasSites
     )
 
     expect(classification).toEqual({
-      outcome: ROW_OUTCOME.INCLUDED,
+      outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
       reasons: [{ code: 'WITHIN_ACCREDITATION_PERIOD' }],
       transactionAmount: 100
     })
   })
 
-  it('surfaces an excluded classifier outcome and reasons, contributing no amount', async () => {
+  it('stamps a no-accreditation record NOT_APPLICABLE', async () => {
     await setSchema({
       classifyForWasteBalance: () => ({
-        outcome: ROW_OUTCOME.IGNORED,
-        reasons: [{ code: 'PRN_ISSUED' }]
+        outcome: ROW_OUTCOME.INCLUDED,
+        reasons: [],
+        transactionAmount: 100
       })
     })
-    const record = buildRecord()
 
     const { classification } = classifyWasteRecord(
-      record,
-      accreditation,
+      buildRecord(),
+      null,
       overseasSites
     )
 
     expect(classification).toEqual({
-      outcome: ROW_OUTCOME.IGNORED,
-      reasons: [{ code: 'PRN_ISSUED' }],
+      outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
+      reasons: [],
       transactionAmount: 0
     })
   })
@@ -140,7 +110,7 @@ describe('getTargetAmount', () => {
   it('returns the transaction amount for an included classification', () => {
     expect(
       getTargetAmount({
-        outcome: ROW_OUTCOME.INCLUDED,
+        outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
         reasons: [],
         transactionAmount: 75
       })
@@ -150,7 +120,7 @@ describe('getTargetAmount', () => {
   it('returns zero for a non-included classification', () => {
     expect(
       getTargetAmount({
-        outcome: ROW_OUTCOME.EXCLUDED,
+        outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
         reasons: [],
         transactionAmount: 0
       })

--- a/src/waste-balances/application/update-via-ledger.js
+++ b/src/waste-balances/application/update-via-ledger.js
@@ -19,7 +19,7 @@ import { classifyWasteRecord, getTargetAmount } from './target-amount.js'
  *
  * @param {Object} params
  * @param {Array<import('#domain/waste-records/model.js').WasteRecord>} params.wasteRecords
- * @param {{ id: string, validFrom?: string, validTo?: string }} params.accreditation
+ * @param {import('#domain/organisations/accreditation.js').Accreditation} params.accreditation
  * @param {import('./waste-balance-service.js').CommitSummaryLogSubmittedEvent} params.commitSummaryLogSubmittedEvent
  * @param {Object} [params.dependencies]
  * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [params.dependencies.systemLogsRepository]

--- a/src/waste-balances/application/update-via-ledger.test.js
+++ b/src/waste-balances/application/update-via-ledger.test.js
@@ -46,13 +46,17 @@ vi.mock('#domain/summary-logs/table-schemas/index.js', () => ({
   findSchemaForProcessingType: vi.fn()
 }))
 
+/** @typedef {import('#domain/organisations/accreditation.js').Accreditation} Accreditation */
+
 const accreditationId = 'acc-1'
 
-const accreditation = {
-  id: accreditationId,
-  validFrom: '2023-01-01',
-  validTo: '2030-12-31'
-}
+const accreditation = /** @type {Accreditation} */ (
+  /** @type {unknown} */ ({
+    id: accreditationId,
+    validFrom: '2023-01-01',
+    validTo: '2030-12-31'
+  })
+)
 
 const overseasSites = /** @type {*} */ (new Map())
 const user = {

--- a/src/waste-balances/domain/waste-balance-classification.js
+++ b/src/waste-balances/domain/waste-balance-classification.js
@@ -1,0 +1,87 @@
+import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/index.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+
+/**
+ * @import {WasteBalanceClassificationReason} from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+ */
+
+/**
+ * Waste-balance classification outcomes. INCLUDED, EXCLUDED and IGNORED are the
+ * per-row outcomes a table schema's `classifyForWasteBalance` produces, kept
+ * string-identical to the shared validation `ROW_OUTCOME` so schema results map
+ * straight through. NOT_APPLICABLE is waste-balance-specific: the record's
+ * registration or template cannot contribute a per-row decision at all — there
+ * is no accreditation, or the table schema has no waste-balance classifier
+ * (which also covers registered-only templates).
+ */
+export const WASTE_BALANCE_OUTCOME = Object.freeze({
+  INCLUDED: ROW_OUTCOME.INCLUDED,
+  EXCLUDED: ROW_OUTCOME.EXCLUDED,
+  IGNORED: ROW_OUTCOME.IGNORED,
+  NOT_APPLICABLE: 'NOT_APPLICABLE'
+})
+
+/** @typedef {typeof WASTE_BALANCE_OUTCOME[keyof typeof WASTE_BALANCE_OUTCOME]} WasteBalanceOutcome */
+
+/**
+ * A record's waste-balance classification: the outcome, the reasons behind it,
+ * and the tonnage it contributes (zero unless INCLUDED).
+ *
+ * @typedef {Object} WasteBalanceClassification
+ * @property {WasteBalanceOutcome} outcome
+ * @property {WasteBalanceClassificationReason[]} reasons
+ * @property {number} transactionAmount
+ */
+
+/**
+ * Classify a waste record for the waste balance. NOT_APPLICABLE takes
+ * precedence: a record with no accreditation, or whose table schema has no
+ * waste-balance classifier, is not-applicable regardless of whether it was
+ * manually excluded. A manually excluded record with both an accreditation and
+ * a classifier is EXCLUDED with no contribution. Otherwise the table schema's
+ * classifier decides the outcome, and only an INCLUDED row contributes tonnage.
+ *
+ * @param {import('#domain/waste-records/model.js').WasteRecord} record
+ * @param {import('#domain/organisations/accreditation.js').Accreditation | null} accreditation
+ * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} overseasSites
+ * @returns {WasteBalanceClassification}
+ */
+export const classifyRecordForWasteBalance = (
+  record,
+  accreditation,
+  overseasSites
+) => {
+  const schema = findSchemaForProcessingType(
+    record.data?.processingType,
+    record.type
+  )
+
+  if (!accreditation || !schema?.classifyForWasteBalance) {
+    return {
+      outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
+      reasons: [],
+      transactionAmount: 0
+    }
+  }
+
+  if (record.excludedFromWasteBalance) {
+    return {
+      outcome: WASTE_BALANCE_OUTCOME.EXCLUDED,
+      reasons: [],
+      transactionAmount: 0
+    }
+  }
+
+  const result = schema.classifyForWasteBalance(record.data, {
+    accreditation,
+    overseasSites
+  })
+  return {
+    outcome: result.outcome,
+    reasons: result.reasons,
+    transactionAmount:
+      result.outcome === WASTE_BALANCE_OUTCOME.INCLUDED
+        ? result.transactionAmount
+        : 0
+  }
+}

--- a/src/waste-balances/domain/waste-balance-classification.test.js
+++ b/src/waste-balances/domain/waste-balance-classification.test.js
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import {
+  WASTE_BALANCE_OUTCOME,
+  classifyRecordForWasteBalance
+} from './waste-balance-classification.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+
+vi.mock('#domain/summary-logs/table-schemas/index.js', () => ({
+  findSchemaForProcessingType: vi.fn()
+}))
+
+const accreditation =
+  /** @type {import('#domain/organisations/accreditation.js').Accreditation} */ (
+    /** @type {unknown} */ ({ id: 'acc-1' })
+  )
+const overseasSites = /** @type {*} */ (new Map())
+
+const buildRecord = (overrides = {}) =>
+  /** @type {*} */ ({
+    rowId: 'row-1',
+    type: 'EXPORTED',
+    data: { processingType: PROCESSING_TYPES.EXPORTER, tonnage: 100 },
+    excludedFromWasteBalance: false,
+    ...overrides
+  })
+
+const setSchema = async (schema) => {
+  const { findSchemaForProcessingType } =
+    await import('#domain/summary-logs/table-schemas/index.js')
+  vi.mocked(findSchemaForProcessingType).mockReturnValue(
+    /** @type {*} */ (schema)
+  )
+}
+
+describe('WASTE_BALANCE_OUTCOME', () => {
+  it('keeps INCLUDED, EXCLUDED and IGNORED string-identical to the shared validation outcomes', () => {
+    expect(WASTE_BALANCE_OUTCOME.INCLUDED).toBe(ROW_OUTCOME.INCLUDED)
+    expect(WASTE_BALANCE_OUTCOME.EXCLUDED).toBe(ROW_OUTCOME.EXCLUDED)
+    expect(WASTE_BALANCE_OUTCOME.IGNORED).toBe(ROW_OUTCOME.IGNORED)
+  })
+
+  it('adds a NOT_APPLICABLE outcome absent from the shared validation outcomes', () => {
+    expect(WASTE_BALANCE_OUTCOME.NOT_APPLICABLE).toBe('NOT_APPLICABLE')
+    expect(Object.values(ROW_OUTCOME)).not.toContain(
+      WASTE_BALANCE_OUTCOME.NOT_APPLICABLE
+    )
+  })
+})
+
+describe('classifyRecordForWasteBalance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('is NOT_APPLICABLE when there is no accreditation', async () => {
+    await setSchema({
+      classifyForWasteBalance: () => ({
+        outcome: ROW_OUTCOME.INCLUDED,
+        reasons: [],
+        transactionAmount: 100
+      })
+    })
+
+    expect(
+      classifyRecordForWasteBalance(buildRecord(), null, overseasSites)
+    ).toEqual({
+      outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
+      reasons: [],
+      transactionAmount: 0
+    })
+  })
+
+  it('is NOT_APPLICABLE when the schema has no waste-balance classifier', async () => {
+    await setSchema(null)
+
+    expect(
+      classifyRecordForWasteBalance(buildRecord(), accreditation, overseasSites)
+    ).toEqual({
+      outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
+      reasons: [],
+      transactionAmount: 0
+    })
+  })
+
+  it('treats NOT_APPLICABLE as taking precedence over a manual exclusion', async () => {
+    await setSchema({
+      classifyForWasteBalance: () => ({
+        outcome: ROW_OUTCOME.INCLUDED,
+        reasons: [],
+        transactionAmount: 100
+      })
+    })
+    const record = buildRecord({ excludedFromWasteBalance: true })
+
+    expect(classifyRecordForWasteBalance(record, null, overseasSites)).toEqual({
+      outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
+      reasons: [],
+      transactionAmount: 0
+    })
+  })
+
+  it('is EXCLUDED for a manually excluded record with an accreditation and schema', async () => {
+    await setSchema({
+      classifyForWasteBalance: () => ({
+        outcome: ROW_OUTCOME.INCLUDED,
+        reasons: [],
+        transactionAmount: 100
+      })
+    })
+    const record = buildRecord({ excludedFromWasteBalance: true })
+
+    expect(
+      classifyRecordForWasteBalance(record, accreditation, overseasSites)
+    ).toEqual({
+      outcome: WASTE_BALANCE_OUTCOME.EXCLUDED,
+      reasons: [],
+      transactionAmount: 0
+    })
+  })
+
+  it('surfaces the included outcome, reasons and amount from the schema classifier', async () => {
+    await setSchema({
+      classifyForWasteBalance: () => ({
+        outcome: ROW_OUTCOME.INCLUDED,
+        reasons: [{ code: 'WITHIN_ACCREDITATION_PERIOD' }],
+        transactionAmount: 100
+      })
+    })
+
+    expect(
+      classifyRecordForWasteBalance(buildRecord(), accreditation, overseasSites)
+    ).toEqual({
+      outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
+      reasons: [{ code: 'WITHIN_ACCREDITATION_PERIOD' }],
+      transactionAmount: 100
+    })
+  })
+
+  it('surfaces an ignored classifier outcome and reasons, contributing no amount', async () => {
+    await setSchema({
+      classifyForWasteBalance: () => ({
+        outcome: ROW_OUTCOME.IGNORED,
+        reasons: [{ code: 'PRN_ISSUED' }]
+      })
+    })
+
+    expect(
+      classifyRecordForWasteBalance(buildRecord(), accreditation, overseasSites)
+    ).toEqual({
+      outcome: WASTE_BALANCE_OUTCOME.IGNORED,
+      reasons: [{ code: 'PRN_ISSUED' }],
+      transactionAmount: 0
+    })
+  })
+})

--- a/src/waste-balances/domain/waste-balance-classification.test.js
+++ b/src/waste-balances/domain/waste-balance-classification.test.js
@@ -101,6 +101,19 @@ describe('classifyRecordForWasteBalance', () => {
     })
   })
 
+  it('is NOT_APPLICABLE for a manually excluded record whose schema has no classifier', async () => {
+    await setSchema(null)
+    const record = buildRecord({ excludedFromWasteBalance: true })
+
+    expect(
+      classifyRecordForWasteBalance(record, accreditation, overseasSites)
+    ).toEqual({
+      outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
+      reasons: [],
+      transactionAmount: 0
+    })
+  })
+
   it('is EXCLUDED for a manually excluded record with an accreditation and schema', async () => {
     await setSchema({
       classifyForWasteBalance: () => ({

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -12,7 +12,7 @@ import * as shared from '#domain/summary-logs/table-schemas/shared/fields.js'
 /** @import {Organisation} from '#domain/organisations/model.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
-/** @import {WasteBalanceClassification} from './is-included-in-waste-balance.js' */
+/** @import {CsvWasteBalanceClassification} from './is-included-in-waste-balance.js' */
 
 const FORMULA_INJECTION_PREFIX = /^[=+\-@]/
 
@@ -163,7 +163,7 @@ const buildWasteBalanceCells = (classification) =>
  * @property {Accreditation | null} accreditation
  * @property {WasteRecord} record
  * @property {{ submittedAt: string } | null | undefined} summaryLogEntry
- * @property {WasteBalanceClassification | null} wasteBalanceClassification
+ * @property {CsvWasteBalanceClassification | null} wasteBalanceClassification
  * @property {Record<string, import('./overseas-sites-context.js').OverseasSiteContextEntry>} [overseasSites]
  * @property {string[]} dataFieldColumns
  */

--- a/src/waste-records-export/domain/is-included-in-waste-balance.js
+++ b/src/waste-records-export/domain/is-included-in-waste-balance.js
@@ -9,7 +9,7 @@ import {
 /** @import {WasteRecord} from '#domain/waste-records/model.js' */
 
 /**
- * @typedef {Object} WasteBalanceClassification
+ * @typedef {Object} CsvWasteBalanceClassification
  * @property {boolean} included - Whether the record is included in the waste balance
  * @property {WasteBalanceClassificationReason[]} reasons - Exclusion reasons; empty when included
  * @property {number | null} tonnage - Rounded waste balance tonnage; null when excluded
@@ -31,7 +31,7 @@ import {
  * @param {WasteRecord} record
  * @param {Accreditation | null} accreditation
  * @param {OverseasSitesContext} overseasSites
- * @returns {WasteBalanceClassification | null}
+ * @returns {CsvWasteBalanceClassification | null}
  */
 export const getWasteBalanceClassification = (
   record,

--- a/src/waste-records-export/domain/is-included-in-waste-balance.js
+++ b/src/waste-records-export/domain/is-included-in-waste-balance.js
@@ -1,5 +1,7 @@
-import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/index.js'
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import {
+  WASTE_BALANCE_OUTCOME,
+  classifyRecordForWasteBalance
+} from '#waste-balances/domain/waste-balance-classification.js'
 
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 /** @import {OverseasSitesContext} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
@@ -14,14 +16,15 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
  */
 
 /**
- * Returns the waste balance inclusion status and any exclusion reasons for a record.
- * Mirrors the same logic as the waste-balances calculation path.
+ * Returns the waste balance inclusion status and any exclusion reasons for a
+ * record, adapting the shared waste-balance classification to the CSV export's
+ * shape.
  *
- * Returns `null` when inclusion cannot be computed for this record at all
- * (no accreditation, or no classification schema for the processing type —
- * which is also how registered-only templates are excluded, since their
- * table schemas never define `classifyForWasteBalance`) — these are
- * registration or template-level states, not a per-row classification
+ * Returns `null` when inclusion cannot be computed for this record at all — the
+ * classification is not-applicable (no accreditation, or no classification
+ * schema for the processing type, which is also how registered-only templates
+ * are excluded since their table schemas never define `classifyForWasteBalance`).
+ * These are registration or template-level states, not a per-row classification
  * outcome, so there is no meaningful reason code to report. The CSV export
  * renders `null` as "NA".
  *
@@ -35,27 +38,19 @@ export const getWasteBalanceClassification = (
   accreditation,
   overseasSites
 ) => {
-  const schema = findSchemaForProcessingType(
-    record.data?.processingType,
-    record.type
+  const { outcome, reasons, transactionAmount } = classifyRecordForWasteBalance(
+    record,
+    accreditation,
+    overseasSites
   )
 
-  if (!accreditation || !schema?.classifyForWasteBalance) {
+  if (outcome === WASTE_BALANCE_OUTCOME.NOT_APPLICABLE) {
     return null
   }
 
-  if (record.excludedFromWasteBalance) {
-    return { included: false, reasons: [], tonnage: null }
+  if (outcome === WASTE_BALANCE_OUTCOME.INCLUDED) {
+    return { included: true, reasons: [], tonnage: transactionAmount }
   }
 
-  const result = schema.classifyForWasteBalance(record.data, {
-    accreditation,
-    overseasSites
-  })
-
-  if (result.outcome === ROW_OUTCOME.INCLUDED) {
-    return { included: true, reasons: [], tonnage: result.transactionAmount }
-  }
-
-  return { included: false, reasons: result.reasons, tonnage: null }
+  return { included: false, reasons, tonnage: null }
 }

--- a/src/waste-records/application/project-summary-log-row-state.test.js
+++ b/src/waste-records/application/project-summary-log-row-state.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 
 import { projectSummaryLogRowState } from './project-summary-log-row-state.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 
 const overseasSites = /** @type {any} */ (new Map())
 
@@ -28,7 +28,7 @@ describe('projectSummaryLogRowState', () => {
       rowId: '1',
       wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
       classification: {
-        outcome: ROW_OUTCOME.EXCLUDED,
+        outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
         reasons: [],
         transactionAmount: 0
       },

--- a/src/waste-records/application/write-summary-log-row-states.test.js
+++ b/src/waste-records/application/write-summary-log-row-states.test.js
@@ -4,7 +4,7 @@ import { writeSummaryLogRowStates } from './write-summary-log-row-states.js'
 import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 
 const buildRegisteredOnlyRecord = ({ rowId, tonnage }) => ({
   organisationId: 'org-1',
@@ -117,7 +117,7 @@ describe('writeSummaryLogRowStates', () => {
       accreditationId: null,
       wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
       classification: {
-        outcome: ROW_OUTCOME.EXCLUDED,
+        outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
         reasons: [],
         transactionAmount: 0
       },

--- a/src/waste-records/backfill/reconstruct-submission-summary-log-row-states.test.js
+++ b/src/waste-records/backfill/reconstruct-submission-summary-log-row-states.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 import { SUMMARY_LOG_STATUS } from '#domain/summary-logs/status.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
@@ -225,7 +225,7 @@ describe('reconstructSubmissionSummaryLogRowStates', () => {
       wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
       data: { supplierName: 'Acme' },
       classification: {
-        outcome: ROW_OUTCOME.EXCLUDED,
+        outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
         reasons: [],
         transactionAmount: 0
       }

--- a/src/waste-records/monitoring/reconcile-registration.js
+++ b/src/waste-records/monitoring/reconcile-registration.js
@@ -1,5 +1,5 @@
 import { add, toNumber } from '#common/helpers/decimal-utils.js'
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 import { getWasteBalanceClassification } from '#waste-records-export/domain/is-included-in-waste-balance.js'
 
 /**
@@ -39,7 +39,7 @@ const toRowRef = (row) => ({ rowId: row.rowId, wasteRecordType: typeOf(row) })
 const wasteRecordStateCreditTotal = (wasteRecordStates) =>
   wasteRecordStates.reduce(
     (total, { classification }) =>
-      classification.outcome === ROW_OUTCOME.INCLUDED
+      classification.outcome === WASTE_BALANCE_OUTCOME.INCLUDED
         ? toNumber(add(total, classification.transactionAmount))
         : total,
     0
@@ -68,7 +68,7 @@ const classificationDivergencesBetween = ({
       return []
     }
     const wasteRecordStateIncluded =
-      wasteRecordState.classification.outcome === ROW_OUTCOME.INCLUDED
+      wasteRecordState.classification.outcome === WASTE_BALANCE_OUTCOME.INCLUDED
     const legacyClassification = getWasteBalanceClassification(
       record,
       accreditation,

--- a/src/waste-records/monitoring/reconcile-registration.test.js
+++ b/src/waste-records/monitoring/reconcile-registration.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 import {
   WASTE_RECORD_TYPE,
   VERSION_STATUS
@@ -33,7 +33,7 @@ const includedWasteRecordState = (rowId, transactionAmount, reasons = []) => ({
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   data: { ROW_ID: rowId },
   classification: {
-    outcome: ROW_OUTCOME.INCLUDED,
+    outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
     reasons,
     transactionAmount
   }
@@ -44,7 +44,18 @@ const excludedWasteRecordState = (rowId) => ({
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   data: { ROW_ID: rowId },
   classification: {
-    outcome: ROW_OUTCOME.EXCLUDED,
+    outcome: WASTE_BALANCE_OUTCOME.EXCLUDED,
+    reasons: [],
+    transactionAmount: 0
+  }
+})
+
+const notApplicableWasteRecordState = (rowId) => ({
+  rowId,
+  wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+  data: { ROW_ID: rowId },
+  classification: {
+    outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
     reasons: [],
     transactionAmount: 0
   }
@@ -303,6 +314,25 @@ describe('reconcileRegistration', () => {
     })
 
     expect(result.classificationDivergences).toHaveLength(1)
+    expect(result.isClean).toBe(true)
+  })
+
+  it('reconciles a not-applicable waste record state against a not-included legacy row without drift or divergence', () => {
+    const result = reconcile({
+      head: 'log-2',
+      eventCreditTotal: 0,
+      wasteRecordStates: [notApplicableWasteRecordState('row-1')],
+      wasteRecords: [committedRecord('row-1', 'log-2')],
+      accreditation: null,
+      overseasSites: {}
+    })
+
+    expect(result.creditTotal).toEqual({
+      wasteRecordStates: 0,
+      event: 0,
+      drift: 0
+    })
+    expect(result.classificationDivergences).toEqual([])
     expect(result.isClean).toBe(true)
   })
 

--- a/src/waste-records/repository/schema.js
+++ b/src/waste-records/repository/schema.js
@@ -1,20 +1,22 @@
 import Joi from 'joi'
 
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 import { CLASSIFICATION_REASON } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
 /**
- * @typedef {import('#domain/summary-logs/table-schemas/validation-pipeline.js').RowOutcome} RowOutcome
+ * @typedef {import('#waste-balances/domain/waste-balance-classification.js').WasteBalanceOutcome} WasteBalanceOutcome
  */
 
 /**
  * Stamped classification for a summary-log row state. `outcome` and
  * `transactionAmount` are the row's contribution to the waste balance at the
  * time it committed; `reasons` carry the codes explaining a non-included row.
+ * A NOT_APPLICABLE outcome stamps a row whose registration or template cannot
+ * contribute a per-row waste-balance decision at all.
  *
  * @typedef {Object} RowClassification
- * @property {RowOutcome} outcome
+ * @property {WasteBalanceOutcome} outcome
  * @property {Array<{ code: string, field?: string }>} reasons
  * @property {number} transactionAmount
  */
@@ -74,7 +76,7 @@ const classificationReasonSchema = Joi.object({
 
 const classificationSchema = Joi.object({
   outcome: Joi.string()
-    .valid(...Object.values(ROW_OUTCOME))
+    .valid(...Object.values(WASTE_BALANCE_OUTCOME))
     .required(),
   reasons: Joi.array().items(classificationReasonSchema).required(),
   transactionAmount: Joi.number().required()

--- a/src/waste-records/repository/schema.test.js
+++ b/src/waste-records/repository/schema.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 
 import { summaryLogRowStateInsertSchema } from './schema.js'
 import {
@@ -25,6 +26,19 @@ describe('row state insert schema', () => {
         classification: {
           outcome: ROW_OUTCOME.EXCLUDED,
           reasons: [{ code: 'MISSING_REQUIRED_FIELD', field: 'tonnage' }],
+          transactionAmount: 0
+        }
+      })
+    )
+    expect(error).toBeUndefined()
+  })
+
+  it('accepts a NOT_APPLICABLE row state carrying no reasons', () => {
+    const { error } = validate(
+      buildSummaryLogRowState({
+        classification: {
+          outcome: WASTE_BALANCE_OUTCOME.NOT_APPLICABLE,
+          reasons: [],
           transactionAmount: 0
         }
       })


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)
The committed row-state store — the ADR-0037 forward-write path, currently behind a default-off feature flag — recorded a row whose waste-balance classification cannot be computed as `EXCLUDED`, the same outcome as a genuine validation exclusion. The admin CSV export already distinguishes this case, rendering "NA". This brings the store to parity with the CSV so a later read-cutover can render "NA" straight from the store.

## What changed

- A waste-balance-specific outcome vocabulary `WASTE_BALANCE_OUTCOME` (`INCLUDED` / `EXCLUDED` / `IGNORED` / `NOT_APPLICABLE`) in the waste-balances domain, distinct from the shared validation `ROW_OUTCOME` used across the summary-log pipeline. The three shared values are string-identical to `ROW_OUTCOME`'s, so table-schema classifier results and existing outcome comparisons carry through unchanged.
- A single classification core, `classifyRecordForWasteBalance`, that both the store's classifier and the CSV export's `getWasteBalanceClassification` now adapt over — removing the duplicated logic that had let the two drift. A row is `NOT_APPLICABLE` when it has no accreditation, or its table schema has no waste-balance classifier (registered-only templates included); this is decided before the manual-exclusion check, matching the CSV's precedence exactly. The CSV export's output is unchanged.
- The row-state persistence schema accepts the `NOT_APPLICABLE` outcome, and the reconciliation diagnostic reads the stored outcome through the new vocabulary. A not-applicable row contributes nothing to the balance, exactly as an excluded row did, so no waste-balance arithmetic changes.
- The ledger balance path's `accreditation` parameter is typed as the full `Accreditation` it already receives at runtime, rather than a narrower partial shape.

The stored stamp reflects how the data was interpreted at submission time and is deliberately not recalculated later: a row stamped `NOT_APPLICABLE` because no accreditation existed when it committed keeps that stamp even if the registration is accredited afterwards. No behaviour reaches production yet — the forward-write path remains behind its default-off flag.

[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ