### PR TITLE
PAE-1339: type server test fixture exports

### DIFF
--- a/.vite/fixtures/server-with-db.js
+++ b/.vite/fixtures/server-with-db.js
@@ -1,18 +1,30 @@
 import { it as dbTest } from './mongo.js'
 
-export const it = dbTest.extend({
-  server: [
-    async ({ db }, use) => {
-      // db parameter triggers MongoDB setup (unused directly)
-      const _dbUri = db
-      const { createServer } = await import('#server/server.js')
-      const server = await createServer()
-      await server.initialize()
+/**
+ * vitest cannot infer scoped-fixture (tuple-form) value types in JSDoc/tsc, so
+ * the fixture shape is asserted here, at the boundary, and flows to every
+ * consumer typed.
+ */
+export const it =
+  /**
+   * @type {import('vitest').TestAPI<{
+   *   db: string
+   *   server: import('#common/hapi-types.js').HapiServer
+   * }>}
+   */ (
+    dbTest.extend({
+      server: [
+        // destructuring db triggers MongoDB setup even though it is unused here
+        async ({ db: _db }, use) => {
+          const { createServer } = await import('#server/server.js')
+          const server = await createServer()
+          await server.initialize()
 
-      await use(server)
+          await use(server)
 
-      await server.stop()
-    },
-    { scope: 'file' }
-  ]
-})
+          await server.stop()
+        },
+        { scope: 'file' }
+      ]
+    })
+  )

--- a/.vite/fixtures/server-with-mock-db.js
+++ b/.vite/fixtures/server-with-mock-db.js
@@ -2,7 +2,12 @@ import { test, vi } from 'vitest'
 import { createMockOidcServers } from '#vite/helpers/mock-oidc-servers.js'
 
 /**
- * @typedef {import('#common/hapi-types.js').HapiServer & {
+ * The `db` decoration is replaced with the spyable mock this fixture installs,
+ * so tests can `vi.spyOn(server.db, 'collection')` without fighting the real
+ * `Db` type.
+ *
+ * @typedef {Omit<import('#common/hapi-types.js').HapiServer, 'db'> & {
+ *   db: { collection: import('vitest').Mock }
  *   loggerMocks: {
  *     info: ReturnType<typeof vi.fn>
  *     error: ReturnType<typeof vi.fn>
@@ -20,66 +25,78 @@ import { createMockOidcServers } from '#vite/helpers/mock-oidc-servers.js'
  * delete this file and use createTestServer() with in-memory repositories instead.
  *
  * ~10x faster than testServerFixture because it skips MongoDB startup.
+ *
+ * vitest cannot infer scoped-fixture (tuple-form) value types in JSDoc/tsc, so
+ * the fixture shape is asserted here, at the boundary, and flows to every
+ * consumer typed.
  */
-export const it = test.extend({
-  mockOidcServer: [
-    // eslint-disable-next-line no-empty-pattern
-    async ({}, use) => {
-      const mockOidcServer = createMockOidcServers()
-      mockOidcServer.listen({ onUnhandledRequest: 'warn' })
+export const it =
+  /**
+   * @type {import('vitest').TestAPI<{
+   *   mockOidcServer: ReturnType<typeof createMockOidcServers>
+   *   server: TestServer
+   * }>}
+   */ (
+    test.extend({
+      mockOidcServer: [
+        // eslint-disable-next-line no-empty-pattern
+        async ({}, use) => {
+          const mockOidcServer = createMockOidcServers()
+          mockOidcServer.listen({ onUnhandledRequest: 'warn' })
 
-      await use(mockOidcServer)
+          await use(mockOidcServer)
 
-      mockOidcServer.resetHandlers()
-      mockOidcServer.close()
-    },
-    { auto: true } // Always initialize this fixture even if not used in test
-  ],
-  server: [
-    // eslint-disable-next-line no-empty-pattern
-    async ({}, use) => {
-      const { createServer } = await import('#server/server.js')
-      const testServer = await createServer({
-        _testOnlyLegacyApplyRoutes: true
-      })
+          mockOidcServer.resetHandlers()
+          mockOidcServer.close()
+        },
+        { auto: true } // Always initialize this fixture even if not used in test
+      ],
+      server: [
+        // eslint-disable-next-line no-empty-pattern
+        async ({}, use) => {
+          const { createServer } = await import('#server/server.js')
+          const testServer = await createServer({
+            _testOnlyLegacyApplyRoutes: true
+          })
 
-      // Add a mock db object that can be spied on
-      // This allows tests to do: vi.spyOn(server.db, 'collection')
-      const mockDb = {
-        collection: vi.fn()
-      }
+          // Add a mock db object that can be spied on
+          // This allows tests to do: vi.spyOn(server.db, 'collection')
+          const mockDb = {
+            collection: vi.fn()
+          }
 
-      testServer.decorate('server', 'db', mockDb)
-      testServer.decorate('request', 'db', mockDb)
+          testServer.decorate('server', 'db', mockDb)
+          testServer.decorate('request', 'db', mockDb)
 
-      await testServer.initialize()
+          await testServer.initialize()
 
-      /** @type {TestServer} */
-      const server = /** @type {*} */ (testServer)
+          /** @type {TestServer} */
+          const server = /** @type {*} */ (testServer)
 
-      server.loggerMocks = {
-        info: vi.fn(),
-        error: vi.fn(),
-        warn: vi.fn()
-      }
+          server.loggerMocks = {
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn()
+          }
 
-      server.ext('onRequest', (request, h) => {
-        vi.spyOn(request.logger, 'info').mockImplementation(
-          server.loggerMocks.info
-        )
-        vi.spyOn(request.logger, 'error').mockImplementation(
-          server.loggerMocks.error
-        )
-        vi.spyOn(request.logger, 'warn').mockImplementation(
-          server.loggerMocks.warn
-        )
-        return h.continue
-      })
+          server.ext('onRequest', (request, h) => {
+            vi.spyOn(request.logger, 'info').mockImplementation(
+              server.loggerMocks.info
+            )
+            vi.spyOn(request.logger, 'error').mockImplementation(
+              server.loggerMocks.error
+            )
+            vi.spyOn(request.logger, 'warn').mockImplementation(
+              server.loggerMocks.warn
+            )
+            return h.continue
+          })
 
-      await use(server)
+          await use(server)
 
-      await testServer.stop()
-    },
-    { scope: 'file' }
-  ]
-})
+          await testServer.stop()
+        },
+        { scope: 'file' }
+      ]
+    })
+  )


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
type the `server-with-mock-db` and `server-with-db` vitest fixture exports so consumers get a typed `server` (and mock `db`) instead of `unknown`.

- assert fixture shape via `TestAPI<{...}>` at the boundary (vitest can't infer scoped/tuple-form fixture value types in tsc/jsdoc)
- override `db` on `TestServer` to the spyable mock the fixture installs

test-only change; prod `[src]` typecheck unaffected. drops `lint:types:tests` errors 748 -> 703 (-45) across the apply route tests.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ