### PR TITLE
PAE-1657: Add admin endpoint listing all submissions per period

### DIFF
--- a/src/reports/domain/build-all-submission-periods.js
+++ b/src/reports/domain/build-all-submission-periods.js
@@ -1,5 +1,4 @@
 import { buildCalendarPeriods } from './build-calendar-periods.js'
-import { PERIOD_STATUS } from './period-status.js'
 
 /**
  * @import { MergedPeriod } from './merge-reporting-periods.js'
@@ -16,9 +15,10 @@ import { PERIOD_STATUS } from './period-status.js'
  * report plus, when a resubmission is pending, the requires_resubmission
  * skeleton) then adds any previous submissions not already surfaced, deduped on
  * submissionNumber so the flagged submitted report the skeleton derives from is
- * not emitted twice. Historical submissions carry periodStatus 'submitted' (each
- * was submitted once); no new status value is introduced. Items within a period
- * are ordered by submissionNumber ascending.
+ * not emitted twice. Each historical item takes its own report status as its
+ * periodStatus (in practice always 'submitted', since only submitted reports are
+ * ever superseded); no new status value is introduced. Items within a period are
+ * ordered by submissionNumber ascending.
  *
  * @param {MergedPeriod[]} mergedPeriods
  * @returns {CalendarPeriod[]}
@@ -36,7 +36,10 @@ export const buildAllSubmissionPeriods = (mergedPeriods) =>
       .map((submission) => ({
         ...period,
         submissionNumber: submission.submissionNumber,
-        periodStatus: PERIOD_STATUS.SUBMITTED,
+        // Derived from the report rather than blanket-stamped 'submitted' so
+        // periodStatus and report.status can never disagree, even if a
+        // non-submitted report ever ends up below the current submission.
+        periodStatus: submission.status,
         report: submission
       }))
 

--- a/src/reports/domain/build-all-submission-periods.js
+++ b/src/reports/domain/build-all-submission-periods.js
@@ -1,0 +1,46 @@
+import { buildCalendarPeriods } from './build-calendar-periods.js'
+import { PERIOD_STATUS } from './period-status.js'
+
+/**
+ * @import { MergedPeriod } from './merge-reporting-periods.js'
+ * @import { CalendarPeriod } from './build-calendar-periods.js'
+ */
+
+/**
+ * Expands merged reporting periods into one calendar item per submission, for
+ * the admin history view. Superseded submissions are deliberately hidden from
+ * the shared calendar (ADR-0038); the regulator's overview needs the full audit
+ * trail instead.
+ *
+ * Reuses buildCalendarPeriods for each period's current-state items (the current
+ * report plus, when a resubmission is pending, the requires_resubmission
+ * skeleton) then adds any previous submissions not already surfaced, deduped on
+ * submissionNumber so the flagged submitted report the skeleton derives from is
+ * not emitted twice. Historical submissions carry periodStatus 'submitted' (each
+ * was submitted once); no new status value is introduced. Items within a period
+ * are ordered by submissionNumber ascending.
+ *
+ * @param {MergedPeriod[]} mergedPeriods
+ * @returns {CalendarPeriod[]}
+ */
+export const buildAllSubmissionPeriods = (mergedPeriods) =>
+  mergedPeriods.flatMap((mergedPeriod) => {
+    const { previousSubmissions = [], ...period } = mergedPeriod
+    const currentStateItems = buildCalendarPeriods([mergedPeriod])
+    const surfaced = new Set(
+      currentStateItems.map((item) => item.submissionNumber)
+    )
+
+    const historicalItems = previousSubmissions
+      .filter((submission) => !surfaced.has(submission.submissionNumber))
+      .map((submission) => ({
+        ...period,
+        submissionNumber: submission.submissionNumber,
+        periodStatus: PERIOD_STATUS.SUBMITTED,
+        report: submission
+      }))
+
+    return [...currentStateItems, ...historicalItems].sort(
+      (a, b) => a.submissionNumber - b.submissionNumber
+    )
+  })

--- a/src/reports/domain/build-all-submission-periods.test.js
+++ b/src/reports/domain/build-all-submission-periods.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import { buildAllSubmissionPeriods } from './build-all-submission-periods.js'
+
+const submittedReport = (overrides = {}) => ({
+  id: 'report-1',
+  status: 'submitted',
+  submissionNumber: 1,
+  submittedAt: '2026-01-20T10:00:00.000Z',
+  submittedBy: { name: 'Test User' },
+  resubmissionRequired: null,
+  ...overrides
+})
+
+const resubmissionFlag = {
+  uploadedAt: '2026-05-01T12:00:00.000Z',
+  reason: 'closed_period_restated',
+  summaryLogId: 'sl-2'
+}
+
+const period = (report, overrides = {}) => ({
+  year: 2026,
+  period: 1,
+  startDate: '2026-01-01',
+  endDate: '2026-01-31',
+  dueDate: '2026-02-20',
+  submissionNumber: report?.submissionNumber ?? 1,
+  report,
+  previousSubmissions: [],
+  ...overrides
+})
+
+describe('buildAllSubmissionPeriods', () => {
+  it('emits every submission for a period, superseded ones as submitted, ordered ascending', () => {
+    const current = submittedReport({ id: 'report-2', submissionNumber: 2 })
+    const superseded = submittedReport({ id: 'report-1', submissionNumber: 1 })
+    const merged = period(current, {
+      submissionNumber: 2,
+      previousSubmissions: [superseded]
+    })
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result.map((item) => item.submissionNumber)).toEqual([1, 2])
+    expect(result.map((item) => item.periodStatus)).toEqual([
+      'submitted',
+      'submitted'
+    ])
+    expect(result[0].report).toBe(superseded)
+    expect(result[1].report).toBe(current)
+  })
+
+  it('preserves the requires_resubmission skeleton alongside historical submissions', () => {
+    const draft = submittedReport({
+      id: 'report-3',
+      status: 'in_progress',
+      submissionNumber: 3,
+      submittedAt: null,
+      submittedBy: null
+    })
+    const flagged = submittedReport({
+      id: 'report-2',
+      submissionNumber: 2,
+      resubmissionRequired: resubmissionFlag
+    })
+    const superseded = submittedReport({ id: 'report-1', submissionNumber: 1 })
+    const merged = period(draft, {
+      submissionNumber: 3,
+      previousSubmissions: [flagged, superseded]
+    })
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result.map((item) => item.submissionNumber)).toEqual([1, 2, 3])
+    expect(result.map((item) => item.periodStatus)).toEqual([
+      'submitted',
+      'submitted',
+      'requires_resubmission'
+    ])
+    expect(result[2].report).toBe(draft)
+  })
+
+  it('does not duplicate the flagged submitted report the skeleton derives from', () => {
+    const flagged = submittedReport({ resubmissionRequired: resubmissionFlag })
+    const merged = period(flagged, { previousSubmissions: [] })
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result.map((item) => item.submissionNumber)).toEqual([1, 2])
+    expect(result.map((item) => item.periodStatus)).toEqual([
+      'submitted',
+      'requires_resubmission'
+    ])
+    expect(result[1].report).toBeNull()
+  })
+
+  it('emits a single item for a period with only a current submission', () => {
+    const merged = period(submittedReport(), { previousSubmissions: [] })
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      submissionNumber: 1,
+      periodStatus: 'submitted'
+    })
+  })
+
+  it('defaults a missing previousSubmissions array to no history', () => {
+    const { previousSubmissions: _omitted, ...merged } =
+      period(submittedReport())
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].submissionNumber).toBe(1)
+  })
+
+  it('expands each period independently', () => {
+    const jan = period(submittedReport({ id: 'jan-2', submissionNumber: 2 }), {
+      submissionNumber: 2,
+      previousSubmissions: [
+        submittedReport({ id: 'jan-1', submissionNumber: 1 })
+      ]
+    })
+    const feb = period(submittedReport({ id: 'feb-1' }), {
+      period: 2,
+      startDate: '2026-02-01',
+      endDate: '2026-02-28',
+      dueDate: '2026-03-20',
+      previousSubmissions: []
+    })
+
+    const result = buildAllSubmissionPeriods([jan, feb])
+
+    expect(
+      result.filter((item) => item.period === 1).map((i) => i.submissionNumber)
+    ).toEqual([1, 2])
+    expect(
+      result.filter((item) => item.period === 2).map((i) => i.submissionNumber)
+    ).toEqual([1])
+  })
+})

--- a/src/reports/domain/build-all-submission-periods.test.js
+++ b/src/reports/domain/build-all-submission-periods.test.js
@@ -93,6 +93,29 @@ describe('buildAllSubmissionPeriods', () => {
     expect(result[1].report).toBeNull()
   })
 
+  it('takes a historical item periodStatus from its own report status, not a blanket submitted', () => {
+    // Defends the invariant: were a non-submitted report ever to sit below the
+    // current submission number, its periodStatus must match its report rather
+    // than being mislabelled 'submitted'.
+    const superseded = submittedReport({
+      id: 'report-1',
+      status: 'in_progress',
+      submissionNumber: 1,
+      submittedAt: null,
+      submittedBy: null
+    })
+    const current = submittedReport({ id: 'report-2', submissionNumber: 2 })
+    const merged = period(current, {
+      submissionNumber: 2,
+      previousSubmissions: [superseded]
+    })
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result[0].submissionNumber).toBe(1)
+    expect(result[0].periodStatus).toBe('in_progress')
+  })
+
   it('emits a single item for a period with only a current submission', () => {
     const merged = period(submittedReport(), { previousSubmissions: [] })
 

--- a/src/reports/routes/admin-report-submissions.js
+++ b/src/reports/routes/admin-report-submissions.js
@@ -3,7 +3,7 @@ import Joi from 'joi'
 
 import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
-import { buildCalendarPeriods } from '#reports/domain/build-calendar-periods.js'
+import { buildAllSubmissionPeriods } from '#reports/domain/build-all-submission-periods.js'
 import { buildReportingCalendar } from './shared.js'
 import { reportsCalendarResponseSchema } from './response.schema.js'
 
@@ -13,15 +13,15 @@ import { reportsCalendarResponseSchema } from './response.schema.js'
  * @import { ReportsRepository } from '#reports/repository/port.js'
  */
 
-export const reportsGetPath =
-  '/v1/organisations/{organisationId}/registrations/{registrationId}/reports/calendar'
+export const adminReportSubmissionsGetPath =
+  '/v1/admin/organisations/{organisationId}/registrations/{registrationId}/report-submissions'
 
-export const reportsGet = {
+export const adminReportSubmissionsGet = {
   method: 'GET',
-  path: reportsGetPath,
+  path: adminReportSubmissionsGetPath,
   options: {
-    auth: getAuthConfig([SCOPES.organisationRead, SCOPES.adminRead]),
-    tags: ['api'],
+    auth: getAuthConfig([SCOPES.adminRead]),
+    tags: ['api', 'admin'],
     validate: {
       params: Joi.object({
         organisationId: Joi.string().required(),
@@ -40,7 +40,10 @@ export const reportsGet = {
    * @param {HapiResponseToolkit} h
    */
   handler: async (request, h) => {
-    const body = await buildReportingCalendar(request, buildCalendarPeriods)
+    const body = await buildReportingCalendar(
+      request,
+      buildAllSubmissionPeriods
+    )
     return h.response(body).code(StatusCodes.OK)
   }
 }

--- a/src/reports/routes/admin-report-submissions.js
+++ b/src/reports/routes/admin-report-submissions.js
@@ -4,7 +4,7 @@ import Joi from 'joi'
 import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { buildAllSubmissionPeriods } from '#reports/domain/build-all-submission-periods.js'
-import { buildReportingCalendar } from './shared.js'
+import { buildReportingPeriodsResponse } from './shared.js'
 import { reportsCalendarResponseSchema } from './response.schema.js'
 
 /**
@@ -40,7 +40,7 @@ export const adminReportSubmissionsGet = {
    * @param {HapiResponseToolkit} h
    */
   handler: async (request, h) => {
-    const body = await buildReportingCalendar(
+    const body = await buildReportingPeriodsResponse(
       request,
       buildAllSubmissionPeriods
     )

--- a/src/reports/routes/admin-report-submissions.test.js
+++ b/src/reports/routes/admin-report-submissions.test.js
@@ -1,0 +1,284 @@
+import { ObjectId } from 'mongodb'
+import { StatusCodes } from 'http-status-codes'
+import { createTestServer } from '#test/create-test-server.js'
+import { asSupport, asOperator } from '#test/inject-auth.js'
+import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
+import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
+import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
+import {
+  REPORT_STATUS,
+  REPORT_STATUS_SLOT
+} from '#reports/domain/report-status.js'
+import {
+  buildOrganisationWithRegistration,
+  buildRegistration
+} from '#repositories/organisations/contract/test-data.js'
+import { adminReportSubmissionsGetPath } from './admin-report-submissions.js'
+
+/**
+ * @import { TestServer } from '#test/create-test-server.js'
+ */
+
+describe(`GET ${adminReportSubmissionsGetPath}`, () => {
+  setupAuthContext()
+
+  const changedBy = { id: 'user-1', name: 'Test', position: 'Officer' }
+
+  const makeUrl = (orgId, regId) =>
+    `/v1/admin/organisations/${orgId}/registrations/${regId}/report-submissions`
+
+  /**
+   * @returns {Promise<{ server: TestServer, organisationId: string, registrationId: string, repo: object }>}
+   */
+  const setup = async () => {
+    const reportsRepositoryFactory = createInMemoryReportsRepository()
+    const registration = buildRegistration({
+      wasteProcessingType: 'exporter',
+      accreditationId: new ObjectId().toString()
+    })
+    const org = buildOrganisationWithRegistration(registration, 'approved')
+
+    const server = await createTestServer({
+      repositories: {
+        organisationsRepository: createInMemoryOrganisationsRepository([org]),
+        reportsRepository: reportsRepositoryFactory
+      },
+      featureFlags: createInMemoryFeatureFlags({})
+    })
+
+    return {
+      server,
+      organisationId: org.id,
+      registrationId: registration.id,
+      repo: reportsRepositoryFactory()
+    }
+  }
+
+  const monthDates = (year, period) => ({
+    startDate: `${year}-${String(period).padStart(2, '0')}-01`,
+    endDate: `${year}-${String(period).padStart(2, '0')}-28`,
+    dueDate: `${year}-${String(period + 1).padStart(2, '0')}-20`
+  })
+
+  const buildCreatePayload = ({
+    organisationId,
+    registrationId,
+    year,
+    period,
+    submissionNumber
+  }) => ({
+    organisationId,
+    registrationId,
+    year,
+    cadence: 'monthly',
+    period,
+    ...monthDates(year, period),
+    changedBy,
+    submissionNumber,
+    material: 'plastic',
+    wasteProcessingType: 'exporter',
+    source: { summaryLogId: 'sl-1', lastUploadedAt: `${year}-01-15` },
+    prn: null,
+    recyclingActivity: {
+      suppliers: [],
+      totalTonnageReceived: 0,
+      tonnageRecycled: null,
+      tonnageNotRecycled: null
+    },
+    wasteSent: {
+      tonnageSentToReprocessor: 0,
+      tonnageSentToExporter: 0,
+      tonnageSentToAnotherSite: 0,
+      finalDestinations: []
+    }
+  })
+
+  const submit = async (repo, id) => {
+    await repo.updateReportStatus({
+      reportId: id,
+      version: 1,
+      status: REPORT_STATUS.READY_TO_SUBMIT,
+      slot: REPORT_STATUS_SLOT.READY,
+      changedBy
+    })
+    await repo.updateReportStatus({
+      reportId: id,
+      version: 2,
+      status: REPORT_STATUS.SUBMITTED,
+      slot: REPORT_STATUS_SLOT.SUBMITTED,
+      changedBy,
+      submissionDeclaredBy: 'Test User'
+    })
+  }
+
+  /** Submits submission N for the period, returning its report id. */
+  const seedSubmitted = async (repo, args) => {
+    const { id } = await repo.createReport(buildCreatePayload(args))
+    await submit(repo, id)
+    return id
+  }
+
+  const flagForResubmission = (
+    repo,
+    { organisationId, registrationId, year, period }
+  ) =>
+    repo.markSubmittedReportsRequiringResubmission({
+      organisationId,
+      registrationId,
+      summaryLogId: 'sl-2',
+      uploadedAt: `${year}-05-01T12:00:00.000Z`,
+      periods: [{ year, cadence: 'monthly', period }]
+    })
+
+  const periodItems = async (
+    server,
+    organisationId,
+    registrationId,
+    p,
+    injector = asSupport
+  ) => {
+    const response = await server.inject({
+      method: 'GET',
+      url: makeUrl(organisationId, registrationId),
+      ...injector()
+    })
+    return JSON.parse(response.payload).reportingPeriods.filter(
+      (item) => item.period === p
+    )
+  }
+
+  it('returns 200 for an admin.read user', async () => {
+    const { server, organisationId, registrationId } = await setup()
+
+    const response = await server.inject({
+      method: 'GET',
+      url: makeUrl(organisationId, registrationId),
+      ...asSupport()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+  })
+
+  it('forbids a non-admin operator', async () => {
+    const { server, organisationId, registrationId } = await setup()
+
+    const response = await server.inject({
+      method: 'GET',
+      url: makeUrl(organisationId, registrationId),
+      ...asOperator()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+  })
+
+  it('returns 404 for an unknown registration', async () => {
+    const { server, organisationId } = await setup()
+
+    const response = await server.inject({
+      method: 'GET',
+      url: makeUrl(organisationId, new ObjectId().toString()),
+      ...asSupport()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+  })
+
+  it('lists every submission for a period after a completed resubmission cycle', async () => {
+    const year = new Date().getUTCFullYear()
+    const { server, organisationId, registrationId, repo } = await setup()
+
+    const sub1 = await seedSubmitted(repo, {
+      organisationId,
+      registrationId,
+      year,
+      period: 1,
+      submissionNumber: 1
+    })
+    await flagForResubmission(repo, {
+      organisationId,
+      registrationId,
+      year,
+      period: 1
+    })
+    const sub2 = await seedSubmitted(repo, {
+      organisationId,
+      registrationId,
+      year,
+      period: 1,
+      submissionNumber: 2
+    })
+
+    const january = await periodItems(server, organisationId, registrationId, 1)
+
+    expect(january.map((item) => item.submissionNumber)).toEqual([1, 2])
+    expect(january.map((item) => item.periodStatus)).toEqual([
+      'submitted',
+      'submitted'
+    ])
+    expect(january[0].report.id).toBe(sub1)
+    expect(january[1].report.id).toBe(sub2)
+  })
+
+  it('preserves the requires_resubmission skeleton for a flagged period', async () => {
+    const year = new Date().getUTCFullYear()
+    const { server, organisationId, registrationId, repo } = await setup()
+
+    const sub1 = await seedSubmitted(repo, {
+      organisationId,
+      registrationId,
+      year,
+      period: 1,
+      submissionNumber: 1
+    })
+    await flagForResubmission(repo, {
+      organisationId,
+      registrationId,
+      year,
+      period: 1
+    })
+
+    const january = await periodItems(server, organisationId, registrationId, 1)
+
+    expect(january.map((item) => item.submissionNumber)).toEqual([1, 2])
+    const original = january.find((item) => item.periodStatus === 'submitted')
+    expect(original.report.id).toBe(sub1)
+    const skeleton = january.find(
+      (item) => item.periodStatus === 'requires_resubmission'
+    )
+    expect(skeleton).toMatchObject({ submissionNumber: 2, report: null })
+  })
+
+  it('curates historical submissions to the list shape', async () => {
+    const year = new Date().getUTCFullYear()
+    const { server, organisationId, registrationId, repo } = await setup()
+
+    await seedSubmitted(repo, {
+      organisationId,
+      registrationId,
+      year,
+      period: 1,
+      submissionNumber: 1
+    })
+    await flagForResubmission(repo, {
+      organisationId,
+      registrationId,
+      year,
+      period: 1
+    })
+    await seedSubmitted(repo, {
+      organisationId,
+      registrationId,
+      year,
+      period: 1,
+      submissionNumber: 2
+    })
+
+    const january = await periodItems(server, organisationId, registrationId, 1)
+    const superseded = january.find((item) => item.submissionNumber === 1)
+
+    expect(Object.keys(superseded.report).sort()).toStrictEqual(
+      ['id', 'status', 'submissionNumber', 'submittedAt', 'submittedBy'].sort()
+    )
+  })
+})

--- a/src/reports/routes/get.js
+++ b/src/reports/routes/get.js
@@ -4,7 +4,7 @@ import Joi from 'joi'
 import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { buildCalendarPeriods } from '#reports/domain/build-calendar-periods.js'
-import { buildReportingCalendar } from './shared.js'
+import { buildReportingPeriodsResponse } from './shared.js'
 import { reportsCalendarResponseSchema } from './response.schema.js'
 
 /**
@@ -40,7 +40,10 @@ export const reportsGet = {
    * @param {HapiResponseToolkit} h
    */
   handler: async (request, h) => {
-    const body = await buildReportingCalendar(request, buildCalendarPeriods)
+    const body = await buildReportingPeriodsResponse(
+      request,
+      buildCalendarPeriods
+    )
     return h.response(body).code(StatusCodes.OK)
   }
 }

--- a/src/reports/routes/index.js
+++ b/src/reports/routes/index.js
@@ -1,3 +1,4 @@
+export { adminReportSubmissionsGet } from './admin-report-submissions.js'
 export { reportsDelete } from './delete.js'
 export { reportsGet } from './get.js'
 export { reportsGetDetail } from './get-detail.js'

--- a/src/reports/routes/shared.js
+++ b/src/reports/routes/shared.js
@@ -1,6 +1,17 @@
 import Joi from 'joi'
 
 import { cadenceSchema, periodSchema } from '#reports/repository/schema.js'
+import { CADENCE } from '#reports/domain/cadence.js'
+import { generateReportingPeriods } from '#reports/domain/generate-reporting-periods.js'
+import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
+import { mergeReportingPeriods } from '#reports/domain/merge-reporting-periods.js'
+
+/**
+ * @import { HapiRequest } from '#common/hapi-types.js'
+ * @import { MergedPeriod } from '#reports/domain/merge-reporting-periods.js'
+ * @import { CalendarPeriod } from '#reports/domain/build-calendar-periods.js'
+ * @import { ReportSummary, ReportListItem } from '#reports/repository/port.js'
+ */
 
 const MIN_YEAR = 2024
 const MAX_YEAR = 2100
@@ -42,6 +53,74 @@ export function withRegistrationDetails(report, registration) {
       site: registration.site
     }
   }
+}
+
+/**
+ * Curates a full report summary down to the calendar list-response shape so
+ * calendar-style endpoints don't leak heavy activity payloads.
+ * @param {ReportSummary | null} report
+ * @returns {ReportListItem | null}
+ */
+export function toReportListItem(report) {
+  if (!report) {
+    return null
+  }
+  const { id, status, submissionNumber, submittedAt, submittedBy } = report
+  return { id, status, submissionNumber, submittedAt, submittedBy }
+}
+
+/**
+ * Shared read model for the calendar-shaped reporting endpoints. Resolves the
+ * cadence from the registration, computes the current-year periods, merges the
+ * persisted reports, expands them via the supplied builder, then curates each
+ * item's report to the list shape. The builder decides whether superseded
+ * submissions are collapsed (calendar) or all surfaced (admin history).
+ * @param {HapiRequest & {
+ *   organisationsRepository: import('#repositories/organisations/port.js').OrganisationsRepository,
+ *   reportsRepository: import('#reports/repository/port.js').ReportsRepository
+ * }} request
+ * @param {(mergedPeriods: MergedPeriod[]) => CalendarPeriod[]} buildPeriods
+ * @returns {Promise<{ cadence: string, reportingPeriods: object[] }>}
+ */
+export async function buildReportingCalendar(request, buildPeriods) {
+  const { organisationsRepository, reportsRepository, params } = request
+  const { organisationId, registrationId } = params
+
+  const registration = await organisationsRepository.findRegistrationById(
+    organisationId,
+    registrationId
+  )
+
+  const cadence = isRegistrationAccredited(registration)
+    ? CADENCE.monthly
+    : CADENCE.quarterly
+
+  /**
+   * We simply return for the current year for now for both Registered-Only
+   * and Accredited Operators. Registered-only operators will need multi-year
+   * support once outstanding historical reports are submitted.
+   */
+  const currentYear = new Date().getUTCFullYear()
+  const computedPeriods = generateReportingPeriods(cadence, currentYear)
+
+  const periodicReports = await reportsRepository.findPeriodicReports({
+    organisationId,
+    registrationId
+  })
+
+  const merged = mergeReportingPeriods(
+    computedPeriods,
+    periodicReports,
+    cadence
+  )
+
+  // Calendar periods are ended or carry a report, so periodStatus is non-null.
+  const reportingPeriods = buildPeriods(merged).map((period) => ({
+    ...period,
+    report: toReportListItem(period.report)
+  }))
+
+  return { cadence, reportingPeriods }
 }
 
 /**

--- a/src/reports/routes/shared.js
+++ b/src/reports/routes/shared.js
@@ -82,7 +82,7 @@ export function toReportListItem(report) {
  * @param {(mergedPeriods: MergedPeriod[]) => CalendarPeriod[]} buildPeriods
  * @returns {Promise<{ cadence: string, reportingPeriods: object[] }>}
  */
-export async function buildReportingCalendar(request, buildPeriods) {
+export async function buildReportingPeriodsResponse(request, buildPeriods) {
   const { organisationsRepository, reportsRepository, params } = request
   const { organisationId, registrationId } = params
 


### PR DESCRIPTION
## What

Adds a new admin-scoped read endpoint that lists every submission for each reporting period of a registration:

```
GET /v1/admin/organisations/{organisationId}/registrations/{registrationId}/report-submissions
```

It returns the same `{ cadence, reportingPeriods }` shape as the existing reports calendar, but the `reportingPeriods` array is not collapsed: for any period that has been submitted more than once, every submission appears as its own item, including superseded ones. Each historical submission carries its own report status as `periodStatus` (in practice always `submitted`, since only submitted reports are ever superseded), and the `requires_resubmission` skeleton item is preserved exactly as the calendar emits it. As with the calendar, a period that has ended without a submission still yields a single item with `report: null` and a `due`/`overdue` status, so the array is not strictly one-item-per-submission for unstarted periods. Items are ordered by submission number ascending, and the response is scoped to `admin.read`.

## Why

The reports calendar (`GET .../reports/calendar`) deliberately collapses each period to its current submission and never emits superseded ones (ADR-0038): the operator view should only surface what to act on. The regulator's registration overview needs the opposite: the full audit trail, so every submission for a period is visible and reachable. Rather than extend the shared calendar (which four consumers depend on and which ADR-0038 keeps free of history), this adds a dedicated admin endpoint. The frontend work that consumes it is tracked separately under the same ticket.

The full history was already assembled server-side by `groupAsPeriodicReports` (`current` plus `previousSubmissions`) and simply discarded before the response. This endpoint exposes it; no new persistence or derivation is introduced.

## How it fits together

- `buildAllSubmissionPeriods` reuses `buildCalendarPeriods` for each period's current-state items (current report plus, when a resubmission is pending, the `requires_resubmission` skeleton), then appends any previous submissions not already surfaced, deduped on submission number so the flagged report the skeleton derives from is not emitted twice. Each historical item takes its `periodStatus` from its own report status rather than a blanket value, so `periodStatus` and `report.status` can never disagree.
- The read model shared by both endpoints (resolve cadence, compute periods, merge, curate) is extracted into `buildReportingPeriodsResponse` in `shared.js`, so the calendar route and the new admin route differ only in which period builder they pass in. The existing calendar route keeps its behaviour unchanged.