### PR TITLE
PAE-1665: Exclude cancelled/awaiting cancellation PRNs from issued tonnage

### DIFF
--- a/src/packaging-recycling-notes/application/get-issued-tonnage.test.js
+++ b/src/packaging-recycling-notes/application/get-issued-tonnage.test.js
@@ -72,6 +72,42 @@ async function acceptPrn(repo, id, { acceptedAt = IN_PERIOD } = {}) {
   })
 }
 
+/**
+ * Transitions an issued PRN to awaiting_cancellation.
+ *
+ * @param {object} repo
+ * @param {string} id
+ */
+async function requestCancelPrn(repo, id) {
+  const current = await repo.findById(id)
+  return repo.updateStatus({
+    id,
+    version: current.version,
+    status: PRN_STATUS.AWAITING_CANCELLATION,
+    updatedAt: IN_PERIOD,
+    updatedBy: ACTOR
+  })
+}
+
+/**
+ * Transitions a PRN awaiting cancellation to cancelled, populating the
+ * cancelled slot.
+ *
+ * @param {object} repo
+ * @param {string} id
+ */
+async function cancelPrn(repo, id) {
+  const current = await repo.findById(id)
+  return repo.updateStatus({
+    id,
+    version: current.version,
+    status: PRN_STATUS.CANCELLED,
+    updatedAt: IN_PERIOD,
+    updatedBy: ACTOR,
+    operation: { slot: 'cancelled', at: IN_PERIOD, by: ACTOR }
+  })
+}
+
 describe('getIssuedTonnage', () => {
   it('returns null when accreditationId is absent', async () => {
     const result = await getIssuedTonnage(createRepo(), {
@@ -148,5 +184,21 @@ describe('getIssuedTonnage', () => {
     const result = await getIssuedTonnage(repo, defaultParams)
 
     expect(result).toEqual({ issuedTonnage: 40 })
+  })
+
+  it('excludes cancelled and awaiting-cancellation PRNs, but keeps accepted and in-flight ones, all issued within the period', async () => {
+    const repo = createRepo()
+    await issuePrn(repo, { tonnage: 30 })
+    const accepted = await issuePrn(repo, { tonnage: 20 })
+    await acceptPrn(repo, accepted.id)
+    const awaitingCancellation = await issuePrn(repo, { tonnage: 75 })
+    await requestCancelPrn(repo, awaitingCancellation.id)
+    const cancelled = await issuePrn(repo, { tonnage: 75 })
+    await requestCancelPrn(repo, cancelled.id)
+    await cancelPrn(repo, cancelled.id)
+
+    const result = await getIssuedTonnage(repo, defaultParams)
+
+    expect(result).toEqual({ issuedTonnage: 50 })
   })
 })

--- a/src/packaging-recycling-notes/application/get-issued-tonnage.test.js
+++ b/src/packaging-recycling-notes/application/get-issued-tonnage.test.js
@@ -3,6 +3,7 @@ import { PRN_STATUS } from '../domain/model.js'
 import { getIssuedTonnage } from './get-issued-tonnage.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '../repository/inmemory.plugin.js'
 import { buildPrn } from '../repository/contract/test-data.js'
+import { createMockLogger } from '#test/mock-logger.js'
 
 const PERIOD_START = '2025-01-01'
 const PERIOD_END = '2025-12-31'
@@ -18,7 +19,7 @@ const defaultParams = {
 }
 
 function createRepo() {
-  return createInMemoryPackagingRecyclingNotesRepository()()
+  return createInMemoryPackagingRecyclingNotesRepository()(createMockLogger())
 }
 
 /**

--- a/src/packaging-recycling-notes/domain/model.js
+++ b/src/packaging-recycling-notes/domain/model.js
@@ -16,6 +16,15 @@ export const PRN_STATUS = Object.freeze({
 })
 
 /**
+ * Cancelled PRN statuses.
+ * @type {Set<PrnStatus>}
+ */
+export const CANCELLED_PRN_STATUSES = new Set([
+  PRN_STATUS.AWAITING_CANCELLATION,
+  PRN_STATUS.CANCELLED
+])
+
+/**
  * Actor types that can trigger PRN status transitions
  * @typedef {typeof PRN_ACTOR[keyof typeof PRN_ACTOR]} PrnActor
  */

--- a/src/packaging-recycling-notes/domain/tonnage.js
+++ b/src/packaging-recycling-notes/domain/tonnage.js
@@ -22,8 +22,13 @@ import { CANCELLED_PRN_STATUSES } from './model.js'
 export function aggregateIssuedTonnage(prns, { startDate, endDate }) {
   const isInPeriod = (at) => !isNil(at) && at >= startDate && at <= endDate
 
+  const isIssuedInPeriod = (prn) => isInPeriod(prn.status.issued?.at)
+
+  const isNotCancelled = (prn) =>
+    !CANCELLED_PRN_STATUSES.has(prn.status.currentStatus)
+
   return prns
-    .filter((prn) => isInPeriod(prn.status.issued?.at))
-    .filter((prn) => !CANCELLED_PRN_STATUSES.has(prn.status.currentStatus))
+    .filter(isIssuedInPeriod)
+    .filter(isNotCancelled)
     .reduce((total, prn) => total + prn.tonnage, 0)
 }

--- a/src/packaging-recycling-notes/domain/tonnage.js
+++ b/src/packaging-recycling-notes/domain/tonnage.js
@@ -1,4 +1,5 @@
 import { isNil } from '#common/helpers/is-nil.js'
+import { CANCELLED_PRN_STATUSES } from './model.js'
 
 /**
  * @typedef {Object} AggregateTonnageParams
@@ -10,7 +11,9 @@ import { isNil } from '#common/helpers/is-nil.js'
  * Aggregates tonnage from PRNs where issued.at falls within the period.
  *
  * The reporting period is always determined by when the PRN was issued
- * (status.issued.at), regardless of when it was accepted or cancelled.
+ * (status.issued.at), regardless of when it was accepted. PRNs whose current
+ * status is Cancelled or Awaiting Cancellation are excluded, even if they
+ * were issued within the period.
  *
  * @param {import('./model.js').PackagingRecyclingNote[]} prns
  * @param {AggregateTonnageParams} params
@@ -21,5 +24,6 @@ export function aggregateIssuedTonnage(prns, { startDate, endDate }) {
 
   return prns
     .filter((prn) => isInPeriod(prn.status.issued?.at))
+    .filter((prn) => !CANCELLED_PRN_STATUSES.has(prn.status.currentStatus))
     .reduce((total, prn) => total + prn.tonnage, 0)
 }

--- a/src/packaging-recycling-notes/domain/tonnage.test.js
+++ b/src/packaging-recycling-notes/domain/tonnage.test.js
@@ -84,7 +84,7 @@ describe('aggregateIssuedTonnage', () => {
   describe('cancelled PRNs', () => {
     const cancelledParams = params
 
-    it('includes PRN created before the period, issued within it, cancelled after it', () => {
+    it('excludes PRN created before the period, issued within it, cancelled after it', () => {
       const prn = buildPrn('prn-1', 75, {
         currentStatus: PRN_STATUS.CANCELLED,
         currentStatusAt: APR,
@@ -94,10 +94,10 @@ describe('aggregateIssuedTonnage', () => {
         cancelled: { at: APR, by: ACTOR }
       })
 
-      expect(aggregateIssuedTonnage([prn], cancelledParams)).toBe(75)
+      expect(aggregateIssuedTonnage([prn], cancelledParams)).toBe(0)
     })
 
-    it('includes PRN created and issued within the period but cancelled after it', () => {
+    it('excludes PRN created and issued within the period but cancelled after it', () => {
       const prn = buildPrn('prn-1', 75, {
         currentStatus: PRN_STATUS.CANCELLED,
         currentStatusAt: APR,
@@ -107,7 +107,32 @@ describe('aggregateIssuedTonnage', () => {
         cancelled: { at: APR, by: ACTOR }
       })
 
-      expect(aggregateIssuedTonnage([prn], cancelledParams)).toBe(75)
+      expect(aggregateIssuedTonnage([prn], cancelledParams)).toBe(0)
+    })
+
+    it('excludes PRN currently awaiting cancellation, even though issued within the period', () => {
+      const prn = buildPrn('prn-1', 75, {
+        currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
+        currentStatusAt: APR,
+        created: { at: MAR, by: ACTOR },
+        issued: { at: MAR, by: ACTOR },
+        accepted: { at: MAR, by: ACTOR }
+      })
+
+      expect(aggregateIssuedTonnage([prn], cancelledParams)).toBe(0)
+    })
+
+    it('excludes a cancelled PRN whose issued.at also falls outside the period', () => {
+      const prn = buildPrn('prn-1', 75, {
+        currentStatus: PRN_STATUS.CANCELLED,
+        currentStatusAt: APR,
+        created: { at: FEB, by: ACTOR },
+        issued: { at: FEB, by: ACTOR },
+        rejected: { at: APR, by: ACTOR },
+        cancelled: { at: APR, by: ACTOR }
+      })
+
+      expect(aggregateIssuedTonnage([prn], cancelledParams)).toBe(0)
     })
   })
 
@@ -133,7 +158,7 @@ describe('aggregateIssuedTonnage', () => {
     expect(aggregateIssuedTonnage([prn], params)).toBe(0)
   })
 
-  it('sums tonnage across multiple qualifying PRNs', () => {
+  it('sums tonnage across multiple qualifying PRNs, excluding a cancelled one', () => {
     const prns = [
       buildPrn('prn-1', 30, {
         currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
@@ -147,6 +172,14 @@ describe('aggregateIssuedTonnage', () => {
         created: { at: MAR, by: ACTOR },
         issued: { at: MAR, by: ACTOR },
         accepted: { at: APR, by: ACTOR }
+      }),
+      buildPrn('prn-3', 75, {
+        currentStatus: PRN_STATUS.CANCELLED,
+        currentStatusAt: APR,
+        created: { at: MAR, by: ACTOR },
+        issued: { at: MAR, by: ACTOR },
+        rejected: { at: APR, by: ACTOR },
+        cancelled: { at: APR, by: ACTOR }
       })
     ]
 


### PR DESCRIPTION
Ticket: [PAE-1665](https://eaflood.atlassian.net/browse/PAE-1665)
- Exclude PRNs currently Cancelled or Awaiting Cancellation from the issued tonnage calculation used when creating a new report, even if they were issued within the reporting period
- Add a `CANCELLED_PRN_STATUSES` constant alongside `PRN_STATUS` to name the disqualifying statuses
- Update `aggregateIssuedTonnage` unit tests to reflect the corrected exclusion behaviour (previously these PRNs were incorrectly included)

[PAE-1665]: https://eaflood.atlassian.net/browse/PAE-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ