### PR TITLE
PAE-1676: add waste balance report aggregation service

### DIFF
--- a/src/waste-balances/application/waste-balance-report.js
+++ b/src/waste-balances/application/waste-balance-report.js
@@ -1,0 +1,172 @@
+import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
+import { add, toNumber } from '#common/helpers/decimal-utils.js'
+import { resolveAccreditation } from '#domain/organisations/registration-utils.js'
+
+/** @import {Organisation} from '#domain/organisations/model.js' */
+/** @import {Registration, RegistrationApproved} from '#domain/organisations/registration.js' */
+/** @import {AccreditationApproved} from '#domain/organisations/accreditation.js' */
+/** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
+/** @import {WasteBalanceLedgerRepository} from '../repository/ledger-port.js' */
+
+const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
+
+/**
+ * @typedef {Object} WasteBalanceReportRow
+ * @property {string} orgId - The organisation's external reference (not its
+ *   internal id), as a string.
+ * @property {string} registrationNumber
+ * @property {string} accreditationNumber
+ * @property {string} material
+ * @property {string} wasteProcessingType
+ * @property {number} amount
+ * @property {number} availableAmount
+ */
+
+/**
+ * @typedef {Object} WasteBalanceReportTotal
+ * @property {string} material
+ * @property {string} wasteProcessingType
+ * @property {number} amount
+ * @property {number} availableAmount
+ */
+
+/**
+ * @typedef {Object} WasteBalanceReport
+ * @property {WasteBalanceReportTotal[]} totals
+ * @property {WasteBalanceReportRow[]} accreditations
+ */
+
+/**
+ * @typedef {Object} WasteBalanceReportDeps
+ * @property {Pick<OrganisationsRepository, 'findAll'>} organisationsRepository
+ * @property {Pick<WasteBalanceLedgerRepository, 'findLatestInLedgerBefore'>} ledgerRepository
+ */
+
+/**
+ * One report row: the accreditation's balance as it stood at the cutoff —
+ * the closing balance of the last ledger event created strictly before it.
+ * An accreditation with no ledger history before the cutoff has a zero
+ * balance.
+ *
+ * @param {WasteBalanceReportDeps['ledgerRepository']} ledgerRepository
+ * @param {Organisation} org
+ * @param {Registration} registration
+ * @param {AccreditationApproved} accreditation
+ * @param {Date} cutoff
+ * @returns {Promise<WasteBalanceReportRow>}
+ */
+const buildReportRow = async (
+  ledgerRepository,
+  org,
+  registration,
+  accreditation,
+  cutoff
+) => {
+  const event = await ledgerRepository.findLatestInLedgerBefore(
+    {
+      organisationId: org.id,
+      registrationId: registration.id,
+      accreditationId: accreditation.id
+    },
+    cutoff
+  )
+
+  const balance = event
+    ? event.closingBalance
+    : { amount: 0, availableAmount: 0 }
+
+  return {
+    orgId: String(org.orgId),
+    // A live accreditation implies a registration that has been approved and
+    // so carries a registrationNumber (validateApprovals enforces the link at
+    // write time) — same cast precedent as getReportableRegistrations.
+    registrationNumber: /** @type {RegistrationApproved} */ (registration)
+      .registrationNumber,
+    accreditationNumber: accreditation.accreditationNumber,
+    material: accreditation.material,
+    wasteProcessingType: accreditation.wasteProcessingType,
+    amount: balance.amount,
+    availableAmount: balance.availableAmount
+  }
+}
+
+/**
+ * Per-material totals across the rows: one entry per (material,
+ * wasteProcessingType) combination that has at least one accredited
+ * registration, summing balance and available balance with exact decimal
+ * arithmetic. A combination whose accreditations all hold zero balances
+ * still appears, summing to zero.
+ *
+ * @param {WasteBalanceReportRow[]} rows
+ * @returns {WasteBalanceReportTotal[]}
+ */
+const totalBalancesPerMaterial = (rows) => {
+  /** @type {Map<string, WasteBalanceReportTotal>} */
+  const totals = new Map()
+
+  for (const row of rows) {
+    const key = `${row.material}|${row.wasteProcessingType}`
+    const total = totals.get(key) ?? {
+      material: row.material,
+      wasteProcessingType: row.wasteProcessingType,
+      amount: 0,
+      availableAmount: 0
+    }
+    total.amount = toNumber(add(total.amount, row.amount))
+    total.availableAmount = toNumber(
+      add(total.availableAmount, row.availableAmount)
+    )
+    totals.set(key, total)
+  }
+
+  return [...totals.values()]
+}
+
+/**
+ * The waste balance report as at a cutoff instant: every live (approved or
+ * suspended) accreditation across all non-test organisations with the
+ * balance from its last ledger event before the cutoff, plus per-material
+ * totals across reprocessors and across exporters. Registered-only
+ * registrations and accreditations in created/rejected/cancelled states are
+ * out of scope — `resolveAccreditation` only yields live accreditations.
+ *
+ * @param {WasteBalanceReportDeps} deps
+ * @param {Date} cutoff
+ * @returns {Promise<WasteBalanceReport>}
+ */
+export const generateWasteBalanceReport = async (
+  { organisationsRepository, ledgerRepository },
+  cutoff
+) => {
+  const organisations = await organisationsRepository.findAll()
+
+  /** @type {WasteBalanceReportRow[]} */
+  const accreditations = []
+
+  for (const org of organisations) {
+    if (TEST_ORGANISATIONS.has(org.orgId)) {
+      continue
+    }
+
+    for (const registration of org.registrations) {
+      const accreditation = /** @type {AccreditationApproved | null} */ (
+        resolveAccreditation(registration, org)
+      )
+      if (!accreditation) {
+        continue
+      }
+
+      accreditations.push(
+        await buildReportRow(
+          ledgerRepository,
+          org,
+          registration,
+          accreditation,
+          cutoff
+        )
+      )
+    }
+  }
+
+  return { totals: totalBalancesPerMaterial(accreditations), accreditations }
+}

--- a/src/waste-balances/application/waste-balance-report.test.js
+++ b/src/waste-balances/application/waste-balance-report.test.js
@@ -1,0 +1,484 @@
+import { generateWasteBalanceReport } from './waste-balance-report.js'
+import { createInMemoryLedgerRepository } from '../repository/ledger-inmemory.js'
+import { buildLedgerEvent } from '../repository/ledger-test-data.js'
+
+const CUTOFF = new Date('2026-07-01T00:00:00.000Z')
+const BEFORE_CUTOFF = new Date('2026-06-15T10:00:00.000Z')
+
+/**
+ * An organisation with one registration linked to one accreditation,
+ * carrying only the fields the report reads. The accreditation link is
+ * resolved through `registration.accreditationId` against
+ * `org.accreditations`, as it is on repository `findAll` output.
+ */
+const orgWithAccreditation = ({
+  id,
+  orgId,
+  registrationId,
+  accreditationId,
+  registrationNumber,
+  accreditationNumber,
+  material,
+  wasteProcessingType,
+  accreditationStatus = 'approved'
+}) => ({
+  id,
+  orgId,
+  registrations: [
+    {
+      id: registrationId,
+      accreditationId,
+      registrationNumber,
+      material,
+      wasteProcessingType
+    }
+  ],
+  accreditations: [
+    {
+      id: accreditationId,
+      status: accreditationStatus,
+      accreditationNumber,
+      material,
+      wasteProcessingType
+    }
+  ]
+})
+
+const organisationsRepository = (orgs) => ({
+  findAll: vi.fn().mockResolvedValue(orgs)
+})
+
+const seededLedger = async (events) => {
+  const ledgerRepository = createInMemoryLedgerRepository()()
+  for (const event of events) {
+    await ledgerRepository.appendEvents([buildLedgerEvent(event)])
+  }
+  return ledgerRepository
+}
+
+describe('generateWasteBalanceReport', () => {
+  it('sums balance and available balance per material and processing type', async () => {
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-a',
+        orgId: 500001,
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        registrationNumber: 'REG-A',
+        accreditationNumber: 'ACC-A',
+        material: 'plastic',
+        wasteProcessingType: 'reprocessor'
+      }),
+      orgWithAccreditation({
+        id: 'org-b',
+        orgId: 500002,
+        registrationId: 'reg-b',
+        accreditationId: 'acc-b',
+        registrationNumber: 'REG-B',
+        accreditationNumber: 'ACC-B',
+        material: 'plastic',
+        wasteProcessingType: 'reprocessor'
+      }),
+      orgWithAccreditation({
+        id: 'org-c',
+        orgId: 500003,
+        registrationId: 'reg-c',
+        accreditationId: 'acc-c',
+        registrationNumber: 'REG-C',
+        accreditationNumber: 'ACC-C',
+        material: 'plastic',
+        wasteProcessingType: 'exporter'
+      }),
+      orgWithAccreditation({
+        id: 'org-d',
+        orgId: 500004,
+        registrationId: 'reg-d',
+        accreditationId: 'acc-d',
+        registrationNumber: 'REG-D',
+        accreditationNumber: 'ACC-D',
+        material: 'glass',
+        wasteProcessingType: 'reprocessor'
+      })
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-a',
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        number: 1,
+        closingBalance: { amount: 700, availableAmount: 500 },
+        createdAt: BEFORE_CUTOFF
+      },
+      {
+        organisationId: 'org-b',
+        registrationId: 'reg-b',
+        accreditationId: 'acc-b',
+        number: 1,
+        closingBalance: { amount: 500, availableAmount: 400 },
+        createdAt: BEFORE_CUTOFF
+      },
+      {
+        organisationId: 'org-c',
+        registrationId: 'reg-c',
+        accreditationId: 'acc-c',
+        number: 1,
+        closingBalance: { amount: 400, availableAmount: 350 },
+        createdAt: BEFORE_CUTOFF
+      },
+      {
+        organisationId: 'org-d',
+        registrationId: 'reg-d',
+        accreditationId: 'acc-d',
+        number: 1,
+        closingBalance: { amount: 800, availableAmount: 700 },
+        createdAt: BEFORE_CUTOFF
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.totals).toHaveLength(3)
+    expect(report.totals).toEqual(
+      expect.arrayContaining([
+        {
+          material: 'plastic',
+          wasteProcessingType: 'reprocessor',
+          amount: 1200,
+          availableAmount: 900
+        },
+        {
+          material: 'plastic',
+          wasteProcessingType: 'exporter',
+          amount: 400,
+          availableAmount: 350
+        },
+        {
+          material: 'glass',
+          wasteProcessingType: 'reprocessor',
+          amount: 800,
+          availableAmount: 700
+        }
+      ])
+    )
+    expect(report.accreditations).toHaveLength(4)
+    expect(report.accreditations).toEqual(
+      expect.arrayContaining([
+        {
+          orgId: '500001',
+          registrationNumber: 'REG-A',
+          accreditationNumber: 'ACC-A',
+          material: 'plastic',
+          wasteProcessingType: 'reprocessor',
+          amount: 700,
+          availableAmount: 500
+        }
+      ])
+    )
+  })
+
+  it('sums fractional tonnages with exact decimal arithmetic', async () => {
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-a',
+        orgId: 500001,
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        registrationNumber: 'REG-A',
+        accreditationNumber: 'ACC-A',
+        material: 'steel',
+        wasteProcessingType: 'reprocessor'
+      }),
+      orgWithAccreditation({
+        id: 'org-b',
+        orgId: 500002,
+        registrationId: 'reg-b',
+        accreditationId: 'acc-b',
+        registrationNumber: 'REG-B',
+        accreditationNumber: 'ACC-B',
+        material: 'steel',
+        wasteProcessingType: 'reprocessor'
+      })
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-a',
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        number: 1,
+        closingBalance: { amount: 0.1, availableAmount: 0.1 },
+        createdAt: BEFORE_CUTOFF
+      },
+      {
+        organisationId: 'org-b',
+        registrationId: 'reg-b',
+        accreditationId: 'acc-b',
+        number: 1,
+        closingBalance: { amount: 0.2, availableAmount: 0.2 },
+        createdAt: BEFORE_CUTOFF
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.totals).toHaveLength(1)
+    expect(report.totals[0].amount).toBe(0.3)
+    expect(report.totals[0].availableAmount).toBe(0.3)
+  })
+
+  it('includes an accreditation with no ledger history before the cutoff at a zero balance', async () => {
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-a',
+        orgId: 500001,
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        registrationNumber: 'REG-A',
+        accreditationNumber: 'ACC-A',
+        material: 'wood',
+        wasteProcessingType: 'exporter'
+      })
+    ]
+    const ledgerRepository = await seededLedger([])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.accreditations).toEqual([
+      {
+        orgId: '500001',
+        registrationNumber: 'REG-A',
+        accreditationNumber: 'ACC-A',
+        material: 'wood',
+        wasteProcessingType: 'exporter',
+        amount: 0,
+        availableAmount: 0
+      }
+    ])
+    expect(report.totals).toEqual([
+      {
+        material: 'wood',
+        wasteProcessingType: 'exporter',
+        amount: 0,
+        availableAmount: 0
+      }
+    ])
+  })
+
+  it('takes the balance from the last event before the cutoff, however old, ignoring later events', async () => {
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-a',
+        orgId: 500001,
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        registrationNumber: 'REG-A',
+        accreditationNumber: 'ACC-A',
+        material: 'paper',
+        wasteProcessingType: 'reprocessor'
+      })
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-a',
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        number: 1,
+        closingBalance: { amount: 75, availableAmount: 60 },
+        createdAt: new Date('2026-02-14T10:00:00.000Z')
+      },
+      {
+        organisationId: 'org-a',
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        number: 2,
+        closingBalance: { amount: 999, availableAmount: 999 },
+        createdAt: new Date('2026-07-08T10:00:00.000Z')
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.accreditations).toHaveLength(1)
+    expect(report.accreditations[0].amount).toBe(75)
+    expect(report.accreditations[0].availableAmount).toBe(60)
+  })
+
+  it('includes suspended accreditations and excludes created, rejected and cancelled ones', async () => {
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-suspended',
+        orgId: 500001,
+        registrationId: 'reg-s',
+        accreditationId: 'acc-s',
+        registrationNumber: 'REG-S',
+        accreditationNumber: 'ACC-S',
+        material: 'aluminium',
+        wasteProcessingType: 'reprocessor',
+        accreditationStatus: 'suspended'
+      }),
+      orgWithAccreditation({
+        id: 'org-created',
+        orgId: 500002,
+        registrationId: 'reg-cr',
+        accreditationId: 'acc-cr',
+        registrationNumber: 'REG-CR',
+        accreditationNumber: 'ACC-CR',
+        material: 'fibre',
+        wasteProcessingType: 'reprocessor',
+        accreditationStatus: 'created'
+      }),
+      orgWithAccreditation({
+        id: 'org-rejected',
+        orgId: 500003,
+        registrationId: 'reg-rj',
+        accreditationId: 'acc-rj',
+        registrationNumber: 'REG-RJ',
+        accreditationNumber: 'ACC-RJ',
+        material: 'fibre',
+        wasteProcessingType: 'exporter',
+        accreditationStatus: 'rejected'
+      }),
+      orgWithAccreditation({
+        id: 'org-cancelled',
+        orgId: 500004,
+        registrationId: 'reg-cn',
+        accreditationId: 'acc-cn',
+        registrationNumber: 'REG-CN',
+        accreditationNumber: 'ACC-CN',
+        material: 'steel',
+        wasteProcessingType: 'exporter',
+        accreditationStatus: 'cancelled'
+      })
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-suspended',
+        registrationId: 'reg-s',
+        accreditationId: 'acc-s',
+        number: 1,
+        closingBalance: { amount: 50, availableAmount: 40 },
+        createdAt: BEFORE_CUTOFF
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.accreditations).toEqual([
+      {
+        orgId: '500001',
+        registrationNumber: 'REG-S',
+        accreditationNumber: 'ACC-S',
+        material: 'aluminium',
+        wasteProcessingType: 'reprocessor',
+        amount: 50,
+        availableAmount: 40
+      }
+    ])
+    expect(report.totals).toHaveLength(1)
+  })
+
+  it('excludes registered-only registrations with no linked accreditation', async () => {
+    const orgs = [
+      {
+        id: 'org-a',
+        orgId: 500001,
+        registrations: [
+          {
+            id: 'reg-a',
+            registrationNumber: 'REG-A',
+            material: 'glass',
+            wasteProcessingType: 'reprocessor'
+          }
+        ],
+        accreditations: []
+      }
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-a',
+        registrationId: 'reg-a',
+        accreditationId: null,
+        number: 1,
+        closingBalance: { amount: 123, availableAmount: 123 },
+        createdAt: BEFORE_CUTOFF
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.accreditations).toEqual([])
+    expect(report.totals).toEqual([])
+  })
+
+  it('excludes test organisations', async () => {
+    // 999999 is set as a test organisation via process.env.TEST_ORGANISATIONS
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-test',
+        orgId: 999999,
+        registrationId: 'reg-t',
+        accreditationId: 'acc-t',
+        registrationNumber: 'REG-T',
+        accreditationNumber: 'ACC-T',
+        material: 'plastic',
+        wasteProcessingType: 'reprocessor'
+      })
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-test',
+        registrationId: 'reg-t',
+        accreditationId: 'acc-t',
+        number: 1,
+        closingBalance: { amount: 1000, availableAmount: 1000 },
+        createdAt: BEFORE_CUTOFF
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.accreditations).toEqual([])
+    expect(report.totals).toEqual([])
+  })
+})

--- a/src/waste-balances/repository/ledger-contract/findLatestInLedgerBefore.contract.js
+++ b/src/waste-balances/repository/ledger-contract/findLatestInLedgerBefore.contract.js
@@ -1,0 +1,272 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { buildLedgerEvent, buildLedgerId } from '../ledger-test-data.js'
+
+const CUTOFF = new Date('2026-07-01T00:00:00.000Z')
+
+export const testFindLatestInLedgerBeforeBehaviour = (it) => {
+  describe('findLatestInLedgerBefore', () => {
+    let repository
+
+    beforeEach(
+      async (
+        /** @type {{ ledgerRepository: import('../ledger-port.js').WasteBalanceLedgerRepositoryFactory }} */ {
+          ledgerRepository
+        }
+      ) => {
+        repository = await ledgerRepository()
+      }
+    )
+
+    it('returns null when no events exist for the ledger', async () => {
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-empty',
+          accreditationId: 'acc-empty'
+        }),
+        CUTOFF
+      )
+      expect(result).toBeNull()
+    })
+
+    it('returns null when every event was created at or after the cutoff', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-after',
+          accreditationId: 'acc-after',
+          number: 1,
+          createdAt: new Date('2026-07-05T09:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-after',
+          accreditationId: 'acc-after'
+        }),
+        CUTOFF
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('does not return an event created at exactly the cutoff instant', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-exact',
+          accreditationId: 'acc-exact',
+          number: 1,
+          createdAt: CUTOFF
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-exact',
+          accreditationId: 'acc-exact'
+        }),
+        CUTOFF
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('returns the highest-numbered of several events before the cutoff', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many',
+          number: 1,
+          payload: { summaryLogId: 'log-1', creditTotal: 100 },
+          closingBalance: { amount: 10, availableAmount: 10 },
+          createdAt: new Date('2026-05-10T10:00:00.000Z')
+        })
+      ])
+      const [stored] = await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many',
+          number: 2,
+          payload: { summaryLogId: 'log-2', creditTotal: 200 },
+          closingBalance: { amount: 20, availableAmount: 18 },
+          createdAt: new Date('2026-06-20T10:00:00.000Z')
+        })
+      ])
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many',
+          number: 3,
+          payload: { summaryLogId: 'log-3', creditTotal: 300 },
+          closingBalance: { amount: 30, availableAmount: 25 },
+          createdAt: new Date('2026-07-08T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many'
+        }),
+        CUTOFF
+      )
+
+      expect(result.id).toBe(stored.id)
+      expect(result.number).toBe(2)
+      expect(result.closingBalance).toEqual({ amount: 20, availableAmount: 18 })
+    })
+
+    it('picks the highest-numbered event, not the latest-created, when the orders disagree', async () => {
+      const [, second] = await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-disorder',
+          accreditationId: 'acc-disorder',
+          number: 1,
+          payload: { summaryLogId: 'log-1', creditTotal: 100 },
+          closingBalance: { amount: 10, availableAmount: 10 },
+          createdAt: new Date('2026-06-15T10:00:00.000Z')
+        }),
+        buildLedgerEvent({
+          registrationId: 'reg-disorder',
+          accreditationId: 'acc-disorder',
+          number: 2,
+          payload: { summaryLogId: 'log-2', creditTotal: 200 },
+          closingBalance: { amount: 20, availableAmount: 18 },
+          createdAt: new Date('2026-06-10T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-disorder',
+          accreditationId: 'acc-disorder'
+        }),
+        CUTOFF
+      )
+
+      expect(result.id).toBe(second.id)
+      expect(result.number).toBe(2)
+    })
+
+    it('returns an event from long before the cutoff when nothing newer precedes it', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-carry',
+          accreditationId: 'acc-carry',
+          number: 1,
+          closingBalance: { amount: 75, availableAmount: 60 },
+          createdAt: new Date('2026-02-14T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-carry',
+          accreditationId: 'acc-carry'
+        }),
+        CUTOFF
+      )
+
+      expect(result.number).toBe(1)
+      expect(result.closingBalance).toEqual({ amount: 75, availableAmount: 60 })
+    })
+
+    it('isolates results by ledgerId', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-x',
+          accreditationId: 'acc-x',
+          number: 1,
+          createdAt: new Date('2026-06-01T10:00:00.000Z')
+        })
+      ])
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-y',
+          accreditationId: 'acc-y',
+          number: 1,
+          payload: { summaryLogId: 'log-y', creditTotal: 500 },
+          createdAt: new Date('2026-08-01T10:00:00.000Z')
+        })
+      ])
+
+      const x = await repository.findLatestInLedgerBefore(
+        buildLedgerId({ registrationId: 'reg-x', accreditationId: 'acc-x' }),
+        CUTOFF
+      )
+      const y = await repository.findLatestInLedgerBefore(
+        buildLedgerId({ registrationId: 'reg-y', accreditationId: 'acc-y' }),
+        CUTOFF
+      )
+
+      expect(x.number).toBe(1)
+      expect(x.accreditationId).toBe('acc-x')
+      expect(y).toBeNull()
+    })
+
+    it('does not read a ledger named under a different organisation', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          organisationId: 'org-owner',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned',
+          number: 1,
+          createdAt: new Date('2026-06-01T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          organisationId: 'org-stranger',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned'
+        }),
+        CUTOFF
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('treats null and non-null accreditationId as separate ledgers', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-null-test',
+          accreditationId: null,
+          number: 1,
+          closingBalance: { amount: 0, availableAmount: 0 },
+          createdAt: new Date('2026-06-01T10:00:00.000Z')
+        })
+      ])
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-null-test',
+          accreditationId: 'acc-non-null',
+          number: 1,
+          closingBalance: { amount: 999, availableAmount: 999 },
+          createdAt: new Date('2026-08-01T10:00:00.000Z')
+        })
+      ])
+
+      const nullLedger = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-null-test',
+          accreditationId: null
+        }),
+        CUTOFF
+      )
+      const nonNullLedger = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-null-test',
+          accreditationId: 'acc-non-null'
+        }),
+        CUTOFF
+      )
+
+      expect(nullLedger.closingBalance).toEqual({
+        amount: 0,
+        availableAmount: 0
+      })
+      expect(nonNullLedger).toBeNull()
+    })
+  })
+}

--- a/src/waste-balances/repository/ledger-inmemory.js
+++ b/src/waste-balances/repository/ledger-inmemory.js
@@ -115,6 +115,22 @@ export const createInMemoryLedgerRepository = (initialEvents = []) => {
 
     /**
      * @param {WasteBalanceLedgerId} ledgerId
+     * @param {Date} cutoff
+     */
+    findLatestInLedgerBefore: async (ledgerId, cutoff) => {
+      const matches = storage.filter(
+        (event) => matchesLedger(event, ledgerId) && event.createdAt < cutoff
+      )
+
+      if (matches.length === 0) {
+        return null
+      }
+
+      return structuredClone(/** @type {LedgerEvent} */ (matches.at(-1)))
+    },
+
+    /**
+     * @param {WasteBalanceLedgerId} ledgerId
      * @param {import('./ledger-schema.js').LedgerEventKind} kind
      */
     findLatestInLedgerByKind: async (ledgerId, kind) => {

--- a/src/waste-balances/repository/ledger-mongodb.js
+++ b/src/waste-balances/repository/ledger-mongodb.js
@@ -141,6 +141,19 @@ const performFindLatestInLedger = (collection) => async (ledgerId) => {
 
 /**
  * @param {Collection} collection
+ * @returns {(ledgerId: WasteBalanceLedgerId, cutoff: Date) => Promise<LedgerEvent | null>}
+ */
+const performFindLatestInLedgerBefore =
+  (collection) => async (ledgerId, cutoff) => {
+    const doc = await collection.findOne(
+      { ...ledgerFilter(ledgerId), createdAt: { $lt: cutoff } },
+      { sort: { number: -1 } }
+    )
+    return doc ? toLedgerEvent(doc) : null
+  }
+
+/**
+ * @param {Collection} collection
  * @returns {(ledgerId: WasteBalanceLedgerId, kind: string) => Promise<LedgerEvent | null>}
  */
 const performFindLatestInLedgerByKind =
@@ -261,6 +274,7 @@ export const createMongoLedgerRepository = async (db) => {
 
   return () => ({
     findLatestInLedger: performFindLatestInLedger(collection),
+    findLatestInLedgerBefore: performFindLatestInLedgerBefore(collection),
     findLatestInLedgerByKind: performFindLatestInLedgerByKind(collection),
     findEventsByPrnIdAfter: performFindEventsByPrnIdAfter(collection),
     findAllInLedger: performFindAllInLedger(collection),

--- a/src/waste-balances/repository/ledger-port.contract.js
+++ b/src/waste-balances/repository/ledger-port.contract.js
@@ -1,5 +1,6 @@
 import { testAppendEventsBehaviour } from './ledger-contract/appendEvents.contract.js'
 import { testFindLatestInLedgerBehaviour } from './ledger-contract/findLatestInLedger.contract.js'
+import { testFindLatestInLedgerBeforeBehaviour } from './ledger-contract/findLatestInLedgerBefore.contract.js'
 import { testFindLatestInLedgerByKindBehaviour } from './ledger-contract/findLatestInLedgerByKind.contract.js'
 import { testFindEventsByPrnIdAfterBehaviour } from './ledger-contract/findEventsByPrnIdAfter.contract.js'
 import { testFindAllInLedgerBehaviour } from './ledger-contract/findAllInLedger.contract.js'
@@ -8,6 +9,7 @@ import { testDeleteAllInLedgerBehaviour } from './ledger-contract/deleteAllInLed
 export const testLedgerRepositoryContract = (it) => {
   testAppendEventsBehaviour(it)
   testFindLatestInLedgerBehaviour(it)
+  testFindLatestInLedgerBeforeBehaviour(it)
   testFindLatestInLedgerByKindBehaviour(it)
   testFindEventsByPrnIdAfterBehaviour(it)
   testFindAllInLedgerBehaviour(it)

--- a/src/waste-balances/repository/ledger-port.js
+++ b/src/waste-balances/repository/ledger-port.js
@@ -110,6 +110,10 @@ export class LedgerSequenceError extends Error {
  * @property {(ledgerId: WasteBalanceLedgerId) => Promise<LedgerEvent | null>} findLatestInLedger
  *   Return the highest-numbered event for the ledger, or `null`
  *   if none exist.
+ * @property {(ledgerId: WasteBalanceLedgerId, cutoff: Date) => Promise<LedgerEvent | null>} findLatestInLedgerBefore
+ *   Return the highest-numbered event for the ledger whose `createdAt` is
+ *   strictly before `cutoff`, or `null` if no event precedes it. An event
+ *   created at exactly `cutoff` does not count as before it.
  * @property {(ledgerId: WasteBalanceLedgerId, kind: import('./ledger-schema.js').LedgerEventKind) => Promise<LedgerEvent | null>} findLatestInLedgerByKind
  *   Return the highest-numbered event of the given kind for the ledger,
  *   or `null` if none of that kind exist.


### PR DESCRIPTION
Ticket: [PAE-1676](https://eaflood.atlassian.net/browse/PAE-1676)
## Summary

- Adds the application-layer aggregation service for the waste balance report (PAE-1676, PRN market supply): given a cutoff instant, it produces every live accreditation's balance as it stood at that cutoff, plus per-material totals across reprocessors and across exporters.
- Per accreditation: the closing balance of the last ledger event created strictly before the cutoff (via `findLatestInLedgerBefore`); no event before the cutoff → included with a zero balance. Totals are summed with exact decimal arithmetic (`decimal-utils`), matching the ledger's own summation pattern.
- Uses `resolveAccreditation(registration, org)` rather than `isRegistrationAccredited` — repository `findAll` does not hydrate `registration.accreditation` (only `findRegistrationById` does), and `resolveAccreditation` applies the same approved/suspended filter over exactly the shape `findAll` returns, as the waste-records export already does.
- Rows carry the organisation's external `orgId` (coerced to string), registration number, accreditation number, material, type, balance and available balance. Test organisations, registered-only registrations, and created/rejected/cancelled accreditations are excluded.

Stacked on #1504 (`findLatestInLedgerBefore`) — this branch contains that commit until it merges. The admin route wiring follows in the next PR.

## Changes

- `src/waste-balances/application/waste-balance-report.js` — `generateWasteBalanceReport({ organisationsRepository, ledgerRepository }, cutoff)`: iterate non-test organisations, resolve each registration's live accreditation, read the last pre-cutoff ledger event per `(organisationId, registrationId, accreditationId)` partition, and total per material × processing type. Deps are `Pick`-narrowed to what the service reads.
- `src/waste-balances/application/waste-balance-report.test.js` — 7 behaviour tests with hand-built org literals (mocked `findAll`) and the real in-memory ledger repository: totals arithmetic, exact decimal summation (0.1 + 0.2 = 0.3), zero-balance inclusion with zero-sum totals, carry-over from an event months before the cutoff (ignoring later events), suspended in / created-rejected-cancelled out, registered-only ledger partitions ignored, test organisations excluded.


[PAE-1676]: https://eaflood.atlassian.net/browse/PAE-1676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ