### PR TITLE
PAE-1676: add findLatestInLedgerBefore to the ledger repository

### DIFF
--- a/src/waste-balances/repository/ledger-contract/findLatestInLedgerBefore.contract.js
+++ b/src/waste-balances/repository/ledger-contract/findLatestInLedgerBefore.contract.js
@@ -1,0 +1,272 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { buildLedgerEvent, buildLedgerId } from '../ledger-test-data.js'
+
+const CUTOFF = new Date('2026-07-01T00:00:00.000Z')
+
+export const testFindLatestInLedgerBeforeBehaviour = (it) => {
+  describe('findLatestInLedgerBefore', () => {
+    let repository
+
+    beforeEach(
+      async (
+        /** @type {{ ledgerRepository: import('../ledger-port.js').WasteBalanceLedgerRepositoryFactory }} */ {
+          ledgerRepository
+        }
+      ) => {
+        repository = await ledgerRepository()
+      }
+    )
+
+    it('returns null when no events exist for the ledger', async () => {
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-empty',
+          accreditationId: 'acc-empty'
+        }),
+        CUTOFF
+      )
+      expect(result).toBeNull()
+    })
+
+    it('returns null when every event was created at or after the cutoff', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-after',
+          accreditationId: 'acc-after',
+          number: 1,
+          createdAt: new Date('2026-07-05T09:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-after',
+          accreditationId: 'acc-after'
+        }),
+        CUTOFF
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('does not return an event created at exactly the cutoff instant', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-exact',
+          accreditationId: 'acc-exact',
+          number: 1,
+          createdAt: CUTOFF
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-exact',
+          accreditationId: 'acc-exact'
+        }),
+        CUTOFF
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('returns the highest-numbered of several events before the cutoff', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many',
+          number: 1,
+          payload: { summaryLogId: 'log-1', creditTotal: 100 },
+          closingBalance: { amount: 10, availableAmount: 10 },
+          createdAt: new Date('2026-05-10T10:00:00.000Z')
+        })
+      ])
+      const [stored] = await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many',
+          number: 2,
+          payload: { summaryLogId: 'log-2', creditTotal: 200 },
+          closingBalance: { amount: 20, availableAmount: 18 },
+          createdAt: new Date('2026-06-20T10:00:00.000Z')
+        })
+      ])
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many',
+          number: 3,
+          payload: { summaryLogId: 'log-3', creditTotal: 300 },
+          closingBalance: { amount: 30, availableAmount: 25 },
+          createdAt: new Date('2026-07-08T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many'
+        }),
+        CUTOFF
+      )
+
+      expect(result.id).toBe(stored.id)
+      expect(result.number).toBe(2)
+      expect(result.closingBalance).toEqual({ amount: 20, availableAmount: 18 })
+    })
+
+    it('picks the highest-numbered event, not the latest-created, when the orders disagree', async () => {
+      const [, second] = await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-disorder',
+          accreditationId: 'acc-disorder',
+          number: 1,
+          payload: { summaryLogId: 'log-1', creditTotal: 100 },
+          closingBalance: { amount: 10, availableAmount: 10 },
+          createdAt: new Date('2026-06-15T10:00:00.000Z')
+        }),
+        buildLedgerEvent({
+          registrationId: 'reg-disorder',
+          accreditationId: 'acc-disorder',
+          number: 2,
+          payload: { summaryLogId: 'log-2', creditTotal: 200 },
+          closingBalance: { amount: 20, availableAmount: 18 },
+          createdAt: new Date('2026-06-10T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-disorder',
+          accreditationId: 'acc-disorder'
+        }),
+        CUTOFF
+      )
+
+      expect(result.id).toBe(second.id)
+      expect(result.number).toBe(2)
+    })
+
+    it('returns an event from long before the cutoff when nothing newer precedes it', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-carry',
+          accreditationId: 'acc-carry',
+          number: 1,
+          closingBalance: { amount: 75, availableAmount: 60 },
+          createdAt: new Date('2026-02-14T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-carry',
+          accreditationId: 'acc-carry'
+        }),
+        CUTOFF
+      )
+
+      expect(result.number).toBe(1)
+      expect(result.closingBalance).toEqual({ amount: 75, availableAmount: 60 })
+    })
+
+    it('isolates results by ledgerId', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-x',
+          accreditationId: 'acc-x',
+          number: 1,
+          createdAt: new Date('2026-06-01T10:00:00.000Z')
+        })
+      ])
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-y',
+          accreditationId: 'acc-y',
+          number: 1,
+          payload: { summaryLogId: 'log-y', creditTotal: 500 },
+          createdAt: new Date('2026-08-01T10:00:00.000Z')
+        })
+      ])
+
+      const x = await repository.findLatestInLedgerBefore(
+        buildLedgerId({ registrationId: 'reg-x', accreditationId: 'acc-x' }),
+        CUTOFF
+      )
+      const y = await repository.findLatestInLedgerBefore(
+        buildLedgerId({ registrationId: 'reg-y', accreditationId: 'acc-y' }),
+        CUTOFF
+      )
+
+      expect(x.number).toBe(1)
+      expect(x.accreditationId).toBe('acc-x')
+      expect(y).toBeNull()
+    })
+
+    it('does not read a ledger named under a different organisation', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          organisationId: 'org-owner',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned',
+          number: 1,
+          createdAt: new Date('2026-06-01T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          organisationId: 'org-stranger',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned'
+        }),
+        CUTOFF
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('treats null and non-null accreditationId as separate ledgers', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-null-test',
+          accreditationId: null,
+          number: 1,
+          closingBalance: { amount: 0, availableAmount: 0 },
+          createdAt: new Date('2026-06-01T10:00:00.000Z')
+        })
+      ])
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-null-test',
+          accreditationId: 'acc-non-null',
+          number: 1,
+          closingBalance: { amount: 999, availableAmount: 999 },
+          createdAt: new Date('2026-08-01T10:00:00.000Z')
+        })
+      ])
+
+      const nullLedger = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-null-test',
+          accreditationId: null
+        }),
+        CUTOFF
+      )
+      const nonNullLedger = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-null-test',
+          accreditationId: 'acc-non-null'
+        }),
+        CUTOFF
+      )
+
+      expect(nullLedger.closingBalance).toEqual({
+        amount: 0,
+        availableAmount: 0
+      })
+      expect(nonNullLedger).toBeNull()
+    })
+  })
+}

--- a/src/waste-balances/repository/ledger-inmemory.js
+++ b/src/waste-balances/repository/ledger-inmemory.js
@@ -115,6 +115,22 @@ export const createInMemoryLedgerRepository = (initialEvents = []) => {
 
     /**
      * @param {WasteBalanceLedgerId} ledgerId
+     * @param {Date} cutoff
+     */
+    findLatestInLedgerBefore: async (ledgerId, cutoff) => {
+      const matches = storage.filter(
+        (event) => matchesLedger(event, ledgerId) && event.createdAt < cutoff
+      )
+
+      if (matches.length === 0) {
+        return null
+      }
+
+      return structuredClone(/** @type {LedgerEvent} */ (matches.at(-1)))
+    },
+
+    /**
+     * @param {WasteBalanceLedgerId} ledgerId
      * @param {import('./ledger-schema.js').LedgerEventKind} kind
      */
     findLatestInLedgerByKind: async (ledgerId, kind) => {

--- a/src/waste-balances/repository/ledger-mongodb.js
+++ b/src/waste-balances/repository/ledger-mongodb.js
@@ -141,6 +141,19 @@ const performFindLatestInLedger = (collection) => async (ledgerId) => {
 
 /**
  * @param {Collection} collection
+ * @returns {(ledgerId: WasteBalanceLedgerId, cutoff: Date) => Promise<LedgerEvent | null>}
+ */
+const performFindLatestInLedgerBefore =
+  (collection) => async (ledgerId, cutoff) => {
+    const doc = await collection.findOne(
+      { ...ledgerFilter(ledgerId), createdAt: { $lt: cutoff } },
+      { sort: { number: -1 } }
+    )
+    return doc ? toLedgerEvent(doc) : null
+  }
+
+/**
+ * @param {Collection} collection
  * @returns {(ledgerId: WasteBalanceLedgerId, kind: string) => Promise<LedgerEvent | null>}
  */
 const performFindLatestInLedgerByKind =
@@ -261,6 +274,7 @@ export const createMongoLedgerRepository = async (db) => {
 
   return () => ({
     findLatestInLedger: performFindLatestInLedger(collection),
+    findLatestInLedgerBefore: performFindLatestInLedgerBefore(collection),
     findLatestInLedgerByKind: performFindLatestInLedgerByKind(collection),
     findEventsByPrnIdAfter: performFindEventsByPrnIdAfter(collection),
     findAllInLedger: performFindAllInLedger(collection),

--- a/src/waste-balances/repository/ledger-port.contract.js
+++ b/src/waste-balances/repository/ledger-port.contract.js
@@ -1,5 +1,6 @@
 import { testAppendEventsBehaviour } from './ledger-contract/appendEvents.contract.js'
 import { testFindLatestInLedgerBehaviour } from './ledger-contract/findLatestInLedger.contract.js'
+import { testFindLatestInLedgerBeforeBehaviour } from './ledger-contract/findLatestInLedgerBefore.contract.js'
 import { testFindLatestInLedgerByKindBehaviour } from './ledger-contract/findLatestInLedgerByKind.contract.js'
 import { testFindEventsByPrnIdAfterBehaviour } from './ledger-contract/findEventsByPrnIdAfter.contract.js'
 import { testFindAllInLedgerBehaviour } from './ledger-contract/findAllInLedger.contract.js'
@@ -8,6 +9,7 @@ import { testDeleteAllInLedgerBehaviour } from './ledger-contract/deleteAllInLed
 export const testLedgerRepositoryContract = (it) => {
   testAppendEventsBehaviour(it)
   testFindLatestInLedgerBehaviour(it)
+  testFindLatestInLedgerBeforeBehaviour(it)
   testFindLatestInLedgerByKindBehaviour(it)
   testFindEventsByPrnIdAfterBehaviour(it)
   testFindAllInLedgerBehaviour(it)

--- a/src/waste-balances/repository/ledger-port.js
+++ b/src/waste-balances/repository/ledger-port.js
@@ -110,6 +110,10 @@ export class LedgerSequenceError extends Error {
  * @property {(ledgerId: WasteBalanceLedgerId) => Promise<LedgerEvent | null>} findLatestInLedger
  *   Return the highest-numbered event for the ledger, or `null`
  *   if none exist.
+ * @property {(ledgerId: WasteBalanceLedgerId, cutoff: Date) => Promise<LedgerEvent | null>} findLatestInLedgerBefore
+ *   Return the highest-numbered event for the ledger whose `createdAt` is
+ *   strictly before `cutoff`, or `null` if no event precedes it. An event
+ *   created at exactly `cutoff` does not count as before it.
  * @property {(ledgerId: WasteBalanceLedgerId, kind: import('./ledger-schema.js').LedgerEventKind) => Promise<LedgerEvent | null>} findLatestInLedgerByKind
  *   Return the highest-numbered event of the given kind for the ledger,
  *   or `null` if none of that kind exist.


### PR DESCRIPTION
Ticket: [PAE-1676](https://eaflood.atlassian.net/browse/PAE-1676)
## Summary

- Adds `findLatestInLedgerBefore(ledgerId, cutoff)` to the waste-balance ledger repository: the highest-numbered event for a ledger created strictly before a cutoff instant, or `null` if none precedes it.
- Needed for PAE-1676 (monthly waste balance report for PRN market supply): the existing read path only returns the newest ledger event, with no way to ask "what was the balance as at this instant". The report service (next PR) calls this per accreditation with the selected month's closing cutoff.
- No new index: the existing `partition_number` index covers the partition filter and `number` sort, with the `createdAt` bound applied as a filter; per-partition event counts are small.
- An aggregation-pipeline alternative (`$match` + `$sort` + `$group` first-per-partition) was considered and rejected — the per-ledger `findOne` reuses the existing index and `ledgerFilter`, is contract-testable, and N is hundreds of accreditations.

## Changes

- `src/waste-balances/repository/ledger-port.js` — port typedef gains `findLatestInLedgerBefore` with strictly-before semantics documented (an event created at exactly the cutoff does not count).
- `src/waste-balances/repository/ledger-mongodb.js` — `performFindLatestInLedgerBefore`: `findOne` on `ledgerFilter` + `createdAt: { $lt: cutoff }`, sorted `number: -1`; registered in the factory.
- `src/waste-balances/repository/ledger-inmemory.js` — matching in-memory implementation (partition + `createdAt < cutoff` filter, highest-numbered match).
- `src/waste-balances/repository/ledger-contract/findLatestInLedgerBefore.contract.js` — new contract: null on empty ledger, null when all events at/after cutoff, exact-cutoff instant excluded, highest-numbered-of-several returned, highest-numbered wins over latest-created when the orders disagree, carry-over from months earlier, ledger isolation, organisation isolation, null vs non-null `accreditationId` separation.
- `src/waste-balances/repository/ledger-port.contract.js` — registers the new contract so both MongoDB (testcontainers) and in-memory suites run it.


[PAE-1676]: https://eaflood.atlassian.net/browse/PAE-1676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ