### PR TITLE
PAE-1593: Identify a waste balance ledger by its full id

### DIFF
--- a/src/packaging-recycling-notes/application/get-projected-prn.js
+++ b/src/packaging-recycling-notes/application/get-projected-prn.js
@@ -26,6 +26,7 @@ const projectFromStreamTail = async (prn, ledgerRepository) => {
   const tailEvents = await createWasteBalanceService(
     ledgerRepository
   ).prnCatchupEvents({
+    organisationId: prn.organisation.id,
     registrationId: prn.registrationId,
     accreditationId: prn.accreditation.id,
     prnId: prn.id,

--- a/src/packaging-recycling-notes/application/update-status-concurrency.test.js
+++ b/src/packaging-recycling-notes/application/update-status-concurrency.test.js
@@ -152,7 +152,11 @@ const expectOneWinsOneStreamConflict = async (
   expect(rejected).toHaveLength(1)
   expect(rejected[0].reason).toBeInstanceOf(LedgerSlotConflictError)
 
-  const latest = await ledgerRepository.findLatestInLedger(REG_ID, ACC_ID)
+  const latest = await ledgerRepository.findLatestInLedger({
+    organisationId: ORG_ID,
+    registrationId: REG_ID,
+    accreditationId: ACC_ID
+  })
   expect(latest?.number).toBe(COMMITTED_EVENT_NUMBER)
 
   const prn = await prnRepository.findById(PRN_ID)

--- a/src/packaging-recycling-notes/application/update-status-stream.test.js
+++ b/src/packaging-recycling-notes/application/update-status-stream.test.js
@@ -286,7 +286,11 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       })
     ).rejects.toThrow('doc write failed')
 
-    const all = await ledgerRepository.findAllInLedger(REG_ID, ACC_ID)
+    const all = await ledgerRepository.findAllInLedger({
+      organisationId: ORG_ID,
+      registrationId: REG_ID,
+      accreditationId: ACC_ID
+    })
     expect(all).toHaveLength(2)
     expect(all.at(-1)?.kind).toBe(LEDGER_EVENT_KIND.PRN_CREATED)
   })
@@ -413,7 +417,11 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
       })
     ).rejects.toThrow('doc write failed')
 
-    const all = await ledgerRepository.findAllInLedger(REG_ID, ACC_ID)
+    const all = await ledgerRepository.findAllInLedger({
+      organisationId: ORG_ID,
+      registrationId: REG_ID,
+      accreditationId: ACC_ID
+    })
     expect(all).toHaveLength(2)
     expect(all.at(-1)?.kind).toBe(LEDGER_EVENT_KIND.PRN_ISSUED)
   })

--- a/src/packaging-recycling-notes/routes/accept.test.js
+++ b/src/packaging-recycling-notes/routes/accept.test.js
@@ -148,10 +148,11 @@ describe(`POST /v1/packaging-recycling-notes/{prnNumber}/accept`, () => {
     expect(stored?.updatedBy).toEqual(rpd)
     expect(stored?.status.accepted?.by).toEqual(rpd)
 
-    const latestEvent = await ledgerRepository.findLatestInLedger(
+    const latestEvent = await ledgerRepository.findLatestInLedger({
+      organisationId,
       registrationId,
       accreditationId
-    )
+    })
     expect(latestEvent.kind).toBe(LEDGER_EVENT_KIND.PRN_ACCEPTED)
     expect(latestEvent.createdBy).toEqual(rpd)
     // Acceptance is balance-neutral: the closing balance matches the opening one.

--- a/src/packaging-recycling-notes/routes/external-transition-handler.test.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.test.js
@@ -178,7 +178,11 @@ describe('external PRN transition read-side fold', () => {
 
     expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
 
-    const latest = await ledgerRepository.findLatestInLedger(REG_ID, ACC_ID)
+    const latest = await ledgerRepository.findLatestInLedger({
+      organisationId: ORG_ID,
+      registrationId: REG_ID,
+      accreditationId: ACC_ID
+    })
     expect(latest.kind).toBe(LEDGER_EVENT_KIND.PRN_ACCEPTED)
     expect(latest.createdBy).toEqual({
       id: externalApiClientId,

--- a/src/packaging-recycling-notes/routes/reject.test.js
+++ b/src/packaging-recycling-notes/routes/reject.test.js
@@ -148,10 +148,11 @@ describe(`POST /v1/packaging-recycling-notes/{prnNumber}/reject`, () => {
     expect(stored?.updatedBy).toEqual(rpd)
     expect(stored?.status.rejected?.by).toEqual(rpd)
 
-    const latestEvent = await ledgerRepository.findLatestInLedger(
+    const latestEvent = await ledgerRepository.findLatestInLedger({
+      organisationId,
       registrationId,
       accreditationId
-    )
+    })
     expect(latestEvent.kind).toBe(LEDGER_EVENT_KIND.PRN_REJECTED)
     expect(latestEvent.createdBy).toEqual(rpd)
     // Rejection is balance-neutral: the closing balance matches the opening one.

--- a/src/packaging-recycling-notes/routes/status.test.js
+++ b/src/packaging-recycling-notes/routes/status.test.js
@@ -534,10 +534,11 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
           payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
         })
 
-        const events = await ledgerRepository.findAllInLedger(
+        const events = await ledgerRepository.findAllInLedger({
+          organisationId,
           registrationId,
           accreditationId
-        )
+        })
         expect(events.at(-1)?.kind).toBe(LEDGER_EVENT_KIND.PRN_CREATED)
         expect(events.at(-1)?.createdBy).toEqual(
           expect.objectContaining({ id: userId, name: userName })
@@ -561,10 +562,11 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
           payload: { status: PRN_STATUS.AWAITING_AUTHORISATION }
         })
 
-        const events = await ledgerRepository.findAllInLedger(
+        const events = await ledgerRepository.findAllInLedger({
+          organisationId,
           registrationId,
           accreditationId
-        )
+        })
         expect(events.at(-1)?.createdBy).toEqual(
           expect.objectContaining({ id: 'unknown', name: 'unknown' })
         )
@@ -869,10 +871,11 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
         })
 
         expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
-        const events = await ledgerRepository.findAllInLedger(
+        const events = await ledgerRepository.findAllInLedger({
+          organisationId,
           registrationId,
           accreditationId
-        )
+        })
         expect(events).toHaveLength(1)
         expect(events[0]?.kind).toBe(LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
       })

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -23,7 +23,7 @@ import { summaryLogUploadsReportRoutes } from '#routes/v1/organisations/registra
 import * as reportsRoutes from '#reports/routes/index.js'
 import { reportsUnsubmit } from '#reports/routes/unsubmit.js'
 import { adminMeGet } from '#routes/v1/admin/me/get.js'
-import { ledgerEventsGet } from '#routes/v1/admin/registrations/accreditations/ledger-events/get.js'
+import { ledgerEventsGet } from '#routes/v1/admin/organisations/registrations/accreditations/ledger-events/get.js'
 import { dlqMessagesGet } from '#routes/v1/admin/queues/dlq/messages.get.js'
 import { dlqPurgePost } from '#routes/v1/admin/queues/dlq/purge.post.js'
 

--- a/src/routes/v1/admin/organisations/registrations/accreditations/ledger-events/get.js
+++ b/src/routes/v1/admin/organisations/registrations/accreditations/ledger-events/get.js
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes'
 import { SCOPES } from '#common/helpers/auth/constants.js'
 
 export const ledgerEventsGetPath =
-  '/v1/admin/registrations/{registrationId}/accreditations/{accreditationId}/waste-balance-events'
+  '/v1/admin/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/waste-balance-events'
 
 export const ledgerEventsGet = {
   method: 'GET',
@@ -15,12 +15,13 @@ export const ledgerEventsGet = {
   },
   handler: async (request, h) => {
     const { ledgerRepository } = request
-    const { registrationId, accreditationId } = request.params
+    const { organisationId, registrationId, accreditationId } = request.params
 
-    const events = await ledgerRepository.findAllInLedger(
+    const events = await ledgerRepository.findAllInLedger({
+      organisationId,
       registrationId,
       accreditationId
-    )
+    })
 
     return h.response(events).code(StatusCodes.OK)
   }

--- a/src/routes/v1/admin/organisations/registrations/accreditations/ledger-events/get.test.js
+++ b/src/routes/v1/admin/organisations/registrations/accreditations/ledger-events/get.test.js
@@ -7,8 +7,9 @@ import { asServiceMaintainer } from '#test/inject-auth.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 import { ledgerEventsGetPath } from './get.js'
 
-const makePath = (regId, accId) =>
+const makePath = (orgId, regId, accId) =>
   ledgerEventsGetPath
+    .replace('{organisationId}', orgId)
     .replace('{registrationId}', regId)
     .replace('{accreditationId}', accId)
 
@@ -35,7 +36,7 @@ describe(`GET ${ledgerEventsGetPath}`, () => {
 
     const response = await server.inject({
       method: 'GET',
-      url: makePath('reg-1', 'acc-1'),
+      url: makePath('org-1', 'reg-1', 'acc-1'),
       ...asServiceMaintainer()
     })
 
@@ -66,7 +67,7 @@ describe(`GET ${ledgerEventsGetPath}`, () => {
 
     const response = await server.inject({
       method: 'GET',
-      url: makePath('reg-2', 'acc-2'),
+      url: makePath('org-2', 'reg-2', 'acc-2'),
       ...asServiceMaintainer()
     })
 
@@ -80,7 +81,7 @@ describe(`GET ${ledgerEventsGetPath}`, () => {
   it('returns an empty array when no events exist', async () => {
     const response = await server.inject({
       method: 'GET',
-      url: makePath('reg-none', 'acc-none'),
+      url: makePath('org-none', 'reg-none', 'acc-none'),
       ...asServiceMaintainer()
     })
 
@@ -89,10 +90,30 @@ describe(`GET ${ledgerEventsGetPath}`, () => {
     expect(result).toEqual([])
   })
 
+  it('returns no events for a registration named under a different organisation', async () => {
+    await ledgerRepository.appendEvents([
+      buildLedgerEvent({
+        organisationId: 'org-owner',
+        registrationId: 'reg-owned',
+        accreditationId: 'acc-owned',
+        number: 1
+      })
+    ])
+
+    const response = await server.inject({
+      method: 'GET',
+      url: makePath('org-stranger', 'reg-owned', 'acc-owned'),
+      ...asServiceMaintainer()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+    expect(JSON.parse(response.payload)).toEqual([])
+  })
+
   it('returns 401 when not authenticated', async () => {
     const response = await server.inject({
       method: 'GET',
-      url: makePath('some-reg', 'some-acc')
+      url: makePath('some-org', 'some-reg', 'some-acc')
     })
 
     expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.prn-transition-actor.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.prn-transition-actor.test.js
@@ -167,7 +167,7 @@ describe('PRN transition actor on the waste-balance stream', () => {
 
   it('carries the requesting human id, name and email onto the appended stream event', async () => {
     const env = await setupLedgerEnv()
-    const { ledgerRepository, registrationId } = env
+    const { ledgerRepository, organisationId, registrationId } = env
 
     await submitCredit(env, 300)
 
@@ -179,10 +179,11 @@ describe('PRN transition actor on the waste-balance stream', () => {
     })
     expect(response.statusCode).toBe(200)
 
-    const latest = await ledgerRepository.findLatestInLedger(
+    const latest = await ledgerRepository.findLatestInLedger({
+      organisationId,
       registrationId,
-      LEDGER_ACCREDITATION_ID
-    )
+      accreditationId: LEDGER_ACCREDITATION_ID
+    })
     assert(latest)
     expect(latest.kind).toBe(LEDGER_EVENT_KIND.PRN_CREATED)
     expect(latest.payload).toEqual({ prnId: prn.id, amount: 50 })

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-arithmetic.test.js
@@ -1150,6 +1150,7 @@ describe('Waste balance arithmetic integration tests', () => {
       const {
         packagingRecyclingNotesRepository,
         ledgerRepository,
+        organisationId,
         registrationId
       } = env
 
@@ -1173,10 +1174,11 @@ describe('Waste balance arithmetic integration tests', () => {
       expect(balance.availableAmount).toBe(250) // 300 - 50 ringfenced
 
       // The document watermark is the event the raise appended, not just any number.
-      const latest = await ledgerRepository.findLatestInLedger(
+      const latest = await ledgerRepository.findLatestInLedger({
+        organisationId,
         registrationId,
-        'ACC-123'
-      )
+        accreditationId: 'ACC-123'
+      })
       const stored = await packagingRecyclingNotesRepository.findById(prn.id)
       assert(stored)
       expect(stored.lastAppliedEventNumber).toBe(latest?.number)

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-ledger.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.waste-balance-ledger.test.js
@@ -112,7 +112,12 @@ describe('Waste balance stream (Exporter)', () => {
 
   it('appends a single stream event with aggregate creditTotal on first upload', async () => {
     const env = await setupStream()
-    const { ledgerRepository, registrationId, wasteBalanceService } = env
+    const {
+      ledgerRepository,
+      organisationId,
+      registrationId,
+      wasteBalanceService
+    } = env
 
     await performSubmission(
       env,
@@ -129,10 +134,11 @@ describe('Waste balance stream (Exporter)', () => {
       ])
     )
 
-    const latest = await ledgerRepository.findLatestInLedger(
+    const latest = await ledgerRepository.findLatestInLedger({
+      organisationId,
       registrationId,
-      'ACC-123'
-    )
+      accreditationId: 'ACC-123'
+    })
     expect(latest).not.toBeNull()
     if (!latest) throw new Error('latest stream event is null')
     expect(latest.number).toBe(1)
@@ -156,20 +162,22 @@ describe('Waste balance stream (Exporter)', () => {
 
   it('computes correct delta on re-upload with identical data', async () => {
     const env = await setupStream()
-    const { ledgerRepository, registrationId } = env
+    const { ledgerRepository, organisationId, registrationId } = env
     const data = createUploadData([{ rowId: 2001, exportTonnage: 50 }])
 
     await performSubmission(env, 'log-a', 'file-a', data)
-    const afterFirst = await ledgerRepository.findLatestInLedger(
+    const afterFirst = await ledgerRepository.findLatestInLedger({
+      organisationId,
       registrationId,
-      'ACC-123'
-    )
+      accreditationId: 'ACC-123'
+    })
 
     await performSubmission(env, 'log-b', 'file-b', data)
-    const afterSecond = await ledgerRepository.findLatestInLedger(
+    const afterSecond = await ledgerRepository.findLatestInLedger({
+      organisationId,
       registrationId,
-      'ACC-123'
-    )
+      accreditationId: 'ACC-123'
+    })
 
     if (!afterSecond) throw new Error('afterSecond stream event is null')
     if (!afterFirst) throw new Error('afterFirst stream event is null')
@@ -179,7 +187,7 @@ describe('Waste balance stream (Exporter)', () => {
 
   it('computes correct delta when a row is corrected on re-upload', async () => {
     const env = await setupStream()
-    const { ledgerRepository, registrationId } = env
+    const { ledgerRepository, organisationId, registrationId } = env
 
     await performSubmission(
       env,
@@ -215,10 +223,11 @@ describe('Waste balance stream (Exporter)', () => {
       ])
     )
 
-    const latest = await ledgerRepository.findLatestInLedger(
+    const latest = await ledgerRepository.findLatestInLedger({
+      organisationId,
       registrationId,
-      'ACC-123'
-    )
+      accreditationId: 'ACC-123'
+    })
     if (!latest) throw new Error('latest stream event is null')
     expect(latest.number).toBe(2)
     expect(

--- a/src/waste-balances/application/current-waste-balance.js
+++ b/src/waste-balances/application/current-waste-balance.js
@@ -16,22 +16,15 @@ import { LEDGER_EVENT_KIND } from '../repository/ledger-schema.js'
  *   registration or accreditation whose ledger is read.
  * @returns {Promise<import('../domain/model.js').WasteBalance | null>}
  */
-export const currentWasteBalance = async (
-  ledgerRepository,
-  { organisationId, registrationId, accreditationId }
-) => {
-  const latest = await ledgerRepository.findLatestInLedger(
-    registrationId,
-    accreditationId
-  )
+export const currentWasteBalance = async (ledgerRepository, ledgerId) => {
+  const latest = await ledgerRepository.findLatestInLedger(ledgerId)
 
   if (!latest) {
     return null
   }
 
   const latestSubmission = await ledgerRepository.findLatestInLedgerByKind(
-    registrationId,
-    accreditationId,
+    ledgerId,
     LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED
   )
 
@@ -42,9 +35,7 @@ export const currentWasteBalance = async (
     : 0
 
   return {
-    organisationId,
-    registrationId,
-    accreditationId,
+    ...ledgerId,
     amount: latest.closingBalance.amount,
     availableAmount: latest.closingBalance.availableAmount,
     eventNumber: latest.number,

--- a/src/waste-balances/application/latest-submitted-summary-log-id.js
+++ b/src/waste-balances/application/latest-submitted-summary-log-id.js
@@ -6,16 +6,15 @@ import { LEDGER_EVENT_KIND } from '../repository/ledger-schema.js'
  * `null` when the ledger has no summary-log submission yet.
  *
  * @param {import('../repository/ledger-port.js').WasteBalanceLedgerRepository} ledgerRepository
- * @param {{ registrationId: string, accreditationId: string | null }} ledgerId
+ * @param {import('../repository/ledger-schema.js').WasteBalanceLedgerId} ledgerId
  * @returns {Promise<string | null>}
  */
 export const latestSubmittedSummaryLogId = async (
   ledgerRepository,
-  { registrationId, accreditationId }
+  ledgerId
 ) => {
   const latest = await ledgerRepository.findLatestInLedgerByKind(
-    registrationId,
-    accreditationId,
+    ledgerId,
     LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED
   )
 

--- a/src/waste-balances/application/latest-submitted-summary-log-id.test.js
+++ b/src/waste-balances/application/latest-submitted-summary-log-id.test.js
@@ -3,11 +3,12 @@ import { describe, it, expect } from 'vitest'
 import { createInMemoryLedgerRepository } from '../repository/ledger-inmemory.js'
 import {
   buildLedgerEvent,
+  buildLedgerId,
   buildPrnCreatedEvent
 } from '../repository/ledger-test-data.js'
 import { latestSubmittedSummaryLogId } from './latest-submitted-summary-log-id.js'
 
-const LEDGER_ID = { registrationId: 'reg-1', accreditationId: 'acc-1' }
+const LEDGER_ID = buildLedgerId()
 
 describe('latestSubmittedSummaryLogId', () => {
   it('returns null when the ledger has no events', async () => {
@@ -69,10 +70,10 @@ describe('latestSubmittedSummaryLogId', () => {
     ])()
 
     expect(
-      await latestSubmittedSummaryLogId(ledgerRepository, {
-        registrationId: 'reg-1',
-        accreditationId: null
-      })
+      await latestSubmittedSummaryLogId(
+        ledgerRepository,
+        buildLedgerId({ accreditationId: null })
+      )
     ).toBe('log-1')
   })
 })

--- a/src/waste-balances/application/update-via-ledger.test.js
+++ b/src/waste-balances/application/update-via-ledger.test.js
@@ -50,6 +50,12 @@ vi.mock('#domain/summary-logs/table-schemas/index.js', () => ({
 
 const accreditationId = 'acc-1'
 
+const ledgerId = {
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  accreditationId
+}
+
 const accreditation = /** @type {Accreditation} */ (
   /** @type {unknown} */ ({
     id: accreditationId,
@@ -125,10 +131,7 @@ describe('performUpdateViaLedger', () => {
         summaryLogId: 'log-A'
       })
 
-      const latest = await ledgerRepository.findLatestInLedger(
-        'reg-1',
-        accreditationId
-      )
+      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
       expect(latest.number).toBe(1)
       expect(latest.kind).toBe(LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED)
       expect(latest.payload).toEqual({
@@ -171,10 +174,7 @@ describe('performUpdateViaLedger', () => {
         summaryLogId: 'log-B'
       })
 
-      const latest = await ledgerRepository.findLatestInLedger(
-        'reg-1',
-        accreditationId
-      )
+      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
       expect(latest.number).toBe(2)
       expect(latest.payload).toEqual({
         summaryLogId: 'log-B',
@@ -207,10 +207,7 @@ describe('performUpdateViaLedger', () => {
         summaryLogId: 'log-A'
       })
 
-      const latest = await ledgerRepository.findLatestInLedger(
-        'reg-1',
-        accreditationId
-      )
+      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
       expect(latest.payload.creditTotal).toBe(100)
     })
   })
@@ -238,10 +235,7 @@ describe('performUpdateViaLedger', () => {
         summaryLogId: 'log-A'
       })
 
-      const latest = await ledgerRepository.findLatestInLedger(
-        'reg-1',
-        accreditationId
-      )
+      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
       expect(latest.payload.creditTotal).toBe(
         includedTonnages.reduce((sum, tonnage) => sum + tonnage, 0)
       )
@@ -283,10 +277,7 @@ describe('performUpdateViaLedger', () => {
         summaryLogId: 'log-A'
       })
 
-      const latest = await ledgerRepository.findLatestInLedger(
-        'reg-1',
-        accreditationId
-      )
+      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
 
       const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
       expect(systemLogs).toHaveLength(1)
@@ -324,10 +315,7 @@ describe('performUpdateViaLedger', () => {
         summaryLogId: 'log-A'
       })
 
-      const latest = await ledgerRepository.findLatestInLedger(
-        'reg-1',
-        accreditationId
-      )
+      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
       expect(latest.number).toBe(1)
       expect(latest.payload.creditTotal).toBe(100)
 
@@ -359,10 +347,7 @@ describe('performUpdateViaLedger', () => {
         summaryLogId: 'log-A'
       })
 
-      const latest = await ledgerRepository.findLatestInLedger(
-        'reg-1',
-        accreditationId
-      )
+      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
       expect(latest.payload.creditTotal).toBe(0)
     })
   })
@@ -379,10 +364,7 @@ describe('performUpdateViaLedger', () => {
         summaryLogId: 'log-A'
       })
 
-      const latest = await ledgerRepository.findLatestInLedger(
-        'reg-1',
-        accreditationId
-      )
+      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
       expect(latest.createdBy).toEqual({
         id: user.id,
         name: user.name,
@@ -406,10 +388,7 @@ describe('performUpdateViaLedger', () => {
         summaryLogId: 'log-A'
       })
 
-      const latest = await ledgerRepository.findLatestInLedger(
-        'reg-1',
-        accreditationId
-      )
+      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
       expect(latest.createdBy).toEqual({
         id: 'user-2',
         email: 'noname@example.test'
@@ -441,10 +420,7 @@ describe('performUpdateViaLedger', () => {
       expect(rejected).toHaveLength(1)
       expect(rejected[0].reason).toBeInstanceOf(LedgerSlotConflictError)
 
-      const all = await ledgerRepository.findAllInLedger(
-        'reg-1',
-        accreditationId
-      )
+      const all = await ledgerRepository.findAllInLedger(ledgerId)
       expect(all).toHaveLength(1)
     })
   })

--- a/src/waste-balances/application/waste-balance-service.js
+++ b/src/waste-balances/application/waste-balance-service.js
@@ -249,20 +249,26 @@ export const createWasteBalanceService = (
 
     /**
      * The PRN's ledger events after a watermark: the catch-up tail a read
-     * projection folds onto a fetched PRN to bring it current.
+     * projection folds onto a fetched PRN to bring it current. This is a ledger
+     * read that happens to be about a PRN, so it names its ledger in full and
+     * the `prnId` selects within it.
      *
-     * @param {{ registrationId: string, accreditationId: string, prnId: string, afterEventNumber: number }} params
+     * @param {{ organisationId: string, registrationId: string, accreditationId: string, prnId: string, afterEventNumber: number }} params
      * @returns {Promise<import('../repository/ledger-port.js').LedgerEvent[]>}
      */
     prnCatchupEvents: async ({
+      organisationId,
       registrationId,
       accreditationId,
       prnId,
       afterEventNumber
     }) =>
       ledgerRepository.findEventsByPrnIdAfter(
-        registrationId,
-        validateAccreditationId(accreditationId),
+        {
+          organisationId,
+          registrationId,
+          accreditationId: validateAccreditationId(accreditationId)
+        },
         prnId,
         afterEventNumber
       )

--- a/src/waste-balances/application/waste-balance-service.test.js
+++ b/src/waste-balances/application/waste-balance-service.test.js
@@ -101,7 +101,11 @@ describe('createWasteBalanceService', () => {
       expect(rejected).toHaveLength(1)
       expect(rejected[0].reason).toBeInstanceOf(LedgerSlotConflictError)
 
-      const all = await ledgerRepository.findAllInLedger('reg-1', 'acc-1')
+      const all = await ledgerRepository.findAllInLedger({
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1'
+      })
       expect(all).toHaveLength(1)
     })
   })
@@ -147,7 +151,11 @@ describe('createWasteBalanceService', () => {
         status: PRN_COMMAND_STATUS.REJECTED,
         reason: PRN_COMMAND_REJECTION.INSUFFICIENT_AVAILABLE_BALANCE
       })
-      const all = await ledgerRepository.findAllInLedger('reg-1', 'acc-1')
+      const all = await ledgerRepository.findAllInLedger({
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1'
+      })
       expect(all).toHaveLength(1)
     })
 
@@ -287,7 +295,11 @@ describe('createWasteBalanceService', () => {
         service.createPrn(ledgerId, { prnId: 'prn-1', amount: -100 }, createdBy)
       ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 500 } })
 
-      const all = await ledgerRepository.findAllInLedger('reg-1', 'acc-1')
+      const all = await ledgerRepository.findAllInLedger({
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1'
+      })
       expect(all).toHaveLength(1)
     })
 
@@ -315,6 +327,7 @@ describe('createWasteBalanceService', () => {
 
   describe('prnCatchupEvents', () => {
     const catchupParams = {
+      organisationId: 'org-1',
       registrationId: 'reg-1',
       accreditationId: 'acc-1',
       prnId: 'prn-1'
@@ -371,7 +384,11 @@ describe('createWasteBalanceService', () => {
         summaryLogId: 'log-A'
       })
 
-      const all = await ledgerRepository.findAllInLedger('reg-1', 'acc-1')
+      const all = await ledgerRepository.findAllInLedger({
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1'
+      })
       expect(all).toHaveLength(0)
     })
   })

--- a/src/waste-balances/repository/ledger-contract/appendEvents.contract.js
+++ b/src/waste-balances/repository/ledger-contract/appendEvents.contract.js
@@ -1,6 +1,6 @@
 import { describe, beforeEach, expect } from 'vitest'
 
-import { buildLedgerEvent } from '../ledger-test-data.js'
+import { buildLedgerEvent, buildLedgerId } from '../ledger-test-data.js'
 import { LedgerSequenceError, LedgerSlotConflictError } from '../ledger-port.js'
 
 export const testAppendEventsBehaviour = (it) => {
@@ -98,9 +98,10 @@ export const testAppendEventsBehaviour = (it) => {
       )
     })
 
-    it('LedgerSequenceError carries the provided and expected numbers', async () => {
+    it('LedgerSequenceError carries the full ledger identity and both numbers', async () => {
       await repository.appendEvents([
         buildLedgerEvent({
+          organisationId: 'org-seq-err',
           registrationId: 'reg-seq-err',
           accreditationId: 'acc-seq-err',
           number: 1
@@ -110,6 +111,7 @@ export const testAppendEventsBehaviour = (it) => {
       await expect(
         repository.appendEvents([
           buildLedgerEvent({
+            organisationId: 'org-seq-err',
             registrationId: 'reg-seq-err',
             accreditationId: 'acc-seq-err',
             number: 5,
@@ -117,6 +119,7 @@ export const testAppendEventsBehaviour = (it) => {
           })
         ])
       ).rejects.toMatchObject({
+        organisationId: 'org-seq-err',
         registrationId: 'reg-seq-err',
         accreditationId: 'acc-seq-err',
         providedNumber: 5,
@@ -147,9 +150,10 @@ export const testAppendEventsBehaviour = (it) => {
       )
     })
 
-    it('LedgerSlotConflictError carries the ledger identity and slot number', async () => {
+    it('LedgerSlotConflictError carries the full ledger identity and slot number', async () => {
       await repository.appendEvents([
         buildLedgerEvent({
+          organisationId: 'org-slot-err',
           registrationId: 'reg-slot-err',
           accreditationId: 'acc-slot-err',
           number: 1
@@ -159,6 +163,7 @@ export const testAppendEventsBehaviour = (it) => {
       await expect(
         repository.appendEvents([
           buildLedgerEvent({
+            organisationId: 'org-slot-err',
             registrationId: 'reg-slot-err',
             accreditationId: 'acc-slot-err',
             number: 1,
@@ -166,6 +171,7 @@ export const testAppendEventsBehaviour = (it) => {
           })
         ])
       ).rejects.toMatchObject({
+        organisationId: 'org-slot-err',
         registrationId: 'reg-slot-err',
         accreditationId: 'acc-slot-err',
         slotNumber: 1
@@ -235,7 +241,9 @@ export const testAppendEventsBehaviour = (it) => {
 
       await repository.appendEvents(events)
 
-      const latest = await repository.findLatestInLedger('reg-vis', 'acc-vis')
+      const latest = await repository.findLatestInLedger(
+        buildLedgerId({ registrationId: 'reg-vis', accreditationId: 'acc-vis' })
+      )
       expect(latest).not.toBeNull()
       expect(latest.number).toBe(2)
     })

--- a/src/waste-balances/repository/ledger-contract/deleteAllInLedger.contract.js
+++ b/src/waste-balances/repository/ledger-contract/deleteAllInLedger.contract.js
@@ -1,6 +1,6 @@
 import { describe, beforeEach, expect } from 'vitest'
 
-import { buildLedgerEvent } from '../ledger-test-data.js'
+import { buildLedgerEvent, buildLedgerId } from '../ledger-test-data.js'
 
 /**
  * @typedef {object} LedgerContractContext
@@ -35,16 +35,25 @@ export const testDeleteAllInLedgerBehaviour = (it) => {
         })
       ])
 
-      const count = await repository.deleteAllInLedger('reg-del', 'acc-del')
+      const count = await repository.deleteAllInLedger(
+        buildLedgerId({ registrationId: 'reg-del', accreditationId: 'acc-del' })
+      )
 
       expect(count).toBe(2)
 
-      const latest = await repository.findLatestInLedger('reg-del', 'acc-del')
+      const latest = await repository.findLatestInLedger(
+        buildLedgerId({ registrationId: 'reg-del', accreditationId: 'acc-del' })
+      )
       expect(latest).toBeNull()
     })
 
     it('returns 0 when the ledger is empty', async () => {
-      const count = await repository.deleteAllInLedger('reg-empty', 'acc-empty')
+      const count = await repository.deleteAllInLedger(
+        buildLedgerId({
+          registrationId: 'reg-empty',
+          accreditationId: 'acc-empty'
+        })
+      )
 
       expect(count).toBe(0)
     })
@@ -65,11 +74,52 @@ export const testDeleteAllInLedgerBehaviour = (it) => {
         })
       ])
 
-      await repository.deleteAllInLedger('reg-remove', 'acc-remove')
+      await repository.deleteAllInLedger(
+        buildLedgerId({
+          registrationId: 'reg-remove',
+          accreditationId: 'acc-remove'
+        })
+      )
 
-      const kept = await repository.findLatestInLedger('reg-keep', 'acc-keep')
+      const kept = await repository.findLatestInLedger(
+        buildLedgerId({
+          registrationId: 'reg-keep',
+          accreditationId: 'acc-keep'
+        })
+      )
       expect(kept).not.toBeNull()
       expect(kept?.registrationId).toBe('reg-keep')
+    })
+
+    it('deletes nothing from a ledger named under a different organisation', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          organisationId: 'org-owner',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned',
+          number: 1
+        })
+      ])
+
+      const count = await repository.deleteAllInLedger(
+        buildLedgerId({
+          organisationId: 'org-stranger',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned'
+        })
+      )
+
+      expect(count).toBe(0)
+
+      const survivor = await repository.findLatestInLedger(
+        buildLedgerId({
+          organisationId: 'org-owner',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned'
+        })
+      )
+      expect(survivor).not.toBeNull()
+      expect(survivor?.number).toBe(1)
     })
 
     it("deletes one accreditation's ledgerId without touching the same registration's registered-only ledger", async () => {
@@ -90,19 +140,25 @@ export const testDeleteAllInLedgerBehaviour = (it) => {
         })
       ])
 
-      const count = await repository.deleteAllInLedger('reg-shared', 'acc-1')
+      const count = await repository.deleteAllInLedger(
+        buildLedgerId({
+          registrationId: 'reg-shared',
+          accreditationId: 'acc-1'
+        })
+      )
 
       expect(count).toBe(1)
 
       const accreditationLedger = await repository.findLatestInLedger(
-        'reg-shared',
-        'acc-1'
+        buildLedgerId({
+          registrationId: 'reg-shared',
+          accreditationId: 'acc-1'
+        })
       )
       expect(accreditationLedger).toBeNull()
 
       const registeredOnlyLedger = await repository.findLatestInLedger(
-        'reg-shared',
-        null
+        buildLedgerId({ registrationId: 'reg-shared', accreditationId: null })
       )
       expect(registeredOnlyLedger).not.toBeNull()
       expect(registeredOnlyLedger?.accreditationId).toBeNull()

--- a/src/waste-balances/repository/ledger-contract/findAllInLedger.contract.js
+++ b/src/waste-balances/repository/ledger-contract/findAllInLedger.contract.js
@@ -1,6 +1,6 @@
 import { describe, beforeEach, expect } from 'vitest'
 
-import { buildLedgerEvent } from '../ledger-test-data.js'
+import { buildLedgerEvent, buildLedgerId } from '../ledger-test-data.js'
 
 export const testFindAllInLedgerBehaviour = (it) => {
   describe('findAllInLedger', () => {
@@ -17,7 +17,12 @@ export const testFindAllInLedgerBehaviour = (it) => {
     )
 
     it('returns an empty array when no events exist for the ledger', async () => {
-      const result = await repository.findAllInLedger('reg-empty', 'acc-empty')
+      const result = await repository.findAllInLedger(
+        buildLedgerId({
+          registrationId: 'reg-empty',
+          accreditationId: 'acc-empty'
+        })
+      )
       expect(result).toEqual([])
     })
 
@@ -47,7 +52,9 @@ export const testFindAllInLedgerBehaviour = (it) => {
         })
       ])
 
-      const result = await repository.findAllInLedger('reg-all', 'acc-all')
+      const result = await repository.findAllInLedger(
+        buildLedgerId({ registrationId: 'reg-all', accreditationId: 'acc-all' })
+      )
 
       expect(result).toHaveLength(3)
       expect(result[0].number).toBe(1)
@@ -71,11 +78,34 @@ export const testFindAllInLedgerBehaviour = (it) => {
         })
       ])
 
-      const result = await repository.findAllInLedger('reg-a', 'acc-a')
+      const result = await repository.findAllInLedger(
+        buildLedgerId({ registrationId: 'reg-a', accreditationId: 'acc-a' })
+      )
 
       expect(result).toHaveLength(1)
       expect(result[0].registrationId).toBe('reg-a')
       expect(result[0].accreditationId).toBe('acc-a')
+    })
+
+    it('does not read a ledger named under a different organisation', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          organisationId: 'org-owner',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned',
+          number: 1
+        })
+      ])
+
+      const result = await repository.findAllInLedger(
+        buildLedgerId({
+          organisationId: 'org-stranger',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned'
+        })
+      )
+
+      expect(result).toEqual([])
     })
   })
 }

--- a/src/waste-balances/repository/ledger-contract/findEventsByPrnIdAfter.contract.js
+++ b/src/waste-balances/repository/ledger-contract/findEventsByPrnIdAfter.contract.js
@@ -2,6 +2,7 @@ import { describe, beforeEach, expect } from 'vitest'
 
 import { LEDGER_EVENT_KIND } from '../ledger-schema.js'
 import {
+  buildLedgerId,
   buildPrnCreatedEvent,
   buildPrnCancelledAfterIssueEvent
 } from '../ledger-test-data.js'
@@ -39,8 +40,10 @@ export const testFindEventsByPrnIdAfterBehaviour = (it) => {
       ])
 
       const result = await repository.findEventsByPrnIdAfter(
-        'reg-prn',
-        'acc-prn',
+        buildLedgerId({
+          registrationId: 'reg-prn',
+          accreditationId: 'acc-prn'
+        }),
         'prn-watermark',
         0
       )
@@ -71,8 +74,7 @@ export const testFindEventsByPrnIdAfterBehaviour = (it) => {
       ])
 
       const result = await repository.findEventsByPrnIdAfter(
-        'reg-wm',
-        'acc-wm',
+        buildLedgerId({ registrationId: 'reg-wm', accreditationId: 'acc-wm' }),
         'prn-filter',
         1
       )
@@ -92,8 +94,10 @@ export const testFindEventsByPrnIdAfterBehaviour = (it) => {
       ])
 
       const result = await repository.findEventsByPrnIdAfter(
-        'reg-caught-up',
-        'acc-caught-up',
+        buildLedgerId({
+          registrationId: 'reg-caught-up',
+          accreditationId: 'acc-caught-up'
+        }),
         'prn-caught-up',
         1
       )
@@ -103,8 +107,10 @@ export const testFindEventsByPrnIdAfterBehaviour = (it) => {
 
     it('returns an empty array when no events exist for the prnId', async () => {
       const result = await repository.findEventsByPrnIdAfter(
-        'reg-none',
-        'acc-none',
+        buildLedgerId({
+          registrationId: 'reg-none',
+          accreditationId: 'acc-none'
+        }),
         'prn-nonexistent',
         0
       )
@@ -131,8 +137,7 @@ export const testFindEventsByPrnIdAfterBehaviour = (it) => {
       ])
 
       const result = await repository.findEventsByPrnIdAfter(
-        'reg-a',
-        'acc-a',
+        buildLedgerId({ registrationId: 'reg-a', accreditationId: 'acc-a' }),
         'prn-shared',
         0
       )
@@ -140,6 +145,30 @@ export const testFindEventsByPrnIdAfterBehaviour = (it) => {
       expect(result).toHaveLength(1)
       expect(result[0].registrationId).toBe('reg-a')
       expect(result[0].accreditationId).toBe('acc-a')
+    })
+
+    it('does not read a ledger named under a different organisation', async () => {
+      await repository.appendEvents([
+        buildPrnCreatedEvent({
+          organisationId: 'org-owner',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned',
+          number: 1,
+          payload: { prnId: 'prn-owned', amount: 50 }
+        })
+      ])
+
+      const result = await repository.findEventsByPrnIdAfter(
+        buildLedgerId({
+          organisationId: 'org-stranger',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned'
+        }),
+        'prn-owned',
+        0
+      )
+
+      expect(result).toEqual([])
     })
   })
 }

--- a/src/waste-balances/repository/ledger-contract/findLatestInLedger.contract.js
+++ b/src/waste-balances/repository/ledger-contract/findLatestInLedger.contract.js
@@ -1,6 +1,6 @@
 import { describe, beforeEach, expect } from 'vitest'
 
-import { buildLedgerEvent } from '../ledger-test-data.js'
+import { buildLedgerEvent, buildLedgerId } from '../ledger-test-data.js'
 
 export const testFindLatestInLedgerBehaviour = (it) => {
   describe('findLatestInLedger', () => {
@@ -18,8 +18,10 @@ export const testFindLatestInLedgerBehaviour = (it) => {
 
     it('returns null when no events exist for the ledger', async () => {
       const result = await repository.findLatestInLedger(
-        'reg-empty',
-        'acc-empty'
+        buildLedgerId({
+          registrationId: 'reg-empty',
+          accreditationId: 'acc-empty'
+        })
       )
       expect(result).toBeNull()
     })
@@ -35,8 +37,10 @@ export const testFindLatestInLedgerBehaviour = (it) => {
       ])
 
       const result = await repository.findLatestInLedger(
-        'reg-single',
-        'acc-single'
+        buildLedgerId({
+          registrationId: 'reg-single',
+          accreditationId: 'acc-single'
+        })
       )
 
       expect(result).not.toBeNull()
@@ -74,7 +78,12 @@ export const testFindLatestInLedgerBehaviour = (it) => {
         })
       ])
 
-      const result = await repository.findLatestInLedger('reg-many', 'acc-many')
+      const result = await repository.findLatestInLedger(
+        buildLedgerId({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many'
+        })
+      )
 
       expect(result.number).toBe(3)
       expect(result.closingBalance).toEqual({ amount: 30, availableAmount: 25 })
@@ -97,13 +106,38 @@ export const testFindLatestInLedgerBehaviour = (it) => {
         })
       ])
 
-      const x = await repository.findLatestInLedger('reg-x', 'acc-x')
-      const y = await repository.findLatestInLedger('reg-y', 'acc-y')
+      const x = await repository.findLatestInLedger(
+        buildLedgerId({ registrationId: 'reg-x', accreditationId: 'acc-x' })
+      )
+      const y = await repository.findLatestInLedger(
+        buildLedgerId({ registrationId: 'reg-y', accreditationId: 'acc-y' })
+      )
 
       expect(x.number).toBe(1)
       expect(x.accreditationId).toBe('acc-x')
       expect(y.number).toBe(1)
       expect(y.accreditationId).toBe('acc-y')
+    })
+
+    it('does not read a ledger named under a different organisation', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          organisationId: 'org-owner',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned',
+          number: 1
+        })
+      ])
+
+      const result = await repository.findLatestInLedger(
+        buildLedgerId({
+          organisationId: 'org-stranger',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned'
+        })
+      )
+
+      expect(result).toBeNull()
     })
 
     it('treats null and non-null accreditationId as separate ledgers', async () => {
@@ -125,12 +159,16 @@ export const testFindLatestInLedgerBehaviour = (it) => {
       ])
 
       const nullLedger = await repository.findLatestInLedger(
-        'reg-null-test',
-        null
+        buildLedgerId({
+          registrationId: 'reg-null-test',
+          accreditationId: null
+        })
       )
       const nonNullLedger = await repository.findLatestInLedger(
-        'reg-null-test',
-        'acc-non-null'
+        buildLedgerId({
+          registrationId: 'reg-null-test',
+          accreditationId: 'acc-non-null'
+        })
       )
 
       expect(nullLedger.closingBalance).toEqual({
@@ -156,8 +194,10 @@ export const testFindLatestInLedgerBehaviour = (it) => {
       ])
 
       const result = await repository.findLatestInLedger(
-        'reg-precision',
-        'acc-precision'
+        buildLedgerId({
+          registrationId: 'reg-precision',
+          accreditationId: 'acc-precision'
+        })
       )
 
       expect(result.closingBalance.amount).toBe(200.005)

--- a/src/waste-balances/repository/ledger-contract/findLatestInLedgerByKind.contract.js
+++ b/src/waste-balances/repository/ledger-contract/findLatestInLedgerByKind.contract.js
@@ -1,7 +1,11 @@
 import { describe, beforeEach, expect } from 'vitest'
 
 import { LEDGER_EVENT_KIND } from '../ledger-schema.js'
-import { buildLedgerEvent, buildPrnCreatedEvent } from '../ledger-test-data.js'
+import {
+  buildLedgerEvent,
+  buildLedgerId,
+  buildPrnCreatedEvent
+} from '../ledger-test-data.js'
 
 export const testFindLatestInLedgerByKindBehaviour = (it) => {
   describe('findLatestInLedgerByKind', () => {
@@ -27,8 +31,10 @@ export const testFindLatestInLedgerByKindBehaviour = (it) => {
       ])
 
       const result = await repository.findLatestInLedgerByKind(
-        'reg-kind',
-        'acc-kind',
+        buildLedgerId({
+          registrationId: 'reg-kind',
+          accreditationId: 'acc-kind'
+        }),
         LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED
       )
 
@@ -62,8 +68,10 @@ export const testFindLatestInLedgerByKindBehaviour = (it) => {
       ])
 
       const result = await repository.findLatestInLedgerByKind(
-        'reg-filter',
-        'acc-filter',
+        buildLedgerId({
+          registrationId: 'reg-filter',
+          accreditationId: 'acc-filter'
+        }),
         LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED
       )
 
@@ -90,13 +98,11 @@ export const testFindLatestInLedgerByKindBehaviour = (it) => {
       ])
 
       const a = await repository.findLatestInLedgerByKind(
-        'reg-a',
-        'acc-a',
+        buildLedgerId({ registrationId: 'reg-a', accreditationId: 'acc-a' }),
         LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED
       )
       const b = await repository.findLatestInLedgerByKind(
-        'reg-b',
-        'acc-b',
+        buildLedgerId({ registrationId: 'reg-b', accreditationId: 'acc-b' }),
         LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED
       )
 
@@ -104,6 +110,29 @@ export const testFindLatestInLedgerByKindBehaviour = (it) => {
       expect(a.payload.summaryLogId).toBe('log-a')
       expect(b.accreditationId).toBe('acc-b')
       expect(b.payload.summaryLogId).toBe('log-b')
+    })
+
+    it('does not read a ledger named under a different organisation', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          organisationId: 'org-owner',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned',
+          number: 1,
+          payload: { summaryLogId: 'log-owned', creditTotal: 100 }
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerByKind(
+        buildLedgerId({
+          organisationId: 'org-stranger',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned'
+        }),
+        LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED
+      )
+
+      expect(result).toBeNull()
     })
 
     it('treats null and non-null accreditationId as separate ledgers', async () => {
@@ -127,13 +156,14 @@ export const testFindLatestInLedgerByKindBehaviour = (it) => {
       ])
 
       const nullResult = await repository.findLatestInLedgerByKind(
-        'reg-null',
-        null,
+        buildLedgerId({ registrationId: 'reg-null', accreditationId: null }),
         LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED
       )
       const nonNullResult = await repository.findLatestInLedgerByKind(
-        'reg-null',
-        'acc-present',
+        buildLedgerId({
+          registrationId: 'reg-null',
+          accreditationId: 'acc-present'
+        }),
         LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED
       )
 
@@ -149,8 +179,10 @@ export const testFindLatestInLedgerByKindBehaviour = (it) => {
 
     it('returns null when the ledger is empty', async () => {
       const result = await repository.findLatestInLedgerByKind(
-        'reg-empty',
-        'acc-empty',
+        buildLedgerId({
+          registrationId: 'reg-empty',
+          accreditationId: 'acc-empty'
+        }),
         LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED
       )
 

--- a/src/waste-balances/repository/ledger-inmemory.js
+++ b/src/waste-balances/repository/ledger-inmemory.js
@@ -19,27 +19,28 @@ import { validateLedgerEventInsert } from './ledger-validation.js'
  */
 
 /**
- * @param {LedgerEvent} event
- * @param {string} registrationId
- * @param {string | null} accreditationId
+ * @typedef {import('./ledger-schema.js').WasteBalanceLedgerId} WasteBalanceLedgerId
  */
-const matchesLedger = (event, registrationId, accreditationId) =>
-  event.registrationId === registrationId &&
-  event.accreditationId === accreditationId
+
+/**
+ * @param {LedgerEvent} event
+ * @param {WasteBalanceLedgerId} ledgerId
+ */
+const matchesLedger = (event, ledgerId) =>
+  event.organisationId === ledgerId.organisationId &&
+  event.registrationId === ledgerId.registrationId &&
+  event.accreditationId === ledgerId.accreditationId
 
 /**
  * Migration PAE-1382: delete all events for a ledgerId.
  *
  * @param {LedgerEvent[]} storage
- * @param {string} registrationId
- * @param {string | null} accreditationId
+ * @param {WasteBalanceLedgerId} ledgerId
  * @returns {number}
  */
-const doDeleteInLedger = (storage, registrationId, accreditationId) => {
+const doDeleteInLedger = (storage, ledgerId) => {
   const before = storage.length
-  const remaining = storage.filter(
-    (event) => !matchesLedger(event, registrationId, accreditationId)
-  )
+  const remaining = storage.filter((event) => !matchesLedger(event, ledgerId))
   storage.length = 0
   storage.push(...remaining)
   return before - remaining.length
@@ -60,7 +61,7 @@ const doAppendEvents = (storage, events) => {
 
   const first = events[0]
   const ledgerEvents = storage.filter((existing) =>
-    matchesLedger(existing, first.registrationId, first.accreditationId)
+    matchesLedger(existing, first)
   )
   const currentMax =
     ledgerEvents.length > 0
@@ -71,29 +72,15 @@ const doAppendEvents = (storage, events) => {
 
   if (first.number !== expectedStart) {
     if (ledgerEvents.some((e) => e.number === first.number)) {
-      throw new LedgerSlotConflictError(
-        first.registrationId,
-        first.accreditationId,
-        first.number
-      )
+      throw new LedgerSlotConflictError(first)
     }
-    throw new LedgerSequenceError(
-      first.registrationId,
-      first.accreditationId,
-      first.number,
-      expectedStart
-    )
+    throw new LedgerSequenceError(first, expectedStart)
   }
 
   for (let i = 1; i < events.length; i++) {
     const expected = first.number + i
     if (events[i].number !== expected) {
-      throw new LedgerSequenceError(
-        events[i].registrationId,
-        events[i].accreditationId,
-        events[i].number,
-        expected
-      )
+      throw new LedgerSequenceError(events[i], expected)
     }
   }
 
@@ -114,13 +101,10 @@ export const createInMemoryLedgerRepository = (initialEvents = []) => {
 
   return () => ({
     /**
-     * @param {string} registrationId
-     * @param {string | null} accreditationId
+     * @param {WasteBalanceLedgerId} ledgerId
      */
-    findLatestInLedger: async (registrationId, accreditationId) => {
-      const matches = storage.filter((event) =>
-        matchesLedger(event, registrationId, accreditationId)
-      )
+    findLatestInLedger: async (ledgerId) => {
+      const matches = storage.filter((event) => matchesLedger(event, ledgerId))
 
       if (matches.length === 0) {
         return null
@@ -130,15 +114,12 @@ export const createInMemoryLedgerRepository = (initialEvents = []) => {
     },
 
     /**
-     * @param {string} registrationId
-     * @param {string | null} accreditationId
+     * @param {WasteBalanceLedgerId} ledgerId
      * @param {import('./ledger-schema.js').LedgerEventKind} kind
      */
-    findLatestInLedgerByKind: async (registrationId, accreditationId, kind) => {
+    findLatestInLedgerByKind: async (ledgerId, kind) => {
       const matches = storage.filter(
-        (event) =>
-          matchesLedger(event, registrationId, accreditationId) &&
-          event.kind === kind
+        (event) => matchesLedger(event, ledgerId) && event.kind === kind
       )
 
       if (matches.length === 0) {
@@ -149,21 +130,15 @@ export const createInMemoryLedgerRepository = (initialEvents = []) => {
     },
 
     /**
-     * @param {string} registrationId
-     * @param {string | null} accreditationId
+     * @param {WasteBalanceLedgerId} ledgerId
      * @param {string} prnId
      * @param {number} afterNumber
      */
-    findEventsByPrnIdAfter: async (
-      registrationId,
-      accreditationId,
-      prnId,
-      afterNumber
-    ) => {
+    findEventsByPrnIdAfter: async (ledgerId, prnId, afterNumber) => {
       const matches = storage
         .filter(
           (event) =>
-            matchesLedger(event, registrationId, accreditationId) &&
+            matchesLedger(event, ledgerId) &&
             /** @type {*} */ (event.payload).prnId === prnId &&
             event.number > afterNumber
         )
@@ -173,21 +148,20 @@ export const createInMemoryLedgerRepository = (initialEvents = []) => {
     },
 
     /**
-     * @param {string} registrationId
-     * @param {string | null} accreditationId
+     * @param {WasteBalanceLedgerId} ledgerId
      */
-    findAllInLedger: async (registrationId, accreditationId) => {
+    findAllInLedger: async (ledgerId) => {
       const matches = storage
-        .filter((event) =>
-          matchesLedger(event, registrationId, accreditationId)
-        )
+        .filter((event) => matchesLedger(event, ledgerId))
         .sort((a, b) => a.number - b.number)
 
       return structuredClone(matches)
     },
 
-    deleteAllInLedger: async (registrationId, accreditationId) =>
-      doDeleteInLedger(storage, registrationId, accreditationId),
+    /**
+     * @param {WasteBalanceLedgerId} ledgerId
+     */
+    deleteAllInLedger: async (ledgerId) => doDeleteInLedger(storage, ledgerId),
 
     appendEvents: async (events) => doAppendEvents(storage, events)
   })

--- a/src/waste-balances/repository/ledger-mongodb.js
+++ b/src/waste-balances/repository/ledger-mongodb.js
@@ -8,6 +8,10 @@
  * @typedef {import('./ledger-schema.js').LedgerEvent} LedgerEvent
  */
 
+/**
+ * @typedef {import('./ledger-schema.js').WasteBalanceLedgerId} WasteBalanceLedgerId
+ */
+
 import { LedgerSlotConflictError, LedgerSequenceError } from './ledger-port.js'
 import {
   validateLedgerEventInsert,
@@ -78,11 +82,7 @@ const classifyDuplicateKeyError = (error, event) => {
   }
 
   if (writeError.keyPattern?.number) {
-    return new LedgerSlotConflictError(
-      event.registrationId,
-      event.accreditationId,
-      event.number
-    )
+    return new LedgerSlotConflictError(event)
   }
 
   return undefined
@@ -121,26 +121,36 @@ const findDuplicateKeyWriteError = (error) => {
 }
 
 /**
- * @param {Collection} collection
- * @returns {(registrationId: string, accreditationId: string | null) => Promise<LedgerEvent | null>}
+ * The filter selecting exactly the events of one ledger. Every read builds its
+ * filter from this, so no read can name a ledger by less than its whole id.
+ *
+ * @param {WasteBalanceLedgerId} ledgerId
  */
-const performFindLatestInLedger =
-  (collection) => async (registrationId, accreditationId) => {
-    const doc = await collection.findOne(
-      { registrationId, accreditationId },
-      { sort: { number: -1 } }
-    )
-    return doc ? toLedgerEvent(doc) : null
-  }
+const ledgerFilter = ({ organisationId, registrationId, accreditationId }) => ({
+  organisationId,
+  registrationId,
+  accreditationId
+})
 
 /**
  * @param {Collection} collection
- * @returns {(registrationId: string, accreditationId: string | null, kind: string) => Promise<LedgerEvent | null>}
+ * @returns {(ledgerId: WasteBalanceLedgerId) => Promise<LedgerEvent | null>}
+ */
+const performFindLatestInLedger = (collection) => async (ledgerId) => {
+  const doc = await collection.findOne(ledgerFilter(ledgerId), {
+    sort: { number: -1 }
+  })
+  return doc ? toLedgerEvent(doc) : null
+}
+
+/**
+ * @param {Collection} collection
+ * @returns {(ledgerId: WasteBalanceLedgerId, kind: string) => Promise<LedgerEvent | null>}
  */
 const performFindLatestInLedgerByKind =
-  (collection) => async (registrationId, accreditationId, kind) => {
+  (collection) => async (ledgerId, kind) => {
     const doc = await collection.findOne(
-      { registrationId, accreditationId, kind },
+      { ...ledgerFilter(ledgerId), kind },
       { sort: { number: -1 } }
     )
     return doc ? toLedgerEvent(doc) : null
@@ -148,15 +158,13 @@ const performFindLatestInLedgerByKind =
 
 /**
  * @param {Collection} collection
- * @returns {(registrationId: string, accreditationId: string | null, prnId: string, afterNumber: number) => Promise<LedgerEvent[]>}
+ * @returns {(ledgerId: WasteBalanceLedgerId, prnId: string, afterNumber: number) => Promise<LedgerEvent[]>}
  */
 const performFindEventsByPrnIdAfter =
-  (collection) =>
-  async (registrationId, accreditationId, prnId, afterNumber) => {
+  (collection) => async (ledgerId, prnId, afterNumber) => {
     const docs = await collection
       .find({
-        registrationId,
-        accreditationId,
+        ...ledgerFilter(ledgerId),
         'payload.prnId': prnId,
         number: { $gt: afterNumber }
       })
@@ -168,31 +176,26 @@ const performFindEventsByPrnIdAfter =
 
 /**
  * @param {Collection} collection
- * @returns {(registrationId: string, accreditationId: string | null) => Promise<LedgerEvent[]>}
+ * @returns {(ledgerId: WasteBalanceLedgerId) => Promise<LedgerEvent[]>}
  */
-const performFindAllInLedger =
-  (collection) => async (registrationId, accreditationId) => {
-    const docs = await collection
-      .find({ registrationId, accreditationId })
-      .sort({ number: 1 })
-      .toArray()
+const performFindAllInLedger = (collection) => async (ledgerId) => {
+  const docs = await collection
+    .find(ledgerFilter(ledgerId))
+    .sort({ number: 1 })
+    .toArray()
 
-    return docs.map(toLedgerEvent)
-  }
+  return docs.map(toLedgerEvent)
+}
 
 /**
  * @migration PAE-1382 — delete all events for a ledgerId.
  * @param {Collection} collection
- * @returns {(registrationId: string, accreditationId: string | null) => Promise<number>}
+ * @returns {(ledgerId: WasteBalanceLedgerId) => Promise<number>}
  */
-const performDeleteInLedger =
-  (collection) => async (registrationId, accreditationId) => {
-    const result = await collection.deleteMany({
-      registrationId,
-      accreditationId
-    })
-    return result.deletedCount
-  }
+const performDeleteInLedger = (collection) => async (ledgerId) => {
+  const result = await collection.deleteMany(ledgerFilter(ledgerId))
+  return result.deletedCount
+}
 
 /**
  * Append a contiguous batch of events. Validates sequence: events must be
@@ -216,41 +219,24 @@ const performAppendEvents = (collection) => async (events) => {
 
   const first = validated[0]
 
-  const latest = await collection.findOne(
-    {
-      registrationId: first.registrationId,
-      accreditationId: first.accreditationId
-    },
-    { sort: { number: -1 }, projection: { number: 1 } }
-  )
+  const latest = await collection.findOne(ledgerFilter(first), {
+    sort: { number: -1 },
+    projection: { number: 1 }
+  })
 
   const expectedStart = (latest?.number ?? 0) + 1
 
   if (first.number !== expectedStart) {
     if (first.number <= (latest?.number ?? 0)) {
-      throw new LedgerSlotConflictError(
-        first.registrationId,
-        first.accreditationId,
-        first.number
-      )
+      throw new LedgerSlotConflictError(first)
     }
-    throw new LedgerSequenceError(
-      first.registrationId,
-      first.accreditationId,
-      first.number,
-      expectedStart
-    )
+    throw new LedgerSequenceError(first, expectedStart)
   }
 
   for (let i = 1; i < validated.length; i++) {
     const expected = first.number + i
     if (validated[i].number !== expected) {
-      throw new LedgerSequenceError(
-        validated[i].registrationId,
-        validated[i].accreditationId,
-        validated[i].number,
-        expected
-      )
+      throw new LedgerSequenceError(validated[i], expected)
     }
   }
 

--- a/src/waste-balances/repository/ledger-port.js
+++ b/src/waste-balances/repository/ledger-port.js
@@ -9,12 +9,32 @@
  */
 
 /**
- * Raised by `appendEvents` when a `(registrationId, accreditationId, number)`
- * slot is already occupied. Adapters translate their native conflict signal
- * (MongoDB `E11000`, in-memory index check) into this typed error so callers
- * can react uniformly.
+ * @typedef {import('./ledger-schema.js').LedgerPosition} LedgerPosition
+ */
+
+/**
+ * @typedef {import('./ledger-schema.js').WasteBalanceLedgerId} WasteBalanceLedgerId
+ */
+
+/**
+ * Names the ledger a failed append was addressing. Both append errors report the
+ * full ledger coordinate, so a caller or a log line never has to guess which
+ * organisation's ledger refused the write.
+ *
+ * @param {WasteBalanceLedgerId} ledgerId
+ */
+const describeLedger = ({ organisationId, registrationId, accreditationId }) =>
+  `organisation ${organisationId} registration ${registrationId} accreditation ${accreditationId}`
+
+/**
+ * Raised by `appendEvents` when the slot a position addresses is already
+ * occupied. Adapters translate their native conflict signal (MongoDB `E11000`,
+ * in-memory occupancy check) into this typed error so callers can react
+ * uniformly.
  */
 export class LedgerSlotConflictError extends Error {
+  /** @type {string} */
+  organisationId
   /** @type {string} */
   registrationId
   /** @type {string | null} */
@@ -23,18 +43,17 @@ export class LedgerSlotConflictError extends Error {
   slotNumber
 
   /**
-   * @param {string} registrationId
-   * @param {string | null} accreditationId
-   * @param {number} slotNumber
+   * @param {LedgerPosition} position
    */
-  constructor(registrationId, accreditationId, slotNumber) {
+  constructor(position) {
     super(
-      `Ledger slot already occupied for registration ${registrationId} accreditation ${accreditationId} number ${slotNumber}`
+      `Ledger slot already occupied for ${describeLedger(position)} number ${position.number}`
     )
     this.name = 'LedgerSlotConflictError'
-    this.registrationId = registrationId
-    this.accreditationId = accreditationId
-    this.slotNumber = slotNumber
+    this.organisationId = position.organisationId
+    this.registrationId = position.registrationId
+    this.accreditationId = position.accreditationId
+    this.slotNumber = position.number
   }
 }
 
@@ -46,6 +65,8 @@ export class LedgerSlotConflictError extends Error {
  */
 export class LedgerSequenceError extends Error {
   /** @type {string} */
+  organisationId
+  /** @type {string} */
   registrationId
   /** @type {string | null} */
   accreditationId
@@ -55,19 +76,18 @@ export class LedgerSequenceError extends Error {
   expectedNumber
 
   /**
-   * @param {string} registrationId
-   * @param {string | null} accreditationId
-   * @param {number} providedNumber
-   * @param {number} expectedNumber
+   * @param {LedgerPosition} position - The position the event claimed.
+   * @param {number} expectedNumber - The only number the ledger would accept.
    */
-  constructor(registrationId, accreditationId, providedNumber, expectedNumber) {
+  constructor(position, expectedNumber) {
     super(
-      `Ledger sequence violation for registration ${registrationId} accreditation ${accreditationId}: expected number ${expectedNumber}, got ${providedNumber}`
+      `Ledger sequence violation for ${describeLedger(position)}: expected number ${expectedNumber}, got ${position.number}`
     )
     this.name = 'LedgerSequenceError'
-    this.registrationId = registrationId
-    this.accreditationId = accreditationId
-    this.providedNumber = providedNumber
+    this.organisationId = position.organisationId
+    this.registrationId = position.registrationId
+    this.accreditationId = position.accreditationId
+    this.providedNumber = position.number
     this.expectedNumber = expectedNumber
   }
 }
@@ -81,21 +101,27 @@ export class LedgerSequenceError extends Error {
  */
 
 /**
+ * Every read names its ledger with a complete `WasteBalanceLedgerId`, and every
+ * adapter filters on all three of its ids. A ledger read that names a
+ * registration or accreditation under the wrong organisation matches nothing —
+ * it does not fall back to the ledger that registration happens to live in.
+ *
  * @typedef {Object} WasteBalanceLedgerRepository
- * @property {(registrationId: string, accreditationId: string | null) => Promise<LedgerEvent | null>} findLatestInLedger
+ * @property {(ledgerId: WasteBalanceLedgerId) => Promise<LedgerEvent | null>} findLatestInLedger
  *   Return the highest-numbered event for the ledger, or `null`
  *   if none exist.
- * @property {(registrationId: string, accreditationId: string | null, kind: import('./ledger-schema.js').LedgerEventKind) => Promise<LedgerEvent | null>} findLatestInLedgerByKind
- *   Return the highest-numbered event of the given kind for the ledger
- *   ledger, or `null` if none of that kind exist.
- * @property {(registrationId: string, accreditationId: string | null, prnId: string, afterNumber: number) => Promise<LedgerEvent[]>} findEventsByPrnIdAfter
+ * @property {(ledgerId: WasteBalanceLedgerId, kind: import('./ledger-schema.js').LedgerEventKind) => Promise<LedgerEvent | null>} findLatestInLedgerByKind
+ *   Return the highest-numbered event of the given kind for the ledger,
+ *   or `null` if none of that kind exist.
+ * @property {(ledgerId: WasteBalanceLedgerId, prnId: string, afterNumber: number) => Promise<LedgerEvent[]>} findEventsByPrnIdAfter
  *   Return events referencing the given `prnId` in `payload.prnId` within
  *   the specified ledger, with `number > afterNumber`, ordered by
- *   `number` ascending.
- * @property {(registrationId: string, accreditationId: string | null) => Promise<LedgerEvent[]>} findAllInLedger
+ *   `number` ascending. A ledger read that happens to be about a PRN: it takes
+ *   a ledger id, not a PRN's ancestry.
+ * @property {(ledgerId: WasteBalanceLedgerId) => Promise<LedgerEvent[]>} findAllInLedger
  *   Return all events for the given ledger, ordered by `number`
  *   ascending. Returns an empty array if the ledger has no events.
- * @property {(registrationId: string, accreditationId: string | null) => Promise<number>} deleteAllInLedger
+ * @property {(ledgerId: WasteBalanceLedgerId) => Promise<number>} deleteAllInLedger
  *   Migration PAE-1382: delete all events for the given ledger.
  *   Returns the number of deleted events. No-op on empty ledger.
  * @property {(events: LedgerEventInsert[]) => Promise<LedgerEvent[]>} appendEvents

--- a/src/waste-balances/repository/ledger-schema.js
+++ b/src/waste-balances/repository/ledger-schema.js
@@ -67,10 +67,9 @@ export const BACKFILL_ACTOR = Object.freeze({ id: 'system', name: 'backfill' })
 
 /**
  * The identity of an accreditation, or of a registration in its registered-only
- * phase (`accreditationId` null). `organisationId` is denormalised owner context
- * carried for attribution — the storage uniqueness key is
- * `(registrationId, accreditationId)`, not org — but it always travels with the
- * id and any event can recover it. Named for what it is: a registration or
+ * phase (`accreditationId` null). An accreditation belongs to a registration,
+ * which belongs to an organisation: all three ids are constitutive, and naming
+ * one names those above it. Named for what it is: a registration or
  * accreditation identity, not a ledger-specific type. It is what we key a waste
  * balance ledger by.
  *

--- a/src/waste-balances/repository/ledger-test-data.js
+++ b/src/waste-balances/repository/ledger-test-data.js
@@ -3,6 +3,20 @@ import { LEDGER_EVENT_KIND } from './ledger-schema.js'
 const DEFAULT_CREATED_AT = new Date('2026-01-15T10:00:00.000Z')
 
 /**
+ * Build the id of a waste balance ledger. Defaults match `buildLedgerEvent`, so
+ * a ledger id built with no overrides names the ledger that event belongs to.
+ *
+ * @param {Partial<import('./ledger-schema.js').WasteBalanceLedgerId>} [overrides]
+ * @returns {import('./ledger-schema.js').WasteBalanceLedgerId}
+ */
+export const buildLedgerId = (overrides = {}) => ({
+  organisationId: 'org-1',
+  registrationId: 'reg-1',
+  accreditationId: 'acc-1',
+  ...overrides
+})
+
+/**
  * Build a valid ledger event (insert shape — no `id`).
  * Defaults to a summary-log-submitted event.
  * @param {object} [overrides]

--- a/src/waste-records/application/read-summary-log-row-states.js
+++ b/src/waste-records/application/read-summary-log-row-states.js
@@ -68,10 +68,12 @@ const summaryLogRowStatesForHead = async (
 export const summaryLogRowStatesForRegistration = async ({
   ledgerRepository,
   summaryLogRowStateRepository,
+  organisationId,
   registrationId,
   accreditationId
 }) => {
   const head = await latestSubmittedSummaryLogId(ledgerRepository, {
+    organisationId,
     registrationId,
     accreditationId
   })


### PR DESCRIPTION
Ticket: [PAE-1593](https://eaflood.atlassian.net/browse/PAE-1593)

## Summary

A waste balance ledger belongs to an accreditation — or to a registration in its registered-only phase — and an accreditation belongs to a registration, which belongs to an organisation. All three ids are constitutive of the ledger's identity. The port did not treat them that way: every read and delete took `(registrationId, accreditationId)` positionally, the organisation was dropped at the boundary, and `organisationId` sat on stored events as attribution nothing queried on. A type called `WasteBalanceLedgerId` should name a ledger.

Every read and delete on `WasteBalanceLedgerRepository` now takes a whole `WasteBalanceLedgerId`, and both adapters filter on all three of its ids. `LedgerSlotConflictError` and `LedgerSequenceError` carry the organisation too, so a failed append names the ledger it was addressing rather than a partial coordinate.

The `partition_number` uniqueness key is unchanged and no stored document changes shape, so this is an identity change in code with nothing to migrate.

## Behaviour

- The contract suite states the scoping rule as behaviour rather than as a comment: the same registration and accreditation named under a **different** organisation reads nothing and deletes nothing. It runs against both the MongoDB and the in-memory adapter, so the two cannot drift.
- `GET /v1/admin/.../waste-balance-events` moves into the organisation-scoped route tree and gains an `{organisationId}` path segment, which is what lets its handler build a complete ledger id. Paired with DEFRA/epr-re-ex-admin-frontend#468, which already holds the organisation and now sends it.

## Changes

- `src/waste-balances/repository/ledger-port.js` — the five read/delete methods take a `WasteBalanceLedgerId`; both append errors take a `LedgerPosition` and report the full coordinate.
- `src/waste-balances/repository/ledger-schema.js` — `RegistrationOrAccreditationId` documents the three ids as constitutive; the type is what a ledger is keyed by.
- `src/waste-balances/repository/ledger-mongodb.js` — one `ledgerFilter` builds the selector for all six queries, so no read can name a ledger by less than its whole id.
- `src/waste-balances/repository/ledger-inmemory.js` — `matchesLedger` compares all three ids.
- `src/waste-balances/repository/ledger-contract/*.contract.js` — object arguments throughout, plus a cross-organisation scoping test per method.
- `src/routes/v1/admin/organisations/registrations/accreditations/ledger-events/` — moved from the registration-rooted tree; the handler passes a complete ledger id.
- Callers (`current-waste-balance.js`, `latest-submitted-summary-log-id.js`, `waste-balance-service.js`, `get-projected-prn.js`, `read-summary-log-row-states.js`) build a complete ledger id from context they already carry.


[PAE-1593]: https://eaflood.atlassian.net/browse/PAE-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ