### PR TITLE
PAE-1305: enforce whole-number tonnage and validate report-detail response

### DIFF
--- a/src/common/validation/tonnage-schema.js
+++ b/src/common/validation/tonnage-schema.js
@@ -1,0 +1,10 @@
+import Joi from 'joi'
+
+/**
+ * A whole-number tonnage. PERNs/PRNs are issued in whole tonnes, so a tonnage
+ * value - and any sum of them, such as a report's issued tonnage - is a
+ * non-negative integer. Callers add `.min()` to raise the floor, `.required()`
+ * or `.allow(null)` as the field needs.
+ * @returns {import('joi').NumberSchema}
+ */
+export const wholeTonnage = () => Joi.number().integer().min(0)

--- a/src/common/validation/tonnage-schema.js
+++ b/src/common/validation/tonnage-schema.js
@@ -1,10 +1,16 @@
 import Joi from 'joi'
 
 /**
- * A whole-number tonnage. PERNs/PRNs are issued in whole tonnes, so a tonnage
- * value - and any sum of them, such as a report's issued tonnage - is a
- * non-negative integer. Callers add `.min()` to raise the floor, `.required()`
- * or `.allow(null)` as the field needs.
+ * A tonnage value: a non-negative number. Callers add `.required()`,
+ * `.allow(null)` or `.custom(...)` as the field needs.
  * @returns {import('joi').NumberSchema}
  */
-export const wholeTonnage = () => Joi.number().integer().min(0)
+export const tonnage = () => Joi.number().min(0)
+
+/**
+ * A whole-number tonnage: a tonnage that is also an integer. PERNs/PRNs are
+ * issued in whole tonnes, so a tonnage value - and any sum of them, such as a
+ * report's issued tonnage - is a non-negative integer.
+ * @returns {import('joi').NumberSchema}
+ */
+export const wholeTonnage = () => tonnage().integer()

--- a/src/common/validation/tonnage-schema.test.js
+++ b/src/common/validation/tonnage-schema.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { wholeTonnage } from './tonnage-schema.js'
+import { expectValidationError } from './validation-test-helpers.js'
+
+describe('#wholeTonnage', () => {
+  it('accepts a whole number', () => {
+    const { error, value } = wholeTonnage().validate(100)
+
+    expect(error).toBeUndefined()
+    expect(value).toBe(100)
+  })
+
+  it('accepts zero', () => {
+    const { error } = wholeTonnage().validate(0)
+
+    expect(error).toBeUndefined()
+  })
+
+  it('rejects a decimal value', () => {
+    const [detail] = expectValidationError(wholeTonnage(), 100.5)
+
+    expect(detail.type).toBe('number.integer')
+  })
+
+  it('rejects a negative value', () => {
+    const [detail] = expectValidationError(wholeTonnage(), -1)
+
+    expect(detail.type).toBe('number.min')
+  })
+})

--- a/src/common/validation/tonnage-schema.test.js
+++ b/src/common/validation/tonnage-schema.test.js
@@ -1,6 +1,27 @@
 import { describe, expect, it } from 'vitest'
-import { wholeTonnage } from './tonnage-schema.js'
+import { tonnage, wholeTonnage } from './tonnage-schema.js'
 import { expectValidationError } from './validation-test-helpers.js'
+
+describe('#tonnage', () => {
+  it('accepts a whole number', () => {
+    const { error, value } = tonnage().validate(100)
+
+    expect(error).toBeUndefined()
+    expect(value).toBe(100)
+  })
+
+  it('accepts a decimal', () => {
+    const { error } = tonnage().validate(100.5)
+
+    expect(error).toBeUndefined()
+  })
+
+  it('rejects a negative value', () => {
+    const [detail] = expectValidationError(tonnage(), -1)
+
+    expect(detail.type).toBe('number.min')
+  })
+})
 
 describe('#wholeTonnage', () => {
   it('accepts a whole number', () => {

--- a/src/packaging-recycling-notes/routes/post.schema.js
+++ b/src/packaging-recycling-notes/routes/post.schema.js
@@ -1,5 +1,7 @@
 import Joi from 'joi'
 
+import { wholeTonnage } from '#common/validation/tonnage-schema.js'
+
 const POSITIVE_INTEGER = 1
 const MAX_NOTES_LENGTH = 200
 
@@ -10,7 +12,7 @@ export const packagingRecyclingNotesCreatePayloadSchema = Joi.object({
     tradingName: Joi.string().empty(Joi.valid(null, '')).optional(),
     registrationType: Joi.string().optional()
   }).required(),
-  tonnage: Joi.number().integer().min(POSITIVE_INTEGER).required(),
+  tonnage: wholeTonnage().min(POSITIVE_INTEGER).required(),
   notes: Joi.string().max(MAX_NOTES_LENGTH).allow('').optional()
 }).messages({
   'any.required': '{#label} is required',

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -1,4 +1,5 @@
 import { toDecimal } from '#common/helpers/decimal-utils.js'
+import { wholeTonnage } from '#common/validation/tonnage-schema.js'
 import {
   TONNAGE_MONITORING_MATERIALS,
   WASTE_PROCESSING_TYPE
@@ -49,7 +50,7 @@ export const maxTwoDecimalPlaces = (value, helpers) => {
 // manual-entry fields are populated by the user via the reporting journey.
 export const prnManualFields = {
   totalRevenue: Joi.number().min(0).allow(null).custom(maxTwoDecimalPlaces),
-  freeTonnage: Joi.number().integer().min(0).allow(null)
+  freeTonnage: wholeTonnage().allow(null)
 }
 
 export const recyclingManualFields = {
@@ -65,7 +66,7 @@ export const exportManualFields = {
 }
 
 export const prnSchema = Joi.object({
-  issuedTonnage: Joi.number().min(0).required(),
+  issuedTonnage: wholeTonnage().required(),
   averagePricePerTonne: Joi.number().min(0).allow(null),
   ...prnManualFields
 }).optional()

--- a/src/reports/repository/schema.js
+++ b/src/reports/repository/schema.js
@@ -1,5 +1,5 @@
 import { toDecimal } from '#common/helpers/decimal-utils.js'
-import { wholeTonnage } from '#common/validation/tonnage-schema.js'
+import { tonnage, wholeTonnage } from '#common/validation/tonnage-schema.js'
 import {
   TONNAGE_MONITORING_MATERIALS,
   WASTE_PROCESSING_TYPE
@@ -54,15 +54,12 @@ export const prnManualFields = {
 }
 
 export const recyclingManualFields = {
-  tonnageRecycled: Joi.number().min(0).allow(null).custom(maxTwoDecimalPlaces),
-  tonnageNotRecycled: Joi.number()
-    .min(0)
-    .allow(null)
-    .custom(maxTwoDecimalPlaces)
+  tonnageRecycled: tonnage().allow(null).custom(maxTwoDecimalPlaces),
+  tonnageNotRecycled: tonnage().allow(null).custom(maxTwoDecimalPlaces)
 }
 
 export const exportManualFields = {
-  tonnageReceivedNotExported: Joi.number().min(0).allow(null)
+  tonnageReceivedNotExported: tonnage().allow(null)
 }
 
 export const prnSchema = Joi.object({
@@ -77,12 +74,12 @@ const supplierSchema = Joi.object({
   supplierAddress: Joi.string().allow(null).optional(),
   supplierPhone: Joi.string().allow(null).optional(),
   supplierEmail: Joi.string().allow(null).optional(),
-  tonnageReceived: Joi.number().min(0).required()
+  tonnageReceived: tonnage().required()
 })
 
 export const recyclingActivitySchema = Joi.object({
   suppliers: Joi.array().items(supplierSchema).required(),
-  totalTonnageReceived: Joi.number().min(0).required(),
+  totalTonnageReceived: tonnage().required(),
   ...recyclingManualFields
 }).required()
 
@@ -90,13 +87,13 @@ const overseasSiteSchema = Joi.object({
   orsId: Joi.string().required(),
   siteName: Joi.string().allow(null).required(),
   country: Joi.string().allow(null).required(),
-  tonnageExported: Joi.number().min(0).required(),
+  tonnageExported: tonnage().required(),
   approved: Joi.boolean().required()
 })
 
 const unapprovedOverseasSiteSchema = Joi.object({
   orsId: Joi.string().required(),
-  tonnageExported: Joi.number().min(0).required()
+  tonnageExported: tonnage().required()
 })
 
 export const exportActivitySchema = Joi.object({
@@ -104,11 +101,11 @@ export const exportActivitySchema = Joi.object({
   unapprovedOverseasSites: Joi.array()
     .items(unapprovedOverseasSiteSchema)
     .required(),
-  totalTonnageExported: Joi.number().min(0).required(),
-  tonnageRefusedAtDestination: Joi.number().min(0).required(),
-  tonnageStoppedDuringExport: Joi.number().min(0).required(),
-  totalTonnageRefusedOrStopped: Joi.number().min(0).required(),
-  tonnageRepatriated: Joi.number().min(0).required(),
+  totalTonnageExported: tonnage().required(),
+  tonnageRefusedAtDestination: tonnage().required(),
+  tonnageStoppedDuringExport: tonnage().required(),
+  totalTonnageRefusedOrStopped: tonnage().required(),
+  tonnageRepatriated: tonnage().required(),
   ...exportManualFields
 }).optional()
 
@@ -116,13 +113,13 @@ const finalDestinationSchema = Joi.object({
   recipientName: Joi.string().allow(null).optional(),
   facilityType: Joi.string().allow(null).optional(),
   address: Joi.string().allow(null).optional(),
-  tonnageSentOn: Joi.number().min(0).required()
+  tonnageSentOn: tonnage().required()
 })
 
 const wasteSentSchema = Joi.object({
-  tonnageSentToReprocessor: Joi.number().min(0).required(),
-  tonnageSentToExporter: Joi.number().min(0).required(),
-  tonnageSentToAnotherSite: Joi.number().min(0).required(),
+  tonnageSentToReprocessor: tonnage().required(),
+  tonnageSentToExporter: tonnage().required(),
+  tonnageSentToAnotherSite: tonnage().required(),
   finalDestinations: Joi.array().items(finalDestinationSchema).required()
 }).required()
 
@@ -163,20 +160,13 @@ const updatableFieldsSchema = Joi.object({
   supportingInformation: Joi.string().allow(''),
   prn: prnSchema.fork('issuedTonnage', (s) => s.optional()),
   exportActivity: Joi.object({
-    tonnageReceivedNotExported: Joi.number()
-      .min(0)
+    tonnageReceivedNotExported: tonnage()
       .allow(null)
       .custom(maxTwoDecimalPlaces)
   }),
   recyclingActivity: Joi.object({
-    tonnageRecycled: Joi.number()
-      .min(0)
-      .allow(null)
-      .custom(maxTwoDecimalPlaces),
-    tonnageNotRecycled: Joi.number()
-      .min(0)
-      .allow(null)
-      .custom(maxTwoDecimalPlaces)
+    tonnageRecycled: tonnage().allow(null).custom(maxTwoDecimalPlaces),
+    tonnageNotRecycled: tonnage().allow(null).custom(maxTwoDecimalPlaces)
   }).unknown(true)
 })
   .min(1)

--- a/src/reports/routes/get-detail.js
+++ b/src/reports/routes/get-detail.js
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { fetchOrGenerateReportForPeriod } from '#reports/application/report-service.js'
 import { periodParamsSchema, withRegistrationDetails } from './shared.js'
+import { reportDetailResponseSchema } from './response.schema.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { SCOPES } from '#common/helpers/auth/constants.js'
 
@@ -26,6 +27,10 @@ export const reportsGetDetail = {
     tags: ['api'],
     validate: {
       params: periodParamsSchema
+    },
+    response: {
+      schema: reportDetailResponseSchema,
+      failAction: 'error'
     }
   },
   /**

--- a/src/reports/routes/post.js
+++ b/src/reports/routes/post.js
@@ -15,6 +15,7 @@ import {
   periodParamsSchema,
   withRegistrationDetails
 } from './shared.js'
+import { reportDetailResponseSchema } from './response.schema.js'
 
 /**
  * @import { HapiRequest, HapiResponseToolkit, TypedLogger } from '#common/hapi-types.js'
@@ -57,6 +58,10 @@ export const reportsPost = {
     tags: ['api'],
     validate: {
       params: periodParamsSchema
+    },
+    response: {
+      schema: reportDetailResponseSchema,
+      failAction: 'error'
     }
   },
   /**

--- a/src/reports/routes/response.schema.js
+++ b/src/reports/routes/response.schema.js
@@ -1,8 +1,14 @@
 import Joi from 'joi'
 
+import { tonnage } from '#common/validation/tonnage-schema.js'
 import { CADENCE } from '#reports/domain/cadence.js'
 import { PERIOD_STATUS } from '#reports/domain/period-status.js'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
+import {
+  cadenceSchema,
+  periodSchema,
+  prnSchema
+} from '#reports/repository/schema.js'
 
 const userSummarySchema = Joi.object({
   id: Joi.string().required(),
@@ -40,3 +46,52 @@ export const reportsCalendarResponseSchema = Joi.object({
     .required(),
   reportingPeriods: Joi.array().items(reportingPeriodSchema).required()
 })
+
+/**
+ * Response contract for the report-detail GET/POST, shared by every reports page
+ * in the frontend. Validates the sections the frontend consumes - notably `prn`,
+ * whose `issuedTonnage`/`freeTonnage` are whole numbers via the shared tonnage
+ * schema - and tolerates backend-internal fields (id, status, diagnostics,
+ * version, stale, ...) that vary between stored and computed reports.
+ */
+export const reportDetailResponseSchema = Joi.object({
+  cadence: cadenceSchema.optional(),
+  details: Joi.object({
+    material: Joi.string().required(),
+    site: Joi.object().unknown(true).allow(null).optional()
+  }).required(),
+  dueDate: Joi.string().isoDate().optional(),
+  endDate: Joi.string().isoDate().optional(),
+  exportActivity: Joi.object({
+    overseasSites: Joi.array().required(),
+    totalTonnageExported: tonnage().required(),
+    unapprovedOverseasSites: Joi.array().required()
+  })
+    .unknown(true)
+    .optional(),
+  operatorCategory: Joi.string().optional(),
+  period: periodSchema.optional(),
+  prn: prnSchema.allow(null),
+  recyclingActivity: Joi.object({
+    suppliers: Joi.array().required(),
+    totalTonnageReceived: tonnage().required()
+  })
+    .unknown(true)
+    .required(),
+  source: Joi.object({
+    lastUploadedAt: Joi.string().isoDate().allow(null),
+    summaryLogId: Joi.string().allow(null)
+  })
+    .unknown(true)
+    .required(),
+  startDate: Joi.string().isoDate().optional(),
+  wasteSent: Joi.object({
+    finalDestinations: Joi.array().required(),
+    tonnageSentToAnotherSite: tonnage().required(),
+    tonnageSentToExporter: tonnage().required(),
+    tonnageSentToReprocessor: tonnage().required()
+  })
+    .unknown(true)
+    .required(),
+  year: Joi.number().optional()
+}).unknown(true)


### PR DESCRIPTION
Ticket: [PAE-1305](https://eaflood.atlassian.net/browse/PAE-1305)
hardening that came out of reviewing the /reports FE dedup PR.

- add a shared `wholeTonnage()` / `tonnage()` schema (`#common/validation`) and use it across the reports + PRN-create schemas
- enforce `.integer()` on `prn.issuedTonnage` (was `min(0)` only) so it matches `freeTonnage` and the whole-tonne invariant the create API already enforces
- add a response schema on the report-detail GET and POST (`reportDetailResponseSchema`) validating the payload every reports page consumes, incl. whole-number prn tonnages

behaviour-preserving; full suite green.

[PAE-1305]: https://eaflood.atlassian.net/browse/PAE-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ