### PR TITLE
PAE-1732: Fix month-end boundary truncation in stale issued-tonnage diagnostic

### DIFF
--- a/src/common/helpers/date-formatter.js
+++ b/src/common/helpers/date-formatter.js
@@ -28,8 +28,8 @@ const britishDateTimeDotsFormatter = new Intl.DateTimeFormat('en-GB', {
 
 /**
  * Formats a Date object or date string to British format (DD/MM/YYYY)
- * @param {Date|string} date - Date object or ISO date string (YYYY-MM-DD) to format
- * @returns {string} - Formatted date string (e.g., '22/01/2026')
+ * @param {Date|string|null|undefined} date - Date object or ISO date string (YYYY-MM-DD) to format
+ * @returns {string} - Formatted date string (e.g., '22/01/2026'), or '' when date is null/undefined
  */
 export function formatDate(date) {
   if (!date) {
@@ -60,6 +60,41 @@ export function formatDateTimeDots(date) {
  */
 export function formatDateISO(year, month, day) {
   return new Date(Date.UTC(year, month, day)).toISOString().slice(0, 10)
+}
+
+/**
+ * Extracts the YYYY-MM-DD calendar date from a date field, tolerant of either
+ * a bare date string or a full ISO datetime string — older persisted
+ * documents may carry the latter due to historical Joi coercion. Slicing to
+ * the first 10 characters means callers never need to know or care which
+ * shape a given stored value is in.
+ * @param {string} dateString
+ * @returns {string} YYYY-MM-DD
+ */
+export function calendarDate(dateString) {
+  return dateString.slice(0, 10)
+}
+
+/**
+ * Expands a calendar-date string (bare YYYY-MM-DD or a full ISO datetime,
+ * either accepted) into the Date representing UTC start-of-day
+ * (00:00:00.000) for that calendar date.
+ * @param {string} dateString
+ * @returns {Date}
+ */
+export function startOfDay(dateString) {
+  return new Date(`${calendarDate(dateString)}T00:00:00.000Z`)
+}
+
+/**
+ * Expands a calendar-date string (bare YYYY-MM-DD or a full ISO datetime,
+ * either accepted) into the Date representing UTC end-of-day (23:59:59.999)
+ * for that calendar date.
+ * @param {string} dateString
+ * @returns {Date}
+ */
+export function endOfDay(dateString) {
+  return new Date(`${calendarDate(dateString)}T23:59:59.999Z`)
 }
 
 /**

--- a/src/common/helpers/date-formatter.test.js
+++ b/src/common/helpers/date-formatter.test.js
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import {
+  calendarDate,
+  endOfDay,
   formatDate,
   formatDateISO,
   formatDateTimeDots,
+  startOfDay,
   toISOString,
   getMonthNames,
   getMonthRange
@@ -50,6 +53,60 @@ describe('formatDateISO', () => {
 
   it('handles month overflow into next year', () => {
     expect(formatDateISO(2026, 12, 1)).toBe('2027-01-01')
+  })
+})
+
+describe('calendarDate', () => {
+  it('returns a bare date string unchanged', () => {
+    expect(calendarDate('2025-01-31')).toBe('2025-01-31')
+  })
+
+  it('extracts the calendar date from a full ISO datetime with start-of-day time', () => {
+    expect(calendarDate('2025-01-31T00:00:00.000Z')).toBe('2025-01-31')
+  })
+
+  it('extracts the calendar date from a full ISO datetime with end-of-day time', () => {
+    expect(calendarDate('2025-01-31T23:59:59.999Z')).toBe('2025-01-31')
+  })
+})
+
+describe('startOfDay', () => {
+  it('expands a bare date string to UTC start-of-day', () => {
+    expect(startOfDay('2025-01-31').toISOString()).toBe(
+      '2025-01-31T00:00:00.000Z'
+    )
+  })
+
+  it('expands an already-coerced full-datetime start-of-day string to the same instant', () => {
+    expect(startOfDay('2025-01-31T00:00:00.000Z').toISOString()).toBe(
+      '2025-01-31T00:00:00.000Z'
+    )
+  })
+
+  it('normalises a full-datetime end-of-day string back to start-of-day for the same calendar date', () => {
+    expect(startOfDay('2025-01-31T23:59:59.999Z').toISOString()).toBe(
+      '2025-01-31T00:00:00.000Z'
+    )
+  })
+})
+
+describe('endOfDay', () => {
+  it('expands a bare date string to UTC end-of-day', () => {
+    expect(endOfDay('2025-01-31').toISOString()).toBe(
+      '2025-01-31T23:59:59.999Z'
+    )
+  })
+
+  it('normalises an already-coerced full-datetime start-of-day string to end-of-day for the same calendar date', () => {
+    expect(endOfDay('2025-01-31T00:00:00.000Z').toISOString()).toBe(
+      '2025-01-31T23:59:59.999Z'
+    )
+  })
+
+  it('expands a full-datetime end-of-day string to the same instant', () => {
+    expect(endOfDay('2025-01-31T23:59:59.999Z').toISOString()).toBe(
+      '2025-01-31T23:59:59.999Z'
+    )
   })
 })
 

--- a/src/packaging-recycling-notes/application/get-issued-tonnage.js
+++ b/src/packaging-recycling-notes/application/get-issued-tonnage.js
@@ -1,10 +1,13 @@
+import { endOfDay, startOfDay } from '#common/helpers/date-formatter.js'
 import { aggregateIssuedTonnage } from '#packaging-recycling-notes/domain/tonnage.js'
 
 /**
  * @typedef {Object} GetIssuedTonnageParams
  * @property {string | null | undefined} accreditationId
- * @property {string} startDate - ISO date string e.g. '2025-01-01'
- * @property {string} endDate - ISO date string e.g. '2025-01-31'
+ * @property {string} startDate - Calendar-date string e.g. '2025-01-01', bare
+ *   or a full ISO datetime — startOfDay()/endOfDay() tolerate either shape.
+ * @property {string} endDate - Calendar-date string e.g. '2025-01-31', bare
+ *   or a full ISO datetime — startOfDay()/endOfDay() tolerate either shape.
  */
 
 /**
@@ -21,8 +24,8 @@ export async function getIssuedTonnage(prnRepository, params) {
   if (!accreditationId) {
     return null
   }
-  const start = new Date(startDate + 'T00:00:00.000Z')
-  const end = new Date(endDate + 'T23:59:59.999Z')
+  const start = startOfDay(startDate)
+  const end = endOfDay(endDate)
   // PRN volumes per accreditation are in the hundreds, so in-memory filtering is negligible.
   // Period filtering stays in the domain layer while the "issued in period" rules are still fluid.
   // Once stable, it could move to the repository with an index on status.issued.at.

--- a/src/packaging-recycling-notes/domain/tonnage.js
+++ b/src/packaging-recycling-notes/domain/tonnage.js
@@ -3,8 +3,12 @@ import { CANCELLED_PRN_STATUSES } from './model.js'
 
 /**
  * @typedef {Object} AggregateTonnageParams
- * @property {Date} startDate
- * @property {Date} endDate
+ * @property {Date} startDate - A concrete instant, not a calendar-date
+ *   string. Callers must have already expanded a calendar-date string via
+ *   startOfDay() from #common/helpers/date-formatter.js.
+ * @property {Date} endDate - A concrete instant. Callers must have already
+ *   expanded a calendar-date string via endOfDay() from
+ *   #common/helpers/date-formatter.js.
  */
 
 /**

--- a/src/reports/monitoring/stale-issued-tonnage.js
+++ b/src/reports/monitoring/stale-issued-tonnage.js
@@ -1,3 +1,4 @@
+import { endOfDay, startOfDay } from '#common/helpers/date-formatter.js'
 import { isNil } from '#common/helpers/is-nil.js'
 import { CANCELLED_PRN_STATUSES } from '#packaging-recycling-notes/domain/model.js'
 import { aggregateIssuedTonnage } from '#packaging-recycling-notes/domain/tonnage.js'
@@ -10,31 +11,6 @@ const REVIEWABLE_REPORT_STATUSES = new Set([
   REPORT_STATUS.IN_PROGRESS,
   REPORT_STATUS.READY_TO_SUBMIT
 ])
-
-/**
- * Extracts the YYYY-MM-DD calendar date from a report's stored startDate/
- * endDate, which may be a bare date string (createReportForPeriod, via
- * formatDateISO) or a full ISO datetime string (summary-log-triggered report
- * creation), depending on which code path created the report.
- *
- * @param {string} dateString
- * @returns {string}
- */
-const calendarDate = (dateString) => dateString.slice(0, 10)
-
-/**
- * @param {string} dateString
- * @returns {Date}
- */
-const startOfDay = (dateString) =>
-  new Date(`${calendarDate(dateString)}T00:00:00.000Z`)
-
-/**
- * @param {string} dateString
- * @returns {Date}
- */
-const endOfDay = (dateString) =>
-  new Date(`${calendarDate(dateString)}T23:59:59.999Z`)
 
 /**
  * Sum of tonnage for PRNs issued within the period but currently cancelled or

--- a/src/reports/monitoring/stale-issued-tonnage.js
+++ b/src/reports/monitoring/stale-issued-tonnage.js
@@ -7,8 +7,34 @@ import { formatPeriodLabel } from '#reports/domain/period-labels.js'
 /** @type {Set<import('#reports/domain/report-status.js').ReportStatus>} */
 const REVIEWABLE_REPORT_STATUSES = new Set([
   REPORT_STATUS.SUBMITTED,
-  REPORT_STATUS.IN_PROGRESS
+  REPORT_STATUS.IN_PROGRESS,
+  REPORT_STATUS.READY_TO_SUBMIT
 ])
+
+/**
+ * Extracts the YYYY-MM-DD calendar date from a report's stored startDate/
+ * endDate, which may be a bare date string (createReportForPeriod, via
+ * formatDateISO) or a full ISO datetime string (summary-log-triggered report
+ * creation), depending on which code path created the report.
+ *
+ * @param {string} dateString
+ * @returns {string}
+ */
+const calendarDate = (dateString) => dateString.slice(0, 10)
+
+/**
+ * @param {string} dateString
+ * @returns {Date}
+ */
+const startOfDay = (dateString) =>
+  new Date(`${calendarDate(dateString)}T00:00:00.000Z`)
+
+/**
+ * @param {string} dateString
+ * @returns {Date}
+ */
+const endOfDay = (dateString) =>
+  new Date(`${calendarDate(dateString)}T23:59:59.999Z`)
 
 /**
  * Sum of tonnage for PRNs issued within the period but currently cancelled or
@@ -29,8 +55,9 @@ const issuedButLaterCancelledTonnage = (prns, { startDate, endDate }) => {
 }
 
 /**
- * Submitted or in-progress monthly report rows extracted from the estate-wide
- * periodic report groupings, flattened to the fields this diagnostic needs.
+ * Submitted, in-progress, or ready-to-submit monthly report rows extracted
+ * from the estate-wide periodic report groupings, flattened to the fields
+ * this diagnostic needs.
  *
  * @param {import('#reports/repository/port.js').PeriodicReport[]} periodicReports
  * @returns {Array<{
@@ -91,8 +118,8 @@ export const findReviewableMonthlyReportRows = (periodicReports) =>
  */
 export const diagnoseReportRow = (row, prns) => {
   const period = {
-    startDate: new Date(row.startDate),
-    endDate: new Date(row.endDate)
+    startDate: startOfDay(row.startDate),
+    endDate: endOfDay(row.endDate)
   }
   const recalculatedTonnage = aggregateIssuedTonnage(prns, period)
 
@@ -125,9 +152,9 @@ export const formatStaleIssuedTonnageFinding = (finding) =>
   `issued-but-later-cancelled ${finding.issuedButLaterCancelledTonnage}`
 
 /**
- * Scans every submitted or in-progress monthly report across the estate,
- * recalculates issuedTonnage from the current PRN state, and returns the
- * reports whose stored value no longer matches. Read-only.
+ * Scans every submitted, in-progress, or ready-to-submit monthly report
+ * across the estate, recalculates issuedTonnage from the current PRN state,
+ * and returns the reports whose stored value no longer matches. Read-only.
  *
  * @param {Object} params
  * @param {import('#reports/repository/port.js').ReportsRepository} params.reportsRepository

--- a/src/reports/monitoring/stale-issued-tonnage.test.js
+++ b/src/reports/monitoring/stale-issued-tonnage.test.js
@@ -1,11 +1,17 @@
+import { ObjectId } from 'mongodb'
 import { describe, expect, it, vi } from 'vitest'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
+import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
+import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import {
   diagnoseReportRow,
   findReviewableMonthlyReportRows,
   findStaleIssuedTonnageReports,
   formatStaleIssuedTonnageFinding
 } from './stale-issued-tonnage.js'
+
+const newId = () => new ObjectId().toHexString()
 
 const ACTOR = { id: 'u', name: 'U' }
 const IN_PERIOD = new Date('2025-06-15T12:00:00Z')
@@ -29,8 +35,8 @@ function buildRow(overrides = {}) {
     registrationId: 'reg-1',
     year: 2025,
     period: 6,
-    startDate: '2025-06-01T00:00:00.000Z',
-    endDate: '2025-06-30T23:59:59.999Z',
+    startDate: '2025-06-01',
+    endDate: '2025-06-30',
     reportId: 'report-1',
     reportStatus: 'submitted',
     storedIssuedTonnage: 50,
@@ -51,8 +57,8 @@ describe('findReviewableMonthlyReportRows', () => {
       reports: {
         monthly: {
           6: {
-            startDate: '2025-06-01T00:00:00.000Z',
-            endDate: '2025-06-30T23:59:59.999Z',
+            startDate: '2025-06-01',
+            endDate: '2025-06-30',
             dueDate: '2025-07-15T00:00:00.000Z',
             current: {
               id: 'report-1',
@@ -75,8 +81,8 @@ describe('findReviewableMonthlyReportRows', () => {
         registrationId: 'reg-1',
         year: 2025,
         period: 6,
-        startDate: '2025-06-01T00:00:00.000Z',
-        endDate: '2025-06-30T23:59:59.999Z',
+        startDate: '2025-06-01',
+        endDate: '2025-06-30',
         reportId: 'report-1',
         reportStatus: 'submitted',
         storedIssuedTonnage: 50
@@ -98,7 +104,7 @@ describe('findReviewableMonthlyReportRows', () => {
     expect(rows).toHaveLength(1)
   })
 
-  it('excludes a ready_to_submit report', () => {
+  it('includes a ready_to_submit report', () => {
     const periodicReport = basePeriodicReport({
       current: {
         id: 'report-1',
@@ -107,7 +113,9 @@ describe('findReviewableMonthlyReportRows', () => {
       }
     })
 
-    expect(findReviewableMonthlyReportRows([periodicReport])).toEqual([])
+    const rows = findReviewableMonthlyReportRows([periodicReport])
+
+    expect(rows).toHaveLength(1)
   })
 
   it('excludes a report with no prn data (non-accredited operator)', () => {
@@ -225,6 +233,186 @@ describe('diagnoseReportRow', () => {
 
     expect(diagnoseReportRow(row, prns)).toBeNull()
   })
+
+  it('counts a PRN issued in the afternoon of the period end date (last-day boundary)', () => {
+    const row = buildRow({ storedIssuedTonnage: 50 })
+    const issuedLateOnEndDate = new Date('2025-06-30T10:31:50.375Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.ACCEPTED,
+        currentStatusAt: issuedLateOnEndDate,
+        issued: { at: issuedLateOnEndDate, by: ACTOR }
+      })
+    ]
+
+    expect(diagnoseReportRow(row, prns)).toBeNull()
+  })
+
+  it('counts a PRN issued moments before midnight on the period end date', () => {
+    const row = buildRow({ storedIssuedTonnage: 50 })
+    const issuedAtEndOfDay = new Date('2025-06-30T23:59:59.998Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.ACCEPTED,
+        currentStatusAt: issuedAtEndOfDay,
+        issued: { at: issuedAtEndOfDay, by: ACTOR }
+      })
+    ]
+
+    expect(diagnoseReportRow(row, prns)).toBeNull()
+  })
+
+  it('counts a PRN issued at the first moment of the period start date', () => {
+    const row = buildRow({ storedIssuedTonnage: 50 })
+    const issuedAtStartOfDay = new Date('2025-06-01T00:00:00.000Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.ACCEPTED,
+        currentStatusAt: issuedAtStartOfDay,
+        issued: { at: issuedAtStartOfDay, by: ACTOR }
+      })
+    ]
+
+    expect(diagnoseReportRow(row, prns)).toBeNull()
+  })
+
+  it('excludes a PRN issued one millisecond after the period end date', () => {
+    const row = buildRow({ storedIssuedTonnage: 0 })
+    const issuedJustAfterEnd = new Date('2025-07-01T00:00:00.000Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.ACCEPTED,
+        currentStatusAt: issuedJustAfterEnd,
+        issued: { at: issuedJustAfterEnd, by: ACTOR }
+      })
+    ]
+
+    expect(diagnoseReportRow(row, prns)).toBeNull()
+  })
+
+  it('excludes a PRN issued one millisecond before the period start date', () => {
+    const row = buildRow({ storedIssuedTonnage: 0 })
+    const issuedJustBeforeStart = new Date('2025-05-31T23:59:59.999Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.ACCEPTED,
+        currentStatusAt: issuedJustBeforeStart,
+        issued: { at: issuedJustBeforeStart, by: ACTOR }
+      })
+    ]
+
+    expect(diagnoseReportRow(row, prns)).toBeNull()
+  })
+
+  it('includes issued-but-later-cancelled tonnage for a PRN cancelled after being issued late on the period end date', () => {
+    const row = buildRow({ storedIssuedTonnage: 50 })
+    const issuedLateOnEndDate = new Date('2025-06-30T10:22:50.901Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.CANCELLED,
+        currentStatusAt: AFTER_PERIOD,
+        issued: { at: issuedLateOnEndDate, by: ACTOR },
+        cancelled: { at: AFTER_PERIOD, by: ACTOR }
+      })
+    ]
+
+    const finding = diagnoseReportRow(row, prns)
+
+    expect(finding).toMatchObject({
+      recalculatedTonnage: 0,
+      issuedButLaterCancelledTonnage: 50
+    })
+  })
+
+  it('includes issued-but-later-cancelled tonnage for a PRN awaiting cancellation after being issued late on the period end date', () => {
+    const row = buildRow({ storedIssuedTonnage: 50 })
+    const issuedLateOnEndDate = new Date('2025-06-30T10:22:50.901Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
+        currentStatusAt: AFTER_PERIOD,
+        issued: { at: issuedLateOnEndDate, by: ACTOR }
+      })
+    ]
+
+    const finding = diagnoseReportRow(row, prns)
+
+    expect(finding).toMatchObject({
+      recalculatedTonnage: 0,
+      issuedButLaterCancelledTonnage: 50
+    })
+  })
+
+  it('excludes issued-but-later-cancelled tonnage for a cancelled PRN issued one millisecond after the period end date', () => {
+    const row = buildRow({ storedIssuedTonnage: 0 })
+    const issuedJustAfterEnd = new Date('2025-07-01T00:00:00.000Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.CANCELLED,
+        currentStatusAt: AFTER_PERIOD,
+        issued: { at: issuedJustAfterEnd, by: ACTOR },
+        cancelled: { at: AFTER_PERIOD, by: ACTOR }
+      })
+    ]
+
+    expect(diagnoseReportRow(row, prns)).toBeNull()
+  })
+
+  it('excludes issued-but-later-cancelled tonnage for an awaiting-cancellation PRN issued one millisecond before the period start date', () => {
+    const row = buildRow({ storedIssuedTonnage: 0 })
+    const issuedJustBeforeStart = new Date('2025-05-31T23:59:59.999Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.AWAITING_CANCELLATION,
+        currentStatusAt: AFTER_PERIOD,
+        issued: { at: issuedJustBeforeStart, by: ACTOR }
+      })
+    ]
+
+    expect(diagnoseReportRow(row, prns)).toBeNull()
+  })
+
+  it('counts a PRN issued late on the period end date when the row stores full ISO datetime strings, not bare dates', () => {
+    const row = buildRow({
+      storedIssuedTonnage: 50,
+      startDate: '2025-06-01T00:00:00.000Z',
+      endDate: '2025-06-30T00:00:00.000Z'
+    })
+    const issuedLateOnEndDate = new Date('2025-06-30T10:31:50.375Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.ACCEPTED,
+        currentStatusAt: issuedLateOnEndDate,
+        issued: { at: issuedLateOnEndDate, by: ACTOR }
+      })
+    ]
+
+    expect(diagnoseReportRow(row, prns)).toBeNull()
+  })
+
+  it('includes issued-but-later-cancelled tonnage for a cancelled PRN issued late on the period end date when the row stores full ISO datetime strings', () => {
+    const row = buildRow({
+      storedIssuedTonnage: 50,
+      startDate: '2025-06-01T00:00:00.000Z',
+      endDate: '2025-06-30T00:00:00.000Z'
+    })
+    const issuedLateOnEndDate = new Date('2025-06-30T10:31:50.375Z')
+    const prns = [
+      buildPrn(50, {
+        currentStatus: PRN_STATUS.CANCELLED,
+        currentStatusAt: AFTER_PERIOD,
+        issued: { at: issuedLateOnEndDate, by: ACTOR },
+        cancelled: { at: AFTER_PERIOD, by: ACTOR }
+      })
+    ]
+
+    const finding = diagnoseReportRow(row, prns)
+
+    expect(finding).toMatchObject({
+      recalculatedTonnage: 0,
+      issuedButLaterCancelledTonnage: 50
+    })
+  })
 })
 
 describe('formatStaleIssuedTonnageFinding', () => {
@@ -249,98 +437,183 @@ describe('formatStaleIssuedTonnageFinding', () => {
 })
 
 describe('findStaleIssuedTonnageReports', () => {
-  const periodicReportFor = (organisationId, registrationId) => ({
+  /**
+   * Builds a submitted monthly report document as it would be persisted,
+   * seeded directly into the in-memory reports repository's store (bypassing
+   * the create/status-transition API, which isn't needed for read-path tests).
+   */
+  const buildStoredReport = ({
+    organisationId,
+    registrationId,
+    reportId = 'report-1',
+    issuedTonnage = 999
+  }) => ({
+    id: reportId,
+    version: 1,
+    schemaVersion: 1,
     organisationId,
     registrationId,
     year: 2025,
-    reports: {
-      monthly: {
-        6: {
-          startDate: '2025-06-01T00:00:00.000Z',
-          endDate: '2025-06-30T23:59:59.999Z',
-          dueDate: '2025-07-15T00:00:00.000Z',
-          current: {
-            id: 'report-1',
-            status: 'submitted',
-            prn: { issuedTonnage: 999 }
-          },
-          previousSubmissions: []
-        }
-      }
+    cadence: 'monthly',
+    period: 6,
+    submissionNumber: 1,
+    startDate: '2025-06-01',
+    endDate: '2025-06-30',
+    dueDate: '2025-07-15T00:00:00.000Z',
+    prn: { issuedTonnage },
+    status: {
+      currentStatus: 'submitted',
+      currentStatusAt: '2025-07-01T00:00:00.000Z',
+      submitted: { at: '2025-07-01T00:00:00.000Z', by: ACTOR },
+      history: [
+        { status: 'submitted', at: '2025-07-01T00:00:00.000Z', by: ACTOR }
+      ]
     }
   })
 
+  const APPROVED_STATUS_HISTORY = [
+    { status: 'approved', updatedAt: '2025-01-01T00:00:00.000Z' }
+  ]
+
+  const buildOrganisationWithAccreditation = ({
+    organisationId,
+    registrationId,
+    accreditationId
+  }) =>
+    /** @type {any} */ ({
+      id: organisationId,
+      statusHistory: APPROVED_STATUS_HISTORY,
+      registrations: [
+        {
+          id: registrationId,
+          accreditationId,
+          statusHistory: APPROVED_STATUS_HISTORY
+        }
+      ],
+      accreditations: accreditationId
+        ? [{ id: accreditationId, statusHistory: APPROVED_STATUS_HISTORY }]
+        : []
+    })
+
   it('skips a row whose registration lookup throws (e.g. deleted org/registration)', async () => {
-    const packagingRecyclingNotesRepository = {
-      findByAccreditation: vi.fn()
-    }
-    const { scanned, findings } = await findStaleIssuedTonnageReports(
-      /** @type {any} */ ({
-        reportsRepository: {
-          findAllPeriodicReports: vi
-            .fn()
-            .mockResolvedValue([periodicReportFor('org-1', 'reg-1')])
-        },
-        organisationsRepository: {
-          findRegistrationById: vi
-            .fn()
-            .mockRejectedValue(new Error('not found'))
-        },
-        packagingRecyclingNotesRepository
-      })
-    )
+    const organisationId = newId()
+    const registrationId = newId()
+    const reportsRepository = createInMemoryReportsRepository(
+      new Map([
+        [
+          'report-1',
+          buildStoredReport({
+            organisationId,
+            registrationId
+          })
+        ]
+      ])
+    )()
+    const organisationsRepository = createInMemoryOrganisationsRepository([])()
+    const findByAccreditation = vi.fn()
+    const packagingRecyclingNotesRepository = /** @type {any} */ ({
+      findByAccreditation
+    })
+
+    const { scanned, findings } = await findStaleIssuedTonnageReports({
+      reportsRepository,
+      organisationsRepository,
+      packagingRecyclingNotesRepository
+    })
 
     expect(scanned).toBe(1)
     expect(findings).toEqual([])
-    expect(
-      packagingRecyclingNotesRepository.findByAccreditation
-    ).not.toHaveBeenCalled()
+    expect(findByAccreditation).not.toHaveBeenCalled()
   })
 
   it('skips a row whose registration has no accreditationId', async () => {
-    const packagingRecyclingNotesRepository = {
-      findByAccreditation: vi.fn()
-    }
-    const { findings } = await findStaleIssuedTonnageReports(
-      /** @type {any} */ ({
-        reportsRepository: {
-          findAllPeriodicReports: vi
-            .fn()
-            .mockResolvedValue([periodicReportFor('org-1', 'reg-1')])
-        },
-        organisationsRepository: {
-          findRegistrationById: vi.fn().mockResolvedValue({})
-        },
-        packagingRecyclingNotesRepository
+    const organisationId = newId()
+    const registrationId = newId()
+    const reportsRepository = createInMemoryReportsRepository(
+      new Map([
+        [
+          'report-1',
+          buildStoredReport({
+            organisationId,
+            registrationId
+          })
+        ]
+      ])
+    )()
+    const organisationsRepository = createInMemoryOrganisationsRepository([
+      buildOrganisationWithAccreditation({
+        organisationId,
+        registrationId,
+        accreditationId: undefined
       })
-    )
+    ])()
+    const findByAccreditation = vi.fn()
+    const packagingRecyclingNotesRepository = /** @type {any} */ ({
+      findByAccreditation
+    })
+
+    const { findings } = await findStaleIssuedTonnageReports({
+      reportsRepository,
+      organisationsRepository,
+      packagingRecyclingNotesRepository
+    })
 
     expect(findings).toEqual([])
-    expect(
-      packagingRecyclingNotesRepository.findByAccreditation
-    ).not.toHaveBeenCalled()
+    expect(findByAccreditation).not.toHaveBeenCalled()
   })
 
   it('reuses a cached PRN list for a second row sharing the same accreditationId', async () => {
-    const findByAccreditation = vi.fn().mockResolvedValue([])
-    const { scanned, findings } = await findStaleIssuedTonnageReports(
-      /** @type {any} */ ({
-        reportsRepository: {
-          findAllPeriodicReports: vi
-            .fn()
-            .mockResolvedValue([
-              periodicReportFor('org-1', 'reg-1'),
-              periodicReportFor('org-2', 'reg-2')
-            ])
-        },
-        organisationsRepository: {
-          findRegistrationById: vi
-            .fn()
-            .mockResolvedValue({ accreditationId: 'acc-1' })
-        },
-        packagingRecyclingNotesRepository: { findByAccreditation }
+    const organisationId1 = newId()
+    const registrationId1 = newId()
+    const organisationId2 = newId()
+    const registrationId2 = newId()
+    const accreditationId = newId()
+    const reportsRepository = createInMemoryReportsRepository(
+      new Map([
+        [
+          'report-1',
+          buildStoredReport({
+            organisationId: organisationId1,
+            registrationId: registrationId1,
+            reportId: 'report-1'
+          })
+        ],
+        [
+          'report-2',
+          buildStoredReport({
+            organisationId: organisationId2,
+            registrationId: registrationId2,
+            reportId: 'report-2'
+          })
+        ]
+      ])
+    )()
+    const organisationsRepository = createInMemoryOrganisationsRepository([
+      buildOrganisationWithAccreditation({
+        organisationId: organisationId1,
+        registrationId: registrationId1,
+        accreditationId
+      }),
+      buildOrganisationWithAccreditation({
+        organisationId: organisationId2,
+        registrationId: registrationId2,
+        accreditationId
       })
+    ])()
+    const packagingRecyclingNotesRepository =
+      createInMemoryPackagingRecyclingNotesRepository([])(
+        /** @type {any} */ ({ error: vi.fn() })
+      )
+    const findByAccreditation = vi.spyOn(
+      packagingRecyclingNotesRepository,
+      'findByAccreditation'
     )
+
+    const { scanned, findings } = await findStaleIssuedTonnageReports({
+      reportsRepository,
+      organisationsRepository,
+      packagingRecyclingNotesRepository
+    })
 
     expect(scanned).toBe(2)
     expect(findings).toHaveLength(2)
@@ -348,26 +621,92 @@ describe('findStaleIssuedTonnageReports', () => {
   })
 
   it('does not report a row whose recalculated tonnage matches the stored value', async () => {
-    const periodicReport = periodicReportFor('org-1', 'reg-1')
-    periodicReport.reports.monthly[6].current.prn.issuedTonnage = 0
-
-    const { scanned, findings } = await findStaleIssuedTonnageReports(
-      /** @type {any} */ ({
-        reportsRepository: {
-          findAllPeriodicReports: vi.fn().mockResolvedValue([periodicReport])
-        },
-        organisationsRepository: {
-          findRegistrationById: vi
-            .fn()
-            .mockResolvedValue({ accreditationId: 'acc-1' })
-        },
-        packagingRecyclingNotesRepository: {
-          findByAccreditation: vi.fn().mockResolvedValue([])
-        }
+    const organisationId = newId()
+    const registrationId = newId()
+    const accreditationId = newId()
+    const reportsRepository = createInMemoryReportsRepository(
+      new Map([
+        [
+          'report-1',
+          buildStoredReport({
+            organisationId,
+            registrationId,
+            issuedTonnage: 0
+          })
+        ]
+      ])
+    )()
+    const organisationsRepository = createInMemoryOrganisationsRepository([
+      buildOrganisationWithAccreditation({
+        organisationId,
+        registrationId,
+        accreditationId
       })
-    )
+    ])()
+    const packagingRecyclingNotesRepository =
+      createInMemoryPackagingRecyclingNotesRepository([])(
+        /** @type {any} */ ({ error: vi.fn() })
+      )
+
+    const { scanned, findings } = await findStaleIssuedTonnageReports({
+      reportsRepository,
+      organisationsRepository,
+      packagingRecyclingNotesRepository
+    })
 
     expect(scanned).toBe(1)
+    expect(findings).toEqual([])
+  })
+
+  it('reports a PRN issued in the afternoon of the period end date as counted, not stale, end-to-end through the in-memory repos', async () => {
+    const organisationId = newId()
+    const registrationId = newId()
+    const accreditationId = newId()
+    const reportsRepository = createInMemoryReportsRepository(
+      new Map([
+        [
+          'report-1',
+          buildStoredReport({
+            organisationId,
+            registrationId,
+            issuedTonnage: 50
+          })
+        ]
+      ])
+    )()
+    const organisationsRepository = createInMemoryOrganisationsRepository([
+      buildOrganisationWithAccreditation({
+        organisationId,
+        registrationId,
+        accreditationId
+      })
+    ])()
+    const packagingRecyclingNotesRepository =
+      createInMemoryPackagingRecyclingNotesRepository(
+        /** @type {any} */ ([
+          {
+            id: 'prn-1',
+            accreditation: { id: accreditationId },
+            tonnage: 50,
+            status: {
+              currentStatus: PRN_STATUS.ACCEPTED,
+              currentStatusAt: new Date('2025-06-30T10:31:50.375Z'),
+              issued: {
+                at: new Date('2025-06-30T10:31:50.375Z'),
+                by: ACTOR
+              },
+              history: []
+            }
+          }
+        ])
+      )(/** @type {any} */ ({ error: vi.fn() }))
+
+    const { findings } = await findStaleIssuedTonnageReports({
+      reportsRepository,
+      organisationsRepository,
+      packagingRecyclingNotesRepository
+    })
+
     expect(findings).toEqual([])
   })
 })

--- a/src/reports/repository/contract/findAllPeriodicReports.contract.js
+++ b/src/reports/repository/contract/findAllPeriodicReports.contract.js
@@ -255,9 +255,9 @@ export const testFindAllPeriodicReportsBehaviour = (it) => {
         buildCreateReportParams({
           period: MONTHLY_PERIODS.January,
           year: NEXT_YEAR,
-          startDate: `${NEXT_YEAR}-01-01T00:00:00.000Z`,
-          endDate: `${NEXT_YEAR}-01-31T00:00:00.000Z`,
-          dueDate: `${NEXT_YEAR}-02-15T00:00:00.000Z`
+          startDate: `${NEXT_YEAR}-01-01`,
+          endDate: `${NEXT_YEAR}-01-31`,
+          dueDate: `${NEXT_YEAR}-02-15`
         })
       )
 

--- a/src/reports/repository/contract/test-data.js
+++ b/src/reports/repository/contract/test-data.js
@@ -9,9 +9,9 @@ import {
 
 export const DEFAULT_ORG_ID = new ObjectId().toString()
 export const DEFAULT_REG_ID = new ObjectId().toString()
-export const DEFAULT_REPORT_START_DATE = '2024-01-01T00:00:00.000Z'
-export const DEFAULT_REPORT_END_DATE = '2024-01-31T00:00:00.000Z'
-export const DEFAULT_REPORT_DUE_DATE = '2024-02-15T00:00:00.000Z'
+export const DEFAULT_REPORT_START_DATE = '2024-01-01'
+export const DEFAULT_REPORT_END_DATE = '2024-01-31'
+export const DEFAULT_REPORT_DUE_DATE = '2024-02-15'
 export const DEFAULT_REPORT_YEAR = 2024
 export const DEFAULT_REPORT_PERIOD = MONTHLY_PERIODS.January
 

--- a/src/reports/repository/helpers.js
+++ b/src/reports/repository/helpers.js
@@ -1,9 +1,23 @@
+import { calendarDate } from '#common/helpers/date-formatter.js'
 import {
   REPORT_STATUS,
   REPORT_STATUS_SLOT
 } from '#reports/domain/report-status.js'
 import { periodKey } from '#reports/domain/period-key.js'
 import { randomUUID } from 'node:crypto'
+
+const BARE_DATE_LENGTH = 10
+
+/**
+ * Only reports persisted before the bare-date schema fix carry a full ISO
+ * datetime here (historical Joi coercion); new reports are already bare, so
+ * this only does work for the old-shape case. Safe to delete once no
+ * pre-fix reports remain.
+ * @param {string} dateString
+ * @returns {string}
+ */
+const backCompatCalendarDate = (dateString) =>
+  dateString.length > BARE_DATE_LENGTH ? calendarDate(dateString) : dateString
 
 /**
  * Picks the latest submission (highest submissionNumber) per reporting period
@@ -112,9 +126,9 @@ export const groupAsPeriodicReports = (
     )
     const { startDate, endDate, dueDate } = first
     return {
-      startDate,
-      endDate,
-      dueDate,
+      startDate: backCompatCalendarDate(startDate),
+      endDate: backCompatCalendarDate(endDate),
+      dueDate: backCompatCalendarDate(dueDate),
       current: toSubmission(first),
       previousSubmissions: rest.map(toSubmission)
     }

--- a/src/reports/repository/inmemory.test.js
+++ b/src/reports/repository/inmemory.test.js
@@ -17,4 +17,44 @@ describe('In-memory reports repository', () => {
   describe('reports repository contract', () => {
     testReportsRepositoryContract(it)
   })
+
+  describe('backward compatibility with already-coerced report documents', () => {
+    it('resolves the correct start/end-of-day boundary for a report persisted before the bare-date schema fix', async () => {
+      const oldShapeReport = {
+        id: 'legacy-report-1',
+        version: 1,
+        schemaVersion: 1,
+        organisationId: '507f1f77bcf86cd799439011',
+        registrationId: '507f1f77bcf86cd799439012',
+        year: 2024,
+        cadence: 'monthly',
+        period: 1,
+        submissionNumber: 1,
+        startDate: '2024-01-01T00:00:00.000Z',
+        endDate: '2024-01-31T00:00:00.000Z',
+        dueDate: '2024-02-15T00:00:00.000Z',
+        prn: { issuedTonnage: 100 },
+        status: {
+          currentStatus: 'submitted',
+          currentStatusAt: '2024-02-01T00:00:00.000Z',
+          submitted: { at: '2024-02-01T00:00:00.000Z', by: { id: 'u' } },
+          history: []
+        }
+      }
+
+      const repository = createInMemoryReportsRepository(
+        new Map([['legacy-report-1', oldShapeReport]])
+      )()
+
+      const [periodicReport] = await repository.findAllPeriodicReports()
+      const slot =
+        /** @type {NonNullable<typeof periodicReport.reports.monthly>} */ (
+          periodicReport.reports.monthly
+        )[1]
+
+      expect(slot.startDate).toBe('2024-01-01')
+      expect(slot.endDate).toBe('2024-01-31')
+      expect(slot.dueDate).toBe('2024-02-15')
+    })
+  })
 })

--- a/src/reports/repository/mongodb.test.js
+++ b/src/reports/repository/mongodb.test.js
@@ -46,6 +46,50 @@ describe('MongoDB reports repository', () => {
     testReportsRepositoryContract(it)
   })
 
+  describe('backward compatibility with already-coerced report documents', () => {
+    it('resolves the correct start/end-of-day boundary for a report persisted before the bare-date schema fix', /** @param {ReportsFixtures} fixture */ async ({
+      mongoClient,
+      reportsRepository
+    }) => {
+      const database = mongoClient.db(DATABASE_NAME)
+      await database.collection('reports').insertOne(
+        /** @type {any} */ ({
+          _id: 'legacy-report-1',
+          id: 'legacy-report-1',
+          version: 1,
+          schemaVersion: 1,
+          organisationId: '507f1f77bcf86cd799439011',
+          registrationId: '507f1f77bcf86cd799439012',
+          year: 2024,
+          cadence: 'monthly',
+          period: 1,
+          submissionNumber: 1,
+          startDate: '2024-01-01T00:00:00.000Z',
+          endDate: '2024-01-31T00:00:00.000Z',
+          dueDate: '2024-02-21T00:00:00.000Z',
+          prn: { issuedTonnage: 100 },
+          status: {
+            currentStatus: 'submitted',
+            currentStatusAt: '2024-02-01T00:00:00.000Z',
+            submitted: { at: '2024-02-01T00:00:00.000Z', by: { id: 'u' } },
+            history: []
+          }
+        })
+      )
+
+      const repository = reportsRepository()
+      const [periodicReport] = await repository.findAllPeriodicReports()
+      const slot =
+        /** @type {NonNullable<typeof periodicReport.reports.monthly>} */ (
+          periodicReport.reports.monthly
+        )[1]
+
+      expect(slot.startDate).toBe('2024-01-01')
+      expect(slot.endDate).toBe('2024-01-31')
+      expect(slot.dueDate).toBe('2024-02-21')
+    })
+  })
+
   describe('MongoDB-specific error handling', () => {
     it('re-throws non-duplicate key errors during createReport', async () => {
       const unexpectedError = createMongoError('Database connection lost', {

--- a/src/reports/repository/port.js
+++ b/src/reports/repository/port.js
@@ -153,9 +153,9 @@
  * @property {number} year
  * @property {string} cadence
  * @property {number} period
- * @property {string} startDate
- * @property {string} endDate
- * @property {string} dueDate
+ * @property {string} startDate - Bare calendar date (YYYY-MM-DD)
+ * @property {string} endDate - Bare calendar date (YYYY-MM-DD)
+ * @property {string} dueDate - Bare calendar date (YYYY-MM-DD)
  * @property {ReportStatusObject} status
  * @property {string} [material]
  * @property {string} [wasteProcessingType]
@@ -194,9 +194,11 @@
 
 /**
  * @typedef {Object} ReportPerPeriod
- * @property {string} startDate - ISO date string
- * @property {string} endDate - ISO date string
- * @property {string} dueDate - ISO date string
+ * @property {string} startDate - Bare calendar date (YYYY-MM-DD), no timezone. Use
+ *   startOfDay()/endOfDay() from #common/helpers/date-formatter.js to derive
+ *   a concrete instant.
+ * @property {string} endDate - Bare calendar date (YYYY-MM-DD), no timezone.
+ * @property {string} dueDate - Bare calendar date (YYYY-MM-DD), no timezone.
  * @property {ReportSummary|null} current
  * @property {ReportSummary[]} previousSubmissions
  */
@@ -229,9 +231,11 @@
  * @property {number} year
  * @property {string} cadence - 'monthly' or 'quarterly'
  * @property {number} period
- * @property {string} startDate - ISO date string
- * @property {string} endDate - ISO date string
- * @property {string} dueDate - ISO date string
+ * @property {string} startDate - Bare calendar date (YYYY-MM-DD), no timezone. Use
+ *   startOfDay()/endOfDay() from #common/helpers/date-formatter.js to derive
+ *   a concrete instant.
+ * @property {string} endDate - Bare calendar date (YYYY-MM-DD), no timezone.
+ * @property {string} dueDate - Bare calendar date (YYYY-MM-DD), no timezone.
  * @property {UserSummary} changedBy
  * @property {number} submissionNumber
  * @property {string} [material]

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -19,6 +19,13 @@ const YEAR_SCHEMA = Joi.number()
 const MONGO_ID_LENGTH = 24
 const MONGO_ID_SCHEMA = Joi.string().hex().length(MONGO_ID_LENGTH).required()
 
+const CALENDAR_DATE_SCHEMA = Joi.string()
+  .pattern(/^\d{4}-\d{2}-\d{2}$/)
+  .required()
+  .messages({
+    'string.pattern.base': 'must be a bare YYYY-MM-DD date, not a full datetime'
+  })
+
 export const cadenceSchema = Joi.string()
   .valid(...Object.values(CADENCE))
   .required()
@@ -141,9 +148,9 @@ export const createReportSchema = Joi.object({
   year: YEAR_SCHEMA,
   cadence: cadenceSchema,
   period: periodSchema,
-  startDate: Joi.string().isoDate().required(),
-  endDate: Joi.string().isoDate().required(),
-  dueDate: Joi.string().isoDate().required(),
+  startDate: CALENDAR_DATE_SCHEMA,
+  endDate: CALENDAR_DATE_SCHEMA,
+  dueDate: CALENDAR_DATE_SCHEMA,
   material: Joi.string()
     .valid(...TONNAGE_MONITORING_MATERIALS)
     .required(),

--- a/src/reports/repository/validation.js
+++ b/src/reports/repository/validation.js
@@ -20,7 +20,8 @@ import {
  */
 export const validateCreateReport = (params) => {
   const { error, value } = createReportSchema.validate(params, {
-    abortEarly: false
+    abortEarly: false,
+    convert: false
   })
 
   if (error) {

--- a/src/reports/repository/validation.test.js
+++ b/src/reports/repository/validation.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { buildCreateReportParams } from './contract/test-data.js'
+import { validateCreateReport } from './validation.js'
+
+describe('validateCreateReport', () => {
+  it('accepts bare YYYY-MM-DD startDate/endDate/dueDate unchanged', () => {
+    const params = buildCreateReportParams({
+      startDate: '2024-01-01',
+      endDate: '2024-01-31',
+      dueDate: '2024-02-15'
+    })
+
+    const validated = validateCreateReport(params)
+
+    expect(validated.startDate).toBe('2024-01-01')
+    expect(validated.endDate).toBe('2024-01-31')
+    expect(validated.dueDate).toBe('2024-02-15')
+  })
+
+  it('rejects a full ISO datetime startDate instead of silently coercing it', () => {
+    const params = buildCreateReportParams({
+      startDate: '2024-01-01T00:00:00.000Z'
+    })
+
+    expect(() => validateCreateReport(params)).toThrow(
+      /must be a bare YYYY-MM-DD date/
+    )
+  })
+
+  it('rejects a full ISO datetime endDate instead of silently coercing it', () => {
+    const params = buildCreateReportParams({
+      endDate: '2024-01-31T00:00:00.000Z'
+    })
+
+    expect(() => validateCreateReport(params)).toThrow(
+      /must be a bare YYYY-MM-DD date/
+    )
+  })
+
+  it('rejects a full ISO datetime dueDate instead of silently coercing it', () => {
+    const params = buildCreateReportParams({
+      dueDate: '2024-02-15T00:00:00.000Z'
+    })
+
+    expect(() => validateCreateReport(params)).toThrow(
+      /must be a bare YYYY-MM-DD date/
+    )
+  })
+})

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.loads-by-period-status.test.js
@@ -142,9 +142,9 @@ describe('loadsByReportingPeriod population at validate time', () => {
       year: 2025,
       cadence: 'monthly',
       period: MONTHLY_PERIODS.January,
-      startDate: '2025-01-01T00:00:00.000Z',
-      endDate: '2025-01-31T00:00:00.000Z',
-      dueDate: '2025-02-20T00:00:00.000Z'
+      startDate: '2025-01-01',
+      endDate: '2025-01-31',
+      dueDate: '2025-02-20'
     })
 
   const emptyChange = () => ({
@@ -707,9 +707,9 @@ describe('loadsByReportingPeriod population at validate time', () => {
       year: 2025,
       cadence: 'quarterly',
       period: QUARTERLY_PERIODS.Q1,
-      startDate: '2025-01-01T00:00:00.000Z',
-      endDate: '2025-03-31T00:00:00.000Z',
-      dueDate: '2025-05-20T00:00:00.000Z'
+      startDate: '2025-01-01',
+      endDate: '2025-03-31',
+      dueDate: '2025-05-20'
     })
 
     const loadsByReportingPeriod = await uploadAndValidate(


### PR DESCRIPTION
Ticket: [PAE-1732](https://eaflood.atlassian.net/browse/PAE-1732)

- Fixes the stale issued-tonnage diagnostic silently excluding PRNs issued after midnight UTC on a period's last day, causing false-positive stale findings.
- Fixes report startDate/endDate/dueDate being silently coerced into full ISO datetimes by Joi's isoDate() validator instead of staying bare YYYY-MM-DD dates, which made endDate mean the start rather than the end of the period's last day.

[PAE-1732]: https://eaflood.atlassian.net/browse/PAE-1732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ