### PR TITLE
PAE-000: baseline typecheck strictness + hard test-type gate

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -71,12 +71,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: pr-prep
     if: needs.pr-prep.outputs.docs-only != 'true'
-    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write
     steps:
       - uses: DEFRA/epr-re-ex-service/.github/actions/lint-types-tests@main
+        with:
+          fail-on: all
 
   dependency-review:
     name: Dependency Review

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,6 +77,7 @@ export default [
       'no-unused-vars': [
         'error',
         {
+          args: 'all',
           argsIgnorePattern: '^_',
           caughtErrorsIgnorePattern: '^_',
           varsIgnorePattern: '^_'

--- a/jsconfig.typecheck.json
+++ b/jsconfig.typecheck.json
@@ -15,7 +15,10 @@
     "noImplicitAny": false,
     "strictNullChecks": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": false,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
     "paths": {
       "#adapters/*": ["./src/adapters/*"],
       "#application/*": ["./src/application/*"],

--- a/scripts/mongo-performance-test/single-nested-collection/data-generators.js
+++ b/scripts/mongo-performance-test/single-nested-collection/data-generators.js
@@ -253,7 +253,7 @@ export function generatePrnIssuance() {
   }
 }
 
-export function generateRegistration(orgId, material, wasteProcessingType) {
+export function generateRegistration(_orgId, material, wasteProcessingType) {
   const formSubmissionTime = randomDate()
 
   const registration = {
@@ -304,7 +304,7 @@ function getRecyclingProcess() {
   return randomChoices(RECYCLING_PROCESSES, randomInt(1, 2))
 }
 
-export function generateAccreditation(orgId, material, wasteProcessingType) {
+export function generateAccreditation(_orgId, material, wasteProcessingType) {
   const formSubmissionTime = randomDate()
   const accreditation = {
     id: generateObjectId(),

--- a/src/adapters/repositories/public-register/public-register.test.js
+++ b/src/adapters/repositories/public-register/public-register.test.js
@@ -43,6 +43,8 @@ vi.mock('@aws-sdk/client-s3', async () => {
           mockStorage.set(command.input.Key, command.input.Body)
           return {}
         }
+
+        return {}
       })
     }
   }


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
baseline typecheck strictness plus a real gate on the test typecheck.

- enable zero-cost tsc flags: noImplicitReturns, noFallthroughCasesInSwitch, noImplicitOverride, noUnusedParameters
- make the Lint Types - Tests job a hard gate (drop continue-on-error) and set fail-on: all so any test type error fails, not just changed files
- align eslint no-unused-vars to args: all (matches tsc noUnusedParameters; neostandard defaults to args: none)

part of a wider push to raise typecheck strictness now the test suite is green. depends on the epr-re-ex-service PR adding the fail-on input.