### PR TITLE
PAE-1661 Consistently use operator instead of standardUser in tests

### DIFF
--- a/.vite/helpers/test-invalid-roles-scenarios.js
+++ b/.vite/helpers/test-invalid-roles-scenarios.js
@@ -6,13 +6,11 @@ import { defraIdMockAuthTokens } from '#vite/helpers/create-defra-id-test-tokens
  * @param {Object} params
  * @param {() => import('#test/create-test-server.js').TestServer} params.server
  * @param {() => Promise<{method: string, url: string, headers?: Object, payload?: Object}>} params.makeRequest
- * @param {((response: any) => void)=} params.additionalExpectations - Optional additional expectations
  * @param {number=} params.successStatus - Optional success status code (defaults to 200 OK)
  */
 export function testOnlyServiceMaintainerCanAccess({
   server,
   makeRequest,
-  additionalExpectations,
   successStatus = StatusCodes.OK
 }) {
   describe('A user with', () => {
@@ -60,10 +58,6 @@ export function testOnlyServiceMaintainerCanAccess({
         })
 
         expect(response.statusCode).toBe(expectedStatus)
-
-        if (additionalExpectations) {
-          additionalExpectations(response)
-        }
       }
     )
   })
@@ -73,77 +67,10 @@ export function testOnlyServiceMaintainerCanAccess({
  * @param {Object} params
  * @param {() => import('#test/create-test-server.js').TestServer} params.server
  * @param {() => Promise<{method: string, url: string, headers?: Object, payload?: Object}>} params.makeRequest
- * @param {((response: any) => void)=} params.additionalExpectations - Optional additional expectations
  */
-export function testOnlyStandardUserCanAccess({
+export function testOperatorAndServiceMaintainerCanAccess({
   server,
-  makeRequest,
-  additionalExpectations
-}) {
-  describe('A user with', () => {
-    const tokenScenarios = [
-      {
-        token: entraIdMockAuthTokens.validToken,
-        description: 'a valid Entra token with the service maintainer role',
-        expectedStatus: StatusCodes.UNAUTHORIZED
-      },
-      {
-        token: entraIdMockAuthTokens.nonServiceMaintainerUserToken,
-        description:
-          'a valid Entra token but without the service maintainer role',
-        expectedStatus: StatusCodes.FORBIDDEN
-      },
-      {
-        token: defraIdMockAuthTokens.unknownUnauthorisedUserToken,
-        description:
-          'a valid Defra Id token but with an unknown email and contactId',
-        expectedStatus: StatusCodes.UNAUTHORIZED
-      },
-      {
-        token: defraIdMockAuthTokens.validToken,
-        description: 'a valid Defra Id token for a known public user',
-        expectedStatus: StatusCodes.OK
-      },
-      {
-        token: defraIdMockAuthTokens.unknownButAuthorisedUserToken,
-        description:
-          'a valid Defra Id token for an unknown user with a relationshipId pointing at the org',
-        expectedStatus: StatusCodes.OK
-      }
-    ]
-
-    it.each(tokenScenarios)(
-      'returns $expectedStatus for user with $description',
-      async ({ token, expectedStatus }) => {
-        const requestConfig = await makeRequest()
-        const response = await server().inject({
-          ...requestConfig,
-          headers: {
-            ...requestConfig.headers,
-            Authorization: `Bearer ${token}`
-          }
-        })
-
-        expect(response.statusCode).toBe(expectedStatus)
-
-        if (additionalExpectations) {
-          additionalExpectations(response)
-        }
-      }
-    )
-  })
-}
-
-/**
- * @param {Object} params
- * @param {() => import('#test/create-test-server.js').TestServer} params.server
- * @param {() => Promise<{method: string, url: string, headers?: Object, payload?: Object}>} params.makeRequest
- * @param {((response: any) => void)=} params.additionalExpectations - Optional additional expectations
- */
-export function testStandardUserAndServiceMaintainerCanAccess({
-  server,
-  makeRequest,
-  additionalExpectations
+  makeRequest
 }) {
   describe('A user with', () => {
     const tokenScenarios = [
@@ -190,10 +117,6 @@ export function testStandardUserAndServiceMaintainerCanAccess({
         })
 
         expect(response.statusCode).toBe(expectedStatus)
-
-        if (additionalExpectations) {
-          additionalExpectations(response)
-        }
       }
     )
   })

--- a/.vite/helpers/test-invalid-token-scenarios.js
+++ b/.vite/helpers/test-invalid-token-scenarios.js
@@ -6,13 +6,8 @@ import { defraIdMockAuthTokens } from '#vite/helpers/create-defra-id-test-tokens
  * @param {Object} params
  * @param {() => import('#test/create-test-server.js').TestServer} params.server
  * @param {() => Promise<{method: string, url: string, headers?: Object, payload?: Object}>} params.makeRequest
- * @param {((response: any) => void)=} params.additionalExpectations - Optional additional expectations
  */
-export function testInvalidTokenScenarios({
-  server,
-  makeRequest,
-  additionalExpectations
-}) {
+export function testInvalidTokenScenarios({ server, makeRequest }) {
   describe('Invalid tokens', () => {
     describe('user has an Entra token with the wrong credentials', () => {
       const { wrongSignatureToken, wrongIssuerToken, wrongAudienceToken } =
@@ -50,9 +45,9 @@ export function testInvalidTokenScenarios({
 
           expect(response.statusCode).toBe(expectedStatus)
 
-          if (additionalExpectations) {
-            additionalExpectations(response)
-          }
+          expect(response.headers['cache-control']).toBe(
+            'no-cache, no-store, must-revalidate'
+          )
         }
       )
 
@@ -62,9 +57,9 @@ export function testInvalidTokenScenarios({
 
         expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
 
-        if (additionalExpectations) {
-          additionalExpectations(response)
-        }
+        expect(response.headers['cache-control']).toBe(
+          'no-cache, no-store, must-revalidate'
+        )
       })
     })
 
@@ -113,9 +108,9 @@ export function testInvalidTokenScenarios({
 
           expect(response.statusCode).toBe(expectedStatus)
 
-          if (additionalExpectations) {
-            additionalExpectations(response)
-          }
+          expect(response.headers['cache-control']).toBe(
+            'no-cache, no-store, must-revalidate'
+          )
         }
       )
 
@@ -125,9 +120,9 @@ export function testInvalidTokenScenarios({
 
         expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
 
-        if (additionalExpectations) {
-          additionalExpectations(response)
-        }
+        expect(response.headers['cache-control']).toBe(
+          'no-cache, no-store, must-revalidate'
+        )
       })
     })
   })

--- a/src/reports/routes/shared.test.js
+++ b/src/reports/routes/shared.test.js
@@ -4,7 +4,7 @@ import { userSummarySchema } from '#reports/repository/schema.js'
 
 import { extractChangedBy } from './shared.js'
 
-const defraIdStandardUser = {
+const defraIdOperatorUser = {
   id: 'contact-1',
   email: 'ada@example.com',
   name: 'Ada Lovelace',
@@ -21,7 +21,7 @@ const entraAdminUser = {
 
 describe('extractChangedBy', () => {
   it('carries name and email distinctly for a Defra ID standard user', () => {
-    expect(extractChangedBy(defraIdStandardUser)).toEqual({
+    expect(extractChangedBy(defraIdOperatorUser)).toEqual({
       id: 'contact-1',
       name: 'Ada Lovelace',
       email: 'ada@example.com',
@@ -43,7 +43,7 @@ describe('extractChangedBy', () => {
 
   it('produces a value userSummarySchema accepts and preserves email for both providers', () => {
     const defraId = userSummarySchema.validate(
-      extractChangedBy(defraIdStandardUser)
+      extractChangedBy(defraIdOperatorUser)
     )
     expect(defraId.error).toBeUndefined()
     expect(defraId.value.email).toBe('ada@example.com')

--- a/src/routes/v1/form-submissions/get-by-id.test.js
+++ b/src/routes/v1/form-submissions/get-by-id.test.js
@@ -187,11 +187,6 @@ describe('GET /v1/form-submissions/{documentId}', () => {
         method: 'GET',
         url: `/v1/form-submissions/${ORG_A.id}`
       }
-    },
-    additionalExpectations: (response) => {
-      expect(response.headers['cache-control']).toBe(
-        'no-cache, no-store, must-revalidate'
-      )
     }
   })
 

--- a/src/routes/v1/linked-organisations/get.test.js
+++ b/src/routes/v1/linked-organisations/get.test.js
@@ -270,12 +270,7 @@ describe(`GET ${linkedOrganisationsGetAllPath}`, () => {
     makeRequest: async () => ({
       method: 'GET',
       url: linkedOrganisationsGetAllPath
-    }),
-    additionalExpectations: (response) => {
-      expect(response.headers['cache-control']).toBe(
-        'no-cache, no-store, must-revalidate'
-      )
-    }
+    })
   })
 
   testOnlyServiceMaintainerCanAccess({

--- a/src/routes/v1/organisations/get-by-id.test.js
+++ b/src/routes/v1/organisations/get-by-id.test.js
@@ -5,7 +5,7 @@ import { buildOrganisation } from '#repositories/organisations/contract/test-dat
 import { createTestServer } from '#test/create-test-server.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 import { testInvalidTokenScenarios } from '#vite/helpers/test-invalid-token-scenarios.js'
-import { testStandardUserAndServiceMaintainerCanAccess } from '#vite/helpers/test-invalid-roles-scenarios.js'
+import { testOperatorAndServiceMaintainerCanAccess } from '#vite/helpers/test-invalid-roles-scenarios.js'
 import { entraIdMockAuthTokens } from '#vite/helpers/create-entra-id-test-tokens.js'
 import { buildActiveOrg } from '#vite/helpers/build-active-org.js'
 
@@ -118,15 +118,10 @@ describe('GET /v1/organisations/{id}', () => {
         method: 'GET',
         url: `/v1/organisations/${org1.id}`
       }
-    },
-    additionalExpectations: (response) => {
-      expect(response.headers['cache-control']).toBe(
-        'no-cache, no-store, must-revalidate'
-      )
     }
   })
 
-  testStandardUserAndServiceMaintainerCanAccess({
+  testOperatorAndServiceMaintainerCanAccess({
     server: () => server,
     makeRequest: async () => {
       const org1 = await buildActiveOrg(organisationsRepository)

--- a/src/routes/v1/organisations/get.test.js
+++ b/src/routes/v1/organisations/get.test.js
@@ -282,11 +282,6 @@ describe('GET /v1/organisations', () => {
         method: 'GET',
         url: `/v1/organisations/${org1.id}`
       }
-    },
-    additionalExpectations: (response) => {
-      expect(response.headers['cache-control']).toBe(
-        'no-cache, no-store, must-revalidate'
-      )
     }
   })
 

--- a/src/routes/v1/organisations/link.test.js
+++ b/src/routes/v1/organisations/link.test.js
@@ -139,11 +139,6 @@ describe('POST /v1/organisations/{organisationId}/link', () => {
         method: 'POST',
         url: `/v1/organisations/${org1.id}/link`
       }
-    },
-    additionalExpectations: (response) => {
-      expect(response.headers['cache-control']).toBe(
-        'no-cache, no-store, must-revalidate'
-      )
     }
   })
 

--- a/src/routes/v1/organisations/put-by-id.test.js
+++ b/src/routes/v1/organisations/put-by-id.test.js
@@ -400,11 +400,6 @@ describe('PUT /v1/organisations/{id}', () => {
           updateFragment: { ...org1, wasteProcessingTypes: ['reprocessor'] }
         }
       }
-    },
-    additionalExpectations: (response) => {
-      expect(response.headers['cache-control']).toBe(
-        'no-cache, no-store, must-revalidate'
-      )
     }
   })
 

--- a/src/routes/v1/public-register/generate/post.test.js
+++ b/src/routes/v1/public-register/generate/post.test.js
@@ -132,11 +132,6 @@ describe(`POST ${publicRegisterGeneratePath}`, () => {
         method: 'POST',
         url: publicRegisterGeneratePath
       }
-    },
-    additionalExpectations: (response) => {
-      expect(response.headers['cache-control']).toBe(
-        'no-cache, no-store, must-revalidate'
-      )
     }
   })
 

--- a/src/routes/v1/system-logs/get-search.test.js
+++ b/src/routes/v1/system-logs/get-search.test.js
@@ -347,12 +347,7 @@ describe('GET /v1/system-logs/search', () => {
     makeRequest: async () => ({
       method: 'GET',
       url: '/v1/system-logs/search?userId=test'
-    }),
-    additionalExpectations: (response) => {
-      expect(response.headers['cache-control']).toBe(
-        'no-cache, no-store, must-revalidate'
-      )
-    }
+    })
   })
 
   testOnlyServiceMaintainerCanAccess({

--- a/src/routes/v1/tonnage-monitoring/get.test.js
+++ b/src/routes/v1/tonnage-monitoring/get.test.js
@@ -117,12 +117,7 @@ describe(`GET ${tonnageMonitoringPath}`, () => {
     makeRequest: async () => ({
       method: 'GET',
       url: tonnageMonitoringPath
-    }),
-    additionalExpectations: (response) => {
-      expect(response.headers['cache-control']).toBe(
-        'no-cache, no-store, must-revalidate'
-      )
-    }
+    })
   })
 
   testOnlyServiceMaintainerCanAccess({

--- a/src/routes/v1/waste-balance-availability/get.test.js
+++ b/src/routes/v1/waste-balance-availability/get.test.js
@@ -104,12 +104,7 @@ describe(`GET ${wasteBalanceAvailabilityPath}`, () => {
     makeRequest: async () => ({
       method: 'GET',
       url: wasteBalanceAvailabilityPath
-    }),
-    additionalExpectations: (response) => {
-      expect(response.headers['cache-control']).toBe(
-        'no-cache, no-store, must-revalidate'
-      )
-    }
+    })
   })
 
   testOnlyServiceMaintainerCanAccess({


### PR DESCRIPTION
Ticket: [PAE-1661](https://eaflood.atlassian.net/browse/PAE-1661)
## Description

Replaces `[sS]tandardUser` with `[oO]perator` in test code

Also remove unused functions/parameters in auth testing code

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1661]: https://eaflood.atlassian.net/browse/PAE-1661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ