### PR TITLE
PAE-1339: type mongodb repository test fixtures

### DIFF
--- a/src/overseas-sites/imports/repository/mongodb.test.js
+++ b/src/overseas-sites/imports/repository/mongodb.test.js
@@ -1,26 +1,34 @@
 import { it as mongoIt } from '#vite/fixtures/mongo.js'
 import { MongoClient } from 'mongodb'
+import assert from 'node:assert'
 import { afterEach, describe, expect, vi } from 'vitest'
 import { createOrsImportsRepository } from './mongodb.js'
 import { ORS_IMPORT_STATUS } from '../../domain/import-status.js'
 
+/**
+ * @import { OrsImportsRepository } from './port.js'
+ * @typedef {{ mongoClient: MongoClient, repository: OrsImportsRepository }} MongoFixtures
+ */
+
 const DATABASE_NAME = 'epr-backend'
 const COLLECTION_NAME = 'ors-imports'
 
-const it = mongoIt.extend({
-  mongoClient: async ({ db }, use) => {
-    const client = await MongoClient.connect(db)
-    await use(client)
-    await client.close()
-  },
+const it = /** @type {import('vitest').TestAPI<MongoFixtures>} */ (
+  mongoIt.extend({
+    mongoClient: async ({ db }, use) => {
+      const client = await MongoClient.connect(db)
+      await use(client)
+      await client.close()
+    },
 
-  repository: async ({ mongoClient }, use) => {
-    const database = mongoClient.db(DATABASE_NAME)
-    await database.collection(COLLECTION_NAME).deleteMany({})
-    const factory = await createOrsImportsRepository(database)
-    await use(factory())
-  }
-})
+    repository: async ({ mongoClient }, use) => {
+      const database = mongoClient.db(DATABASE_NAME)
+      await database.collection(COLLECTION_NAME).deleteMany({})
+      const factory = await createOrsImportsRepository(database)
+      await use(factory())
+    }
+  })
+)
 
 describe('MongoDB ORS imports repository', () => {
   afterEach(() => {
@@ -39,6 +47,8 @@ describe('MongoDB ORS imports repository', () => {
     expect(created.updatedAt).toBeDefined()
 
     const found = await repository.findById('import-test-1')
+    assert(found)
+
     expect(found._id).toBe('import-test-1')
     expect(found.status).toBe(ORS_IMPORT_STATUS.PREPROCESSING)
     expect(found.files).toHaveLength(1)
@@ -63,6 +73,8 @@ describe('MongoDB ORS imports repository', () => {
 
     expect(result).toBe(true)
     const found = await repository.findById('import-test-2')
+    assert(found)
+
     expect(found.status).toBe(ORS_IMPORT_STATUS.PROCESSING)
   })
 
@@ -92,6 +104,8 @@ describe('MongoDB ORS imports repository', () => {
     await repository.addFiles('import-test-add', files)
 
     const found = await repository.findById('import-test-add')
+    assert(found)
+
     expect(found.files).toHaveLength(2)
     expect(found.files[0]).toEqual(files[0])
     expect(found.files[1]).toEqual(files[1])
@@ -148,6 +162,8 @@ describe('MongoDB ORS imports repository', () => {
     await repository.updateStatus('import-ttl-2', ORS_IMPORT_STATUS.PROCESSING)
 
     const found = await repository.findById('import-ttl-2')
+    assert(found?.expiresAt)
+
     expect(found.expiresAt).toBeInstanceOf(Date)
     expect(found.expiresAt.getTime()).toBeGreaterThan(
       new Date('2026-01-15T13:00:00.000Z').getTime()
@@ -166,6 +182,8 @@ describe('MongoDB ORS imports repository', () => {
     await repository.updateStatus('import-ttl-3', ORS_IMPORT_STATUS.COMPLETED)
 
     const found = await repository.findById('import-ttl-3')
+    assert(found)
+
     expect(found.expiresAt).toBeNull()
   })
 
@@ -185,6 +203,8 @@ describe('MongoDB ORS imports repository', () => {
 
     expect(result).toBe(false)
     const found = await repository.findById('import-forward-1')
+    assert(found)
+
     expect(found.status).toBe(ORS_IMPORT_STATUS.COMPLETED)
   })
 
@@ -204,6 +224,8 @@ describe('MongoDB ORS imports repository', () => {
 
     expect(result).toBe(false)
     const found = await repository.findById('import-forward-2')
+    assert(found)
+
     expect(found.status).toBe(ORS_IMPORT_STATUS.FAILED)
   })
 
@@ -228,6 +250,8 @@ describe('MongoDB ORS imports repository', () => {
     await repository.recordFileResult('import-test-3', 1, result)
 
     const found = await repository.findById('import-test-3')
+    assert(found)
+
     expect(found.files[0].result).toBeUndefined()
     expect(found.files[1].result).toEqual(result)
   })

--- a/src/repositories/organisations/mongodb.ors.test.js
+++ b/src/repositories/organisations/mongodb.ors.test.js
@@ -1,29 +1,41 @@
 import { it as mongoIt } from '#vite/fixtures/mongo.js'
 import { MongoClient, ObjectId } from 'mongodb'
+import assert from 'node:assert'
 import { describe, expect } from 'vitest'
 import { createOrganisationsRepository } from './mongodb.js'
+
+/**
+ * @import { OrganisationsRepository } from './port.js'
+ * @typedef {{
+ *   mongoClient: MongoClient
+ *   repository: OrganisationsRepository
+ *   database: import('mongodb').Db
+ * }} MongoFixtures
+ */
 
 const DATABASE_NAME = 'epr-backend'
 const COLLECTION_NAME = 'epr-organisations'
 
-const it = mongoIt.extend({
-  mongoClient: async ({ db }, use) => {
-    const client = await MongoClient.connect(db)
-    await use(client)
-    await client.close()
-  },
+const it = /** @type {import('vitest').TestAPI<MongoFixtures>} */ (
+  mongoIt.extend({
+    mongoClient: async ({ db }, use) => {
+      const client = await MongoClient.connect(db)
+      await use(client)
+      await client.close()
+    },
 
-  repository: async ({ mongoClient }, use) => {
-    const database = mongoClient.db(DATABASE_NAME)
-    await database.collection(COLLECTION_NAME).deleteMany({})
-    const factory = await createOrganisationsRepository(database)
-    await use(factory())
-  },
+    repository: async ({ mongoClient }, use) => {
+      const database = mongoClient.db(DATABASE_NAME)
+      await database.collection(COLLECTION_NAME).deleteMany({})
+      const factory = await createOrganisationsRepository(database)
+      await use(factory())
+    },
 
-  database: async ({ mongoClient }, use) => {
-    await use(mongoClient.db(DATABASE_NAME))
-  }
-})
+    database: async ({ mongoClient }, use) => {
+      await use(mongoClient.db(DATABASE_NAME))
+    }
+  })
+)
 
 const buildOrganisation = (overrides = {}) => {
   const orgId = overrides.orgId ?? 500001
@@ -88,8 +100,8 @@ describe('Organisations repository - ORS operations', () => {
       await database.collection(COLLECTION_NAME).insertOne(org)
 
       const found = await repository.findByOrgId(500042)
+      assert(found)
 
-      expect(found).not.toBeNull()
       expect(found.orgId).toBe(500042)
       expect(found.id).toBe(org._id.toHexString())
     })
@@ -126,6 +138,7 @@ describe('Organisations repository - ORS operations', () => {
       const updated = await database
         .collection(COLLECTION_NAME)
         .findOne({ _id: ObjectId.createFromHexString(orgId) })
+      assert(updated)
 
       expect(updated.registrations[0].overseasSites).toEqual({
         '001': { overseasSiteId: 'site-aaa' },
@@ -156,6 +169,7 @@ describe('Organisations repository - ORS operations', () => {
       const updated = await database
         .collection(COLLECTION_NAME)
         .findOne({ _id: ObjectId.createFromHexString(orgId) })
+      assert(updated)
 
       expect(updated.registrations[0].overseasSites).toEqual({
         '001': { overseasSiteId: 'new-site' }
@@ -187,6 +201,7 @@ describe('Organisations repository - ORS operations', () => {
       const updated = await database
         .collection(COLLECTION_NAME)
         .findOne({ _id: ObjectId.createFromHexString(orgId) })
+      assert(updated)
 
       expect(updated.registrations[0].overseasSites['001']).toEqual({
         overseasSiteId: 'new-site'


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
type the local `mongoIt.extend({...})` fixtures in two mongodb repository tests so `repository`/`mongoClient`/`database` are typed instead of `unknown`, mirroring the existing `MongoFixtures` cast idiom in `organisations/mongodb.test.js`.

- assert fixture shape via `TestAPI<MongoFixtures>` at the boundary
- narrow the now-typed `findById`/`findOne` results with `node:assert` (already used in repo tests)

test-only; prod `[src]` unaffected. drops `lint:types:tests` errors -45 across the two files (both now clean).

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ