### PR TITLE
PAE-1590: run journey tests with summary-log row states on

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        waste-record-states: [false]
+        waste-record-states: [true]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)
## What

Flips the `test-journey` matrix value from `waste-record-states: [false]` to `[true]` so journey tests run against the backend with the summary-log row-state flag on. The matrix mechanism is kept intact.

## Why

The row-state flag is being enabled in prod ([DEFRA/cdp-app-config#3922](https://github.com/DEFRA/cdp-app-config/pull/3922)), and the `run-journey-tests` action now defaults it on ([DEFRA/epr-backend-journey-tests#561](https://github.com/DEFRA/epr-backend-journey-tests/pull/561)). This PR makes epr-backend's own journey run match that, since it pins the value explicitly rather than relying on the default.

**Merge order:** this depends on [journey-tests#561](https://github.com/DEFRA/epr-backend-journey-tests/pull/561) merging first. epr-backend consumes `run-journey-tests@main`; until #561 is on journey-tests `main`, the action exports the pre-rename env var name and this matrix value has no effect. Once #561 is in, this genuinely exercises the flag-on path.

[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ