### PR TITLE
PAE-1593: Surface mongo's insert-path slot conflict as a typed error

### DIFF
--- a/src/waste-balances/repository/ledger-mongodb.js
+++ b/src/waste-balances/repository/ledger-mongodb.js
@@ -69,28 +69,26 @@ const toLedgerEvent = (doc) => {
 }
 
 /**
- * Classify a MongoDB E11000 duplicate key error by inspecting the
- * `keyPattern` on the write error to determine which index was violated.
+ * Classify a MongoDB E11000 duplicate key error raised by an append.
+ *
+ * `partition_number` is the only unique index on this collection — the other
+ * two are non-unique, and driver-generated `_id`s do not collide — so a
+ * duplicate key can only mean a competing writer took the slot.
  *
  * @param {unknown} error
  * @param {LedgerEventInsert} event
  */
 const classifyDuplicateKeyError = (error, event) => {
-  const writeError = findDuplicateKeyWriteError(error)
-  if (!writeError) {
+  if (!findDuplicateKeyWriteError(error)) {
     return undefined
   }
 
-  if (writeError.keyPattern?.number) {
-    return new LedgerSlotConflictError(event)
-  }
-
-  return undefined
+  return new LedgerSlotConflictError(event)
 }
 
 /**
  * @param {unknown} candidate
- * @returns {candidate is { code: number, keyPattern?: Record<string, number> }}
+ * @returns {candidate is { code: number }}
  */
 const isDuplicateKeyWriteError = (candidate) =>
   typeof candidate === 'object' &&
@@ -99,15 +97,13 @@ const isDuplicateKeyWriteError = (candidate) =>
   candidate.code === MONGODB_DUPLICATE_KEY_ERROR_CODE
 
 /**
+ * `insertMany` reports a failed write as a `writeErrors` entry on the
+ * enclosing `MongoBulkWriteError`. An entry is where a write records its own
+ * outcome, so a duplicate key is looked up there rather than on the aggregate.
+ *
  * @param {unknown} error
  */
 const findDuplicateKeyWriteError = (error) => {
-  if (isDuplicateKeyWriteError(error)) {
-    return /** @type {{ code: number, keyPattern?: Record<string, number> }} */ (
-      error
-    )
-  }
-
   if (
     typeof error === 'object' &&
     error !== null &&

--- a/src/waste-balances/repository/ledger-mongodb.test.js
+++ b/src/waste-balances/repository/ledger-mongodb.test.js
@@ -36,17 +36,22 @@ const it = mongoIt.extend({
   }
 })
 
+const deferred = () => {
+  /** @type {() => void} */
+  let settle = () => undefined
+  const promise = new Promise((resolve) => {
+    settle = () => resolve(undefined)
+  })
+  return { promise, settle }
+}
+
 /**
  * A view of a real database whose `insertMany` waits for `release` before
  * reaching mongod, and which announces when a writer has got that far. Lets a
  * test place two writers past the slot pre-check before either one inserts.
  */
 const databaseHoldingInsert = (/** @type {*} */ database, release) => {
-  /** @type {() => void} */
-  let announce
-  const reachedInsert = new Promise((resolve) => {
-    announce = resolve
-  })
+  const reached = deferred()
 
   const view = {
     collection: (/** @type {string} */ name) =>
@@ -54,7 +59,7 @@ const databaseHoldingInsert = (/** @type {*} */ database, release) => {
         get: (target, property) => {
           if (property === 'insertMany') {
             return async (/** @type {*[]} */ ...args) => {
-              announce()
+              reached.settle()
               await release
               return target.insertMany(...args)
             }
@@ -65,7 +70,7 @@ const databaseHoldingInsert = (/** @type {*} */ database, release) => {
       })
   }
 
-  return { view, reachedInsert }
+  return { view, reachedInsert: reached.promise }
 }
 
 const indexKeyFor = (indexes, name) =>
@@ -176,12 +181,11 @@ describe('MongoDB ledger repository', () => {
       )
       await collection.deleteMany({})
 
-      /** @type {() => void} */
-      let releaseLoserInsert
-      const released = new Promise((resolve) => {
-        releaseLoserInsert = resolve
-      })
-      const { view, reachedInsert } = databaseHoldingInsert(database, released)
+      const loserInsert = deferred()
+      const { view, reachedInsert } = databaseHoldingInsert(
+        database,
+        loserInsert.promise
+      )
 
       const winner = (await createMongoLedgerRepository(database))()
       const loser = (
@@ -195,7 +199,7 @@ describe('MongoDB ledger repository', () => {
       const losingAppend = loser.appendEvents([contestedSlot])
       await reachedInsert
       await winner.appendEvents([contestedSlot])
-      releaseLoserInsert()
+      loserInsert.settle()
 
       const reason = await losingAppend.catch(
         (/** @type {*} */ caught) => caught

--- a/src/waste-balances/repository/ledger-mongodb.test.js
+++ b/src/waste-balances/repository/ledger-mongodb.test.js
@@ -7,6 +7,7 @@ import {
   ensureLedgerCollection,
   WASTE_BALANCE_EVENTS_COLLECTION_NAME
 } from './ledger-mongodb.js'
+import { LedgerSlotConflictError } from './ledger-port.js'
 import { buildLedgerEvent } from './ledger-test-data.js'
 import { testLedgerRepositoryContract } from './ledger-port.contract.js'
 
@@ -34,6 +35,38 @@ const it = mongoIt.extend({
     await use(factory)
   }
 })
+
+/**
+ * A view of a real database whose `insertMany` waits for `release` before
+ * reaching mongod, and which announces when a writer has got that far. Lets a
+ * test place two writers past the slot pre-check before either one inserts.
+ */
+const databaseHoldingInsert = (/** @type {*} */ database, release) => {
+  /** @type {() => void} */
+  let announce
+  const reachedInsert = new Promise((resolve) => {
+    announce = resolve
+  })
+
+  const view = {
+    collection: (/** @type {string} */ name) =>
+      new Proxy(database.collection(name), {
+        get: (target, property) => {
+          if (property === 'insertMany') {
+            return async (/** @type {*[]} */ ...args) => {
+              announce()
+              await release
+              return target.insertMany(...args)
+            }
+          }
+          const value = Reflect.get(target, property)
+          return typeof value === 'function' ? value.bind(target) : value
+        }
+      })
+  }
+
+  return { view, reachedInsert }
+}
 
 const indexKeyFor = (indexes, name) =>
   indexes.find((idx) => idx.name === name)?.key
@@ -134,47 +167,47 @@ describe('MongoDB ledger repository', () => {
       ).rejects.toBe(upstream)
     })
 
-    it('rethrows E11000 with unrecognised keyPattern as the raw error', async () => {
-      const mongoError = Object.assign(new Error('E11000'), {
-        code: 11000,
-        keyPattern: { unknownField: 1 }
-      })
-      const stubCollection = {
-        createIndex: () => Promise.resolve(),
-        findOne: () => Promise.resolve(null),
-        insertMany: () => Promise.reject(mongoError)
-      }
-      const stubDb = { collection: () => stubCollection }
+    it('classifies the loser of a race for the same slot as a slot conflict', async (/** @type {*} */ {
+      mongoClient
+    }) => {
+      const database = mongoClient.db(DATABASE_NAME)
+      const collection = database.collection(
+        WASTE_BALANCE_EVENTS_COLLECTION_NAME
+      )
+      await collection.deleteMany({})
 
-      const repository = (
-        await createMongoLedgerRepository(/** @type {*} */ (stubDb))
+      /** @type {() => void} */
+      let releaseLoserInsert
+      const released = new Promise((resolve) => {
+        releaseLoserInsert = resolve
+      })
+      const { view, reachedInsert } = databaseHoldingInsert(database, released)
+
+      const winner = (await createMongoLedgerRepository(database))()
+      const loser = (
+        await createMongoLedgerRepository(/** @type {*} */ (view))
       )()
 
-      await expect(
-        repository.appendEvents([buildLedgerEvent({ number: 1 })])
-      ).rejects.toBe(mongoError)
-    })
+      // Hold the loser between its slot pre-check and its insert. Both writers
+      // then find slot 1 free and claim it, and only the unique index can
+      // separate them — which is the collision the pre-check cannot see.
+      const contestedSlot = buildLedgerEvent({ number: 1 })
+      const losingAppend = loser.appendEvents([contestedSlot])
+      await reachedInsert
+      await winner.appendEvents([contestedSlot])
+      releaseLoserInsert()
 
-    it('classifies a slot conflict raised when inserting the batch', async () => {
-      const mongoError = Object.assign(new Error('E11000'), {
-        writeErrors: [{ code: 11000, keyPattern: { number: 1 } }]
+      const reason = await losingAppend.catch(
+        (/** @type {*} */ caught) => caught
+      )
+      expect(reason).toBeInstanceOf(LedgerSlotConflictError)
+      expect(reason).toMatchObject({
+        registrationId: contestedSlot.registrationId,
+        accreditationId: contestedSlot.accreditationId,
+        slotNumber: contestedSlot.number
       })
-      const stubCollection = {
-        createIndex: () => Promise.resolve(),
-        findOne: () => Promise.resolve(null),
-        insertMany: () => Promise.reject(mongoError)
-      }
-      const stubDb = { collection: () => stubCollection }
 
-      const repository = (
-        await createMongoLedgerRepository(/** @type {*} */ (stubDb))
-      )()
-
-      await expect(
-        repository.appendEvents([buildLedgerEvent({ number: 1 })])
-      ).rejects.toMatchObject({
-        name: 'LedgerSlotConflictError'
-      })
+      await expect(collection.countDocuments()).resolves.toBe(1)
     })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1593](https://eaflood.atlassian.net/browse/PAE-1593)
## Why

`WasteBalanceLedgerRepository.appendEvents` documents that a starting slot taken by a competing writer *"surfaces as a `LedgerSlotConflictError`, whether detected on the pre-check or on the insert itself."*

The pre-check half worked. The insert half did not. The MongoDB adapter classified a duplicate-key error by reading a `keyPattern` off the write error, and a real mongod never sets one — neither the enclosing `MongoBulkWriteError` nor its `writeErrors` entries carry that property. Classification therefore returned nothing and the raw driver error was rethrown, so the port's contract was false on its MongoDB implementation.

What is lost is error fidelity: a caller could not distinguish "lost an optimistic-concurrency race" from "mongo is unhealthy". Nothing retries on this error today, and nothing in this change starts to — the conflict continues to surface to the caller, per ADR-0036.

## What changed

`partition_number` is the only unique index on the ledger collection; the other two are non-unique, and driver-generated `_id`s do not collide. A duplicate key raised by an append can therefore only mean a competing writer took the slot. Classification now says exactly that, and reads the `writeErrors` entry where a failed write records its own outcome rather than the aggregate error.

## Why the old test never caught it

It asserted the classification against a hand-built error carrying a `keyPattern` mongod does not produce, so it passed against its own fixture while the real path stayed broken. Both existing concurrency tests exercise the in-memory adapter, whose pre-check throws the typed error directly, so neither reached the insert path.

It is replaced by two writers contending for the same slot in the same ledger against a real mongod. The losing writer is held between its slot pre-check and its insert, so both writers find the slot free and the collision can only be caught where the pre-check cannot see it — on the insert itself. The error and the code path are entirely real; only the interleaving is controlled.

That determinism is load-bearing rather than stylistic. An earlier version of this test raced two writers on separate connection pools and left the interleaving to chance. Run alone it reached the insert path every time; run inside the full suite it did not, because the writers serialised under load and the pre-check caught the conflict first. The test still passed — both paths raise the same typed error — while covering none of the code it existed to prove. The coverage gate caught it.

## Notes for review

- No retry is introduced anywhere.
- No index or storage change, and no migration.

[PAE-1593]: https://eaflood.atlassian.net/browse/PAE-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ