### PR TITLE
PAE-1590: Batch summary-log row-state writes into one bulkWrite

### DIFF
--- a/src/waste-records/repository/contract/upsertSummaryLogRowStates.contract.js
+++ b/src/waste-records/repository/contract/upsertSummaryLogRowStates.contract.js
@@ -40,6 +40,12 @@ export const testUpsertSummaryLogRowStatesBehaviour = (it) => {
       expect(state.summaryLogIds).toEqual(['log-1'])
     })
 
+    it('returns an empty list when the submission has no rows', async () => {
+      expect(
+        await repository.upsertSummaryLogRowStates(DEFAULT_LEDGER_ID, [], 'log-1')
+      ).toEqual([])
+    })
+
     it('returns one state document per entry, in input order', async () => {
       const states = await repository.upsertSummaryLogRowStates(
         DEFAULT_LEDGER_ID,

--- a/src/waste-records/repository/contract/upsertSummaryLogRowStates.contract.js
+++ b/src/waste-records/repository/contract/upsertSummaryLogRowStates.contract.js
@@ -42,7 +42,11 @@ export const testUpsertSummaryLogRowStatesBehaviour = (it) => {
 
     it('returns an empty list when the submission has no rows', async () => {
       expect(
-        await repository.upsertSummaryLogRowStates(DEFAULT_LEDGER_ID, [], 'log-1')
+        await repository.upsertSummaryLogRowStates(
+          DEFAULT_LEDGER_ID,
+          [],
+          'log-1'
+        )
       ).toEqual([])
     })
 

--- a/src/waste-records/repository/mongodb.js
+++ b/src/waste-records/repository/mongodb.js
@@ -119,44 +119,62 @@ const hashSummaryLogRowState = (candidate) =>
     .digest('hex')
 
 /**
- * @param {Collection} collection
+ * Builds the content-addressed identity filter for a row state — exactly the
+ * fields of the unique `summary_log_row_state_identity` index. Using the unique
+ * key as the upsert filter is what makes concurrent writers converge on a
+ * single document: MongoDB retries the upsert against the winning insert
+ * instead of surfacing a duplicate-key error.
+ *
  * @param {SummaryLogRowStateInsert} candidate
  * @param {string} contentHash
- * @returns {Promise<import('mongodb').WithId<import('mongodb').Document> | null>}
  */
-const findCommittedStateDoc = (collection, candidate, contentHash) =>
-  collection.findOne({
-    organisationId: candidate.organisationId,
-    registrationId: candidate.registrationId,
-    accreditationId: candidate.accreditationId,
-    rowId: candidate.rowId,
-    wasteRecordType: candidate.wasteRecordType,
-    contentHash
-  })
+const buildIdentityFilter = (candidate, contentHash) => ({
+  organisationId: candidate.organisationId,
+  registrationId: candidate.registrationId,
+  accreditationId: candidate.accreditationId,
+  rowId: candidate.rowId,
+  wasteRecordType: candidate.wasteRecordType,
+  contentHash
+})
+
+const identityKey = (fields) =>
+  JSON.stringify([
+    fields.organisationId,
+    fields.registrationId,
+    fields.accreditationId,
+    fields.rowId,
+    fields.wasteRecordType,
+    fields.contentHash
+  ])
 
 /**
- * @param {Collection} collection
- * @param {import('mongodb').ObjectId} _id
+ * @param {SummaryLogRowStateInsert} candidate
+ * @param {string} contentHash
  * @param {string} summaryLogId
- * @returns {Promise<SummaryLogRowState>}
  */
-const addMembership = async (collection, _id, summaryLogId) => {
-  await collection.updateOne(
-    { _id },
-    { $addToSet: { summaryLogIds: summaryLogId } }
-  )
-  const updated = await collection.findOne({ _id })
-  return toSummaryLogRowState(updated)
-}
+const buildUpsertOperation = (candidate, contentHash, summaryLogId) => ({
+  updateOne: {
+    filter: buildIdentityFilter(candidate, contentHash),
+    // Identity fields materialise from the filter on insert, so they stay out
+    // of $setOnInsert to avoid the filter/setOnInsert path conflict.
+    update: {
+      $setOnInsert: {
+        processingType: candidate.processingType,
+        data: candidate.data,
+        classification: candidate.classification
+      },
+      $addToSet: { summaryLogIds: summaryLogId }
+    },
+    upsert: true
+  }
+})
 
 /**
- * @param {Collection} collection
  * @param {WasteBalanceLedgerId} ledgerId
  * @param {SummaryLogRowStateEntry} entry
  * @param {string} summaryLogId
- * @returns {Promise<SummaryLogRowState>}
  */
-const upsertOne = async (collection, ledgerId, entry, summaryLogId) => {
+const prepareRowState = (ledgerId, entry, summaryLogId) => {
   const candidate = validateSummaryLogRowStateInsert({
     organisationId: ledgerId.organisationId,
     registrationId: ledgerId.registrationId,
@@ -168,48 +186,51 @@ const upsertOne = async (collection, ledgerId, entry, summaryLogId) => {
     classification: entry.classification,
     summaryLogIds: [summaryLogId]
   })
-  const contentHash = hashSummaryLogRowState(candidate)
-
-  const existing = await findCommittedStateDoc(
-    collection,
-    candidate,
-    contentHash
-  )
-  if (existing) {
-    return addMembership(collection, existing._id, summaryLogId)
-  }
-
-  try {
-    const result = await collection.insertOne({ ...candidate, contentHash })
-    return toSummaryLogRowState({
-      _id: result.insertedId,
-      ...candidate,
-      contentHash
-    })
-  } catch (error) {
-    const winner = await findCommittedStateDoc(
-      collection,
-      candidate,
-      contentHash
-    )
-    if (!winner) {
-      throw error
-    }
-    return addMembership(collection, winner._id, summaryLogId)
-  }
+  return { candidate, contentHash: hashSummaryLogRowState(candidate) }
 }
 
 /**
+ * Commits a whole submission's row states in one round trip: a single
+ * `bulkWrite` of content-addressed upserts, then one `find` to read the
+ * committed documents back. Round-trip cost is independent of the row count,
+ * unlike the per-row upsert it replaces. Results are returned one per input
+ * entry, in input order — the `find` result is keyed back to the entries by
+ * their content-addressed identity.
+ *
  * @param {Collection} collection
  * @returns {(ledgerId: WasteBalanceLedgerId, summaryLogRowStates: SummaryLogRowStateEntry[], summaryLogId: string) => Promise<SummaryLogRowState[]>}
  */
 const performUpsertSummaryLogRowStates =
   (collection) => async (ledgerId, summaryLogRowStates, summaryLogId) => {
-    const results = []
-    for (const entry of summaryLogRowStates) {
-      results.push(await upsertOne(collection, ledgerId, entry, summaryLogId))
+    if (summaryLogRowStates.length === 0) {
+      return []
     }
-    return results
+
+    const prepared = summaryLogRowStates.map((entry) =>
+      prepareRowState(ledgerId, entry, summaryLogId)
+    )
+
+    await collection.bulkWrite(
+      prepared.map(({ candidate, contentHash }) =>
+        buildUpsertOperation(candidate, contentHash, summaryLogId)
+      ),
+      { ordered: false }
+    )
+
+    const committed = await collection
+      .find({ summaryLogIds: summaryLogId })
+      .toArray()
+    const committedByIdentity = new Map(
+      committed.map((doc) => [identityKey(doc), doc])
+    )
+
+    return prepared.map(({ candidate, contentHash }) =>
+      toSummaryLogRowState(
+        committedByIdentity.get(
+          identityKey(buildIdentityFilter(candidate, contentHash))
+        )
+      )
+    )
   }
 
 /**

--- a/src/waste-records/repository/mongodb.test.js
+++ b/src/waste-records/repository/mongodb.test.js
@@ -21,6 +21,13 @@ const it = mongoIt.extend({
     await client.close()
   },
 
+  monitoredClient: async (/** @type {*} */ { db }, use) => {
+    const client = new MongoClient(db, { monitorCommands: true })
+    await client.connect()
+    await use(client)
+    await client.close()
+  },
+
   summaryLogRowStatesCollection: async (
     /** @type {*} */ { mongoClient },
     use
@@ -186,12 +193,12 @@ describe('summary-log row states repository - mongodb implementation', () => {
       expect(committed[0].rowId).toBe('row-1')
     })
 
-    it('rethrows a failed insert that is not a summary-log-row-state collision', async () => {
+    it('rethrows a failed write that is not a summary-log-row-state collision', async () => {
       const upstream = new Error('connection lost')
       const stubCollection = {
         createIndex: () => Promise.resolve(),
-        findOne: () => Promise.resolve(null),
-        insertOne: () => Promise.reject(upstream)
+        bulkWrite: () => Promise.reject(upstream),
+        find: () => ({ toArray: () => Promise.resolve([]) })
       }
       const stubDb = { collection: () => stubCollection }
       const repository = (
@@ -206,5 +213,50 @@ describe('summary-log row states repository - mongodb implementation', () => {
         )
       ).rejects.toBe(upstream)
     })
+  })
+})
+
+describe('write round-trip count', () => {
+  const countCommands = async (monitoredClient, run) => {
+    let commands = 0
+    const onCommand = () => {
+      commands += 1
+    }
+    monitoredClient.on('commandStarted', onCommand)
+    await run()
+    monitoredClient.off('commandStarted', onCommand)
+    return commands
+  }
+
+  it('issues a row-count-independent number of write round trips', async (/** @type {*} */ {
+    monitoredClient
+  }) => {
+    const database = monitoredClient.db(DATABASE_NAME)
+    await ensureSummaryLogRowStatesCollection(database)
+    const collection = database.collection(
+      SUMMARY_LOG_ROW_STATES_COLLECTION_NAME
+    )
+    const repository = (
+      await createMongoSummaryLogRowStateRepository(database)
+    )()
+
+    const roundTripsFor = async (rowCount, summaryLogId) => {
+      await collection.deleteMany({})
+      const entries = Array.from({ length: rowCount }, (_, i) =>
+        buildSummaryLogRowStateEntry({ rowId: `row-${i}` })
+      )
+      return countCommands(monitoredClient, () =>
+        repository.upsertSummaryLogRowStates(
+          DEFAULT_LEDGER_ID,
+          entries,
+          summaryLogId
+        )
+      )
+    }
+
+    const forOneRow = await roundTripsFor(1, 'log-1')
+    const forFiftyRows = await roundTripsFor(50, 'log-50')
+
+    expect(forFiftyRows).toBe(forOneRow)
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)
## What

Rewrite the MongoDB summary-log row-state write to issue a single `bulkWrite` of content-addressed upserts instead of a per-row upsert loop.

## Why

Large summary-log submissions risk timing out before they complete — observed in testing, not in production. The write path (`performUpsertSummaryLogRowStates`) issued a sequential upsert per row — a `findOne` on the identity index, then an `insertOne` for a new row or an `updateOne` plus `findOne` for an existing one — costing two or more round trips per row. A ~20k-row upload ran tens of thousands of sequential round trips and hit the queue handler's five-minute timeout; the message was then redelivered and re-ran the same slow loop.

## How

The mongo adapter now prepares every row's content-addressed identity up front, issues one `bulkWrite(..., { ordered: false })` of upserts, then reads the committed documents back with a single `find`, mapping them to input order by identity. Round-trip cost is independent of the row count.

Behaviour is preserved. The upsert filter is exactly the unique `summary_log_row_state_identity` index, so concurrent writers converge on the winning insert through MongoDB's server-side upsert retry — the content-hash dedup and the membership accretion the per-row loop guaranteed hold without any manual duplicate-key handling. Only the mongo adapter changes; the in-memory adapter is untouched. The queue handler's five-minute command timeout is unchanged; with batched writes it is no longer load-bearing.

A regression test asserts the write round-trip count is independent of the row count, guarding against a return to the per-row path.

[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
