### PR TITLE
PAE-1590: Log summary-log row-state backfill progress per registration

### DIFF
--- a/src/server/run-backfill-summary-log-row-states.js
+++ b/src/server/run-backfill-summary-log-row-states.js
@@ -1,15 +1,35 @@
 import { logger } from '#common/helpers/logging/logger.js'
 import { backfillEstateSummaryLogRowStates } from '#waste-records/backfill/backfill-estate-summary-log-row-states.js'
 
-/** @import { OrphanedAccreditation } from '#waste-records/backfill/backfill-estate-summary-log-row-states.js' */
+/** @import { OrphanedAccreditation, EstateBackfillProgress } from '#waste-records/backfill/backfill-estate-summary-log-row-states.js' */
 
 const LOCK_NAME = 'summary-log-row-states-backfill'
+
+export const PROGRESS_LOG_INTERVAL = 100
 
 /**
  * @param {OrphanedAccreditation} orphan
  */
 const formatOrphan = (orphan) =>
   `Waste-record-state backfill orphaned accreditation: organisationId=${orphan.organisationId} registrationId=${orphan.registrationId} accreditationId=${orphan.accreditationId}`
+
+/**
+ * @param {EstateBackfillProgress} progress
+ */
+const formatProgress = (progress) =>
+  `Waste-record-state backfill progress: registrationsProcessed=${progress.registrationsProcessed} organisationId=${progress.organisationId} registrationId=${progress.registrationId} ledgersBackfilled=${progress.ledgersBackfilled} ledgersSkippedComplete=${progress.ledgersSkippedComplete} submissionsBackfilled=${progress.submissionsBackfilled} summaryLogRowStateWrites=${progress.summaryLogRowStateWrites} orphanedAccreditations=${progress.orphanedAccreditations}`
+
+/**
+ * Log a running progress line at every interval boundary, so a long estate sweep
+ * is observable without one line per registration.
+ *
+ * @param {EstateBackfillProgress} progress
+ */
+const logProgress = (progress) => {
+  if (progress.registrationsProcessed % PROGRESS_LOG_INTERVAL === 0) {
+    logger.info({ message: formatProgress(progress) })
+  }
+}
 
 /**
  * @param {Object} server - Hapi server instance
@@ -22,7 +42,8 @@ const runBackfill = async (server) => {
     overseasSitesRepository: server.app.overseasSitesRepository,
     summaryLogRowStateRepository: server.app.summaryLogRowStatesRepository,
     summaryLogRowStatesBackfillWatermarkRepository:
-      server.app.summaryLogRowStatesBackfillWatermarkRepository
+      server.app.summaryLogRowStatesBackfillWatermarkRepository,
+    onProgress: logProgress
   })
 
   for (const orphan of summary.orphanedAccreditations) {

--- a/src/server/run-backfill-summary-log-row-states.js
+++ b/src/server/run-backfill-summary-log-row-states.js
@@ -5,8 +5,6 @@ import { backfillEstateSummaryLogRowStates } from '#waste-records/backfill/backf
 
 const LOCK_NAME = 'summary-log-row-states-backfill'
 
-export const PROGRESS_LOG_INTERVAL = 100
-
 /**
  * @param {OrphanedAccreditation} orphan
  */
@@ -14,21 +12,16 @@ const formatOrphan = (orphan) =>
   `Waste-record-state backfill orphaned accreditation: organisationId=${orphan.organisationId} registrationId=${orphan.registrationId} accreditationId=${orphan.accreditationId}`
 
 /**
- * @param {EstateBackfillProgress} progress
- */
-const formatProgress = (progress) =>
-  `Waste-record-state backfill progress: registrationsProcessed=${progress.registrationsProcessed} organisationId=${progress.organisationId} registrationId=${progress.registrationId} ledgersBackfilled=${progress.ledgersBackfilled} ledgersSkippedComplete=${progress.ledgersSkippedComplete} submissionsBackfilled=${progress.submissionsBackfilled} summaryLogRowStateWrites=${progress.summaryLogRowStateWrites} orphanedAccreditations=${progress.orphanedAccreditations}`
-
-/**
- * Log a running progress line at every interval boundary, so a long estate sweep
- * is observable without one line per registration.
+ * Log a running progress line for each registration as the estate sweep
+ * advances, so a long backfill is observable in-flight. The estate holds only a
+ * few hundred registrations, so one line each is cheap.
  *
  * @param {EstateBackfillProgress} progress
  */
 const logProgress = (progress) => {
-  if (progress.registrationsProcessed % PROGRESS_LOG_INTERVAL === 0) {
-    logger.info({ message: formatProgress(progress) })
-  }
+  logger.info({
+    message: `Waste-record-state backfill progress: registrationsProcessed=${progress.registrationsProcessed} organisationId=${progress.organisationId} registrationId=${progress.registrationId} ledgersBackfilled=${progress.ledgersBackfilled} ledgersSkippedComplete=${progress.ledgersSkippedComplete} submissionsBackfilled=${progress.submissionsBackfilled} summaryLogRowStateWrites=${progress.summaryLogRowStateWrites} orphanedAccreditations=${progress.orphanedAccreditations}`
+  })
 }
 
 /**

--- a/src/server/run-backfill-summary-log-row-states.test.js
+++ b/src/server/run-backfill-summary-log-row-states.test.js
@@ -3,10 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { logger } from '#common/helpers/logging/logger.js'
 import { backfillEstateSummaryLogRowStates } from '#waste-records/backfill/backfill-estate-summary-log-row-states.js'
 
-import {
-  runBackfillSummaryLogRowStates,
-  PROGRESS_LOG_INTERVAL
-} from './run-backfill-summary-log-row-states.js'
+import { runBackfillSummaryLogRowStates } from './run-backfill-summary-log-row-states.js'
 
 vi.mock('#common/helpers/logging/logger.js', () => ({
   logger: {
@@ -171,12 +168,11 @@ describe('runBackfillSummaryLogRowStates', () => {
     orphanedAccreditations: 1
   })
 
-  it('logs a throttled progress line each time the interval boundary is crossed', async () => {
+  it('logs a progress line for every registration the estate sweep reaches', async () => {
     vi.mocked(backfillEstateSummaryLogRowStates).mockImplementation(
       async ({ onProgress }) => {
-        onProgress(progressAt(PROGRESS_LOG_INTERVAL - 1))
-        onProgress(progressAt(PROGRESS_LOG_INTERVAL))
-        onProgress(progressAt(PROGRESS_LOG_INTERVAL * 2))
+        onProgress(progressAt(1))
+        onProgress(progressAt(2))
         return {
           organisationsScanned: 0,
           ledgersBackfilled: 0,
@@ -191,15 +187,12 @@ describe('runBackfillSummaryLogRowStates', () => {
     await runBackfillSummaryLogRowStates(mockServer)
 
     expect(logger.info).toHaveBeenCalledWith({
-      message: `Waste-record-state backfill progress: registrationsProcessed=${PROGRESS_LOG_INTERVAL} organisationId=org-1 registrationId=reg-${PROGRESS_LOG_INTERVAL} ledgersBackfilled=5 ledgersSkippedComplete=2 submissionsBackfilled=12 summaryLogRowStateWrites=80 orphanedAccreditations=1`
+      message:
+        'Waste-record-state backfill progress: registrationsProcessed=1 organisationId=org-1 registrationId=reg-1 ledgersBackfilled=5 ledgersSkippedComplete=2 submissionsBackfilled=12 summaryLogRowStateWrites=80 orphanedAccreditations=1'
     })
     expect(logger.info).toHaveBeenCalledWith({
-      message: `Waste-record-state backfill progress: registrationsProcessed=${PROGRESS_LOG_INTERVAL * 2} organisationId=org-1 registrationId=reg-${PROGRESS_LOG_INTERVAL * 2} ledgersBackfilled=5 ledgersSkippedComplete=2 submissionsBackfilled=12 summaryLogRowStateWrites=80 orphanedAccreditations=1`
-    })
-    expect(logger.info).not.toHaveBeenCalledWith({
-      message: expect.stringContaining(
-        `registrationsProcessed=${PROGRESS_LOG_INTERVAL - 1} `
-      )
+      message:
+        'Waste-record-state backfill progress: registrationsProcessed=2 organisationId=org-1 registrationId=reg-2 ledgersBackfilled=5 ledgersSkippedComplete=2 submissionsBackfilled=12 summaryLogRowStateWrites=80 orphanedAccreditations=1'
     })
   })
 

--- a/src/server/run-backfill-summary-log-row-states.test.js
+++ b/src/server/run-backfill-summary-log-row-states.test.js
@@ -3,7 +3,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { logger } from '#common/helpers/logging/logger.js'
 import { backfillEstateSummaryLogRowStates } from '#waste-records/backfill/backfill-estate-summary-log-row-states.js'
 
-import { runBackfillSummaryLogRowStates } from './run-backfill-summary-log-row-states.js'
+import {
+  runBackfillSummaryLogRowStates,
+  PROGRESS_LOG_INTERVAL
+} from './run-backfill-summary-log-row-states.js'
 
 vi.mock('#common/helpers/logging/logger.js', () => ({
   logger: {
@@ -96,7 +99,8 @@ describe('runBackfillSummaryLogRowStates', () => {
       summaryLogRowStateRepository:
         mockServer.app.summaryLogRowStatesRepository,
       summaryLogRowStatesBackfillWatermarkRepository:
-        mockServer.app.summaryLogRowStatesBackfillWatermarkRepository
+        mockServer.app.summaryLogRowStatesBackfillWatermarkRepository,
+      onProgress: expect.any(Function)
     })
   })
 
@@ -150,6 +154,52 @@ describe('runBackfillSummaryLogRowStates', () => {
     expect(logger.info).toHaveBeenCalledWith({
       message:
         'Waste-record-state backfill complete: organisationsScanned=1 ledgersBackfilled=0 ledgersSkippedComplete=0 submissionsBackfilled=0 summaryLogRowStateWrites=0 orphanedAccreditations=1'
+    })
+  })
+
+  /**
+   * @param {number} registrationsProcessed
+   */
+  const progressAt = (registrationsProcessed) => ({
+    registrationsProcessed,
+    organisationId: 'org-1',
+    registrationId: `reg-${registrationsProcessed}`,
+    ledgersBackfilled: 5,
+    ledgersSkippedComplete: 2,
+    submissionsBackfilled: 12,
+    summaryLogRowStateWrites: 80,
+    orphanedAccreditations: 1
+  })
+
+  it('logs a throttled progress line each time the interval boundary is crossed', async () => {
+    vi.mocked(backfillEstateSummaryLogRowStates).mockImplementation(
+      async ({ onProgress }) => {
+        onProgress(progressAt(PROGRESS_LOG_INTERVAL - 1))
+        onProgress(progressAt(PROGRESS_LOG_INTERVAL))
+        onProgress(progressAt(PROGRESS_LOG_INTERVAL * 2))
+        return {
+          organisationsScanned: 0,
+          ledgersBackfilled: 0,
+          ledgersSkippedComplete: 0,
+          submissionsBackfilled: 0,
+          summaryLogRowStateWrites: 0,
+          orphanedAccreditations: []
+        }
+      }
+    )
+
+    await runBackfillSummaryLogRowStates(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message: `Waste-record-state backfill progress: registrationsProcessed=${PROGRESS_LOG_INTERVAL} organisationId=org-1 registrationId=reg-${PROGRESS_LOG_INTERVAL} ledgersBackfilled=5 ledgersSkippedComplete=2 submissionsBackfilled=12 summaryLogRowStateWrites=80 orphanedAccreditations=1`
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message: `Waste-record-state backfill progress: registrationsProcessed=${PROGRESS_LOG_INTERVAL * 2} organisationId=org-1 registrationId=reg-${PROGRESS_LOG_INTERVAL * 2} ledgersBackfilled=5 ledgersSkippedComplete=2 submissionsBackfilled=12 summaryLogRowStateWrites=80 orphanedAccreditations=1`
+    })
+    expect(logger.info).not.toHaveBeenCalledWith({
+      message: expect.stringContaining(
+        `registrationsProcessed=${PROGRESS_LOG_INTERVAL - 1} `
+      )
     })
   })
 

--- a/src/waste-records/backfill/backfill-estate-summary-log-row-states.js
+++ b/src/waste-records/backfill/backfill-estate-summary-log-row-states.js
@@ -59,6 +59,16 @@ import {
  */
 
 /**
+ * The running counts the estate sweep folds each ledger result into.
+ *
+ * @typedef {Object} EstateBackfillTotals
+ * @property {number} ledgersBackfilled
+ * @property {number} ledgersSkippedComplete
+ * @property {number} submissionsBackfilled
+ * @property {number} summaryLogRowStateWrites
+ */
+
+/**
  * What backfilling a single registration ledger contributed: an orphaned
  * accreditation to surface, the submission and write counts it committed, or a
  * skip because the ledger is already complete at its watermark. `null` means
@@ -296,6 +306,30 @@ export const backfillRegistrationLedger = async ({
 }
 
 /**
+ * Fold one ledger's backfill result into the running estate totals, surfacing an
+ * orphaned accreditation onto the provided list. A null result — a registration
+ * with no submitted summary logs — leaves the totals unchanged.
+ *
+ * @param {LedgerBackfilled | LedgerOrphaned | LedgerSkippedComplete | null} result
+ * @param {EstateBackfillTotals} totals
+ * @param {OrphanedAccreditation[]} orphanedAccreditations
+ */
+const accumulateLedgerResult = (result, totals, orphanedAccreditations) => {
+  if (!result) {
+    return
+  }
+  if ('orphanedAccreditation' in result) {
+    orphanedAccreditations.push(result.orphanedAccreditation)
+  } else if ('skippedComplete' in result) {
+    totals.ledgersSkippedComplete += 1
+  } else {
+    totals.ledgersBackfilled += 1
+    totals.submissionsBackfilled += result.submissionsCommitted
+    totals.summaryLogRowStateWrites += result.summaryLogRowStateWriteCount
+  }
+}
+
+/**
  * Reconstruct the summary-log row state collection for the whole historical estate
  * from sparse version history, mirroring the live submission path's write scope:
  * every registration with submitted summary logs contributes — accredited and
@@ -330,10 +364,12 @@ export const backfillEstateSummaryLogRowStates = async ({
   const organisations = await organisationsRepository.findAll()
 
   let registrationsProcessed = 0
-  let ledgersBackfilled = 0
-  let ledgersSkippedComplete = 0
-  let submissionsBackfilled = 0
-  let summaryLogRowStateWrites = 0
+  const totals = {
+    ledgersBackfilled: 0,
+    ledgersSkippedComplete: 0,
+    submissionsBackfilled: 0,
+    summaryLogRowStateWrites: 0
+  }
   const orphanedAccreditations = []
 
   for (const organisation of organisations) {
@@ -348,26 +384,13 @@ export const backfillEstateSummaryLogRowStates = async ({
         summaryLogRowStateRepository,
         summaryLogRowStatesBackfillWatermarkRepository
       })
-      if (result) {
-        if ('orphanedAccreditation' in result) {
-          orphanedAccreditations.push(result.orphanedAccreditation)
-        } else if ('skippedComplete' in result) {
-          ledgersSkippedComplete += 1
-        } else {
-          ledgersBackfilled += 1
-          submissionsBackfilled += result.submissionsCommitted
-          summaryLogRowStateWrites += result.summaryLogRowStateWriteCount
-        }
-      }
+      accumulateLedgerResult(result, totals, orphanedAccreditations)
       registrationsProcessed += 1
       onProgress({
         registrationsProcessed,
         organisationId: organisation.id,
         registrationId: registration.id,
-        ledgersBackfilled,
-        ledgersSkippedComplete,
-        submissionsBackfilled,
-        summaryLogRowStateWrites,
+        ...totals,
         orphanedAccreditations: orphanedAccreditations.length
       })
     }
@@ -375,10 +398,7 @@ export const backfillEstateSummaryLogRowStates = async ({
 
   return {
     organisationsScanned: organisations.length,
-    ledgersBackfilled,
-    ledgersSkippedComplete,
-    submissionsBackfilled,
-    summaryLogRowStateWrites,
+    ...totals,
     orphanedAccreditations
   }
 }

--- a/src/waste-records/backfill/backfill-estate-summary-log-row-states.js
+++ b/src/waste-records/backfill/backfill-estate-summary-log-row-states.js
@@ -41,6 +41,24 @@ import {
  */
 
 /**
+ * A running snapshot of the estate sweep, emitted once per registration as the
+ * loop advances so a long backfill is observable in-flight. The counters mirror
+ * the terminal EstateBackfillSummary; organisationId and registrationId name the
+ * ledger the sweep has just reached. The server layer decides how often to log
+ * these.
+ *
+ * @typedef {Object} EstateBackfillProgress
+ * @property {number} registrationsProcessed - Registrations iterated so far, across all organisations
+ * @property {string} organisationId - Organisation whose registration was just processed
+ * @property {string} registrationId - Registration just processed
+ * @property {number} ledgersBackfilled
+ * @property {number} ledgersSkippedComplete
+ * @property {number} submissionsBackfilled
+ * @property {number} summaryLogRowStateWrites
+ * @property {number} orphanedAccreditations - Count surfaced so far
+ */
+
+/**
  * What backfilling a single registration ledger contributed: an orphaned
  * accreditation to surface, the submission and write counts it committed, or a
  * skip because the ledger is already complete at its watermark. `null` means
@@ -297,6 +315,7 @@ export const backfillRegistrationLedger = async ({
  * @param {import('#overseas-sites/repository/port.js').OverseasSitesRepository} deps.overseasSitesRepository
  * @param {SummaryLogRowStateRepository} deps.summaryLogRowStateRepository
  * @param {SummaryLogRowStatesBackfillWatermarkRepository} deps.summaryLogRowStatesBackfillWatermarkRepository
+ * @param {(progress: EstateBackfillProgress) => void} [deps.onProgress] - Invoked once per registration with a running snapshot; defaults to a no-op
  * @returns {Promise<EstateBackfillSummary>}
  */
 export const backfillEstateSummaryLogRowStates = async ({
@@ -305,10 +324,12 @@ export const backfillEstateSummaryLogRowStates = async ({
   summaryLogsRepository,
   overseasSitesRepository,
   summaryLogRowStateRepository,
-  summaryLogRowStatesBackfillWatermarkRepository
+  summaryLogRowStatesBackfillWatermarkRepository,
+  onProgress = () => {}
 }) => {
   const organisations = await organisationsRepository.findAll()
 
+  let registrationsProcessed = 0
   let ledgersBackfilled = 0
   let ledgersSkippedComplete = 0
   let submissionsBackfilled = 0
@@ -327,18 +348,28 @@ export const backfillEstateSummaryLogRowStates = async ({
         summaryLogRowStateRepository,
         summaryLogRowStatesBackfillWatermarkRepository
       })
-      if (!result) {
-        continue
+      if (result) {
+        if ('orphanedAccreditation' in result) {
+          orphanedAccreditations.push(result.orphanedAccreditation)
+        } else if ('skippedComplete' in result) {
+          ledgersSkippedComplete += 1
+        } else {
+          ledgersBackfilled += 1
+          submissionsBackfilled += result.submissionsCommitted
+          summaryLogRowStateWrites += result.summaryLogRowStateWriteCount
+        }
       }
-      if ('orphanedAccreditation' in result) {
-        orphanedAccreditations.push(result.orphanedAccreditation)
-      } else if ('skippedComplete' in result) {
-        ledgersSkippedComplete += 1
-      } else {
-        ledgersBackfilled += 1
-        submissionsBackfilled += result.submissionsCommitted
-        summaryLogRowStateWrites += result.summaryLogRowStateWriteCount
-      }
+      registrationsProcessed += 1
+      onProgress({
+        registrationsProcessed,
+        organisationId: organisation.id,
+        registrationId: registration.id,
+        ledgersBackfilled,
+        ledgersSkippedComplete,
+        submissionsBackfilled,
+        summaryLogRowStateWrites,
+        orphanedAccreditations: orphanedAccreditations.length
+      })
     }
   }
 

--- a/src/waste-records/backfill/backfill-estate-summary-log-row-states.js
+++ b/src/waste-records/backfill/backfill-estate-summary-log-row-states.js
@@ -315,7 +315,7 @@ export const backfillRegistrationLedger = async ({
  * @param {import('#overseas-sites/repository/port.js').OverseasSitesRepository} deps.overseasSitesRepository
  * @param {SummaryLogRowStateRepository} deps.summaryLogRowStateRepository
  * @param {SummaryLogRowStatesBackfillWatermarkRepository} deps.summaryLogRowStatesBackfillWatermarkRepository
- * @param {(progress: EstateBackfillProgress) => void} [deps.onProgress] - Invoked once per registration with a running snapshot; defaults to a no-op
+ * @param {(progress: EstateBackfillProgress) => void} deps.onProgress - Invoked once per registration with a running snapshot
  * @returns {Promise<EstateBackfillSummary>}
  */
 export const backfillEstateSummaryLogRowStates = async ({
@@ -325,7 +325,7 @@ export const backfillEstateSummaryLogRowStates = async ({
   overseasSitesRepository,
   summaryLogRowStateRepository,
   summaryLogRowStatesBackfillWatermarkRepository,
-  onProgress = () => {}
+  onProgress
 }) => {
   const organisations = await organisationsRepository.findAll()
 

--- a/src/waste-records/backfill/backfill-estate-summary-log-row-states.test.js
+++ b/src/waste-records/backfill/backfill-estate-summary-log-row-states.test.js
@@ -453,6 +453,104 @@ describe('backfillEstateSummaryLogRowStates', () => {
     ).toEqual(['row-1'])
   })
 
+  it('emits a running progress snapshot for every registration processed', async () => {
+    const regA = reprocessorRegistration({
+      id: 'reg-a',
+      accreditationId: 'acc-a'
+    })
+    const regB = reprocessorRegistration({
+      id: 'reg-b',
+      accreditationId: 'acc-b'
+    })
+    const organisation = buildOrganisation({
+      registrations: [regA, regB],
+      accreditations: [
+        buildAccreditation({ id: 'acc-a', wasteProcessingType: 'reprocessor' }),
+        buildAccreditation({ id: 'acc-b', wasteProcessingType: 'reprocessor' })
+      ]
+    })
+    const wasteRecords = [
+      receivedRecord(organisation.id, 'reg-a', 'row-1', [
+        { summaryLog: { id: fileId('sl-a') }, data: { supplierName: 'Acme' } }
+      ]),
+      receivedRecord(organisation.id, 'reg-b', 'row-1', [
+        { summaryLog: { id: fileId('sl-b') }, data: { supplierName: 'Acme' } }
+      ])
+    ]
+    const deps = inMemoryDeps({ organisations: [organisation], wasteRecords })
+    await insertLog(deps.summaryLogsRepository, 'sl-a', {
+      organisationId: organisation.id,
+      registrationId: 'reg-a',
+      submittedAt: '2025-01-01T00:00:00.000Z'
+    })
+    await insertLog(deps.summaryLogsRepository, 'sl-b', {
+      organisationId: organisation.id,
+      registrationId: 'reg-b',
+      submittedAt: '2025-01-01T00:00:00.000Z'
+    })
+
+    const progress = []
+    await backfillEstateSummaryLogRowStates({
+      ...deps,
+      onProgress: (snapshot) => progress.push(snapshot)
+    })
+
+    expect(progress).toEqual([
+      {
+        registrationsProcessed: 1,
+        organisationId: organisation.id,
+        registrationId: 'reg-a',
+        ledgersBackfilled: 1,
+        ledgersSkippedComplete: 0,
+        submissionsBackfilled: 1,
+        summaryLogRowStateWrites: 1,
+        orphanedAccreditations: 0
+      },
+      {
+        registrationsProcessed: 2,
+        organisationId: organisation.id,
+        registrationId: 'reg-b',
+        ledgersBackfilled: 2,
+        ledgersSkippedComplete: 0,
+        submissionsBackfilled: 2,
+        summaryLogRowStateWrites: 2,
+        orphanedAccreditations: 0
+      }
+    ])
+  })
+
+  it('emits progress for a registration with no submitted logs without advancing the counts', async () => {
+    const registration = reprocessorRegistration({ id: 'reg-empty' })
+    delete registration.accreditationId
+    const organisation = buildOrganisation({
+      registrations: [registration],
+      accreditations: []
+    })
+    const deps = inMemoryDeps({
+      organisations: [organisation],
+      wasteRecords: []
+    })
+
+    const progress = []
+    await backfillEstateSummaryLogRowStates({
+      ...deps,
+      onProgress: (snapshot) => progress.push(snapshot)
+    })
+
+    expect(progress).toEqual([
+      {
+        registrationsProcessed: 1,
+        organisationId: organisation.id,
+        registrationId: 'reg-empty',
+        ledgersBackfilled: 0,
+        ledgersSkippedComplete: 0,
+        submissionsBackfilled: 0,
+        summaryLogRowStateWrites: 0,
+        orphanedAccreditations: 0
+      }
+    ])
+  })
+
   it('resolves the ledger watermark by summary-log id when two submissions share a submittedAt', async () => {
     const registration = reprocessorRegistration({ id: 'reg-1' })
     delete registration.accreditationId

--- a/src/waste-records/backfill/backfill-estate-summary-log-row-states.test.js
+++ b/src/waste-records/backfill/backfill-estate-summary-log-row-states.test.js
@@ -78,7 +78,8 @@ const inMemoryDeps = ({ organisations, wasteRecords }) => ({
   overseasSitesRepository: createInMemoryOverseasSitesRepository()(),
   summaryLogRowStateRepository: createInMemorySummaryLogRowStateRepository()(),
   summaryLogRowStatesBackfillWatermarkRepository:
-    createInMemorySummaryLogRowStatesBackfillWatermarkRepository()()
+    createInMemorySummaryLogRowStatesBackfillWatermarkRepository()(),
+  onProgress: () => {}
 })
 
 describe('backfillEstateSummaryLogRowStates', () => {


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)
The estate-wide summary-log row-state backfill previously logged only a single final summary line plus per-orphan warnings, and emitted nothing while running. A production run took well over an hour on a 1.24 GiB waste-records collection with no way to observe in-flight progress or measure throughput from the logs — only the terminal summary confirmed completion.

The estate loop now emits a running progress snapshot for each registration it reaches (the organisation and registration ids, plus running counts of ledgers backfilled, ledgers skipped as already complete, submissions backfilled and row-state writes), and the server layer logs one info line per registration. With only a few hundred registrations across the estate a line each is cheap, and it makes a stall or a rate collapse visible from the logs as the sweep advances.

The progress callback is a required dependency of the estate function, wired the same way as the repositories it already takes, so a caller cannot silently run the sweep with no observability. The estate loop itself stays free of the logger — it emits snapshots and the server layer owns where they go, mirroring how the final summary and orphan warnings are already logged.

[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ