### PR TITLE
PAE-1657: forbid unsubmit of a superseded submission

### DIFF
--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -3,7 +3,6 @@ import { resolveDetailedMaterial } from '#domain/organisations/registration-util
 import { getOrsDetailsMap } from '#overseas-sites/application/get-ors-details-map.js'
 import { getIssuedTonnage } from '#packaging-recycling-notes/application/get-issued-tonnage.js'
 import { aggregateReportDetail } from '#reports/domain/aggregation/aggregate-report-detail.js'
-import { latestSubmitted } from '#reports/domain/build-calendar-periods.js'
 import { generateAllPeriodsForYear } from '#reports/domain/generate-reporting-periods.js'
 import { getOperatorCategory } from '#reports/domain/operator-category.js'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
@@ -142,12 +141,13 @@ export async function fetchReportBySubmissionNumber(
 }
 
 /**
- * Determines whether a submission is the latest submitted submission for its
- * period. Only the latest submitted submission may be unsubmitted: unsubmitting
- * a superseded submission (an earlier one that a later resubmission has
- * replaced) would silently drop it from the admin submission history (PAE-1657).
- * A resubmission still in progress does not supersede: the earlier submission
- * remains the latest *submitted* one until the resubmission is itself submitted.
+ * Determines whether a submission is the latest submission for its period, by
+ * submission number, regardless of status. Only the latest submission may be
+ * unsubmitted: unsubmitting an earlier one would silently drop it from the admin
+ * submission history (PAE-1657). This intentionally guards the absolute latest
+ * submission, not merely the latest *submitted* one, so an earlier submitted
+ * report cannot be unsubmitted while a later resubmission draft is in progress.
+ * The caller separately requires the target to be submitted.
  * @param {import('#reports/repository/port.js').ReportsRepository} reportsRepository
  * @param {string} organisationId
  * @param {string} registrationId
@@ -157,7 +157,7 @@ export async function fetchReportBySubmissionNumber(
  * @param {number} submissionNumber
  * @returns {Promise<boolean>}
  */
-export async function isLatestSubmittedSubmission(
+export async function isLatestSubmission(
   reportsRepository,
   organisationId,
   registrationId,
@@ -173,11 +173,14 @@ export async function isLatestSubmittedSubmission(
   const slot = periodicReports.find((pr) => pr.year === year)?.reports?.[
     cadence
   ]?.[period]
-  if (!slot) {
+  const submissions = [
+    slot?.current,
+    ...(slot?.previousSubmissions ?? [])
+  ].flatMap((s) => (s ? [s.submissionNumber] : []))
+  if (submissions.length === 0) {
     return false
   }
-  const latest = latestSubmitted(slot.current, slot.previousSubmissions)
-  return latest?.submissionNumber === submissionNumber
+  return Math.max(...submissions) === submissionNumber
 }
 
 /**

--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -3,6 +3,7 @@ import { resolveDetailedMaterial } from '#domain/organisations/registration-util
 import { getOrsDetailsMap } from '#overseas-sites/application/get-ors-details-map.js'
 import { getIssuedTonnage } from '#packaging-recycling-notes/application/get-issued-tonnage.js'
 import { aggregateReportDetail } from '#reports/domain/aggregation/aggregate-report-detail.js'
+import { latestSubmitted } from '#reports/domain/build-calendar-periods.js'
 import { generateAllPeriodsForYear } from '#reports/domain/generate-reporting-periods.js'
 import { getOperatorCategory } from '#reports/domain/operator-category.js'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
@@ -138,6 +139,45 @@ export async function fetchReportBySubmissionNumber(
   }
 
   return reportsRepository.findReportById(currentReportId)
+}
+
+/**
+ * Determines whether a submission is the latest submitted submission for its
+ * period. Only the latest submitted submission may be unsubmitted: unsubmitting
+ * a superseded submission (an earlier one that a later resubmission has
+ * replaced) would silently drop it from the admin submission history (PAE-1657).
+ * A resubmission still in progress does not supersede: the earlier submission
+ * remains the latest *submitted* one until the resubmission is itself submitted.
+ * @param {import('#reports/repository/port.js').ReportsRepository} reportsRepository
+ * @param {string} organisationId
+ * @param {string} registrationId
+ * @param {number} year
+ * @param {Cadence} cadence
+ * @param {number} period
+ * @param {number} submissionNumber
+ * @returns {Promise<boolean>}
+ */
+export async function isLatestSubmittedSubmission(
+  reportsRepository,
+  organisationId,
+  registrationId,
+  year,
+  cadence,
+  period,
+  submissionNumber
+) {
+  const periodicReports = await reportsRepository.findPeriodicReports({
+    organisationId,
+    registrationId
+  })
+  const slot = periodicReports.find((pr) => pr.year === year)?.reports?.[
+    cadence
+  ]?.[period]
+  if (!slot) {
+    return false
+  }
+  const latest = latestSubmitted(slot.current, slot.previousSubmissions)
+  return latest?.submissionNumber === submissionNumber
 }
 
 /**

--- a/src/reports/application/report-service.test.js
+++ b/src/reports/application/report-service.test.js
@@ -16,6 +16,7 @@ import {
   fetchOrGenerateReportForPeriod,
   createReportForPeriod,
   fetchReportBySubmissionNumber,
+  isLatestSubmittedSubmission,
   createReportsService
 } from './report-service.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
@@ -314,6 +315,50 @@ describe('report-service', () => {
       )
 
       expect(result).toBeNull()
+    })
+  })
+
+  describe('isLatestSubmittedSubmission', () => {
+    const stubRepository = (periodicReports) =>
+      /** @type {any} */ ({
+        findPeriodicReports: vi.fn().mockResolvedValue(periodicReports)
+      })
+
+    const slotWith = (current, previousSubmissions = []) => [
+      {
+        year: 2024,
+        reports: { monthly: { 1: { current, previousSubmissions } } }
+      }
+    ]
+
+    it('returns false when the period has no reports at all', async () => {
+      const result = await isLatestSubmittedSubmission(
+        stubRepository([]),
+        'org-1',
+        'reg-1',
+        2024,
+        'monthly',
+        1,
+        1
+      )
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when the period holds no submitted submission', async () => {
+      const draft = { status: REPORT_STATUS.IN_PROGRESS, submissionNumber: 1 }
+
+      const result = await isLatestSubmittedSubmission(
+        stubRepository(slotWith(draft)),
+        'org-1',
+        'reg-1',
+        2024,
+        'monthly',
+        1,
+        1
+      )
+
+      expect(result).toBe(false)
     })
   })
 

--- a/src/reports/application/report-service.test.js
+++ b/src/reports/application/report-service.test.js
@@ -16,7 +16,7 @@ import {
   fetchOrGenerateReportForPeriod,
   createReportForPeriod,
   fetchReportBySubmissionNumber,
-  isLatestSubmittedSubmission,
+  isLatestSubmission,
   createReportsService
 } from './report-service.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
@@ -318,7 +318,7 @@ describe('report-service', () => {
     })
   })
 
-  describe('isLatestSubmittedSubmission', () => {
+  describe('isLatestSubmission', () => {
     const stubRepository = (periodicReports) =>
       /** @type {any} */ ({
         findPeriodicReports: vi.fn().mockResolvedValue(periodicReports)
@@ -332,7 +332,7 @@ describe('report-service', () => {
     ]
 
     it('returns false when the period has no reports at all', async () => {
-      const result = await isLatestSubmittedSubmission(
+      const result = await isLatestSubmission(
         stubRepository([]),
         'org-1',
         'reg-1',
@@ -345,11 +345,12 @@ describe('report-service', () => {
       expect(result).toBe(false)
     })
 
-    it('returns false when the period holds no submitted submission', async () => {
-      const draft = { status: REPORT_STATUS.IN_PROGRESS, submissionNumber: 1 }
+    it('returns false for an earlier submission superseded by a later in-progress draft', async () => {
+      const draft = { status: REPORT_STATUS.IN_PROGRESS, submissionNumber: 2 }
+      const submitted = { status: REPORT_STATUS.SUBMITTED, submissionNumber: 1 }
 
-      const result = await isLatestSubmittedSubmission(
-        stubRepository(slotWith(draft)),
+      const result = await isLatestSubmission(
+        stubRepository(slotWith(draft, [submitted])),
         'org-1',
         'reg-1',
         2024,

--- a/src/reports/domain/build-calendar-periods.js
+++ b/src/reports/domain/build-calendar-periods.js
@@ -27,7 +27,7 @@ const isSubmitted = (report) => report?.status === REPORT_STATUS.SUBMITTED
  * @param {ReportSummary[]} previousSubmissions
  * @returns {ReportSummary | undefined}
  */
-export const latestSubmitted = (current, previousSubmissions) =>
+const latestSubmitted = (current, previousSubmissions) =>
   [current, ...previousSubmissions]
     .filter(isSubmitted)
     .sort((a, b) => b.submissionNumber - a.submissionNumber)[0]

--- a/src/reports/domain/build-calendar-periods.js
+++ b/src/reports/domain/build-calendar-periods.js
@@ -27,7 +27,7 @@ const isSubmitted = (report) => report?.status === REPORT_STATUS.SUBMITTED
  * @param {ReportSummary[]} previousSubmissions
  * @returns {ReportSummary | undefined}
  */
-const latestSubmitted = (current, previousSubmissions) =>
+export const latestSubmitted = (current, previousSubmissions) =>
   [current, ...previousSubmissions]
     .filter(isSubmitted)
     .sort((a, b) => b.submissionNumber - a.submissionNumber)[0]

--- a/src/reports/routes/unsubmit.js
+++ b/src/reports/routes/unsubmit.js
@@ -3,7 +3,10 @@ import { StatusCodes } from 'http-status-codes'
 
 import { SCOPES } from '#common/helpers/auth/constants.js'
 import { auditReportStatusTransition } from '#reports/application/audit.js'
-import { fetchReportBySubmissionNumber } from '#reports/application/report-service.js'
+import {
+  fetchReportBySubmissionNumber,
+  isLatestSubmittedSubmission
+} from '#reports/application/report-service.js'
 import {
   REPORT_STATUS,
   REPORT_STATUS_SLOT
@@ -59,6 +62,24 @@ export const reportsUnsubmit = {
     if (report.status.currentStatus !== REPORT_STATUS.SUBMITTED) {
       throw Boom.conflict(
         `Cannot unsubmit a report with status '${report.status.currentStatus}'`
+      )
+    }
+
+    // Only the latest submitted submission may be unsubmitted. Unsubmitting a
+    // submission that a later resubmission has superseded would silently drop it
+    // from the admin submission history (PAE-1657).
+    const isLatest = await isLatestSubmittedSubmission(
+      reportsRepository,
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    )
+    if (!isLatest) {
+      throw Boom.conflict(
+        `Cannot unsubmit submission ${submissionNumber}: it has been superseded by a later submission`
       )
     }
 

--- a/src/reports/routes/unsubmit.js
+++ b/src/reports/routes/unsubmit.js
@@ -5,7 +5,7 @@ import { SCOPES } from '#common/helpers/auth/constants.js'
 import { auditReportStatusTransition } from '#reports/application/audit.js'
 import {
   fetchReportBySubmissionNumber,
-  isLatestSubmittedSubmission
+  isLatestSubmission
 } from '#reports/application/report-service.js'
 import {
   REPORT_STATUS,
@@ -65,10 +65,11 @@ export const reportsUnsubmit = {
       )
     }
 
-    // Only the latest submitted submission may be unsubmitted. Unsubmitting a
-    // submission that a later resubmission has superseded would silently drop it
-    // from the admin submission history (PAE-1657).
-    const isLatest = await isLatestSubmittedSubmission(
+    // Only the latest submission may be unsubmitted. Unsubmitting one that a
+    // later submission has superseded — whether that later submission is itself
+    // submitted or still an in-progress resubmission draft — would silently drop
+    // it from the admin submission history (PAE-1657).
+    const isLatest = await isLatestSubmission(
       reportsRepository,
       organisationId,
       registrationId,

--- a/src/reports/routes/unsubmit.test.js
+++ b/src/reports/routes/unsubmit.test.js
@@ -391,7 +391,7 @@ describe(`POST ${reportsUnsubmitPath}`, () => {
         expect(response.statusCode).toBe(StatusCodes.OK)
       })
 
-      it('allows unsubmitting the submitted submission while a resubmission draft is in progress', async () => {
+      it('returns 409 when unsubmitting a submitted submission while a later resubmission draft is in progress', async () => {
         const registration = buildRegistration({
           wasteProcessingType: 'reprocessor',
           accreditationId: undefined
@@ -412,8 +412,9 @@ describe(`POST ${reportsUnsubmitPath}`, () => {
           ...period,
           submissionNumber: 1
         })
-        // Submission 2 is only a draft (in_progress), so submission 1 is still
-        // the latest submitted one and remains unsubmittable.
+        // Submission 2 is a draft (in_progress). Even though submission 1 is the
+        // latest *submitted* one, a later submission exists, so unsubmit of 1 is
+        // rejected: only the absolute latest submission may be unsubmitted.
         await reportsRepository.createReport(
           buildCreateReportParams({ ...period, submissionNumber: 2 })
         )
@@ -434,7 +435,7 @@ describe(`POST ${reportsUnsubmitPath}`, () => {
           ...asServiceMaintainer()
         })
 
-        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(response.statusCode).toBe(StatusCodes.CONFLICT)
       })
     })
   })

--- a/src/reports/routes/unsubmit.test.js
+++ b/src/reports/routes/unsubmit.test.js
@@ -109,6 +109,53 @@ describe(`POST ${reportsUnsubmitPath}`, () => {
     return { server, organisationId: org.id, registrationId: registration.id }
   }
 
+  // A period holding two submitted submissions: submission 1 has been
+  // superseded by a later submitted resubmission (submission 2, the current
+  // one). Reproduces Tony Bruce's PAE-1657 finding.
+  const buildServerWithTwoSubmittedSubmissions = async () => {
+    const registration = buildRegistration({
+      wasteProcessingType: 'reprocessor',
+      accreditationId: undefined
+    })
+    const org = buildOrganisationWithRegistration(registration)
+
+    const reportsRepositoryFactory = createInMemoryReportsRepository()
+    const reportsRepository = reportsRepositoryFactory()
+
+    const period = {
+      organisationId: org.id,
+      registrationId: registration.id,
+      year: 2024,
+      cadence: 'monthly',
+      period: 1
+    }
+    const supersededReportId = await createAndSubmitReport(reportsRepository, {
+      ...period,
+      submissionNumber: 1
+    })
+    const currentReportId = await createAndSubmitReport(reportsRepository, {
+      ...period,
+      submissionNumber: 2
+    })
+
+    const server = await createTestServer({
+      repositories: {
+        organisationsRepository: createInMemoryOrganisationsRepository([org]),
+        wasteRecordsRepository: createInMemoryWasteRecordsRepository([]),
+        reportsRepository: reportsRepositoryFactory
+      }
+    })
+
+    return {
+      server,
+      organisationId: org.id,
+      registrationId: registration.id,
+      supersededReportId,
+      currentReportId,
+      reportsRepository
+    }
+  }
+
   describe('when feature flag is enabled', () => {
     describe('successful unsubmit', () => {
       beforeEach(() => vi.clearAllMocks())
@@ -292,6 +339,101 @@ describe(`POST ${reportsUnsubmitPath}`, () => {
         })
 
         expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+      })
+    })
+
+    describe('superseded submission', () => {
+      beforeEach(() => vi.clearAllMocks())
+
+      it('returns 409 when unsubmitting a submission superseded by a later one', async () => {
+        const { server, organisationId, registrationId } =
+          await buildServerWithTwoSubmittedSubmissions()
+
+        const response = await server.inject({
+          method: 'POST',
+          url: makeUrl(organisationId, registrationId, 2024, 'monthly', 1, 1),
+          ...asServiceMaintainer()
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+      })
+
+      it('leaves the superseded submission submitted after a rejected unsubmit', async () => {
+        const {
+          server,
+          organisationId,
+          registrationId,
+          supersededReportId,
+          reportsRepository
+        } = await buildServerWithTwoSubmittedSubmissions()
+
+        await server.inject({
+          method: 'POST',
+          url: makeUrl(organisationId, registrationId, 2024, 'monthly', 1, 1),
+          ...asServiceMaintainer()
+        })
+
+        const report = await reportsRepository.findReportById(supersededReportId)
+        expect(report.status.currentStatus).toBe('submitted')
+      })
+
+      it('allows unsubmitting the latest submitted submission', async () => {
+        const { server, organisationId, registrationId } =
+          await buildServerWithTwoSubmittedSubmissions()
+
+        const response = await server.inject({
+          method: 'POST',
+          url: makeUrl(organisationId, registrationId, 2024, 'monthly', 1, 2),
+          ...asServiceMaintainer()
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+      })
+
+      it('allows unsubmitting the submitted submission while a resubmission draft is in progress', async () => {
+        const registration = buildRegistration({
+          wasteProcessingType: 'reprocessor',
+          accreditationId: undefined
+        })
+        const org = buildOrganisationWithRegistration(registration)
+
+        const reportsRepositoryFactory = createInMemoryReportsRepository()
+        const reportsRepository = reportsRepositoryFactory()
+
+        const period = {
+          organisationId: org.id,
+          registrationId: registration.id,
+          year: 2024,
+          cadence: 'monthly',
+          period: 1
+        }
+        await createAndSubmitReport(reportsRepository, {
+          ...period,
+          submissionNumber: 1
+        })
+        // Submission 2 is only a draft (in_progress), so submission 1 is still
+        // the latest submitted one and remains unsubmittable.
+        await reportsRepository.createReport(
+          buildCreateReportParams({ ...period, submissionNumber: 2 })
+        )
+
+        const server = await createTestServer({
+          repositories: {
+            organisationsRepository: createInMemoryOrganisationsRepository([
+              org
+            ]),
+            wasteRecordsRepository: createInMemoryWasteRecordsRepository([]),
+            reportsRepository: reportsRepositoryFactory
+          }
+        })
+
+        const response = await server.inject({
+          method: 'POST',
+          url: makeUrl(org.id, registration.id, 2024, 'monthly', 1, 1),
+          ...asServiceMaintainer()
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
       })
     })
   })

--- a/src/reports/routes/unsubmit.test.js
+++ b/src/reports/routes/unsubmit.test.js
@@ -373,7 +373,8 @@ describe(`POST ${reportsUnsubmitPath}`, () => {
           ...asServiceMaintainer()
         })
 
-        const report = await reportsRepository.findReportById(supersededReportId)
+        const report =
+          await reportsRepository.findReportById(supersededReportId)
         expect(report.status.currentStatus).toBe('submitted')
       })
 


### PR DESCRIPTION
Ticket: [PAE-1657](https://eaflood.atlassian.net/browse/PAE-1657)
## What

Backend follow-up to PAE-1657 (merged in #1454). During review, **Tony Bruce** flagged that the unsubmit guard was too weak:

> When a period holds two submitted submissions (post-resubmission), clicking Unsubmit on the superseded submission 1 succeeds — the backend's only guard is "is this report submitted?", which a superseded-but-submitted report passes. The unsubmitted submission then disappears from the history view, silently removing a submission from the exact history this ticket adds.

Dan replied on the ticket: *"Will follow up with a fix."* This is that fix (defence-in-depth on the API; a sibling admin-frontend PR hides the affordance).

## Change

- `unsubmit.js` — after the existing `status === submitted` check, reject with **409 conflict** when the target is not the latest submission (by submission number) for its period. The two checks together mean unsubmit requires the target to be **both the latest submission and submitted**.
- `report-service.js` — new `isLatestSubmission` helper reading existing `findPeriodicReports` data; it compares against the highest submission number across the current slot and previous submissions, regardless of status. **No API payload change**, so ADR-0038 (which deliberately keeps the calendar free of `current`/`superseded` fields) is respected.

The guard is against the **absolute latest** submission, not merely the latest *submitted* one (raised by Senthil in review): an earlier submitted report cannot be unsubmitted while a later resubmission draft is still in progress.

Jira: https://eaflood.atlassian.net/browse/PAE-1657

[PAE-1657]: https://eaflood.atlassian.net/browse/PAE-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ