### PR TITLE
PAE-1657: calendar-expand-submissions: Expand reports calendar with an admin all-submissions view

### DIFF
--- a/src/reports/domain/build-all-submission-periods.js
+++ b/src/reports/domain/build-all-submission-periods.js
@@ -1,0 +1,46 @@
+import { buildCalendarPeriods } from './build-calendar-periods.js'
+import { PERIOD_STATUS } from './period-status.js'
+
+/**
+ * @import { MergedPeriod } from './merge-reporting-periods.js'
+ * @import { CalendarPeriod } from './build-calendar-periods.js'
+ */
+
+/**
+ * Expands merged reporting periods into one calendar item per submission, for
+ * the admin (all-submissions) view. Superseded submissions are deliberately
+ * hidden from the collapsed calendar (ADR-0038); the regulator's overview needs
+ * the full audit trail instead.
+ *
+ * Reuses buildCalendarPeriods for each period's current-state items (the current
+ * report plus, when a resubmission is pending, the requires_resubmission
+ * skeleton) then adds any previous submissions not already surfaced, deduped on
+ * submissionNumber so the flagged submitted report the skeleton derives from is
+ * not emitted twice. Historical submissions carry periodStatus 'submitted' (each
+ * was submitted once); no new status value is introduced. Items within a period
+ * are ordered by submissionNumber ascending.
+ *
+ * @param {MergedPeriod[]} mergedPeriods
+ * @returns {CalendarPeriod[]}
+ */
+export const buildAllSubmissionPeriods = (mergedPeriods) =>
+  mergedPeriods.flatMap((mergedPeriod) => {
+    const { previousSubmissions = [], ...period } = mergedPeriod
+    const currentStateItems = buildCalendarPeriods([mergedPeriod])
+    const surfaced = new Set(
+      currentStateItems.map((item) => item.submissionNumber)
+    )
+
+    const historicalItems = previousSubmissions
+      .filter((submission) => !surfaced.has(submission.submissionNumber))
+      .map((submission) => ({
+        ...period,
+        submissionNumber: submission.submissionNumber,
+        periodStatus: PERIOD_STATUS.SUBMITTED,
+        report: submission
+      }))
+
+    return [...currentStateItems, ...historicalItems].sort(
+      (a, b) => a.submissionNumber - b.submissionNumber
+    )
+  })

--- a/src/reports/domain/build-all-submission-periods.js
+++ b/src/reports/domain/build-all-submission-periods.js
@@ -21,11 +21,15 @@ import { REPORT_STATUS } from './report-status.js'
  * never mask a genuine submission.
  *
  * Only submitted previous submissions are emitted, each carrying periodStatus
- * 'submitted'. A new submission number is only allocated once the prior
- * submission is submitted, so every entry below the current one is a completed
- * submission (see groupAsPeriodicReports). Filtering on submitted status
- * enforces that invariant rather than trusting it, so a non-submitted report can
- * never surface mislabelled as 'submitted'.
+ * 'submitted'. Submission numbers are allocated when a draft is created, but a
+ * submission number N > 1 can only be created once submission N-1 has been
+ * submitted and flagged for resubmission (assertResubmissionAllowed in
+ * report-service.js). So a report only drops below the current slot after it has
+ * been submitted: every previous submission is a completed one, and the in-flight
+ * resubmission draft is always the current slot (surfaced as the
+ * requires_resubmission skeleton), never a previous submission. Filtering on
+ * submitted status enforces that invariant defensively rather than trusting it,
+ * so a non-submitted report can never surface mislabelled as 'submitted'.
  *
  * Items within a period are ordered by submissionNumber ascending, including the
  * synthetic skeleton slot.

--- a/src/reports/domain/build-all-submission-periods.js
+++ b/src/reports/domain/build-all-submission-periods.js
@@ -1,5 +1,6 @@
 import { buildCalendarPeriods } from './build-calendar-periods.js'
 import { PERIOD_STATUS } from './period-status.js'
+import { REPORT_STATUS } from './report-status.js'
 
 /**
  * @import { MergedPeriod } from './merge-reporting-periods.js'
@@ -8,17 +9,26 @@ import { PERIOD_STATUS } from './period-status.js'
 
 /**
  * Expands merged reporting periods into one calendar item per submission, for
- * the admin (all-submissions) view. Superseded submissions are deliberately
- * hidden from the collapsed calendar (ADR-0038); the regulator's overview needs
- * the full audit trail instead.
+ * the opt-in all-submissions view. Superseded submissions are collapsed out of
+ * the default calendar (ADR-0038); this view surfaces them for the full history,
+ * the same history already available on the report-detail view.
  *
  * Reuses buildCalendarPeriods for each period's current-state items (the current
- * report plus, when a resubmission is pending, the requires_resubmission
- * skeleton) then adds any previous submissions not already surfaced, deduped on
- * submissionNumber so the flagged submitted report the skeleton derives from is
- * not emitted twice. Historical submissions carry periodStatus 'submitted' (each
- * was submitted once); no new status value is introduced. Items within a period
- * are ordered by submissionNumber ascending.
+ * report, plus a requires_resubmission skeleton when a resubmission is pending),
+ * then adds the period's previous submissions those items do not already
+ * surface. Deduping is keyed on the surfaced reports' ids, not submission
+ * numbers, so the synthetic skeleton slot (which carries no real report) can
+ * never mask a genuine submission.
+ *
+ * Only submitted previous submissions are emitted, each carrying periodStatus
+ * 'submitted'. A new submission number is only allocated once the prior
+ * submission is submitted, so every entry below the current one is a completed
+ * submission (see groupAsPeriodicReports). Filtering on submitted status
+ * enforces that invariant rather than trusting it, so a non-submitted report can
+ * never surface mislabelled as 'submitted'.
+ *
+ * Items within a period are ordered by submissionNumber ascending, including the
+ * synthetic skeleton slot.
  *
  * @param {MergedPeriod[]} mergedPeriods
  * @returns {CalendarPeriod[]}
@@ -27,12 +37,16 @@ export const buildAllSubmissionPeriods = (mergedPeriods) =>
   mergedPeriods.flatMap((mergedPeriod) => {
     const { previousSubmissions = [], ...period } = mergedPeriod
     const currentStateItems = buildCalendarPeriods([mergedPeriod])
-    const surfaced = new Set(
-      currentStateItems.map((item) => item.submissionNumber)
+    const surfacedReportIds = new Set(
+      currentStateItems.flatMap((item) => (item.report ? [item.report.id] : []))
     )
 
     const historicalItems = previousSubmissions
-      .filter((submission) => !surfaced.has(submission.submissionNumber))
+      .filter(
+        (submission) =>
+          submission.status === REPORT_STATUS.SUBMITTED &&
+          !surfacedReportIds.has(submission.id)
+      )
       .map((submission) => ({
         ...period,
         submissionNumber: submission.submissionNumber,

--- a/src/reports/domain/build-all-submission-periods.test.js
+++ b/src/reports/domain/build-all-submission-periods.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import { buildAllSubmissionPeriods } from './build-all-submission-periods.js'
+
+const submittedReport = (overrides = {}) => ({
+  id: 'report-1',
+  status: 'submitted',
+  submissionNumber: 1,
+  submittedAt: '2026-01-20T10:00:00.000Z',
+  submittedBy: { name: 'Test User' },
+  resubmissionRequired: null,
+  ...overrides
+})
+
+const resubmissionFlag = {
+  uploadedAt: '2026-05-01T12:00:00.000Z',
+  reason: 'closed_period_restated',
+  summaryLogId: 'sl-2'
+}
+
+const period = (report, overrides = {}) => ({
+  year: 2026,
+  period: 1,
+  startDate: '2026-01-01',
+  endDate: '2026-01-31',
+  dueDate: '2026-02-20',
+  submissionNumber: report?.submissionNumber ?? 1,
+  report,
+  previousSubmissions: [],
+  ...overrides
+})
+
+describe('buildAllSubmissionPeriods', () => {
+  it('emits every submission for a period, superseded ones as submitted, ordered ascending', () => {
+    const current = submittedReport({ id: 'report-2', submissionNumber: 2 })
+    const superseded = submittedReport({ id: 'report-1', submissionNumber: 1 })
+    const merged = period(current, {
+      submissionNumber: 2,
+      previousSubmissions: [superseded]
+    })
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result.map((item) => item.submissionNumber)).toEqual([1, 2])
+    expect(result.map((item) => item.periodStatus)).toEqual([
+      'submitted',
+      'submitted'
+    ])
+    expect(result[0].report).toBe(superseded)
+    expect(result[1].report).toBe(current)
+  })
+
+  it('preserves the requires_resubmission skeleton alongside historical submissions', () => {
+    const draft = submittedReport({
+      id: 'report-3',
+      status: 'in_progress',
+      submissionNumber: 3,
+      submittedAt: null,
+      submittedBy: null
+    })
+    const flagged = submittedReport({
+      id: 'report-2',
+      submissionNumber: 2,
+      resubmissionRequired: resubmissionFlag
+    })
+    const superseded = submittedReport({ id: 'report-1', submissionNumber: 1 })
+    const merged = period(draft, {
+      submissionNumber: 3,
+      previousSubmissions: [flagged, superseded]
+    })
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result.map((item) => item.submissionNumber)).toEqual([1, 2, 3])
+    expect(result.map((item) => item.periodStatus)).toEqual([
+      'submitted',
+      'submitted',
+      'requires_resubmission'
+    ])
+    expect(result[2].report).toBe(draft)
+  })
+
+  it('does not duplicate the flagged submitted report the skeleton derives from', () => {
+    const flagged = submittedReport({ resubmissionRequired: resubmissionFlag })
+    const merged = period(flagged, { previousSubmissions: [] })
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result.map((item) => item.submissionNumber)).toEqual([1, 2])
+    expect(result.map((item) => item.periodStatus)).toEqual([
+      'submitted',
+      'requires_resubmission'
+    ])
+    expect(result[1].report).toBeNull()
+  })
+
+  it('emits a single item for a period with only a current submission', () => {
+    const merged = period(submittedReport(), { previousSubmissions: [] })
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      submissionNumber: 1,
+      periodStatus: 'submitted'
+    })
+  })
+
+  it('defaults a missing previousSubmissions array to no history', () => {
+    const { previousSubmissions: _omitted, ...merged } =
+      period(submittedReport())
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].submissionNumber).toBe(1)
+  })
+
+  it('expands each period independently', () => {
+    const jan = period(submittedReport({ id: 'jan-2', submissionNumber: 2 }), {
+      submissionNumber: 2,
+      previousSubmissions: [
+        submittedReport({ id: 'jan-1', submissionNumber: 1 })
+      ]
+    })
+    const feb = period(submittedReport({ id: 'feb-1' }), {
+      period: 2,
+      startDate: '2026-02-01',
+      endDate: '2026-02-28',
+      dueDate: '2026-03-20',
+      previousSubmissions: []
+    })
+
+    const result = buildAllSubmissionPeriods([jan, feb])
+
+    expect(
+      result.filter((item) => item.period === 1).map((i) => i.submissionNumber)
+    ).toEqual([1, 2])
+    expect(
+      result.filter((item) => item.period === 2).map((i) => i.submissionNumber)
+    ).toEqual([1])
+  })
+})

--- a/src/reports/domain/build-all-submission-periods.test.js
+++ b/src/reports/domain/build-all-submission-periods.test.js
@@ -1,6 +1,15 @@
 import { describe, it, expect } from 'vitest'
 import { buildAllSubmissionPeriods } from './build-all-submission-periods.js'
 
+/**
+ * Only the two cases the endpoint path cannot reach live here. Everything else
+ * this builder does is exercised through the real submit flow in
+ * `reports/routes/get.test.js` (the `?expand=submissions` view). These two
+ * cannot be: `mergeReportingPeriods` always populates `previousSubmissions`, and
+ * the submission-number invariant means the submit flow never produces a
+ * non-submitted previous submission.
+ */
+
 const submittedReport = (overrides = {}) => ({
   id: 'report-1',
   status: 'submitted',
@@ -10,12 +19,6 @@ const submittedReport = (overrides = {}) => ({
   resubmissionRequired: null,
   ...overrides
 })
-
-const resubmissionFlag = {
-  uploadedAt: '2026-05-01T12:00:00.000Z',
-  reason: 'closed_period_restated',
-  summaryLogId: 'sl-2'
-}
 
 const period = (report, overrides = {}) => ({
   year: 2026,
@@ -30,96 +33,14 @@ const period = (report, overrides = {}) => ({
 })
 
 describe('buildAllSubmissionPeriods', () => {
-  it('emits every submission for a period, superseded ones as submitted, ordered ascending', () => {
-    const current = submittedReport({ id: 'report-2', submissionNumber: 2 })
-    const superseded = submittedReport({ id: 'report-1', submissionNumber: 1 })
-    const merged = period(current, {
-      submissionNumber: 2,
-      previousSubmissions: [superseded]
-    })
+  it('defaults a missing previousSubmissions array to no history', () => {
+    const { previousSubmissions: _omitted, ...merged } =
+      period(submittedReport())
 
     const result = buildAllSubmissionPeriods([merged])
 
-    expect(result.map((item) => item.submissionNumber)).toEqual([1, 2])
-    expect(result.map((item) => item.periodStatus)).toEqual([
-      'submitted',
-      'submitted'
-    ])
-    expect(result[0].report).toBe(superseded)
-    expect(result[1].report).toBe(current)
-  })
-
-  it('preserves the requires_resubmission skeleton alongside historical submissions', () => {
-    const draft = submittedReport({
-      id: 'report-3',
-      status: 'in_progress',
-      submissionNumber: 3,
-      submittedAt: null,
-      submittedBy: null
-    })
-    const flagged = submittedReport({
-      id: 'report-2',
-      submissionNumber: 2,
-      resubmissionRequired: resubmissionFlag
-    })
-    const superseded = submittedReport({ id: 'report-1', submissionNumber: 1 })
-    const merged = period(draft, {
-      submissionNumber: 3,
-      previousSubmissions: [flagged, superseded]
-    })
-
-    const result = buildAllSubmissionPeriods([merged])
-
-    expect(result.map((item) => item.submissionNumber)).toEqual([1, 2, 3])
-    expect(result.map((item) => item.periodStatus)).toEqual([
-      'submitted',
-      'submitted',
-      'requires_resubmission'
-    ])
-    expect(result[2].report).toBe(draft)
-  })
-
-  it('does not duplicate the flagged submitted report the skeleton derives from', () => {
-    const flagged = submittedReport({ resubmissionRequired: resubmissionFlag })
-    const merged = period(flagged, { previousSubmissions: [] })
-
-    const result = buildAllSubmissionPeriods([merged])
-
-    expect(result.map((item) => item.submissionNumber)).toEqual([1, 2])
-    expect(result.map((item) => item.periodStatus)).toEqual([
-      'submitted',
-      'requires_resubmission'
-    ])
-    expect(result[1].report).toBeNull()
-  })
-
-  it('surfaces the flagged submitted report exactly once when it is a previous submission', () => {
-    // Draft in flight: the flagged report has dropped to previousSubmissions and
-    // is also surfaced as the submitted item by buildCalendarPeriods. Deduping
-    // on the report id keeps it to a single item.
-    const draft = submittedReport({
-      id: 'report-3',
-      status: 'in_progress',
-      submissionNumber: 3,
-      submittedAt: null,
-      submittedBy: null
-    })
-    const flagged = submittedReport({
-      id: 'report-2',
-      submissionNumber: 2,
-      resubmissionRequired: resubmissionFlag
-    })
-    const merged = period(draft, {
-      submissionNumber: 3,
-      previousSubmissions: [flagged]
-    })
-
-    const result = buildAllSubmissionPeriods([merged])
-
-    expect(result.map((item) => item.submissionNumber)).toEqual([2, 3])
-    expect(
-      result.filter((item) => item.report?.id === 'report-2')
-    ).toHaveLength(1)
+    expect(result).toHaveLength(1)
+    expect(result[0].submissionNumber).toBe(1)
   })
 
   it('excludes a non-submitted report from the submissions view', () => {
@@ -147,52 +68,5 @@ describe('buildAllSubmissionPeriods', () => {
       'report-1',
       'report-3'
     ])
-  })
-
-  it('emits a single item for a period with only a current submission', () => {
-    const merged = period(submittedReport(), { previousSubmissions: [] })
-
-    const result = buildAllSubmissionPeriods([merged])
-
-    expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      submissionNumber: 1,
-      periodStatus: 'submitted'
-    })
-  })
-
-  it('defaults a missing previousSubmissions array to no history', () => {
-    const { previousSubmissions: _omitted, ...merged } =
-      period(submittedReport())
-
-    const result = buildAllSubmissionPeriods([merged])
-
-    expect(result).toHaveLength(1)
-    expect(result[0].submissionNumber).toBe(1)
-  })
-
-  it('expands each period independently', () => {
-    const jan = period(submittedReport({ id: 'jan-2', submissionNumber: 2 }), {
-      submissionNumber: 2,
-      previousSubmissions: [
-        submittedReport({ id: 'jan-1', submissionNumber: 1 })
-      ]
-    })
-    const feb = period(submittedReport({ id: 'feb-1' }), {
-      period: 2,
-      startDate: '2026-02-01',
-      endDate: '2026-02-28',
-      dueDate: '2026-03-20',
-      previousSubmissions: []
-    })
-
-    const result = buildAllSubmissionPeriods([jan, feb])
-
-    expect(
-      result.filter((item) => item.period === 1).map((i) => i.submissionNumber)
-    ).toEqual([1, 2])
-    expect(
-      result.filter((item) => item.period === 2).map((i) => i.submissionNumber)
-    ).toEqual([1])
   })
 })

--- a/src/reports/domain/build-all-submission-periods.test.js
+++ b/src/reports/domain/build-all-submission-periods.test.js
@@ -44,9 +44,12 @@ describe('buildAllSubmissionPeriods', () => {
   })
 
   it('excludes a non-submitted report from the submissions view', () => {
-    // The invariant: submission numbers are only allocated on submit, so a
-    // previous submission is always submitted. If a non-submitted report ever
-    // reaches previousSubmissions it must not surface mislabelled as submitted.
+    // The invariant: submission number N > 1 is only created once N-1 is
+    // submitted and flagged (assertResubmissionAllowed), so a report only drops
+    // below the current slot after it has been submitted, i.e. a previous
+    // submission is always submitted. This guards the defensive filter against a
+    // future change to that precondition: a non-submitted report reaching
+    // previousSubmissions must not surface mislabelled as submitted.
     const current = submittedReport({ id: 'report-3', submissionNumber: 3 })
     const abandonedDraft = submittedReport({
       id: 'report-2',

--- a/src/reports/domain/build-all-submission-periods.test.js
+++ b/src/reports/domain/build-all-submission-periods.test.js
@@ -93,6 +93,62 @@ describe('buildAllSubmissionPeriods', () => {
     expect(result[1].report).toBeNull()
   })
 
+  it('surfaces the flagged submitted report exactly once when it is a previous submission', () => {
+    // Draft in flight: the flagged report has dropped to previousSubmissions and
+    // is also surfaced as the submitted item by buildCalendarPeriods. Deduping
+    // on the report id keeps it to a single item.
+    const draft = submittedReport({
+      id: 'report-3',
+      status: 'in_progress',
+      submissionNumber: 3,
+      submittedAt: null,
+      submittedBy: null
+    })
+    const flagged = submittedReport({
+      id: 'report-2',
+      submissionNumber: 2,
+      resubmissionRequired: resubmissionFlag
+    })
+    const merged = period(draft, {
+      submissionNumber: 3,
+      previousSubmissions: [flagged]
+    })
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result.map((item) => item.submissionNumber)).toEqual([2, 3])
+    expect(
+      result.filter((item) => item.report?.id === 'report-2')
+    ).toHaveLength(1)
+  })
+
+  it('excludes a non-submitted report from the submissions view', () => {
+    // The invariant: submission numbers are only allocated on submit, so a
+    // previous submission is always submitted. If a non-submitted report ever
+    // reaches previousSubmissions it must not surface mislabelled as submitted.
+    const current = submittedReport({ id: 'report-3', submissionNumber: 3 })
+    const abandonedDraft = submittedReport({
+      id: 'report-2',
+      status: 'in_progress',
+      submissionNumber: 2,
+      submittedAt: null,
+      submittedBy: null
+    })
+    const submitted = submittedReport({ id: 'report-1', submissionNumber: 1 })
+    const merged = period(current, {
+      submissionNumber: 3,
+      previousSubmissions: [abandonedDraft, submitted]
+    })
+
+    const result = buildAllSubmissionPeriods([merged])
+
+    expect(result.map((item) => item.submissionNumber)).toEqual([1, 3])
+    expect(result.map((item) => item.report?.id)).toEqual([
+      'report-1',
+      'report-3'
+    ])
+  })
+
   it('emits a single item for a period with only a current submission', () => {
     const merged = period(submittedReport(), { previousSubmissions: [] })
 

--- a/src/reports/routes/get.js
+++ b/src/reports/routes/get.js
@@ -5,6 +5,7 @@ import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { CADENCE } from '#reports/domain/cadence.js'
 import { buildCalendarPeriods } from '#reports/domain/build-calendar-periods.js'
+import { buildAllSubmissionPeriods } from '#reports/domain/build-all-submission-periods.js'
 import { generateReportingPeriods } from '#reports/domain/generate-reporting-periods.js'
 import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
 import { mergeReportingPeriods } from '#reports/domain/merge-reporting-periods.js'
@@ -37,6 +38,28 @@ const toReportListItem = (current) => {
   return { id, status, submissionNumber, submittedAt, submittedBy }
 }
 
+/**
+ * Chooses the period builder for this request. The expanded (all-submissions)
+ * view surfaces superseded submissions the calendar normally collapses, so it is
+ * opt-in via ?expand=submissions AND gated on admin.read: operators only ever
+ * see today's collapsed calendar (ADR-0038). An operator passing the arg is
+ * ignored rather than refused, keeping the shared route's behaviour unchanged
+ * for every non-admin consumer.
+ * @param {HapiRequest} request
+ * @returns {typeof buildCalendarPeriods}
+ */
+const selectPeriodBuilder = (request) => {
+  const expandRequested =
+    /** @type {{ expand?: string }} */ (request.query).expand === 'submissions'
+  const { scope = [] } = /** @type {{ scope?: string[] }} */ (
+    /** @type {unknown} */ (request.auth.credentials)
+  )
+  const isAdmin = scope.includes(SCOPES.adminRead)
+  return expandRequested && isAdmin
+    ? buildAllSubmissionPeriods
+    : buildCalendarPeriods
+}
+
 export const reportsGet = {
   method: 'GET',
   path: reportsGetPath,
@@ -47,6 +70,9 @@ export const reportsGet = {
       params: Joi.object({
         organisationId: Joi.string().required(),
         registrationId: Joi.string().required()
+      }),
+      query: Joi.object({
+        expand: Joi.string().valid('submissions')
       })
     },
     response: {
@@ -93,7 +119,8 @@ export const reportsGet = {
     )
 
     // Calendar periods are ended or carry a report, so periodStatus is non-null.
-    const reportingPeriods = buildCalendarPeriods(merged).map((period) => ({
+    const buildPeriods = selectPeriodBuilder(request)
+    const reportingPeriods = buildPeriods(merged).map((period) => ({
       ...period,
       report: toReportListItem(period.report)
     }))

--- a/src/reports/routes/get.js
+++ b/src/reports/routes/get.js
@@ -14,11 +14,17 @@ import { reportsCalendarResponseSchema } from './response.schema.js'
 /**
  * @import { HapiRequest, HapiResponseToolkit } from '#common/hapi-types.js'
  * @import { OrganisationsRepository } from '#repositories/organisations/port.js'
+ * @import { MergedPeriod } from '#reports/domain/merge-reporting-periods.js'
+ * @import { CalendarPeriod } from '#reports/domain/build-calendar-periods.js'
  * @import {
  *   ReportsRepository,
  *   ReportSummary,
  *   ReportListItem
  * } from '#reports/repository/port.js'
+ */
+
+/**
+ * @typedef {(mergedPeriods: MergedPeriod[]) => CalendarPeriod[]} PeriodBuilder
  */
 
 export const reportsGetPath =
@@ -39,26 +45,17 @@ const toReportListItem = (current) => {
 }
 
 /**
- * Chooses the period builder for this request. The expanded (all-submissions)
- * view surfaces superseded submissions the calendar normally collapses, so it is
- * opt-in via ?expand=submissions AND gated on admin.read: operators only ever
- * see today's collapsed calendar (ADR-0038). An operator passing the arg is
- * ignored rather than refused, keeping the shared route's behaviour unchanged
- * for every non-admin consumer.
+ * Chooses the period builder for this request. The opt-in ?expand=submissions
+ * view surfaces the previous submissions the default calendar collapses; the
+ * same history is already available on the report-detail view, so it needs no
+ * further gating. Every other request keeps today's collapsing behaviour.
  * @param {HapiRequest} request
- * @returns {typeof buildCalendarPeriods}
+ * @returns {PeriodBuilder}
  */
-const selectPeriodBuilder = (request) => {
-  const expandRequested =
-    /** @type {{ expand?: string }} */ (request.query).expand === 'submissions'
-  const { scope = [] } = /** @type {{ scope?: string[] }} */ (
-    /** @type {unknown} */ (request.auth.credentials)
-  )
-  const isAdmin = scope.includes(SCOPES.adminRead)
-  return expandRequested && isAdmin
+const selectPeriodBuilder = (request) =>
+  /** @type {{ expand?: string }} */ (request.query).expand === 'submissions'
     ? buildAllSubmissionPeriods
     : buildCalendarPeriods
-}
 
 export const reportsGet = {
   method: 'GET',

--- a/src/reports/routes/get.test.js
+++ b/src/reports/routes/get.test.js
@@ -1556,7 +1556,7 @@ describe(`GET ${reportsGetPath}`, () => {
           (p) => p.period === 1
         )
 
-      it('lists every submission per period for an admin caller', async () => {
+      it('lists every submission per period when expand=submissions', async () => {
         const { server, organisationId, registrationId, repo } =
           await createExporterServer()
         const { sub1, sub2 } = await seedResubmittedPeriod(
@@ -1568,7 +1568,7 @@ describe(`GET ${reportsGetPath}`, () => {
         const response = await server.inject({
           method: 'GET',
           url: `${makeUrl(organisationId, registrationId)}?expand=submissions`,
-          ...asServiceMaintainer()
+          ...asOperator()
         })
         const january = januaryItems(response)
 
@@ -1581,7 +1581,7 @@ describe(`GET ${reportsGetPath}`, () => {
         expect(january[1].report.id).toBe(sub2)
       })
 
-      it('collapses superseded submissions for an admin caller when the arg is absent', async () => {
+      it('collapses superseded submissions when the arg is absent', async () => {
         const { server, organisationId, registrationId, repo } =
           await createExporterServer()
         await seedResubmittedPeriod(repo, organisationId, registrationId)
@@ -1589,26 +1589,9 @@ describe(`GET ${reportsGetPath}`, () => {
         const response = await server.inject({
           method: 'GET',
           url: makeUrl(organisationId, registrationId),
-          ...asServiceMaintainer()
-        })
-
-        expect(januaryItems(response).map((p) => p.submissionNumber)).toEqual([
-          2
-        ])
-      })
-
-      it('ignores the arg for a non-admin operator, keeping the collapsed calendar', async () => {
-        const { server, organisationId, registrationId, repo } =
-          await createExporterServer()
-        await seedResubmittedPeriod(repo, organisationId, registrationId)
-
-        const response = await server.inject({
-          method: 'GET',
-          url: `${makeUrl(organisationId, registrationId)}?expand=submissions`,
           ...asOperator()
         })
 
-        expect(response.statusCode).toBe(StatusCodes.OK)
         expect(januaryItems(response).map((p) => p.submissionNumber)).toEqual([
           2
         ])
@@ -1621,7 +1604,7 @@ describe(`GET ${reportsGetPath}`, () => {
         const response = await server.inject({
           method: 'GET',
           url: `${makeUrl(organisationId, registrationId)}?expand=everything`,
-          ...asServiceMaintainer()
+          ...asOperator()
         })
 
         expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)

--- a/src/reports/routes/get.test.js
+++ b/src/reports/routes/get.test.js
@@ -1424,6 +1424,209 @@ describe(`GET ${reportsGetPath}`, () => {
         expect(response.statusCode).toBe(StatusCodes.OK)
       })
     })
+
+    describe('expanded submissions view (?expand=submissions)', () => {
+      const changedBy = { id: 'user-1', name: 'Test', position: 'Officer' }
+      const year = new Date().getUTCFullYear()
+
+      const monthDates = (period) => ({
+        startDate: `${year}-${String(period).padStart(2, '0')}-01`,
+        endDate: `${year}-${String(period).padStart(2, '0')}-28`,
+        dueDate: `${year}-${String(period + 1).padStart(2, '0')}-20`
+      })
+
+      const buildCreatePayload = (
+        organisationId,
+        registrationId,
+        period,
+        submissionNumber
+      ) => ({
+        organisationId,
+        registrationId,
+        year,
+        cadence: 'monthly',
+        period,
+        ...monthDates(period),
+        changedBy,
+        submissionNumber,
+        material: 'plastic',
+        wasteProcessingType: 'exporter',
+        source: { summaryLogId: 'sl-1', lastUploadedAt: `${year}-01-15` },
+        prn: null,
+        recyclingActivity: {
+          suppliers: [],
+          totalTonnageReceived: 0,
+          tonnageRecycled: null,
+          tonnageNotRecycled: null
+        },
+        wasteSent: {
+          tonnageSentToReprocessor: 0,
+          tonnageSentToExporter: 0,
+          tonnageSentToAnotherSite: 0,
+          finalDestinations: []
+        }
+      })
+
+      const submit = async (repo, id) => {
+        await repo.updateReportStatus({
+          reportId: id,
+          version: 1,
+          status: REPORT_STATUS.READY_TO_SUBMIT,
+          slot: REPORT_STATUS_SLOT.READY,
+          changedBy
+        })
+        await repo.updateReportStatus({
+          reportId: id,
+          version: 2,
+          status: REPORT_STATUS.SUBMITTED,
+          slot: REPORT_STATUS_SLOT.SUBMITTED,
+          changedBy,
+          submissionDeclaredBy: 'Test User'
+        })
+      }
+
+      const seedSubmitted = async (
+        repo,
+        organisationId,
+        registrationId,
+        period,
+        submissionNumber
+      ) => {
+        const { id } = await repo.createReport(
+          buildCreatePayload(
+            organisationId,
+            registrationId,
+            period,
+            submissionNumber
+          )
+        )
+        await submit(repo, id)
+        return id
+      }
+
+      const flagForResubmission = (repo, organisationId, registrationId) =>
+        repo.markSubmittedReportsRequiringResubmission({
+          organisationId,
+          registrationId,
+          summaryLogId: 'sl-2',
+          uploadedAt: `${year}-05-01T12:00:00.000Z`,
+          periods: [{ year, cadence: 'monthly', period: 1 }]
+        })
+
+      // A period submitted, flagged, then resubmitted: submission 1 is now
+      // superseded (hidden by the collapsed calendar), submission 2 is current.
+      const seedResubmittedPeriod = async (
+        repo,
+        organisationId,
+        registrationId
+      ) => {
+        const sub1 = await seedSubmitted(
+          repo,
+          organisationId,
+          registrationId,
+          1,
+          1
+        )
+        await flagForResubmission(repo, organisationId, registrationId)
+        const sub2 = await seedSubmitted(
+          repo,
+          organisationId,
+          registrationId,
+          1,
+          2
+        )
+        return { sub1, sub2 }
+      }
+
+      const createExporterServer = async () => {
+        const reportsRepositoryFactory = createInMemoryReportsRepository()
+        const ctx = await createServer(
+          {
+            wasteProcessingType: 'exporter',
+            accreditationId: new ObjectId().toString()
+          },
+          reportsRepositoryFactory,
+          'approved'
+        )
+        return { ...ctx, repo: reportsRepositoryFactory() }
+      }
+
+      const januaryItems = (response) =>
+        JSON.parse(response.payload).reportingPeriods.filter(
+          (p) => p.period === 1
+        )
+
+      it('lists every submission per period for an admin caller', async () => {
+        const { server, organisationId, registrationId, repo } =
+          await createExporterServer()
+        const { sub1, sub2 } = await seedResubmittedPeriod(
+          repo,
+          organisationId,
+          registrationId
+        )
+
+        const response = await server.inject({
+          method: 'GET',
+          url: `${makeUrl(organisationId, registrationId)}?expand=submissions`,
+          ...asServiceMaintainer()
+        })
+        const january = januaryItems(response)
+
+        expect(january.map((p) => p.submissionNumber)).toEqual([1, 2])
+        expect(january.map((p) => p.periodStatus)).toEqual([
+          'submitted',
+          'submitted'
+        ])
+        expect(january[0].report.id).toBe(sub1)
+        expect(january[1].report.id).toBe(sub2)
+      })
+
+      it('collapses superseded submissions for an admin caller when the arg is absent', async () => {
+        const { server, organisationId, registrationId, repo } =
+          await createExporterServer()
+        await seedResubmittedPeriod(repo, organisationId, registrationId)
+
+        const response = await server.inject({
+          method: 'GET',
+          url: makeUrl(organisationId, registrationId),
+          ...asServiceMaintainer()
+        })
+
+        expect(januaryItems(response).map((p) => p.submissionNumber)).toEqual([
+          2
+        ])
+      })
+
+      it('ignores the arg for a non-admin operator, keeping the collapsed calendar', async () => {
+        const { server, organisationId, registrationId, repo } =
+          await createExporterServer()
+        await seedResubmittedPeriod(repo, organisationId, registrationId)
+
+        const response = await server.inject({
+          method: 'GET',
+          url: `${makeUrl(organisationId, registrationId)}?expand=submissions`,
+          ...asOperator()
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(januaryItems(response).map((p) => p.submissionNumber)).toEqual([
+          2
+        ])
+      })
+
+      it('rejects an unknown expand value', async () => {
+        const { server, organisationId, registrationId } =
+          await createExporterServer()
+
+        const response = await server.inject({
+          method: 'GET',
+          url: `${makeUrl(organisationId, registrationId)}?expand=everything`,
+          ...asServiceMaintainer()
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      })
+    })
   })
 
   describe('when feature flag is disabled', () => {

--- a/src/reports/routes/get.test.js
+++ b/src/reports/routes/get.test.js
@@ -1538,6 +1538,24 @@ describe(`GET ${reportsGetPath}`, () => {
         return { sub1, sub2 }
       }
 
+      // Creates a report left in progress (a draft), i.e. not submitted.
+      const seedDraft = async (
+        repo,
+        organisationId,
+        registrationId,
+        submissionNumber
+      ) => {
+        const { id } = await repo.createReport(
+          buildCreatePayload(
+            organisationId,
+            registrationId,
+            1,
+            submissionNumber
+          )
+        )
+        return id
+      }
+
       const createExporterServer = async () => {
         const reportsRepositoryFactory = createInMemoryReportsRepository()
         const ctx = await createServer(
@@ -1550,6 +1568,13 @@ describe(`GET ${reportsGetPath}`, () => {
         )
         return { ...ctx, repo: reportsRepositoryFactory() }
       }
+
+      const expandRequest = (server, organisationId, registrationId) =>
+        server.inject({
+          method: 'GET',
+          url: `${makeUrl(organisationId, registrationId)}?expand=submissions`,
+          ...asOperator()
+        })
 
       const januaryItems = (response) =>
         JSON.parse(response.payload).reportingPeriods.filter(
@@ -1565,11 +1590,11 @@ describe(`GET ${reportsGetPath}`, () => {
           registrationId
         )
 
-        const response = await server.inject({
-          method: 'GET',
-          url: `${makeUrl(organisationId, registrationId)}?expand=submissions`,
-          ...asOperator()
-        })
+        const response = await expandRequest(
+          server,
+          organisationId,
+          registrationId
+        )
         const january = januaryItems(response)
 
         expect(january.map((p) => p.submissionNumber)).toEqual([1, 2])
@@ -1579,6 +1604,64 @@ describe(`GET ${reportsGetPath}`, () => {
         ])
         expect(january[0].report.id).toBe(sub1)
         expect(january[1].report.id).toBe(sub2)
+      })
+
+      it('surfaces a requires_resubmission skeleton with no draft yet', async () => {
+        const { server, organisationId, registrationId, repo } =
+          await createExporterServer()
+        const sub1 = await seedSubmitted(
+          repo,
+          organisationId,
+          registrationId,
+          1,
+          1
+        )
+        await flagForResubmission(repo, organisationId, registrationId)
+
+        const response = await expandRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+        const january = januaryItems(response)
+
+        expect(january.map((p) => p.submissionNumber)).toEqual([1, 2])
+        expect(january.map((p) => p.periodStatus)).toEqual([
+          'submitted',
+          'requires_resubmission'
+        ])
+        expect(january[0].report.id).toBe(sub1)
+        expect(january[1].report).toBeNull()
+      })
+
+      it('shows the flagged submission once with the in-flight resubmission draft', async () => {
+        const { server, organisationId, registrationId, repo } =
+          await createExporterServer()
+        const sub1 = await seedSubmitted(
+          repo,
+          organisationId,
+          registrationId,
+          1,
+          1
+        )
+        await flagForResubmission(repo, organisationId, registrationId)
+        const draft = await seedDraft(repo, organisationId, registrationId, 2)
+
+        const response = await expandRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+        const january = januaryItems(response)
+
+        expect(january.map((p) => p.submissionNumber)).toEqual([1, 2])
+        expect(january.map((p) => p.periodStatus)).toEqual([
+          'submitted',
+          'requires_resubmission'
+        ])
+        expect(january[0].report.id).toBe(sub1)
+        expect(january[1].report.id).toBe(draft)
+        expect(january.filter((p) => p.report?.id === sub1)).toHaveLength(1)
       })
 
       it('collapses superseded submissions when the arg is absent', async () => {


### PR DESCRIPTION
Ticket: [PAE-1657](https://eaflood.atlassian.net/browse/PAE-1657)
## What

Adds an optional `?expand=submissions` query argument to the existing
`GET /v1/organisations/{organisationId}/registrations/{registrationId}/reports/calendar`
endpoint. With the argument, the calendar lists every submission per reporting
period: each superseded submission is surfaced as its own item
(`periodStatus: submitted`), alongside the existing `requires_resubmission`
skeleton. Without the argument, the response is byte-for-byte unchanged.

## Why

Callers that need the full submission history for a registration (for example an
operations overview) can now request it from the calendar itself, rather than
only seeing the collapsed, current-state view. The expanded history is the same
data already available on the report-detail view, so it is exposed to any
authorised caller of the route with no further scope gating. The default,
collapsed calendar continues to serve the operator frontend and public register
exactly as before.

## Changes

- `reports/routes/get.js` — validates `expand` against
  `Joi.string().valid('submissions')` and selects the period builder per request:
  the expanded builder when the argument is set, otherwise today's collapsing
  builder. The two builders share a `PeriodBuilder` type.
- `reports/domain/build-all-submission-periods.js` — new domain builder that
  expands merged periods into one item per submission. It reuses
  `buildCalendarPeriods` for the current-state items, then adds the period's
  previous submissions those items do not already surface. Deduping is keyed on
  report id (not submission number) so the synthetic resubmission skeleton, which
  carries no real report, can never mask a genuine submission. Only submitted
  previous submissions are emitted, enforcing the invariant that a submission
  number is only allocated once the prior submission is submitted.
- Integration and unit tests covering the expansion, the collapsed default when
  the argument is absent, dedup of the flagged report when it is a previous
  submission, exclusion of a non-submitted report, and rejection of an unknown
  `expand` value.

Jira: PAE-1657

[PAE-1657]: https://eaflood.atlassian.net/browse/PAE-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ