### PR TITLE
PAE-1732: Add stale issued-tonnage startup diagnostic

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -393,6 +393,12 @@ const baseConfig = {
       format: Boolean,
       default: false,
       env: 'FEATURE_FLAG_REGISTERED_ONLY_SUBMITTED_EVENTS'
+    },
+    staleIssuedTonnageReport: {
+      doc: 'Feature Flag: Run the estate-wide stale issued-tonnage discrepancy diagnostic on startup (PAE-1665)',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_FLAG_STALE_ISSUED_TONNAGE_REPORT'
     }
   },
   formSubmissionOverrides: {

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -22,5 +22,8 @@ export const createConfigFeatureFlags = (config) => ({
   },
   isRegisteredOnlySubmittedEventsEnabled() {
     return config.get('featureFlags.registeredOnlySubmittedEvents')
+  },
+  isStaleIssuedTonnageReportEnabled() {
+    return config.get('featureFlags.staleIssuedTonnageReport')
   }
 })

--- a/src/feature-flags/feature-flags.config.test.js
+++ b/src/feature-flags/feature-flags.config.test.js
@@ -56,4 +56,13 @@ describe('createConfigFeatureFlags', () => {
       'featureFlags.summaryLogRowStatesDiscrepancyReport'
     )
   })
+
+  it('returns true when staleIssuedTonnageReport flag is enabled', () => {
+    const config = { get: vi.fn().mockReturnValue(true) }
+    const flags = createConfigFeatureFlags(config)
+    expect(flags.isStaleIssuedTonnageReportEnabled()).toBe(true)
+    expect(config.get).toHaveBeenCalledWith(
+      'featureFlags.staleIssuedTonnageReport'
+    )
+  })
 })

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -23,5 +23,8 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   },
   isRegisteredOnlySubmittedEventsEnabled() {
     return flags.registeredOnlySubmittedEvents ?? false
+  },
+  isStaleIssuedTonnageReportEnabled() {
+    return flags.staleIssuedTonnageReport ?? false
   }
 })

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -122,4 +122,23 @@ describe('createInMemoryFeatureFlags', () => {
     const flags = createInMemoryFeatureFlags({})
     expect(flags.isSummaryLogRowStatesDiscrepancyReportEnabled()).toBe(false)
   })
+
+  it('returns true when staleIssuedTonnageReport flag is enabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      staleIssuedTonnageReport: true
+    })
+    expect(flags.isStaleIssuedTonnageReportEnabled()).toBe(true)
+  })
+
+  it('returns false when staleIssuedTonnageReport flag is disabled', () => {
+    const flags = createInMemoryFeatureFlags({
+      staleIssuedTonnageReport: false
+    })
+    expect(flags.isStaleIssuedTonnageReportEnabled()).toBe(false)
+  })
+
+  it('returns false when staleIssuedTonnageReport flag is not provided', () => {
+    const flags = createInMemoryFeatureFlags({})
+    expect(flags.isStaleIssuedTonnageReportEnabled()).toBe(false)
+  })
 })

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -7,6 +7,7 @@
  * @property {() => boolean} isSummaryLogRowStatesBackfillEnabled
  * @property {() => boolean} isSummaryLogRowStatesDiscrepancyReportEnabled
  * @property {() => boolean} isRegisteredOnlySubmittedEventsEnabled
+ * @property {() => boolean} isStaleIssuedTonnageReportEnabled
  */
 
 /**
@@ -18,6 +19,7 @@
  * @property {boolean} [summaryLogRowStatesBackfill]
  * @property {boolean} [summaryLogRowStatesDiscrepancyReport]
  * @property {boolean} [registeredOnlySubmittedEvents]
+ * @property {boolean} [staleIssuedTonnageReport]
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/reports/monitoring/stale-issued-tonnage.js
+++ b/src/reports/monitoring/stale-issued-tonnage.js
@@ -1,0 +1,182 @@
+import { isNil } from '#common/helpers/is-nil.js'
+import { CANCELLED_PRN_STATUSES } from '#packaging-recycling-notes/domain/model.js'
+import { aggregateIssuedTonnage } from '#packaging-recycling-notes/domain/tonnage.js'
+import { REPORT_STATUS } from '#reports/domain/report-status.js'
+import { formatPeriodLabel } from '#reports/domain/period-labels.js'
+
+/** @type {Set<import('#reports/domain/report-status.js').ReportStatus>} */
+const REVIEWABLE_REPORT_STATUSES = new Set([
+  REPORT_STATUS.SUBMITTED,
+  REPORT_STATUS.IN_PROGRESS
+])
+
+/**
+ * Sum of tonnage for PRNs issued within the period but currently cancelled or
+ * awaiting cancellation — the PAE-1665 mechanism that stales a report's
+ * previously-computed issuedTonnage.
+ *
+ * @param {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote[]} prns
+ * @param {{ startDate: Date, endDate: Date }} period
+ * @returns {number}
+ */
+const issuedButLaterCancelledTonnage = (prns, { startDate, endDate }) => {
+  const isInPeriod = (at) => !isNil(at) && at >= startDate && at <= endDate
+
+  return prns
+    .filter((prn) => isInPeriod(prn.status.issued?.at))
+    .filter((prn) => CANCELLED_PRN_STATUSES.has(prn.status.currentStatus))
+    .reduce((total, prn) => total + prn.tonnage, 0)
+}
+
+/**
+ * Submitted or in-progress monthly report rows extracted from the estate-wide
+ * periodic report groupings, flattened to the fields this diagnostic needs.
+ *
+ * @param {import('#reports/repository/port.js').PeriodicReport[]} periodicReports
+ * @returns {Array<{
+ *   organisationId: string,
+ *   registrationId: string,
+ *   year: number,
+ *   period: number,
+ *   startDate: string,
+ *   endDate: string,
+ *   reportId: string,
+ *   reportStatus: string,
+ *   storedIssuedTonnage: number
+ * }>}
+ */
+export const findReviewableMonthlyReportRows = (periodicReports) =>
+  periodicReports.flatMap(({ organisationId, registrationId, year, reports }) =>
+    Object.entries(reports.monthly ?? {}).flatMap(([period, periodInfo]) => {
+      const { current } = periodInfo
+      if (!current || !REVIEWABLE_REPORT_STATUSES.has(current.status)) {
+        return []
+      }
+      if (isNil(current.prn?.issuedTonnage)) {
+        return []
+      }
+      return [
+        {
+          organisationId,
+          registrationId,
+          year,
+          period: Number(period),
+          startDate: periodInfo.startDate,
+          endDate: periodInfo.endDate,
+          reportId: current.id,
+          reportStatus: current.status,
+          storedIssuedTonnage: current.prn.issuedTonnage
+        }
+      ]
+    })
+  )
+
+/**
+ * Compares a report row's stored issuedTonnage against a fresh recalculation
+ * from the current PRN state. Returns null when they match (nothing to
+ * report); otherwise returns the finding to log.
+ *
+ * @param {ReturnType<typeof findReviewableMonthlyReportRows>[number]} row
+ * @param {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote[]} prns
+ * @returns {{
+ *   organisationId: string,
+ *   registrationId: string,
+ *   reportId: string,
+ *   month: string,
+ *   reportStatus: string,
+ *   storedIssuedTonnage: number,
+ *   recalculatedTonnage: number,
+ *   issuedButLaterCancelledTonnage: number
+ * } | null}
+ */
+export const diagnoseReportRow = (row, prns) => {
+  const period = {
+    startDate: new Date(row.startDate),
+    endDate: new Date(row.endDate)
+  }
+  const recalculatedTonnage = aggregateIssuedTonnage(prns, period)
+
+  if (recalculatedTonnage === row.storedIssuedTonnage) {
+    return null
+  }
+
+  return {
+    organisationId: row.organisationId,
+    registrationId: row.registrationId,
+    reportId: row.reportId,
+    month: formatPeriodLabel('monthly', row.period, row.year),
+    reportStatus: row.reportStatus,
+    storedIssuedTonnage: row.storedIssuedTonnage,
+    recalculatedTonnage,
+    issuedButLaterCancelledTonnage: issuedButLaterCancelledTonnage(prns, period)
+  }
+}
+
+/**
+ * Renders a stale-issued-tonnage finding as a single reviewable log line.
+ *
+ * @param {NonNullable<ReturnType<typeof diagnoseReportRow>>} finding
+ * @returns {string}
+ */
+export const formatStaleIssuedTonnageFinding = (finding) =>
+  `Stale issued tonnage: org ${finding.organisationId} / registration ${finding.registrationId}, ` +
+  `report ${finding.reportId} (${finding.month}, ${finding.reportStatus}) — ` +
+  `stored ${finding.storedIssuedTonnage}, recalculated ${finding.recalculatedTonnage}, ` +
+  `issued-but-later-cancelled ${finding.issuedButLaterCancelledTonnage}`
+
+/**
+ * Scans every submitted or in-progress monthly report across the estate,
+ * recalculates issuedTonnage from the current PRN state, and returns the
+ * reports whose stored value no longer matches. Read-only.
+ *
+ * @param {Object} params
+ * @param {import('#reports/repository/port.js').ReportsRepository} params.reportsRepository
+ * @param {import('#repositories/organisations/port.js').OrganisationsRepository} params.organisationsRepository
+ * @param {import('#packaging-recycling-notes/repository/port.js').PackagingRecyclingNotesRepository} params.packagingRecyclingNotesRepository
+ * @returns {Promise<{ scanned: number, findings: NonNullable<ReturnType<typeof diagnoseReportRow>>[] }>}
+ */
+export const findStaleIssuedTonnageReports = async ({
+  reportsRepository,
+  organisationsRepository,
+  packagingRecyclingNotesRepository
+}) => {
+  const periodicReports = await reportsRepository.findAllPeriodicReports()
+  const rows = findReviewableMonthlyReportRows(periodicReports)
+
+  const prnsByAccreditationId = new Map()
+  const findings = []
+
+  for (const row of rows) {
+    let registration
+    try {
+      registration = await organisationsRepository.findRegistrationById(
+        row.organisationId,
+        row.registrationId
+      )
+    } catch {
+      continue
+    }
+
+    const accreditationId = registration?.accreditationId
+    if (!accreditationId) {
+      continue
+    }
+
+    if (!prnsByAccreditationId.has(accreditationId)) {
+      prnsByAccreditationId.set(
+        accreditationId,
+        await packagingRecyclingNotesRepository.findByAccreditation(
+          accreditationId
+        )
+      )
+    }
+    const prns = prnsByAccreditationId.get(accreditationId)
+
+    const finding = diagnoseReportRow(row, prns)
+    if (finding) {
+      findings.push(finding)
+    }
+  }
+
+  return { scanned: rows.length, findings }
+}

--- a/src/reports/monitoring/stale-issued-tonnage.test.js
+++ b/src/reports/monitoring/stale-issued-tonnage.test.js
@@ -1,0 +1,373 @@
+import { describe, expect, it, vi } from 'vitest'
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import {
+  diagnoseReportRow,
+  findReviewableMonthlyReportRows,
+  findStaleIssuedTonnageReports,
+  formatStaleIssuedTonnageFinding
+} from './stale-issued-tonnage.js'
+
+const ACTOR = { id: 'u', name: 'U' }
+const IN_PERIOD = new Date('2025-06-15T12:00:00Z')
+const AFTER_PERIOD = new Date('2025-07-15T12:00:00Z')
+
+/**
+ * @param {number} tonnage
+ * @param {object} status
+ */
+function buildPrn(tonnage, status) {
+  return /** @type {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} */ ({
+    id: 'prn-1',
+    tonnage,
+    status
+  })
+}
+
+function buildRow(overrides = {}) {
+  return {
+    organisationId: 'org-1',
+    registrationId: 'reg-1',
+    year: 2025,
+    period: 6,
+    startDate: '2025-06-01T00:00:00.000Z',
+    endDate: '2025-06-30T23:59:59.999Z',
+    reportId: 'report-1',
+    reportStatus: 'submitted',
+    storedIssuedTonnage: 50,
+    ...overrides
+  }
+}
+
+describe('findReviewableMonthlyReportRows', () => {
+  /**
+   * @param {object} [monthlyOverrides]
+   * @returns {import('#reports/repository/port.js').PeriodicReport}
+   */
+  const basePeriodicReport = (monthlyOverrides = {}) =>
+    /** @type {import('#reports/repository/port.js').PeriodicReport} */ ({
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      year: 2025,
+      reports: {
+        monthly: {
+          6: {
+            startDate: '2025-06-01T00:00:00.000Z',
+            endDate: '2025-06-30T23:59:59.999Z',
+            dueDate: '2025-07-15T00:00:00.000Z',
+            current: {
+              id: 'report-1',
+              status: 'submitted',
+              prn: { issuedTonnage: 50 }
+            },
+            previousSubmissions: [],
+            ...monthlyOverrides
+          }
+        }
+      }
+    })
+
+  it('includes a submitted monthly report with prn data', () => {
+    const rows = findReviewableMonthlyReportRows([basePeriodicReport()])
+
+    expect(rows).toEqual([
+      {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        year: 2025,
+        period: 6,
+        startDate: '2025-06-01T00:00:00.000Z',
+        endDate: '2025-06-30T23:59:59.999Z',
+        reportId: 'report-1',
+        reportStatus: 'submitted',
+        storedIssuedTonnage: 50
+      }
+    ])
+  })
+
+  it('includes an in_progress monthly report', () => {
+    const periodicReport = basePeriodicReport({
+      current: {
+        id: 'report-1',
+        status: 'in_progress',
+        prn: { issuedTonnage: 0 }
+      }
+    })
+
+    const rows = findReviewableMonthlyReportRows([periodicReport])
+
+    expect(rows).toHaveLength(1)
+  })
+
+  it('excludes a ready_to_submit report', () => {
+    const periodicReport = basePeriodicReport({
+      current: {
+        id: 'report-1',
+        status: 'ready_to_submit',
+        prn: { issuedTonnage: 50 }
+      }
+    })
+
+    expect(findReviewableMonthlyReportRows([periodicReport])).toEqual([])
+  })
+
+  it('excludes a report with no prn data (non-accredited operator)', () => {
+    const periodicReport = basePeriodicReport({
+      current: { id: 'report-1', status: 'submitted', prn: undefined }
+    })
+
+    expect(findReviewableMonthlyReportRows([periodicReport])).toEqual([])
+  })
+
+  it('excludes quarterly reports', () => {
+    const periodicReport =
+      /** @type {import('#reports/repository/port.js').PeriodicReport} */ (
+        /** @type {unknown} */ ({
+          organisationId: 'org-1',
+          registrationId: 'reg-1',
+          year: 2025,
+          reports: {
+            quarterly: {
+              2: {
+                startDate: '2025-04-01T00:00:00.000Z',
+                endDate: '2025-06-30T23:59:59.999Z',
+                dueDate: '2025-07-15T00:00:00.000Z',
+                current: {
+                  id: 'report-1',
+                  status: 'submitted',
+                  prn: { issuedTonnage: 50 }
+                },
+                previousSubmissions: []
+              }
+            }
+          }
+        })
+      )
+
+    expect(findReviewableMonthlyReportRows([periodicReport])).toEqual([])
+  })
+
+  it('excludes a period with no current report', () => {
+    const periodicReport = basePeriodicReport({ current: null })
+
+    expect(findReviewableMonthlyReportRows([periodicReport])).toEqual([])
+  })
+})
+
+describe('diagnoseReportRow', () => {
+  it('returns null when recalculated tonnage matches the stored value', () => {
+    const row = buildRow({ storedIssuedTonnage: 50 })
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.ACCEPTED,
+        currentStatusAt: IN_PERIOD,
+        issued: { at: IN_PERIOD, by: ACTOR }
+      })
+    ]
+
+    expect(diagnoseReportRow(row, prns)).toBeNull()
+  })
+
+  it('returns a finding when a PRN issued in-period was later cancelled', () => {
+    const row = buildRow({ storedIssuedTonnage: 50 })
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.CANCELLED,
+        currentStatusAt: AFTER_PERIOD,
+        issued: { at: IN_PERIOD, by: ACTOR },
+        cancelled: { at: AFTER_PERIOD, by: ACTOR }
+      })
+    ]
+
+    const finding = diagnoseReportRow(row, prns)
+
+    expect(finding).toEqual({
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      reportId: 'report-1',
+      month: 'Jun 2025',
+      reportStatus: 'submitted',
+      storedIssuedTonnage: 50,
+      recalculatedTonnage: 0,
+      issuedButLaterCancelledTonnage: 50
+    })
+  })
+
+  it('returns a finding for a mismatch unrelated to cancellation, with zero cancelled tonnage', () => {
+    const row = buildRow({ storedIssuedTonnage: 999 })
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.ACCEPTED,
+        currentStatusAt: IN_PERIOD,
+        issued: { at: IN_PERIOD, by: ACTOR }
+      })
+    ]
+
+    const finding = diagnoseReportRow(row, prns)
+
+    expect(finding).toMatchObject({
+      storedIssuedTonnage: 999,
+      recalculatedTonnage: 50,
+      issuedButLaterCancelledTonnage: 0
+    })
+  })
+
+  it('returns null when a PRN is cancelled but was issued outside the period', () => {
+    const row = buildRow({ storedIssuedTonnage: 0 })
+    const outsidePeriod = new Date('2025-05-01T00:00:00Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.CANCELLED,
+        currentStatusAt: AFTER_PERIOD,
+        issued: { at: outsidePeriod, by: ACTOR },
+        cancelled: { at: AFTER_PERIOD, by: ACTOR }
+      })
+    ]
+
+    expect(diagnoseReportRow(row, prns)).toBeNull()
+  })
+})
+
+describe('formatStaleIssuedTonnageFinding', () => {
+  it('renders a single reviewable line with the key figures', () => {
+    const line = formatStaleIssuedTonnageFinding({
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      reportId: 'report-1',
+      month: 'Jun 2025',
+      reportStatus: 'submitted',
+      storedIssuedTonnage: 50,
+      recalculatedTonnage: 0,
+      issuedButLaterCancelledTonnage: 50
+    })
+
+    expect(line).toBe(
+      'Stale issued tonnage: org org-1 / registration reg-1, ' +
+        'report report-1 (Jun 2025, submitted) — ' +
+        'stored 50, recalculated 0, issued-but-later-cancelled 50'
+    )
+  })
+})
+
+describe('findStaleIssuedTonnageReports', () => {
+  const periodicReportFor = (organisationId, registrationId) => ({
+    organisationId,
+    registrationId,
+    year: 2025,
+    reports: {
+      monthly: {
+        6: {
+          startDate: '2025-06-01T00:00:00.000Z',
+          endDate: '2025-06-30T23:59:59.999Z',
+          dueDate: '2025-07-15T00:00:00.000Z',
+          current: {
+            id: 'report-1',
+            status: 'submitted',
+            prn: { issuedTonnage: 999 }
+          },
+          previousSubmissions: []
+        }
+      }
+    }
+  })
+
+  it('skips a row whose registration lookup throws (e.g. deleted org/registration)', async () => {
+    const packagingRecyclingNotesRepository = {
+      findByAccreditation: vi.fn()
+    }
+    const { scanned, findings } = await findStaleIssuedTonnageReports(
+      /** @type {any} */ ({
+        reportsRepository: {
+          findAllPeriodicReports: vi
+            .fn()
+            .mockResolvedValue([periodicReportFor('org-1', 'reg-1')])
+        },
+        organisationsRepository: {
+          findRegistrationById: vi
+            .fn()
+            .mockRejectedValue(new Error('not found'))
+        },
+        packagingRecyclingNotesRepository
+      })
+    )
+
+    expect(scanned).toBe(1)
+    expect(findings).toEqual([])
+    expect(
+      packagingRecyclingNotesRepository.findByAccreditation
+    ).not.toHaveBeenCalled()
+  })
+
+  it('skips a row whose registration has no accreditationId', async () => {
+    const packagingRecyclingNotesRepository = {
+      findByAccreditation: vi.fn()
+    }
+    const { findings } = await findStaleIssuedTonnageReports(
+      /** @type {any} */ ({
+        reportsRepository: {
+          findAllPeriodicReports: vi
+            .fn()
+            .mockResolvedValue([periodicReportFor('org-1', 'reg-1')])
+        },
+        organisationsRepository: {
+          findRegistrationById: vi.fn().mockResolvedValue({})
+        },
+        packagingRecyclingNotesRepository
+      })
+    )
+
+    expect(findings).toEqual([])
+    expect(
+      packagingRecyclingNotesRepository.findByAccreditation
+    ).not.toHaveBeenCalled()
+  })
+
+  it('reuses a cached PRN list for a second row sharing the same accreditationId', async () => {
+    const findByAccreditation = vi.fn().mockResolvedValue([])
+    const { scanned, findings } = await findStaleIssuedTonnageReports(
+      /** @type {any} */ ({
+        reportsRepository: {
+          findAllPeriodicReports: vi
+            .fn()
+            .mockResolvedValue([
+              periodicReportFor('org-1', 'reg-1'),
+              periodicReportFor('org-2', 'reg-2')
+            ])
+        },
+        organisationsRepository: {
+          findRegistrationById: vi
+            .fn()
+            .mockResolvedValue({ accreditationId: 'acc-1' })
+        },
+        packagingRecyclingNotesRepository: { findByAccreditation }
+      })
+    )
+
+    expect(scanned).toBe(2)
+    expect(findings).toHaveLength(2)
+    expect(findByAccreditation).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not report a row whose recalculated tonnage matches the stored value', async () => {
+    const periodicReport = periodicReportFor('org-1', 'reg-1')
+    periodicReport.reports.monthly[6].current.prn.issuedTonnage = 0
+
+    const { scanned, findings } = await findStaleIssuedTonnageReports(
+      /** @type {any} */ ({
+        reportsRepository: {
+          findAllPeriodicReports: vi.fn().mockResolvedValue([periodicReport])
+        },
+        organisationsRepository: {
+          findRegistrationById: vi
+            .fn()
+            .mockResolvedValue({ accreditationId: 'acc-1' })
+        },
+        packagingRecyclingNotesRepository: {
+          findByAccreditation: vi.fn().mockResolvedValue([])
+        }
+      })
+    )
+
+    expect(scanned).toBe(1)
+    expect(findings).toEqual([])
+  })
+})

--- a/src/server/run-stale-issued-tonnage-report.js
+++ b/src/server/run-stale-issued-tonnage-report.js
@@ -1,0 +1,73 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import {
+  findStaleIssuedTonnageReports,
+  formatStaleIssuedTonnageFinding
+} from '#reports/monitoring/stale-issued-tonnage.js'
+
+const LOCK_NAME = 'stale-issued-tonnage-report'
+
+/**
+ * Recalculates issuedTonnage for every submitted or in-progress monthly
+ * report and logs any report whose stored value no longer matches — the
+ * PAE-1665 rule change (excluding PRNs cancelled after issuance) stales any
+ * report computed before the fix. Read-only, safe under live traffic.
+ *
+ * @param {Object} server - Hapi server instance
+ */
+const runReport = async (server) => {
+  const { scanned, findings } = await findStaleIssuedTonnageReports({
+    reportsRepository: server.app.reportsRepository,
+    organisationsRepository: server.app.organisationsRepository,
+    packagingRecyclingNotesRepository:
+      server.app.packagingRecyclingNotesRepository
+  })
+
+  for (const finding of findings) {
+    logger.warn({ message: formatStaleIssuedTonnageFinding(finding) })
+  }
+
+  const affectedOrganisations = new Set(
+    findings.map((finding) => finding.organisationId)
+  ).size
+
+  logger.info({
+    message: `Stale issued tonnage report: scanned ${scanned}, discrepancies ${findings.length}, affected organisations ${affectedOrganisations}`
+  })
+}
+
+/**
+ * Startup diagnostic that recalculates issuedTonnage for every submitted or
+ * in-progress monthly report and logs discrepancies against the stored
+ * value for human review. Runs under a cross-instance lock so a single pod
+ * per deploy executes and logs it. Read-only.
+ *
+ * Gated by the stale-issued-tonnage-report feature flag: with it off this
+ * returns before touching the locker or any repository.
+ *
+ * @param {Object} server - Hapi server instance
+ */
+export const runStaleIssuedTonnageReport = async (server) => {
+  if (!server.featureFlags.isStaleIssuedTonnageReportEnabled()) {
+    return
+  }
+
+  try {
+    const lock = await server.locker.lock(LOCK_NAME)
+    if (!lock) {
+      logger.info({
+        message: 'Unable to obtain lock, skipping stale issued tonnage report'
+      })
+      return
+    }
+    try {
+      await runReport(server)
+    } finally {
+      await lock.free()
+    }
+  } catch (error) {
+    logger.error({
+      err: error,
+      message: 'Failed to run stale issued tonnage report'
+    })
+  }
+}

--- a/src/server/run-stale-issued-tonnage-report.test.js
+++ b/src/server/run-stale-issued-tonnage-report.test.js
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { logger } from '#common/helpers/logging/logger.js'
+import { runStaleIssuedTonnageReport } from './run-stale-issued-tonnage-report.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const emptyEstateApp = () => ({
+  reportsRepository: {
+    findAllPeriodicReports: vi.fn().mockResolvedValue([])
+  },
+  organisationsRepository: {
+    findRegistrationById: vi.fn()
+  },
+  packagingRecyclingNotesRepository: {
+    findByAccreditation: vi.fn()
+  }
+})
+
+const buildServer = (
+  app,
+  {
+    lock = { free: vi.fn().mockResolvedValue(undefined) },
+    reportEnabled = true
+  } = {}
+) => ({
+  app,
+  featureFlags: {
+    isStaleIssuedTonnageReportEnabled: () => reportEnabled
+  },
+  locker: { lock: vi.fn().mockResolvedValue(lock) }
+})
+
+describe('runStaleIssuedTonnageReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not run and touches nothing when the feature flag is off', async () => {
+    const app = emptyEstateApp()
+    const server = buildServer(app, { reportEnabled: false })
+
+    await runStaleIssuedTonnageReport(server)
+
+    expect(server.locker.lock).not.toHaveBeenCalled()
+    expect(app.reportsRepository.findAllPeriodicReports).not.toHaveBeenCalled()
+    expect(logger.info).not.toHaveBeenCalled()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('acquires a lock scoped to the report and releases it afterwards', async () => {
+    const lock = { free: vi.fn().mockResolvedValue(undefined) }
+    const server = buildServer(emptyEstateApp(), { lock })
+
+    await runStaleIssuedTonnageReport(server)
+
+    expect(server.locker.lock).toHaveBeenCalledWith(
+      'stale-issued-tonnage-report'
+    )
+    expect(lock.free).toHaveBeenCalled()
+  })
+
+  it('skips the report and reads nothing when the lock is held by another instance', async () => {
+    const app = emptyEstateApp()
+    const server = {
+      app,
+      featureFlags: { isStaleIssuedTonnageReportEnabled: () => true },
+      locker: { lock: vi.fn().mockResolvedValue(null) }
+    }
+
+    await runStaleIssuedTonnageReport(server)
+
+    expect(app.reportsRepository.findAllPeriodicReports).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message: 'Unable to obtain lock, skipping stale issued tonnage report'
+    })
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('logs a summary line and no warnings when nothing is stale', async () => {
+    const server = buildServer(emptyEstateApp())
+
+    await runStaleIssuedTonnageReport(server)
+
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Stale issued tonnage report: scanned 0, discrepancies 0, affected organisations 0'
+    })
+  })
+
+  it('logs a warning finding for each stale report', async () => {
+    const app = {
+      reportsRepository: {
+        findAllPeriodicReports: vi.fn().mockResolvedValue([
+          {
+            organisationId: 'org-1',
+            registrationId: 'reg-1',
+            year: 2025,
+            reports: {
+              monthly: {
+                6: {
+                  startDate: '2025-06-01T00:00:00.000Z',
+                  endDate: '2025-06-30T23:59:59.999Z',
+                  dueDate: '2025-07-15T00:00:00.000Z',
+                  current: {
+                    id: 'report-1',
+                    status: 'submitted',
+                    prn: { issuedTonnage: 50 }
+                  },
+                  previousSubmissions: []
+                }
+              }
+            }
+          }
+        ])
+      },
+      organisationsRepository: {
+        findRegistrationById: vi
+          .fn()
+          .mockResolvedValue({ accreditationId: 'acc-1' })
+      },
+      packagingRecyclingNotesRepository: {
+        findByAccreditation: vi.fn().mockResolvedValue([])
+      }
+    }
+    const server = buildServer(app)
+
+    await runStaleIssuedTonnageReport(server)
+
+    expect(logger.warn).toHaveBeenCalledWith({
+      message: expect.stringContaining(
+        'org org-1 / registration reg-1, report report-1'
+      )
+    })
+    expect(logger.warn).toHaveBeenCalledWith({
+      message: expect.stringContaining('stored 50, recalculated 0')
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Stale issued tonnage report: scanned 1, discrepancies 1, affected organisations 1'
+    })
+  })
+
+  it('counts distinct affected organisations, not discrepancy count, when one org has multiple stale reports', async () => {
+    const monthlyReport = (
+      period,
+      reportId,
+      organisationId,
+      registrationId
+    ) => ({
+      organisationId,
+      registrationId,
+      year: 2025,
+      reports: {
+        monthly: {
+          [period]: {
+            startDate: `2025-0${period}-01T00:00:00.000Z`,
+            endDate: `2025-0${period}-28T23:59:59.999Z`,
+            dueDate: `2025-0${period + 1}-15T00:00:00.000Z`,
+            current: {
+              id: reportId,
+              status: 'submitted',
+              prn: { issuedTonnage: 50 }
+            },
+            previousSubmissions: []
+          }
+        }
+      }
+    })
+
+    const app = {
+      reportsRepository: {
+        findAllPeriodicReports: vi
+          .fn()
+          .mockResolvedValue([
+            monthlyReport(6, 'report-1', 'org-1', 'reg-1'),
+            monthlyReport(7, 'report-2', 'org-1', 'reg-1'),
+            monthlyReport(6, 'report-3', 'org-2', 'reg-2')
+          ])
+      },
+      organisationsRepository: {
+        findRegistrationById: vi
+          .fn()
+          .mockResolvedValue({ accreditationId: 'acc-1' })
+      },
+      packagingRecyclingNotesRepository: {
+        findByAccreditation: vi.fn().mockResolvedValue([])
+      }
+    }
+    const server = buildServer(app)
+
+    await runStaleIssuedTonnageReport(server)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Stale issued tonnage report: scanned 3, discrepancies 3, affected organisations 2'
+    })
+  })
+
+  it('releases the lock and logs an error when the run itself throws', async () => {
+    const error = new Error('mongo unavailable')
+    const lock = { free: vi.fn().mockResolvedValue(undefined) }
+    const app = {
+      ...emptyEstateApp(),
+      reportsRepository: {
+        findAllPeriodicReports: vi.fn().mockRejectedValue(error)
+      }
+    }
+    const server = buildServer(app, { lock })
+
+    await runStaleIssuedTonnageReport(server)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run stale issued tonnage report'
+    })
+    expect(lock.free).toHaveBeenCalled()
+  })
+
+  it('tolerates the locker itself throwing', async () => {
+    const error = new Error('locker unavailable')
+    const server = {
+      app: emptyEstateApp(),
+      featureFlags: { isStaleIssuedTonnageReportEnabled: () => true },
+      locker: { lock: vi.fn().mockRejectedValue(error) }
+    }
+
+    await runStaleIssuedTonnageReport(server)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run stale issued tonnage report'
+    })
+  })
+})

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -49,6 +49,7 @@ import { runOrganisationValidationSweep } from '#server/run-organisation-validat
 import { runDuplicateAccreditationLinkMigration } from '#server/run-duplicate-accreditation-link-migration.js'
 import { runBackfillSummaryLogRowStates } from '#server/run-backfill-summary-log-row-states.js'
 import { runWasteRecordStateDiscrepancyReport } from '#server/run-waste-record-state-discrepancy-report.js'
+import { runStaleIssuedTonnageReport } from '#server/run-stale-issued-tonnage-report.js'
 
 /** @import { Lifecycle } from '@hapi/hapi' */
 
@@ -246,6 +247,7 @@ async function createServer(options = {}) {
     runDuplicateAccreditationLinkMigration(server)
     runBackfillSummaryLogRowStates(server)
     runWasteRecordStateDiscrepancyReport(server)
+    runStaleIssuedTonnageReport(server)
   })
 
   return server


### PR DESCRIPTION
Ticket: [PAE-1732](https://eaflood.atlassian.net/browse/PAE-1732)

- Read-only, feature-flagged startup diagnostic that recalculates issuedTonnage for every submitted or in-progress monthly report and logs a warning when it no longer matches the stored value (e.g. PRNs issued in-period but later cancelled, per PAE-1665). Logs the stored vs. recalculated tonnage per report, plus a final summary of scanned reports, discrepancy count, and distinct affected organisations.
- This is temporary code, will be removed once all affected reports/orgs are identified

[PAE-1732]: https://eaflood.atlassian.net/browse/PAE-1732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ