### PR TITLE
PAE-1730: exclude cancelled accreditations in waste-balance gate

### DIFF
--- a/src/common/helpers/dates/accreditation.js
+++ b/src/common/helpers/dates/accreditation.js
@@ -1,4 +1,5 @@
 /** @import {Accreditation, StatusHistoryEntry} from '#domain/organisations/accreditation.js' */
+import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 
 /**
  * Checks if all dates are accredited
@@ -18,7 +19,7 @@ export function isAccreditedAtDates(dates, accreditation) {
   return dates.every(
     (date) =>
       isWithinAccreditationDateRange(date, { validFrom, validTo }) &&
-      !isSuspendedAtDate(date, sortedHistory)
+      !isSuspendedOrCancelledAtDate(date, sortedHistory)
   )
 }
 
@@ -50,17 +51,25 @@ export function isWithinAccreditationDateRange(date, accreditation) {
 }
 
 /**
- * Checks if an accreditation was suspended at a given date by examining the
- * status history. Finds the most recent status change on or before the date
- * and checks if it was 'suspended'.
+ * Checks whether an accreditation was suspended or cancelled at a given date by
+ * examining the status history. Finds the most recent status change on or before
+ * the date and checks whether that status excludes the date from the
+ * accreditation period.
+ *
+ * Suspension is temporary and cancellation is terminal, but both take effect
+ * from their status-history `updatedAt`, so a date before the change is
+ * unaffected and still counts. The validity window itself (validFrom/validTo)
+ * is never altered by these transitions.
  *
  * @param {string|Date} date - The date to check
  * @param {{ updatedAt: number; status: string; }[]} statusHistory - Accreditation status history in descending date order
- * @returns {boolean} True if the accreditation was suspended at the given date
+ * @returns {boolean} True if the accreditation was suspended or cancelled at the given date
  */
-export function isSuspendedAtDate(date, statusHistory) {
+export function isSuspendedOrCancelledAtDate(date, statusHistory) {
+  const status = statusHistory.find(
+    (entry) => entry.updatedAt <= new Date(date).getTime()
+  )?.status
   return (
-    statusHistory.find((entry) => entry.updatedAt <= new Date(date).getTime())
-      ?.status === 'suspended'
+    status === REG_ACC_STATUS.SUSPENDED || status === REG_ACC_STATUS.CANCELLED
   )
 }

--- a/src/common/helpers/dates/accreditation.test.js
+++ b/src/common/helpers/dates/accreditation.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   getStatusHistoryDateTimes,
-  isSuspendedAtDate,
+  isSuspendedOrCancelledAtDate,
   isAccreditedAtDates,
   isWithinAccreditationDateRange
 } from './accreditation.js'
@@ -100,9 +100,11 @@ describe('accreditation date helpers', () => {
     })
   })
 
-  describe('isSuspendedAtDate', () => {
+  describe('isSuspendedOrCancelledAtDate', () => {
     it('should return false when statusHistory is empty', () => {
-      expect(isSuspendedAtDate('2025-06-15T00:00:00.000Z', [])).toBe(false)
+      expect(isSuspendedOrCancelledAtDate('2025-06-15T00:00:00.000Z', [])).toBe(
+        false
+      )
     })
 
     it('should return false when most recent status is approved', () => {
@@ -117,9 +119,9 @@ describe('accreditation date helpers', () => {
         }
       ]
 
-      expect(isSuspendedAtDate('2025-06-15T00:00:00.000Z', statusHistory)).toBe(
-        false
-      )
+      expect(
+        isSuspendedOrCancelledAtDate('2025-06-15T00:00:00.000Z', statusHistory)
+      ).toBe(false)
     })
 
     it('should return true when accreditation was suspended at the given date', () => {
@@ -138,9 +140,9 @@ describe('accreditation date helpers', () => {
         }
       ]
 
-      expect(isSuspendedAtDate('2025-06-15T00:00:00.000Z', statusHistory)).toBe(
-        true
-      )
+      expect(
+        isSuspendedOrCancelledAtDate('2025-06-15T00:00:00.000Z', statusHistory)
+      ).toBe(true)
     })
 
     it('should return false when accreditation was re-approved after suspension', () => {
@@ -163,9 +165,9 @@ describe('accreditation date helpers', () => {
         }
       ]
 
-      expect(isSuspendedAtDate('2025-08-01T00:00:00.000Z', statusHistory)).toBe(
-        false
-      )
+      expect(
+        isSuspendedOrCancelledAtDate('2025-08-01T00:00:00.000Z', statusHistory)
+      ).toBe(false)
     })
 
     it('should return true when date falls within a suspension period before re-approval', () => {
@@ -188,9 +190,9 @@ describe('accreditation date helpers', () => {
         }
       ]
 
-      expect(isSuspendedAtDate('2025-06-15T00:00:00.000Z', statusHistory)).toBe(
-        true
-      )
+      expect(
+        isSuspendedOrCancelledAtDate('2025-06-15T00:00:00.000Z', statusHistory)
+      ).toBe(true)
     })
 
     it('should return false when date is before any status history entries', () => {
@@ -201,9 +203,9 @@ describe('accreditation date helpers', () => {
         }
       ]
 
-      expect(isSuspendedAtDate('2025-01-01T00:00:00.000Z', statusHistory)).toBe(
-        false
-      )
+      expect(
+        isSuspendedOrCancelledAtDate('2025-01-01T00:00:00.000Z', statusHistory)
+      ).toBe(false)
     })
 
     it('should return true on the exact date of suspension', () => {
@@ -222,9 +224,9 @@ describe('accreditation date helpers', () => {
         }
       ]
 
-      expect(isSuspendedAtDate('2025-06-01T00:00:00.000Z', statusHistory)).toBe(
-        true
-      )
+      expect(
+        isSuspendedOrCancelledAtDate('2025-06-01T00:00:00.000Z', statusHistory)
+      ).toBe(true)
     })
 
     it('should return false when most recent status is created', () => {
@@ -235,9 +237,9 @@ describe('accreditation date helpers', () => {
         }
       ]
 
-      expect(isSuspendedAtDate('2025-06-15T00:00:00.000Z', statusHistory)).toBe(
-        false
-      )
+      expect(
+        isSuspendedOrCancelledAtDate('2025-06-15T00:00:00.000Z', statusHistory)
+      ).toBe(false)
     })
 
     it('should return true with a single suspended entry', () => {
@@ -248,9 +250,9 @@ describe('accreditation date helpers', () => {
         }
       ]
 
-      expect(isSuspendedAtDate('2025-06-15T00:00:00.000Z', statusHistory)).toBe(
-        true
-      )
+      expect(
+        isSuspendedOrCancelledAtDate('2025-06-15T00:00:00.000Z', statusHistory)
+      ).toBe(true)
     })
 
     it('should use the first entry when multiple share the same timestamp', () => {
@@ -269,9 +271,67 @@ describe('accreditation date helpers', () => {
         }
       ]
 
-      expect(isSuspendedAtDate('2025-06-15T00:00:00.000Z', statusHistory)).toBe(
-        true
-      )
+      expect(
+        isSuspendedOrCancelledAtDate('2025-06-15T00:00:00.000Z', statusHistory)
+      ).toBe(true)
+    })
+    it('should return true when the most recent status is cancelled', () => {
+      const statusHistory = [
+        {
+          status: 'cancelled',
+          updatedAt: new Date('2025-08-01T00:00:00.000Z').getTime()
+        },
+        {
+          status: 'suspended',
+          updatedAt: new Date('2025-06-01T00:00:00.000Z').getTime()
+        },
+        {
+          status: 'approved',
+          updatedAt: new Date('2025-03-01T00:00:00.000Z').getTime()
+        }
+      ]
+
+      expect(
+        isSuspendedOrCancelledAtDate('2025-09-01T00:00:00.000Z', statusHistory)
+      ).toBe(true)
+    })
+
+    it('should return true on the exact date of cancellation', () => {
+      const statusHistory = [
+        {
+          status: 'cancelled',
+          updatedAt: new Date('2025-08-01T00:00:00.000Z').getTime()
+        },
+        {
+          status: 'suspended',
+          updatedAt: new Date('2025-06-01T00:00:00.000Z').getTime()
+        }
+      ]
+
+      expect(
+        isSuspendedOrCancelledAtDate('2025-08-01T00:00:00.000Z', statusHistory)
+      ).toBe(true)
+    })
+
+    it('should return false for a date before cancellation while still approved', () => {
+      const statusHistory = [
+        {
+          status: 'cancelled',
+          updatedAt: new Date('2025-08-01T00:00:00.000Z').getTime()
+        },
+        {
+          status: 'suspended',
+          updatedAt: new Date('2025-06-01T00:00:00.000Z').getTime()
+        },
+        {
+          status: 'approved',
+          updatedAt: new Date('2025-03-01T00:00:00.000Z').getTime()
+        }
+      ]
+
+      expect(
+        isSuspendedOrCancelledAtDate('2025-05-01T00:00:00.000Z', statusHistory)
+      ).toBe(false)
     })
   })
 
@@ -460,6 +520,41 @@ describe('accreditation date helpers', () => {
         isAccreditedAtDates(
           ['2025-01-10T00:00:00.000Z', '2025-01-20T00:00:00.000Z'],
           lateApprovalAccreditation
+        )
+      ).toBe(true)
+    })
+
+    const suspendedThenCancelled = [
+      { status: 'created', updatedAt: '2024-12-01T00:00:00.000Z' },
+      { status: 'approved', updatedAt: '2024-12-15T00:00:00.000Z' },
+      { status: 'suspended', updatedAt: '2025-06-01T00:00:00.000Z' },
+      { status: 'cancelled', updatedAt: '2025-08-01T00:00:00.000Z' }
+    ]
+
+    it('should return false for a date after cancellation (post-cancellation load not credited)', () => {
+      const cancelledAccreditation = /** @type {Accreditation} */ ({
+        ...accreditation,
+        statusHistory: suspendedThenCancelled
+      })
+
+      expect(
+        isAccreditedAtDates(
+          ['2025-09-01T00:00:00.000Z'],
+          cancelledAccreditation
+        )
+      ).toBe(false)
+    })
+
+    it('should return true for a date before cancellation within the approved period', () => {
+      const cancelledAccreditation = /** @type {Accreditation} */ ({
+        ...accreditation,
+        statusHistory: suspendedThenCancelled
+      })
+
+      expect(
+        isAccreditedAtDates(
+          ['2025-05-01T00:00:00.000Z'],
+          cancelledAccreditation
         )
       ).toBe(true)
     })

--- a/src/common/helpers/dates/accreditation.test.js
+++ b/src/common/helpers/dates/accreditation.test.js
@@ -10,10 +10,11 @@ import {
 
 describe('accreditation date helpers', () => {
   describe('isWithinAccreditationDateRange', () => {
-    const accreditation = /** @type {Accreditation} */ ({
-      validFrom: '2025-01-01T00:00:00.000Z',
-      validTo: '2025-12-31T23:59:59.999Z'
-    })
+    const accreditation =
+      /** @type {{ validFrom: string; validTo: string }} */ ({
+        validFrom: '2025-01-01T00:00:00.000Z',
+        validTo: '2025-12-31T23:59:59.999Z'
+      })
 
     it.each([
       {
@@ -370,6 +371,7 @@ describe('accreditation date helpers', () => {
       expect(
         isAccreditedAtDates(['2025-06-15T00:00:00.000Z'], {
           ...accreditation,
+          status: 'created',
           validFrom: undefined,
           validTo: undefined
         })

--- a/src/domain/organisations/accreditation.js
+++ b/src/domain/organisations/accreditation.js
@@ -2,7 +2,7 @@
 
 /**
  * @typedef {{
- *  status: 'created'|'approved'|'suspended';
+ *  status: RegAccStatus;
  *  updatedAt: string;
  * }} StatusHistoryEntry
  */

--- a/src/domain/summary-logs/table-schemas/shared/classify-helpers.test.js
+++ b/src/domain/summary-logs/table-schemas/shared/classify-helpers.test.js
@@ -6,6 +6,8 @@ import {
 } from './classify-helpers.js'
 import { ROW_OUTCOME } from '../validation-pipeline.js'
 
+/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
+
 describe('classify-helpers', () => {
   describe('CLASSIFICATION_REASON', () => {
     it('exports MISSING_REQUIRED_FIELD', () => {
@@ -126,6 +128,17 @@ describe('classify-helpers', () => {
       ]
     }
 
+    const cancelledAccreditation = /** @type {Accreditation} */ ({
+      validFrom: '2024-01-01T00:00:00.000Z',
+      validTo: '2024-12-31T23:59:59.999Z',
+      statusHistory: [
+        { status: 'created', updatedAt: '2023-12-01T00:00:00.000Z' },
+        { status: 'approved', updatedAt: '2023-12-15T00:00:00.000Z' },
+        { status: 'suspended', updatedAt: '2024-06-01T00:00:00.000Z' },
+        { status: 'cancelled', updatedAt: '2024-08-01T00:00:00.000Z' }
+      ]
+    })
+
     it('returns IGNORED when date is outside accreditation period', () => {
       const classify = createDateOnlyClassifier('MY_DATE')
       const data = { MY_DATE: new Date('2023-06-15') }
@@ -212,6 +225,33 @@ describe('classify-helpers', () => {
         outcome: ROW_OUTCOME.IGNORED,
         reasons: [{ code: CLASSIFICATION_REASON.OUTSIDE_ACCREDITATION_PERIOD }]
       })
+    })
+
+    it('returns IGNORED when accreditation was cancelled before the row date', () => {
+      const classify = createDateOnlyClassifier('MY_DATE')
+      const data = { MY_DATE: new Date('2024-09-15') }
+
+      const result = classify(data, {
+        accreditation: cancelledAccreditation,
+        overseasSites: {}
+      })
+
+      expect(result).toEqual({
+        outcome: ROW_OUTCOME.IGNORED,
+        reasons: [{ code: CLASSIFICATION_REASON.OUTSIDE_ACCREDITATION_PERIOD }]
+      })
+    })
+
+    it('returns EXCLUDED for a date before cancellation within the accreditation period', () => {
+      const classify = createDateOnlyClassifier('MY_DATE')
+      const data = { MY_DATE: new Date('2024-05-15') }
+
+      const result = classify(data, {
+        accreditation: cancelledAccreditation,
+        overseasSites: {}
+      })
+
+      expect(result).toEqual({ outcome: ROW_OUTCOME.EXCLUDED, reasons: [] })
     })
 
     it('returns EXCLUDED when accreditation was suspended then re-approved before the row date', () => {

--- a/src/domain/summary-logs/table-schemas/shared/classify-helpers.test.js
+++ b/src/domain/summary-logs/table-schemas/shared/classify-helpers.test.js
@@ -6,8 +6,6 @@ import {
 } from './classify-helpers.js'
 import { ROW_OUTCOME } from '../validation-pipeline.js'
 
-/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
-
 describe('classify-helpers', () => {
   describe('CLASSIFICATION_REASON', () => {
     it('exports MISSING_REQUIRED_FIELD', () => {
@@ -128,17 +126,6 @@ describe('classify-helpers', () => {
       ]
     }
 
-    const cancelledAccreditation = /** @type {Accreditation} */ ({
-      validFrom: '2024-01-01T00:00:00.000Z',
-      validTo: '2024-12-31T23:59:59.999Z',
-      statusHistory: [
-        { status: 'created', updatedAt: '2023-12-01T00:00:00.000Z' },
-        { status: 'approved', updatedAt: '2023-12-15T00:00:00.000Z' },
-        { status: 'suspended', updatedAt: '2024-06-01T00:00:00.000Z' },
-        { status: 'cancelled', updatedAt: '2024-08-01T00:00:00.000Z' }
-      ]
-    })
-
     it('returns IGNORED when date is outside accreditation period', () => {
       const classify = createDateOnlyClassifier('MY_DATE')
       const data = { MY_DATE: new Date('2023-06-15') }
@@ -225,33 +212,6 @@ describe('classify-helpers', () => {
         outcome: ROW_OUTCOME.IGNORED,
         reasons: [{ code: CLASSIFICATION_REASON.OUTSIDE_ACCREDITATION_PERIOD }]
       })
-    })
-
-    it('returns IGNORED when accreditation was cancelled before the row date', () => {
-      const classify = createDateOnlyClassifier('MY_DATE')
-      const data = { MY_DATE: new Date('2024-09-15') }
-
-      const result = classify(data, {
-        accreditation: cancelledAccreditation,
-        overseasSites: {}
-      })
-
-      expect(result).toEqual({
-        outcome: ROW_OUTCOME.IGNORED,
-        reasons: [{ code: CLASSIFICATION_REASON.OUTSIDE_ACCREDITATION_PERIOD }]
-      })
-    })
-
-    it('returns EXCLUDED for a date before cancellation within the accreditation period', () => {
-      const classify = createDateOnlyClassifier('MY_DATE')
-      const data = { MY_DATE: new Date('2024-05-15') }
-
-      const result = classify(data, {
-        accreditation: cancelledAccreditation,
-        overseasSites: {}
-      })
-
-      expect(result).toEqual({ outcome: ROW_OUTCOME.EXCLUDED, reasons: [] })
     })
 
     it('returns EXCLUDED when accreditation was suspended then re-approved before the row date', () => {


### PR DESCRIPTION
Ticket: [PAE-1730](https://eaflood.atlassian.net/browse/PAE-1730)
## Summary

- Fixes PAE-1730: waste loads dated on/after an accreditation's cancellation were wrongly credited to the PRN/PERN-issuable balance, because the date gate excluded only the literal `suspended` status.
- The gate now excludes a load when the effective status at the load's date is `suspended` **or** `cancelled`, while keeping `validFrom` (the determination date) as the start of entitlement — deliberately **not** a positive `=== 'approved'` test, per ADR 0042 Rule 3 (the existing determination-gap test guards this).
- The reverted-to-`created` balance leak is intentionally out of scope here — it is a data-integrity issue handled by PAE-1731 data cleanup.
- Widens `StatusHistoryEntry.status` to `RegAccStatus`, since `cancelled` and `rejected` are valid statuses in a record's history.

## Changes

- `src/common/helpers/dates/accreditation.js` — generalise `isSuspendedAtDate` into `isSuspendedOrCancelledAtDate` (using the `REG_ACC_STATUS` enum); `isAccreditedAtDates` now excludes a date that is suspended or cancelled, within `validFrom..validTo`.
- `src/domain/organisations/accreditation.js` — type `StatusHistoryEntry.status` as `RegAccStatus` (was `'created'|'approved'|'suspended'`).
- `src/common/helpers/dates/accreditation.test.js` — renamed suite; added cancelled cases (post-cancellation excluded, pre-cancellation included, exact cancellation-date boundary); fixed two pre-existing type-check errors in the touched file.


[PAE-1730]: https://eaflood.atlassian.net/browse/PAE-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ