### PR TITLE
PAE-1339: [5/5] crush test type errors — invalidArg helper + tail cont.

### DIFF
--- a/src/plugins/auth/external-api-auth-plugin.test.js
+++ b/src/plugins/auth/external-api-auth-plugin.test.js
@@ -1,3 +1,4 @@
+import { invalidArg } from '#test/invalid-arg.js'
 import {
   generateExternalApiToken,
   generateExternalApiTokenWithoutClientId
@@ -107,7 +108,10 @@ describe('external API auth plugin', () => {
   })
 
   it('should return 401 when token_use is not access', async () => {
-    const token = generateExternalApiToken(clientId, { token_use: 'id' })
+    const token = generateExternalApiToken(
+      clientId,
+      invalidArg({ token_use: 'id' })
+    )
 
     const response = await server.inject({
       method: 'GET',

--- a/src/reports/domain/operator-category.test.js
+++ b/src/reports/domain/operator-category.test.js
@@ -1,3 +1,4 @@
+import { invalidArg } from '#test/invalid-arg.js'
 import { describe, expect, it } from 'vitest'
 import { OPERATOR_CATEGORY, getOperatorCategory } from './operator-category.js'
 
@@ -119,12 +120,12 @@ describe('getOperatorCategory', () => {
       expected: 'REPROCESSOR_REGISTERED_ONLY'
     }
   ])('returns $expected for $scenario', ({ registration, expected }) => {
-    expect(getOperatorCategory(registration)).toBe(expected)
+    expect(getOperatorCategory(invalidArg(registration))).toBe(expected)
   })
 
   it('throws for unknown wasteProcessingType', () => {
     expect(() => {
-      getOperatorCategory({ wasteProcessingType: 'unknown' })
+      getOperatorCategory(invalidArg({ wasteProcessingType: 'unknown' }))
     }).toThrow('Unknown wasteProcessingType: unknown')
   })
 })

--- a/src/reports/domain/submitted-periods.test.js
+++ b/src/reports/domain/submitted-periods.test.js
@@ -6,21 +6,25 @@ import {
   isDateInSubmittedPeriod
 } from './submitted-periods.js'
 
-/** @import {ReportStatus} from './report-status.js' */
+/**
+ * @import {ReportStatus} from './report-status.js'
+ * @import {ReportSummary} from '#reports/repository/port.js'
+ */
 
 /**
  * @param {ReportStatus} status
  * @param {string} id
- * @returns {import('#reports/repository/port.js').ReportSummary}
+ * @returns {ReportSummary}
  */
-const reportSummary = (status, id) => ({
-  id,
-  status,
-  submissionNumber: 1,
-  submittedAt:
-    status === REPORT_STATUS.SUBMITTED ? '2026-04-10T00:00:00Z' : null,
-  submittedBy: null
-})
+const reportSummary = (status, id) =>
+  /** @type {ReportSummary} */ ({
+    id,
+    status,
+    submissionNumber: 1,
+    submittedAt:
+      status === REPORT_STATUS.SUBMITTED ? '2026-04-10T00:00:00Z' : null,
+    submittedBy: null
+  })
 
 /**
  * @param {Partial<import('#reports/repository/port.js').ReportPerPeriod>} [overrides]


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
continues the tail sweep — **stacked on #1483**. test-only, prod `[src]` unaffected. all touched files type-clean; suites green.

adds the `invalidArg` test helper (in #1483) approach to more files: deliberate-invalid inputs via `invalidArg(...)` (return type inferred from call position — no cast noise), plus builder casts.

cumulative across the stack: `lint:types:tests` **748 -> 117 (~84%)**.

remaining ~117 (≈40 files) tracked in bead repos-316.1. review/merge #1470→#1475→#1479→#1483 first.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ