### PR TITLE
PAE-1738: Emit registered-only submitted events unconditionally

### DIFF
--- a/src/application/waste-records/sync-from-summary-log.js
+++ b/src/application/waste-records/sync-from-summary-log.js
@@ -304,7 +304,7 @@ const commitStateAndBalance = async ({
       overseasSites,
       summaryLogId: summaryLog.file.id
     })
-  } else if (featureFlags?.isRegisteredOnlySubmittedEventsEnabled()) {
+  } else {
     await wasteBalanceService.commitSummaryLogSubmittedEvent(
       {
         registrationId: summaryLog.registrationId,
@@ -318,9 +318,6 @@ const commitStateAndBalance = async ({
         email: user.email
       }
     )
-  } else {
-    // Registered-only submission with the flag off: its summary-log-submitted
-    // event is not recorded yet.
   }
 }
 

--- a/src/application/waste-records/sync-from-summary-log.test.js
+++ b/src/application/waste-records/sync-from-summary-log.test.js
@@ -98,11 +98,12 @@ describe('syncFromSummaryLog', () => {
     const sync = /** @type {any} */ (syncFromSummaryLog)({
       extractor,
       wasteRecordRepository,
+      wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository
     })
 
-    await sync(summaryLog)
+    await sync(summaryLog, TEST_USER)
 
     // Verify records were saved
     const savedRecords = await wasteRecordRepository.findByRegistration(
@@ -268,11 +269,12 @@ describe('syncFromSummaryLog', () => {
     const sync = /** @type {any} */ (syncFromSummaryLog)({
       extractor,
       wasteRecordRepository,
+      wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository
     })
 
-    await sync(summaryLog)
+    await sync(summaryLog, TEST_USER)
 
     // Verify record was updated
     const savedRecords = await wasteRecordRepository.findByRegistration(
@@ -357,11 +359,12 @@ describe('syncFromSummaryLog', () => {
     const sync = /** @type {any} */ (syncFromSummaryLog)({
       extractor,
       wasteRecordRepository,
+      wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository
     })
 
-    await sync(summaryLog)
+    await sync(summaryLog, TEST_USER)
 
     // Verify no new version was created
     const savedRecords = await wasteRecordRepository.findByRegistration(
@@ -444,11 +447,12 @@ describe('syncFromSummaryLog', () => {
     const sync = /** @type {any} */ (syncFromSummaryLog)({
       extractor,
       wasteRecordRepository,
+      wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository
     })
 
-    await sync(summaryLog)
+    await sync(summaryLog, TEST_USER)
 
     const savedRecords = await wasteRecordRepository.findByRegistration(
       'org-1',
@@ -541,11 +545,12 @@ describe('syncFromSummaryLog', () => {
     const sync = /** @type {any} */ (syncFromSummaryLog)({
       extractor,
       wasteRecordRepository,
+      wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository
     })
 
-    await sync(summaryLog)
+    await sync(summaryLog, TEST_USER)
 
     const savedRecords = await wasteRecordRepository.findByRegistration(
       'org-1',
@@ -628,11 +633,12 @@ describe('syncFromSummaryLog', () => {
     const sync = /** @type {any} */ (syncFromSummaryLog)({
       extractor,
       wasteRecordRepository,
+      wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository
     })
 
-    await sync(summaryLog)
+    await sync(summaryLog, TEST_USER)
 
     const savedRecords = await wasteRecordRepository.findByRegistration(
       'org-1',
@@ -694,11 +700,12 @@ describe('syncFromSummaryLog', () => {
     const sync = /** @type {any} */ (syncFromSummaryLog)({
       extractor,
       wasteRecordRepository,
+      wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository
     })
 
-    await sync(summaryLog)
+    await sync(summaryLog, TEST_USER)
 
     const savedRecords = await wasteRecordRepository.findByRegistration(
       'org-1',
@@ -755,11 +762,12 @@ describe('syncFromSummaryLog', () => {
     const sync = /** @type {any} */ (syncFromSummaryLog)({
       extractor,
       wasteRecordRepository,
+      wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository
     })
 
-    await sync(summaryLog)
+    await sync(summaryLog, TEST_USER)
 
     // Only the known table should have been processed
     const savedRecords = await wasteRecordRepository.findByRegistration(
@@ -820,11 +828,12 @@ describe('syncFromSummaryLog', () => {
     const sync = /** @type {any} */ (syncFromSummaryLog)({
       extractor,
       wasteRecordRepository,
+      wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository
     })
 
-    await sync(summaryLog)
+    await sync(summaryLog, TEST_USER)
 
     const savedRecords = await wasteRecordRepository.findByRegistration(
       'org-1',
@@ -1022,7 +1031,7 @@ describe('syncFromSummaryLog', () => {
       overseasSitesRepository
     })
 
-    await sync(summaryLog)
+    await sync(summaryLog, TEST_USER)
 
     expect(wasteBalanceService.submitSummaryLog).not.toHaveBeenCalled()
   })
@@ -1077,7 +1086,7 @@ describe('syncFromSummaryLog', () => {
       overseasSitesRepository
     })
 
-    await expect(sync(summaryLog)).rejects.toThrow(
+    await expect(sync(summaryLog, TEST_USER)).rejects.toThrow(
       'Accreditation not found: acc-missing'
     )
   })
@@ -1110,7 +1119,7 @@ describe('syncFromSummaryLog', () => {
       overseasSitesRepository
     })
 
-    await sync(summaryLog)
+    await sync(summaryLog, TEST_USER)
 
     expect(organisationsRepository.findRegistrationById).toHaveBeenCalled()
   })
@@ -1162,11 +1171,12 @@ describe('syncFromSummaryLog', () => {
       const sync = /** @type {any} */ (syncFromSummaryLog)({
         extractor,
         wasteRecordRepository,
+        wasteBalanceService,
         organisationsRepository,
         overseasSitesRepository
       })
 
-      const result = await sync(summaryLog)
+      const result = await sync(summaryLog, TEST_USER)
 
       expect(result).toEqual({
         created: 2,
@@ -1251,11 +1261,12 @@ describe('syncFromSummaryLog', () => {
       const sync = /** @type {any} */ (syncFromSummaryLog)({
         extractor,
         wasteRecordRepository,
+        wasteBalanceService,
         organisationsRepository,
         overseasSitesRepository
       })
 
-      const result = await sync(summaryLog)
+      const result = await sync(summaryLog, TEST_USER)
 
       expect(result).toEqual({
         created: 1,
@@ -1335,11 +1346,12 @@ describe('syncFromSummaryLog', () => {
       const sync = /** @type {any} */ (syncFromSummaryLog)({
         extractor,
         wasteRecordRepository,
+        wasteBalanceService,
         organisationsRepository,
         overseasSitesRepository
       })
 
-      const result = await sync(summaryLog)
+      const result = await sync(summaryLog, TEST_USER)
 
       expect(result).toEqual({
         created: 0,
@@ -1388,11 +1400,12 @@ describe('syncFromSummaryLog', () => {
     const sync = /** @type {any} */ (syncFromSummaryLog)({
       extractor,
       wasteRecordRepository,
+      wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository
     })
 
-    const result = await sync(summaryLog)
+    const result = await sync(summaryLog, TEST_USER)
 
     expect(result).toEqual({ created: 2, updated: 0 })
 
@@ -1487,11 +1500,12 @@ describe('syncFromSummaryLog', () => {
     const sync = /** @type {any} */ (syncFromSummaryLog)({
       extractor,
       wasteRecordRepository,
+      wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository
     })
 
-    const result = await sync(summaryLog)
+    const result = await sync(summaryLog, TEST_USER)
 
     expect(result).toEqual({ created: 3, updated: 0 })
 
@@ -1772,9 +1786,7 @@ describe('syncFromSummaryLog', () => {
   })
 
   describe('registered-only summary-log submitted event (forward path)', () => {
-    const submittedEventsFlagOn = createInMemoryFeatureFlags({
-      registeredOnlySubmittedEvents: true
-    })
+    const featureFlags = createInMemoryFeatureFlags({})
 
     const regOnlyData = {
       meta: { PROCESSING_TYPE: { value: 'REPROCESSOR_INPUT' } },
@@ -1796,7 +1808,7 @@ describe('syncFromSummaryLog', () => {
       }
     }
 
-    const syncWith = (extractor, featureFlags) =>
+    const syncWith = (extractor) =>
       /** @type {any} */ (syncFromSummaryLog)({
         extractor,
         wasteRecordRepository,
@@ -1808,10 +1820,10 @@ describe('syncFromSummaryLog', () => {
         featureFlags
       })
 
-    it('emits a zero-delta summary-log submitted event for a reg-only submission when the flag is on', async () => {
-      const fileId = 'file-flag-on'
+    it('emits a zero-delta summary-log submitted event for a reg-only submission', async () => {
+      const fileId = 'file-reg-only'
       const summaryLog = {
-        file: { id: fileId, uri: 's3://bucket/flag-on' },
+        file: { id: fileId, uri: 's3://bucket/reg-only' },
         organisationId: 'org-1',
         registrationId: 'reg-1'
       }
@@ -1819,7 +1831,7 @@ describe('syncFromSummaryLog', () => {
         [fileId]: /** @type {any} */ (regOnlyData)
       })
 
-      await syncWith(extractor, submittedEventsFlagOn)(summaryLog, TEST_USER)
+      await syncWith(extractor)(summaryLog, TEST_USER)
 
       expect(
         wasteBalanceService.commitSummaryLogSubmittedEvent
@@ -1847,7 +1859,7 @@ describe('syncFromSummaryLog', () => {
       })
       const namedUser = { ...TEST_USER, name: 'Reg User' }
 
-      await syncWith(extractor, submittedEventsFlagOn)(summaryLog, namedUser)
+      await syncWith(extractor)(summaryLog, namedUser)
 
       expect(
         wasteBalanceService.commitSummaryLogSubmittedEvent
@@ -1860,27 +1872,6 @@ describe('syncFromSummaryLog', () => {
         { summaryLogId: fileId, creditTotal: 0 },
         { id: namedUser.id, name: 'Reg User', email: namedUser.email }
       )
-    })
-
-    it('does not emit a summary-log submitted event when the dedicated flag is off', async () => {
-      const fileId = 'file-flag-off'
-      const summaryLog = {
-        file: { id: fileId, uri: 's3://bucket/flag-off' },
-        organisationId: 'org-1',
-        registrationId: 'reg-1'
-      }
-      const extractor = createInMemorySummaryLogExtractor({
-        [fileId]: /** @type {any} */ (regOnlyData)
-      })
-
-      await syncWith(
-        extractor,
-        createInMemoryFeatureFlags({ registeredOnlySubmittedEvents: false })
-      )(summaryLog, TEST_USER)
-
-      expect(
-        wasteBalanceService.commitSummaryLogSubmittedEvent
-      ).not.toHaveBeenCalled()
     })
 
     it('does not emit a reg-only event for an accredited submission', async () => {
@@ -1920,7 +1911,7 @@ describe('syncFromSummaryLog', () => {
         })
       })
 
-      await syncWith(extractor, submittedEventsFlagOn)(summaryLog, TEST_USER)
+      await syncWith(extractor)(summaryLog, TEST_USER)
 
       expect(
         wasteBalanceService.commitSummaryLogSubmittedEvent

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -11,9 +11,6 @@ export const createConfigFeatureFlags = (config) => ({
   isSummaryLogRowStatesEnabled() {
     return config.get('featureFlags.summaryLogRowStates')
   },
-  isRegisteredOnlySubmittedEventsEnabled() {
-    return config.get('featureFlags.registeredOnlySubmittedEvents')
-  },
   isStaleIssuedTonnageReportEnabled() {
     return config.get('featureFlags.staleIssuedTonnageReport')
   }

--- a/src/feature-flags/feature-flags.config.test.js
+++ b/src/feature-flags/feature-flags.config.test.js
@@ -16,15 +16,6 @@ describe('createConfigFeatureFlags', () => {
     expect(config.get).toHaveBeenCalledWith('featureFlags.summaryLogRowStates')
   })
 
-  it('returns true when registeredOnlySubmittedEvents flag is enabled', () => {
-    const config = { get: vi.fn().mockReturnValue(true) }
-    const flags = createConfigFeatureFlags(config)
-    expect(flags.isRegisteredOnlySubmittedEventsEnabled()).toBe(true)
-    expect(config.get).toHaveBeenCalledWith(
-      'featureFlags.registeredOnlySubmittedEvents'
-    )
-  })
-
   it('returns true when staleIssuedTonnageReport flag is enabled', () => {
     const config = { get: vi.fn().mockReturnValue(true) }
     const flags = createConfigFeatureFlags(config)

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -12,9 +12,6 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   isSummaryLogRowStatesEnabled() {
     return flags.summaryLogRowStates ?? false
   },
-  isRegisteredOnlySubmittedEventsEnabled() {
-    return flags.registeredOnlySubmittedEvents ?? false
-  },
   isStaleIssuedTonnageReportEnabled() {
     return flags.staleIssuedTonnageReport ?? false
   }

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -51,25 +51,6 @@ describe('createInMemoryFeatureFlags', () => {
     expect(flags.isSummaryLogRowStatesEnabled()).toBe(false)
   })
 
-  it('returns true when registeredOnlySubmittedEvents flag is enabled', () => {
-    const flags = createInMemoryFeatureFlags({
-      registeredOnlySubmittedEvents: true
-    })
-    expect(flags.isRegisteredOnlySubmittedEventsEnabled()).toBe(true)
-  })
-
-  it('returns false when registeredOnlySubmittedEvents flag is disabled', () => {
-    const flags = createInMemoryFeatureFlags({
-      registeredOnlySubmittedEvents: false
-    })
-    expect(flags.isRegisteredOnlySubmittedEventsEnabled()).toBe(false)
-  })
-
-  it('returns false when registeredOnlySubmittedEvents flag is not provided', () => {
-    const flags = createInMemoryFeatureFlags({})
-    expect(flags.isRegisteredOnlySubmittedEventsEnabled()).toBe(false)
-  })
-
   it('returns true when staleIssuedTonnageReport flag is enabled', () => {
     const flags = createInMemoryFeatureFlags({
       staleIssuedTonnageReport: true

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -3,7 +3,6 @@
  * @property {() => boolean} isDevEndpointsEnabled
  * @property {() => boolean} isFixDuplicateAccreditationLinksEnabled
  * @property {() => boolean} isSummaryLogRowStatesEnabled
- * @property {() => boolean} isRegisteredOnlySubmittedEventsEnabled
  * @property {() => boolean} isStaleIssuedTonnageReportEnabled
  */
 
@@ -12,7 +11,6 @@
  * @property {boolean} [devEndpoints]
  * @property {boolean} [fixDuplicateAccreditationLinks]
  * @property {boolean} [summaryLogRowStates]
- * @property {boolean} [registeredOnlySubmittedEvents]
  * @property {boolean} [staleIssuedTonnageReport]
  */
 

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -378,6 +378,12 @@ describe('Submission and placeholder tests', () => {
         logger: mockLogger
       })
 
+      const syncUser = {
+        id: 'test-user',
+        email: 'test-user@example.com',
+        scope: ['some-scope']
+      }
+
       const submitterWorker = {
         validate: validateSummaryLog,
         submit: async (summaryLogId) => {
@@ -389,7 +395,7 @@ describe('Submission and placeholder tests', () => {
               existing
             )
 
-          await syncWasteRecords(summaryLog)
+          await syncWasteRecords(summaryLog, syncUser)
 
           await summaryLogsRepository.update(
             summaryLogId,


### PR DESCRIPTION
Ticket: [PAE-1738](https://eaflood.atlassian.net/browse/PAE-1738)
## What

Registered-only (null-accreditation) summary-log submissions now always emit their zero-delta `SUMMARY_LOG_SUBMITTED` head event. The emission was previously gated behind the `FEATURE_FLAG_REGISTERED_ONLY_SUBMITTED_EVENTS` feature flag; this removes the code gate so the head event fires unconditionally on the registered-only submission path.

The now-unused `isRegisteredOnlySubmittedEventsEnabled` predicate is removed from the feature-flags port, the config-backed reader, and the in-memory reader (plus their unit tests).

The convict config schema entry (`featureFlags.registeredOnlySubmittedEvents`, env `FEATURE_FLAG_REGISTERED_ONLY_SUBMITTED_EVENTS`) is deliberately retained so config parsing stays tolerant of the env var, which is still set in deployed environments. Removing the env var and its schema entry is a separate, later step to be done once this change is deployed.

## Why

This is the outstanding post-migration cleanup for registered-only submitted events (PAE-1738). Enabling the migration was meant to be followed by making emission unconditional; that second step was missed, and the flag was later switched on in prod config rather than removed from the code gate.

Because the registered-only head event only fired when the flag was on, any environment that did not set the flag never recorded it — including the journey-test harness, where the flag-on reporting journey zeroed the registered-only report. Making emission unconditional removes that environment dependency and guarantees the head event is recorded everywhere going forward.

## Tests

- The `sync-from-summary-log` forward-path suite now asserts the registered-only head event is emitted unconditionally; the flag-off no-emit case is removed.
- Registered-only persistence tests that previously omitted the waste-balance service and submitting user now supply both, since every registered-only sync now emits the head event.
- The submission integration worker now passes the submitting user through to the sync, matching the production submit worker.


[PAE-1738]: https://eaflood.atlassian.net/browse/PAE-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ