### PR TITLE
PAE-1737: add filterPeriodsFromDate reporting-period trim helper

### DIFF
--- a/src/reports/domain/filter-periods-from-date.js
+++ b/src/reports/domain/filter-periods-from-date.js
@@ -1,0 +1,21 @@
+/**
+ * Filters reporting periods to those not entirely before a start date.
+ *
+ * A period is kept when its end date is on or after `fromDate`, so the period
+ * containing `fromDate` is retained (inclusive boundary) and periods that ended
+ * before it are dropped. Both `endDate` and `fromDate` are `YYYY-MM-DD` strings,
+ * which sort chronologically under a lexical comparison — safe including the
+ * `endDate === fromDate` boundary (matching the string-date ordering used in
+ * derive-period-status.js).
+ *
+ * Pure and cadence-agnostic: the caller decides when to apply it (monthly only,
+ * for the accreditation `validFrom` trim).
+ *
+ * @template {{ endDate: string }} T
+ * @param {T[]} periods
+ * @param {string} fromDate - ISO `YYYY-MM-DD` start date
+ * @returns {T[]}
+ */
+export function filterPeriodsFromDate(periods, fromDate) {
+  return periods.filter((period) => period.endDate.localeCompare(fromDate) >= 0)
+}

--- a/src/reports/domain/filter-periods-from-date.js
+++ b/src/reports/domain/filter-periods-from-date.js
@@ -1,21 +1,30 @@
 /**
- * Filters reporting periods to those not entirely before a start date.
+ * Filters reporting periods to those overlapping a date window.
  *
- * A period is kept when its end date is on or after `fromDate`, so the period
- * containing `fromDate` is retained (inclusive boundary) and periods that ended
- * before it are dropped. Both `endDate` and `fromDate` are `YYYY-MM-DD` strings,
- * which sort chronologically under a lexical comparison — safe including the
- * `endDate === fromDate` boundary (matching the string-date ordering used in
- * derive-period-status.js).
+ * A period is kept when it is not entirely before `fromDate` (its `endDate` is
+ * on or after `fromDate`) and — when an upper bound is supplied — not entirely
+ * after `toDate` (its `startDate` is on or before `toDate`). The boundary
+ * periods, those containing `fromDate` or `toDate`, are kept (inclusive). All
+ * dates are `YYYY-MM-DD` strings, which sort chronologically under a lexical
+ * comparison (matching the string-date ordering in derive-period-status.js), so
+ * the `=== fromDate` / `=== toDate` boundaries are safe.
  *
- * Pure and cadence-agnostic: the caller decides when to apply it (monthly only,
- * for the accreditation `validFrom` trim).
+ * `toDate` is optional: omit it to trim the lower bound only (the accreditation
+ * `validFrom` front trim). It exists for the forthcoming back trim (e.g. a
+ * cancellation date) so callers won't need to change the signature then.
  *
- * @template {{ endDate: string }} T
+ * Pure and cadence-agnostic: the caller decides when to apply it.
+ *
+ * @template {{ startDate: string, endDate: string }} T
  * @param {T[]} periods
- * @param {string} fromDate - ISO `YYYY-MM-DD` start date
+ * @param {string} fromDate - ISO `YYYY-MM-DD` inclusive lower bound
+ * @param {string} [toDate] - ISO `YYYY-MM-DD` inclusive upper bound (open when omitted)
  * @returns {T[]}
  */
-export function filterPeriodsFromDate(periods, fromDate) {
-  return periods.filter((period) => period.endDate.localeCompare(fromDate) >= 0)
+export function filterPeriodsFromDate(periods, fromDate, toDate) {
+  return periods.filter(
+    (period) =>
+      period.endDate.localeCompare(fromDate) >= 0 &&
+      (toDate === undefined || period.startDate.localeCompare(toDate) <= 0)
+  )
 }

--- a/src/reports/domain/filter-periods-from-date.test.js
+++ b/src/reports/domain/filter-periods-from-date.test.js
@@ -27,43 +27,75 @@ const MAR = {
 }
 
 describe('filterPeriodsFromDate', () => {
-  it('drops periods that ended before the start date', () => {
-    // MAR.startDate also exercises the start date landing on a period's start day
-    expect(filterPeriodsFromDate([JAN, FEB, MAR], MAR.startDate)).toEqual([MAR])
+  describe('lower bound (fromDate)', () => {
+    it('drops periods that ended before the start date', () => {
+      // MAR.startDate also exercises the start date landing on a period's start day
+      expect(filterPeriodsFromDate([JAN, FEB, MAR], MAR.startDate)).toEqual([
+        MAR
+      ])
+    })
+
+    it('keeps the period containing a mid-period start date', () => {
+      expect(filterPeriodsFromDate([JAN, FEB, MAR], '2026-03-15')).toEqual([
+        MAR
+      ])
+    })
+
+    it('keeps a period whose end date equals the start date', () => {
+      expect(filterPeriodsFromDate([JAN, FEB, MAR], FEB.endDate)).toEqual([
+        FEB,
+        MAR
+      ])
+    })
+
+    it('keeps every period when the start date precedes them all', () => {
+      expect(filterPeriodsFromDate([JAN, FEB, MAR], '2025-12-31')).toEqual([
+        JAN,
+        FEB,
+        MAR
+      ])
+    })
+
+    it('returns empty when the start date is after every period', () => {
+      expect(filterPeriodsFromDate([JAN, FEB, MAR], '2026-04-01')).toEqual([])
+    })
+
+    it('returns empty for an empty period list', () => {
+      expect(filterPeriodsFromDate([], MAR.startDate)).toEqual([])
+    })
+
+    it('does not mutate the input array', () => {
+      const input = [JAN, FEB, MAR]
+      const result = filterPeriodsFromDate(input, MAR.startDate)
+
+      expect(input).toEqual([JAN, FEB, MAR])
+      expect(result).not.toBe(input)
+    })
   })
 
-  it('keeps the period containing a mid-period start date', () => {
-    expect(filterPeriodsFromDate([JAN, FEB, MAR], '2026-03-15')).toEqual([MAR])
-  })
+  describe('upper bound (toDate)', () => {
+    it('drops periods that start after the end date', () => {
+      expect(
+        filterPeriodsFromDate([JAN, FEB, MAR], JAN.startDate, FEB.endDate)
+      ).toEqual([JAN, FEB])
+    })
 
-  it('keeps a period whose end date equals the start date', () => {
-    expect(filterPeriodsFromDate([JAN, FEB, MAR], FEB.endDate)).toEqual([
-      FEB,
-      MAR
-    ])
-  })
+    it('keeps the period containing a mid-period end date', () => {
+      expect(
+        filterPeriodsFromDate([JAN, FEB, MAR], JAN.startDate, '2026-02-15')
+      ).toEqual([JAN, FEB])
+    })
 
-  it('keeps every period when the start date precedes them all', () => {
-    expect(filterPeriodsFromDate([JAN, FEB, MAR], '2025-12-31')).toEqual([
-      JAN,
-      FEB,
-      MAR
-    ])
-  })
+    it('keeps a period whose start date equals the end date', () => {
+      expect(
+        filterPeriodsFromDate([JAN, FEB, MAR], JAN.startDate, MAR.startDate)
+      ).toEqual([JAN, FEB, MAR])
+    })
 
-  it('returns empty when the start date is after every period', () => {
-    expect(filterPeriodsFromDate([JAN, FEB, MAR], '2026-04-01')).toEqual([])
-  })
-
-  it('returns empty for an empty period list', () => {
-    expect(filterPeriodsFromDate([], MAR.startDate)).toEqual([])
-  })
-
-  it('does not mutate the input array', () => {
-    const input = [JAN, FEB, MAR]
-    const result = filterPeriodsFromDate(input, MAR.startDate)
-
-    expect(input).toEqual([JAN, FEB, MAR])
-    expect(result).not.toBe(input)
+    it('applies the lower and upper bounds together', () => {
+      expect(
+        filterPeriodsFromDate([JAN, FEB, MAR], FEB.startDate, FEB.endDate)
+      ).toEqual([FEB])
+    })
   })
 })

--- a/src/reports/domain/filter-periods-from-date.test.js
+++ b/src/reports/domain/filter-periods-from-date.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { filterPeriodsFromDate } from './filter-periods-from-date.js'
+
+const JAN = {
+  year: 2026,
+  period: 1,
+  startDate: '2026-01-01',
+  endDate: '2026-01-31',
+  dueDate: '2026-02-20',
+  report: null
+}
+const FEB = {
+  year: 2026,
+  period: 2,
+  startDate: '2026-02-01',
+  endDate: '2026-02-28',
+  dueDate: '2026-03-20',
+  report: null
+}
+const MAR = {
+  year: 2026,
+  period: 3,
+  startDate: '2026-03-01',
+  endDate: '2026-03-31',
+  dueDate: '2026-04-20',
+  report: null
+}
+
+describe('filterPeriodsFromDate', () => {
+  it('drops periods that ended before the start date', () => {
+    // MAR.startDate also exercises the start date landing on a period's start day
+    expect(filterPeriodsFromDate([JAN, FEB, MAR], MAR.startDate)).toEqual([MAR])
+  })
+
+  it('keeps the period containing a mid-period start date', () => {
+    expect(filterPeriodsFromDate([JAN, FEB, MAR], '2026-03-15')).toEqual([MAR])
+  })
+
+  it('keeps a period whose end date equals the start date', () => {
+    expect(filterPeriodsFromDate([JAN, FEB, MAR], FEB.endDate)).toEqual([
+      FEB,
+      MAR
+    ])
+  })
+
+  it('keeps every period when the start date precedes them all', () => {
+    expect(filterPeriodsFromDate([JAN, FEB, MAR], '2025-12-31')).toEqual([
+      JAN,
+      FEB,
+      MAR
+    ])
+  })
+
+  it('returns empty when the start date is after every period', () => {
+    expect(filterPeriodsFromDate([JAN, FEB, MAR], '2026-04-01')).toEqual([])
+  })
+
+  it('returns empty for an empty period list', () => {
+    expect(filterPeriodsFromDate([], MAR.startDate)).toEqual([])
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [JAN, FEB, MAR]
+    const result = filterPeriodsFromDate(input, MAR.startDate)
+
+    expect(input).toEqual([JAN, FEB, MAR])
+    expect(result).not.toBe(input)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `filterPeriodsFromDate`, a pure domain helper that trims an array of reporting periods to those overlapping a date window `[fromDate, toDate]` (inclusive of the periods containing either bound).
- First slice of PAE-1737 / PAE-1703 (bead `epr-reex-tcv.1`): the building block for stopping an accredited operator being shown monthly reports for periods before their accreditation `validFrom`.
- Helper only — **not yet wired into any caller**. The operator calendar and admin all-submissions consumers follow in separate beads (`epr-reex-tcv.2`, `.3`).

## Behaviour

- Keeps a period when `endDate >= fromDate` and, when an upper bound is supplied, `startDate <= toDate`, using `localeCompare` on the `YYYY-MM-DD` strings (chronologically safe, consistent with `derive-period-status.js`). Both boundaries are inclusive.
- **`toDate` is optional** and defaults to open — omit it for the `validFrom` front trim. It's included ahead of the forthcoming back trim (e.g. a cancellation date) so callers won't need to change the signature then.
- Pure and cadence-agnostic: the caller decides when to apply it.

## Changes

- `src/reports/domain/filter-periods-from-date.js` — new helper `filterPeriodsFromDate(periods, fromDate, toDate?)`, generically typed to preserve the caller's period shape.
- `src/reports/domain/filter-periods-from-date.test.js` — unit tests covering the lower bound (drop-before, mid-period boundary, start-day boundary, `endDate === fromDate` boundary, no-op, empty result, empty input, immutability) and the upper bound (drop-after, mid-period boundary, `startDate === toDate` boundary, both bounds together). 100% coverage on the changed file.
