### PR TITLE
PAE-1676: waste balance report backend (repository, service, admin route)

### DIFF
--- a/src/waste-balances/application/waste-balance-report.js
+++ b/src/waste-balances/application/waste-balance-report.js
@@ -1,0 +1,172 @@
+import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
+import { add, toNumber } from '#common/helpers/decimal-utils.js'
+import { resolveAccreditation } from '#domain/organisations/registration-utils.js'
+
+/** @import {Organisation} from '#domain/organisations/model.js' */
+/** @import {Registration, RegistrationApproved} from '#domain/organisations/registration.js' */
+/** @import {AccreditationApproved} from '#domain/organisations/accreditation.js' */
+/** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
+/** @import {WasteBalanceLedgerRepository} from '../repository/ledger-port.js' */
+
+const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
+
+/**
+ * @typedef {Object} WasteBalanceReportRow
+ * @property {string} orgId - The organisation's external reference (not its
+ *   internal id), as a string.
+ * @property {string} registrationNumber
+ * @property {string} accreditationNumber
+ * @property {string} material
+ * @property {string} wasteProcessingType
+ * @property {number} amount
+ * @property {number} availableAmount
+ */
+
+/**
+ * @typedef {Object} WasteBalanceReportTotal
+ * @property {string} material
+ * @property {string} wasteProcessingType
+ * @property {number} amount
+ * @property {number} availableAmount
+ */
+
+/**
+ * @typedef {Object} WasteBalanceReport
+ * @property {WasteBalanceReportTotal[]} totals
+ * @property {WasteBalanceReportRow[]} accreditations
+ */
+
+/**
+ * @typedef {Object} WasteBalanceReportDeps
+ * @property {Pick<OrganisationsRepository, 'findAll'>} organisationsRepository
+ * @property {Pick<WasteBalanceLedgerRepository, 'findLatestInLedgerBefore'>} ledgerRepository
+ */
+
+/**
+ * One report row: the accreditation's balance as it stood at the cutoff —
+ * the closing balance of the last ledger event created strictly before it.
+ * An accreditation with no ledger history before the cutoff has a zero
+ * balance.
+ *
+ * @param {WasteBalanceReportDeps['ledgerRepository']} ledgerRepository
+ * @param {Organisation} org
+ * @param {Registration} registration
+ * @param {AccreditationApproved} accreditation
+ * @param {Date} cutoff
+ * @returns {Promise<WasteBalanceReportRow>}
+ */
+const buildReportRow = async (
+  ledgerRepository,
+  org,
+  registration,
+  accreditation,
+  cutoff
+) => {
+  const event = await ledgerRepository.findLatestInLedgerBefore(
+    {
+      organisationId: org.id,
+      registrationId: registration.id,
+      accreditationId: accreditation.id
+    },
+    cutoff
+  )
+
+  const balance = event
+    ? event.closingBalance
+    : { amount: 0, availableAmount: 0 }
+
+  return {
+    orgId: String(org.orgId),
+    // A live accreditation implies a registration that has been approved and
+    // so carries a registrationNumber (validateApprovals enforces the link at
+    // write time) — same cast precedent as getReportableRegistrations.
+    registrationNumber: /** @type {RegistrationApproved} */ (registration)
+      .registrationNumber,
+    accreditationNumber: accreditation.accreditationNumber,
+    material: accreditation.material,
+    wasteProcessingType: accreditation.wasteProcessingType,
+    amount: balance.amount,
+    availableAmount: balance.availableAmount
+  }
+}
+
+/**
+ * Per-material totals across the rows: one entry per (material,
+ * wasteProcessingType) combination that has at least one accredited
+ * registration, summing balance and available balance with exact decimal
+ * arithmetic. A combination whose accreditations all hold zero balances
+ * still appears, summing to zero.
+ *
+ * @param {WasteBalanceReportRow[]} rows
+ * @returns {WasteBalanceReportTotal[]}
+ */
+const totalBalancesPerMaterial = (rows) => {
+  /** @type {Map<string, WasteBalanceReportTotal>} */
+  const totals = new Map()
+
+  for (const row of rows) {
+    const key = `${row.material}|${row.wasteProcessingType}`
+    const total = totals.get(key) ?? {
+      material: row.material,
+      wasteProcessingType: row.wasteProcessingType,
+      amount: 0,
+      availableAmount: 0
+    }
+    total.amount = toNumber(add(total.amount, row.amount))
+    total.availableAmount = toNumber(
+      add(total.availableAmount, row.availableAmount)
+    )
+    totals.set(key, total)
+  }
+
+  return [...totals.values()]
+}
+
+/**
+ * The waste balance report as at a cutoff instant: every live (approved or
+ * suspended) accreditation across all non-test organisations with the
+ * balance from its last ledger event before the cutoff, plus per-material
+ * totals across reprocessors and across exporters. Registered-only
+ * registrations and accreditations in created/rejected/cancelled states are
+ * out of scope — `resolveAccreditation` only yields live accreditations.
+ *
+ * @param {WasteBalanceReportDeps} deps
+ * @param {Date} cutoff
+ * @returns {Promise<WasteBalanceReport>}
+ */
+export const generateWasteBalanceReport = async (
+  { organisationsRepository, ledgerRepository },
+  cutoff
+) => {
+  const organisations = await organisationsRepository.findAll()
+
+  /** @type {WasteBalanceReportRow[]} */
+  const accreditations = []
+
+  for (const org of organisations) {
+    if (TEST_ORGANISATIONS.has(org.orgId)) {
+      continue
+    }
+
+    for (const registration of org.registrations) {
+      const accreditation = /** @type {AccreditationApproved | null} */ (
+        resolveAccreditation(registration, org)
+      )
+      if (!accreditation) {
+        continue
+      }
+
+      accreditations.push(
+        await buildReportRow(
+          ledgerRepository,
+          org,
+          registration,
+          accreditation,
+          cutoff
+        )
+      )
+    }
+  }
+
+  return { totals: totalBalancesPerMaterial(accreditations), accreditations }
+}

--- a/src/waste-balances/application/waste-balance-report.test.js
+++ b/src/waste-balances/application/waste-balance-report.test.js
@@ -1,0 +1,484 @@
+import { generateWasteBalanceReport } from './waste-balance-report.js'
+import { createInMemoryLedgerRepository } from '../repository/ledger-inmemory.js'
+import { buildLedgerEvent } from '../repository/ledger-test-data.js'
+
+const CUTOFF = new Date('2026-07-01T00:00:00.000Z')
+const BEFORE_CUTOFF = new Date('2026-06-15T10:00:00.000Z')
+
+/**
+ * An organisation with one registration linked to one accreditation,
+ * carrying only the fields the report reads. The accreditation link is
+ * resolved through `registration.accreditationId` against
+ * `org.accreditations`, as it is on repository `findAll` output.
+ */
+const orgWithAccreditation = ({
+  id,
+  orgId,
+  registrationId,
+  accreditationId,
+  registrationNumber,
+  accreditationNumber,
+  material,
+  wasteProcessingType,
+  accreditationStatus = 'approved'
+}) => ({
+  id,
+  orgId,
+  registrations: [
+    {
+      id: registrationId,
+      accreditationId,
+      registrationNumber,
+      material,
+      wasteProcessingType
+    }
+  ],
+  accreditations: [
+    {
+      id: accreditationId,
+      status: accreditationStatus,
+      accreditationNumber,
+      material,
+      wasteProcessingType
+    }
+  ]
+})
+
+const organisationsRepository = (orgs) => ({
+  findAll: vi.fn().mockResolvedValue(orgs)
+})
+
+const seededLedger = async (events) => {
+  const ledgerRepository = createInMemoryLedgerRepository()()
+  for (const event of events) {
+    await ledgerRepository.appendEvents([buildLedgerEvent(event)])
+  }
+  return ledgerRepository
+}
+
+describe('generateWasteBalanceReport', () => {
+  it('sums balance and available balance per material and processing type', async () => {
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-a',
+        orgId: 500001,
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        registrationNumber: 'REG-A',
+        accreditationNumber: 'ACC-A',
+        material: 'plastic',
+        wasteProcessingType: 'reprocessor'
+      }),
+      orgWithAccreditation({
+        id: 'org-b',
+        orgId: 500002,
+        registrationId: 'reg-b',
+        accreditationId: 'acc-b',
+        registrationNumber: 'REG-B',
+        accreditationNumber: 'ACC-B',
+        material: 'plastic',
+        wasteProcessingType: 'reprocessor'
+      }),
+      orgWithAccreditation({
+        id: 'org-c',
+        orgId: 500003,
+        registrationId: 'reg-c',
+        accreditationId: 'acc-c',
+        registrationNumber: 'REG-C',
+        accreditationNumber: 'ACC-C',
+        material: 'plastic',
+        wasteProcessingType: 'exporter'
+      }),
+      orgWithAccreditation({
+        id: 'org-d',
+        orgId: 500004,
+        registrationId: 'reg-d',
+        accreditationId: 'acc-d',
+        registrationNumber: 'REG-D',
+        accreditationNumber: 'ACC-D',
+        material: 'glass',
+        wasteProcessingType: 'reprocessor'
+      })
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-a',
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        number: 1,
+        closingBalance: { amount: 700, availableAmount: 500 },
+        createdAt: BEFORE_CUTOFF
+      },
+      {
+        organisationId: 'org-b',
+        registrationId: 'reg-b',
+        accreditationId: 'acc-b',
+        number: 1,
+        closingBalance: { amount: 500, availableAmount: 400 },
+        createdAt: BEFORE_CUTOFF
+      },
+      {
+        organisationId: 'org-c',
+        registrationId: 'reg-c',
+        accreditationId: 'acc-c',
+        number: 1,
+        closingBalance: { amount: 400, availableAmount: 350 },
+        createdAt: BEFORE_CUTOFF
+      },
+      {
+        organisationId: 'org-d',
+        registrationId: 'reg-d',
+        accreditationId: 'acc-d',
+        number: 1,
+        closingBalance: { amount: 800, availableAmount: 700 },
+        createdAt: BEFORE_CUTOFF
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.totals).toHaveLength(3)
+    expect(report.totals).toEqual(
+      expect.arrayContaining([
+        {
+          material: 'plastic',
+          wasteProcessingType: 'reprocessor',
+          amount: 1200,
+          availableAmount: 900
+        },
+        {
+          material: 'plastic',
+          wasteProcessingType: 'exporter',
+          amount: 400,
+          availableAmount: 350
+        },
+        {
+          material: 'glass',
+          wasteProcessingType: 'reprocessor',
+          amount: 800,
+          availableAmount: 700
+        }
+      ])
+    )
+    expect(report.accreditations).toHaveLength(4)
+    expect(report.accreditations).toEqual(
+      expect.arrayContaining([
+        {
+          orgId: '500001',
+          registrationNumber: 'REG-A',
+          accreditationNumber: 'ACC-A',
+          material: 'plastic',
+          wasteProcessingType: 'reprocessor',
+          amount: 700,
+          availableAmount: 500
+        }
+      ])
+    )
+  })
+
+  it('sums fractional tonnages with exact decimal arithmetic', async () => {
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-a',
+        orgId: 500001,
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        registrationNumber: 'REG-A',
+        accreditationNumber: 'ACC-A',
+        material: 'steel',
+        wasteProcessingType: 'reprocessor'
+      }),
+      orgWithAccreditation({
+        id: 'org-b',
+        orgId: 500002,
+        registrationId: 'reg-b',
+        accreditationId: 'acc-b',
+        registrationNumber: 'REG-B',
+        accreditationNumber: 'ACC-B',
+        material: 'steel',
+        wasteProcessingType: 'reprocessor'
+      })
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-a',
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        number: 1,
+        closingBalance: { amount: 0.1, availableAmount: 0.1 },
+        createdAt: BEFORE_CUTOFF
+      },
+      {
+        organisationId: 'org-b',
+        registrationId: 'reg-b',
+        accreditationId: 'acc-b',
+        number: 1,
+        closingBalance: { amount: 0.2, availableAmount: 0.2 },
+        createdAt: BEFORE_CUTOFF
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.totals).toHaveLength(1)
+    expect(report.totals[0].amount).toBe(0.3)
+    expect(report.totals[0].availableAmount).toBe(0.3)
+  })
+
+  it('includes an accreditation with no ledger history before the cutoff at a zero balance', async () => {
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-a',
+        orgId: 500001,
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        registrationNumber: 'REG-A',
+        accreditationNumber: 'ACC-A',
+        material: 'wood',
+        wasteProcessingType: 'exporter'
+      })
+    ]
+    const ledgerRepository = await seededLedger([])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.accreditations).toEqual([
+      {
+        orgId: '500001',
+        registrationNumber: 'REG-A',
+        accreditationNumber: 'ACC-A',
+        material: 'wood',
+        wasteProcessingType: 'exporter',
+        amount: 0,
+        availableAmount: 0
+      }
+    ])
+    expect(report.totals).toEqual([
+      {
+        material: 'wood',
+        wasteProcessingType: 'exporter',
+        amount: 0,
+        availableAmount: 0
+      }
+    ])
+  })
+
+  it('takes the balance from the last event before the cutoff, however old, ignoring later events', async () => {
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-a',
+        orgId: 500001,
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        registrationNumber: 'REG-A',
+        accreditationNumber: 'ACC-A',
+        material: 'paper',
+        wasteProcessingType: 'reprocessor'
+      })
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-a',
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        number: 1,
+        closingBalance: { amount: 75, availableAmount: 60 },
+        createdAt: new Date('2026-02-14T10:00:00.000Z')
+      },
+      {
+        organisationId: 'org-a',
+        registrationId: 'reg-a',
+        accreditationId: 'acc-a',
+        number: 2,
+        closingBalance: { amount: 999, availableAmount: 999 },
+        createdAt: new Date('2026-07-08T10:00:00.000Z')
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.accreditations).toHaveLength(1)
+    expect(report.accreditations[0].amount).toBe(75)
+    expect(report.accreditations[0].availableAmount).toBe(60)
+  })
+
+  it('includes suspended accreditations and excludes created, rejected and cancelled ones', async () => {
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-suspended',
+        orgId: 500001,
+        registrationId: 'reg-s',
+        accreditationId: 'acc-s',
+        registrationNumber: 'REG-S',
+        accreditationNumber: 'ACC-S',
+        material: 'aluminium',
+        wasteProcessingType: 'reprocessor',
+        accreditationStatus: 'suspended'
+      }),
+      orgWithAccreditation({
+        id: 'org-created',
+        orgId: 500002,
+        registrationId: 'reg-cr',
+        accreditationId: 'acc-cr',
+        registrationNumber: 'REG-CR',
+        accreditationNumber: 'ACC-CR',
+        material: 'fibre',
+        wasteProcessingType: 'reprocessor',
+        accreditationStatus: 'created'
+      }),
+      orgWithAccreditation({
+        id: 'org-rejected',
+        orgId: 500003,
+        registrationId: 'reg-rj',
+        accreditationId: 'acc-rj',
+        registrationNumber: 'REG-RJ',
+        accreditationNumber: 'ACC-RJ',
+        material: 'fibre',
+        wasteProcessingType: 'exporter',
+        accreditationStatus: 'rejected'
+      }),
+      orgWithAccreditation({
+        id: 'org-cancelled',
+        orgId: 500004,
+        registrationId: 'reg-cn',
+        accreditationId: 'acc-cn',
+        registrationNumber: 'REG-CN',
+        accreditationNumber: 'ACC-CN',
+        material: 'steel',
+        wasteProcessingType: 'exporter',
+        accreditationStatus: 'cancelled'
+      })
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-suspended',
+        registrationId: 'reg-s',
+        accreditationId: 'acc-s',
+        number: 1,
+        closingBalance: { amount: 50, availableAmount: 40 },
+        createdAt: BEFORE_CUTOFF
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.accreditations).toEqual([
+      {
+        orgId: '500001',
+        registrationNumber: 'REG-S',
+        accreditationNumber: 'ACC-S',
+        material: 'aluminium',
+        wasteProcessingType: 'reprocessor',
+        amount: 50,
+        availableAmount: 40
+      }
+    ])
+    expect(report.totals).toHaveLength(1)
+  })
+
+  it('excludes registered-only registrations with no linked accreditation', async () => {
+    const orgs = [
+      {
+        id: 'org-a',
+        orgId: 500001,
+        registrations: [
+          {
+            id: 'reg-a',
+            registrationNumber: 'REG-A',
+            material: 'glass',
+            wasteProcessingType: 'reprocessor'
+          }
+        ],
+        accreditations: []
+      }
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-a',
+        registrationId: 'reg-a',
+        accreditationId: null,
+        number: 1,
+        closingBalance: { amount: 123, availableAmount: 123 },
+        createdAt: BEFORE_CUTOFF
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.accreditations).toEqual([])
+    expect(report.totals).toEqual([])
+  })
+
+  it('excludes test organisations', async () => {
+    // 999999 is set as a test organisation via process.env.TEST_ORGANISATIONS
+    const orgs = [
+      orgWithAccreditation({
+        id: 'org-test',
+        orgId: 999999,
+        registrationId: 'reg-t',
+        accreditationId: 'acc-t',
+        registrationNumber: 'REG-T',
+        accreditationNumber: 'ACC-T',
+        material: 'plastic',
+        wasteProcessingType: 'reprocessor'
+      })
+    ]
+    const ledgerRepository = await seededLedger([
+      {
+        organisationId: 'org-test',
+        registrationId: 'reg-t',
+        accreditationId: 'acc-t',
+        number: 1,
+        closingBalance: { amount: 1000, availableAmount: 1000 },
+        createdAt: BEFORE_CUTOFF
+      }
+    ])
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: organisationsRepository(orgs),
+        ledgerRepository
+      },
+      CUTOFF
+    )
+
+    expect(report.accreditations).toEqual([])
+    expect(report.totals).toEqual([])
+  })
+})

--- a/src/waste-balances/repository/ledger-contract/findLatestInLedgerBefore.contract.js
+++ b/src/waste-balances/repository/ledger-contract/findLatestInLedgerBefore.contract.js
@@ -1,0 +1,272 @@
+import { describe, beforeEach, expect } from 'vitest'
+
+import { buildLedgerEvent, buildLedgerId } from '../ledger-test-data.js'
+
+const CUTOFF = new Date('2026-07-01T00:00:00.000Z')
+
+export const testFindLatestInLedgerBeforeBehaviour = (it) => {
+  describe('findLatestInLedgerBefore', () => {
+    let repository
+
+    beforeEach(
+      async (
+        /** @type {{ ledgerRepository: import('../ledger-port.js').WasteBalanceLedgerRepositoryFactory }} */ {
+          ledgerRepository
+        }
+      ) => {
+        repository = await ledgerRepository()
+      }
+    )
+
+    it('returns null when no events exist for the ledger', async () => {
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-empty',
+          accreditationId: 'acc-empty'
+        }),
+        CUTOFF
+      )
+      expect(result).toBeNull()
+    })
+
+    it('returns null when every event was created at or after the cutoff', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-after',
+          accreditationId: 'acc-after',
+          number: 1,
+          createdAt: new Date('2026-07-05T09:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-after',
+          accreditationId: 'acc-after'
+        }),
+        CUTOFF
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('does not return an event created at exactly the cutoff instant', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-exact',
+          accreditationId: 'acc-exact',
+          number: 1,
+          createdAt: CUTOFF
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-exact',
+          accreditationId: 'acc-exact'
+        }),
+        CUTOFF
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('returns the highest-numbered of several events before the cutoff', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many',
+          number: 1,
+          payload: { summaryLogId: 'log-1', creditTotal: 100 },
+          closingBalance: { amount: 10, availableAmount: 10 },
+          createdAt: new Date('2026-05-10T10:00:00.000Z')
+        })
+      ])
+      const [stored] = await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many',
+          number: 2,
+          payload: { summaryLogId: 'log-2', creditTotal: 200 },
+          closingBalance: { amount: 20, availableAmount: 18 },
+          createdAt: new Date('2026-06-20T10:00:00.000Z')
+        })
+      ])
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many',
+          number: 3,
+          payload: { summaryLogId: 'log-3', creditTotal: 300 },
+          closingBalance: { amount: 30, availableAmount: 25 },
+          createdAt: new Date('2026-07-08T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-many',
+          accreditationId: 'acc-many'
+        }),
+        CUTOFF
+      )
+
+      expect(result.id).toBe(stored.id)
+      expect(result.number).toBe(2)
+      expect(result.closingBalance).toEqual({ amount: 20, availableAmount: 18 })
+    })
+
+    it('picks the highest-numbered event, not the latest-created, when the orders disagree', async () => {
+      const [, second] = await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-disorder',
+          accreditationId: 'acc-disorder',
+          number: 1,
+          payload: { summaryLogId: 'log-1', creditTotal: 100 },
+          closingBalance: { amount: 10, availableAmount: 10 },
+          createdAt: new Date('2026-06-15T10:00:00.000Z')
+        }),
+        buildLedgerEvent({
+          registrationId: 'reg-disorder',
+          accreditationId: 'acc-disorder',
+          number: 2,
+          payload: { summaryLogId: 'log-2', creditTotal: 200 },
+          closingBalance: { amount: 20, availableAmount: 18 },
+          createdAt: new Date('2026-06-10T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-disorder',
+          accreditationId: 'acc-disorder'
+        }),
+        CUTOFF
+      )
+
+      expect(result.id).toBe(second.id)
+      expect(result.number).toBe(2)
+    })
+
+    it('returns an event from long before the cutoff when nothing newer precedes it', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-carry',
+          accreditationId: 'acc-carry',
+          number: 1,
+          closingBalance: { amount: 75, availableAmount: 60 },
+          createdAt: new Date('2026-02-14T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-carry',
+          accreditationId: 'acc-carry'
+        }),
+        CUTOFF
+      )
+
+      expect(result.number).toBe(1)
+      expect(result.closingBalance).toEqual({ amount: 75, availableAmount: 60 })
+    })
+
+    it('isolates results by ledgerId', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-x',
+          accreditationId: 'acc-x',
+          number: 1,
+          createdAt: new Date('2026-06-01T10:00:00.000Z')
+        })
+      ])
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-y',
+          accreditationId: 'acc-y',
+          number: 1,
+          payload: { summaryLogId: 'log-y', creditTotal: 500 },
+          createdAt: new Date('2026-08-01T10:00:00.000Z')
+        })
+      ])
+
+      const x = await repository.findLatestInLedgerBefore(
+        buildLedgerId({ registrationId: 'reg-x', accreditationId: 'acc-x' }),
+        CUTOFF
+      )
+      const y = await repository.findLatestInLedgerBefore(
+        buildLedgerId({ registrationId: 'reg-y', accreditationId: 'acc-y' }),
+        CUTOFF
+      )
+
+      expect(x.number).toBe(1)
+      expect(x.accreditationId).toBe('acc-x')
+      expect(y).toBeNull()
+    })
+
+    it('does not read a ledger named under a different organisation', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          organisationId: 'org-owner',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned',
+          number: 1,
+          createdAt: new Date('2026-06-01T10:00:00.000Z')
+        })
+      ])
+
+      const result = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          organisationId: 'org-stranger',
+          registrationId: 'reg-owned',
+          accreditationId: 'acc-owned'
+        }),
+        CUTOFF
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('treats null and non-null accreditationId as separate ledgers', async () => {
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-null-test',
+          accreditationId: null,
+          number: 1,
+          closingBalance: { amount: 0, availableAmount: 0 },
+          createdAt: new Date('2026-06-01T10:00:00.000Z')
+        })
+      ])
+      await repository.appendEvents([
+        buildLedgerEvent({
+          registrationId: 'reg-null-test',
+          accreditationId: 'acc-non-null',
+          number: 1,
+          closingBalance: { amount: 999, availableAmount: 999 },
+          createdAt: new Date('2026-08-01T10:00:00.000Z')
+        })
+      ])
+
+      const nullLedger = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-null-test',
+          accreditationId: null
+        }),
+        CUTOFF
+      )
+      const nonNullLedger = await repository.findLatestInLedgerBefore(
+        buildLedgerId({
+          registrationId: 'reg-null-test',
+          accreditationId: 'acc-non-null'
+        }),
+        CUTOFF
+      )
+
+      expect(nullLedger.closingBalance).toEqual({
+        amount: 0,
+        availableAmount: 0
+      })
+      expect(nonNullLedger).toBeNull()
+    })
+  })
+}

--- a/src/waste-balances/repository/ledger-inmemory.js
+++ b/src/waste-balances/repository/ledger-inmemory.js
@@ -115,6 +115,22 @@ export const createInMemoryLedgerRepository = (initialEvents = []) => {
 
     /**
      * @param {WasteBalanceLedgerId} ledgerId
+     * @param {Date} cutoff
+     */
+    findLatestInLedgerBefore: async (ledgerId, cutoff) => {
+      const matches = storage.filter(
+        (event) => matchesLedger(event, ledgerId) && event.createdAt < cutoff
+      )
+
+      if (matches.length === 0) {
+        return null
+      }
+
+      return structuredClone(/** @type {LedgerEvent} */ (matches.at(-1)))
+    },
+
+    /**
+     * @param {WasteBalanceLedgerId} ledgerId
      * @param {import('./ledger-schema.js').LedgerEventKind} kind
      */
     findLatestInLedgerByKind: async (ledgerId, kind) => {

--- a/src/waste-balances/repository/ledger-mongodb.js
+++ b/src/waste-balances/repository/ledger-mongodb.js
@@ -141,6 +141,19 @@ const performFindLatestInLedger = (collection) => async (ledgerId) => {
 
 /**
  * @param {Collection} collection
+ * @returns {(ledgerId: WasteBalanceLedgerId, cutoff: Date) => Promise<LedgerEvent | null>}
+ */
+const performFindLatestInLedgerBefore =
+  (collection) => async (ledgerId, cutoff) => {
+    const doc = await collection.findOne(
+      { ...ledgerFilter(ledgerId), createdAt: { $lt: cutoff } },
+      { sort: { number: -1 } }
+    )
+    return doc ? toLedgerEvent(doc) : null
+  }
+
+/**
+ * @param {Collection} collection
  * @returns {(ledgerId: WasteBalanceLedgerId, kind: string) => Promise<LedgerEvent | null>}
  */
 const performFindLatestInLedgerByKind =
@@ -261,6 +274,7 @@ export const createMongoLedgerRepository = async (db) => {
 
   return () => ({
     findLatestInLedger: performFindLatestInLedger(collection),
+    findLatestInLedgerBefore: performFindLatestInLedgerBefore(collection),
     findLatestInLedgerByKind: performFindLatestInLedgerByKind(collection),
     findEventsByPrnIdAfter: performFindEventsByPrnIdAfter(collection),
     findAllInLedger: performFindAllInLedger(collection),

--- a/src/waste-balances/repository/ledger-port.contract.js
+++ b/src/waste-balances/repository/ledger-port.contract.js
@@ -1,5 +1,6 @@
 import { testAppendEventsBehaviour } from './ledger-contract/appendEvents.contract.js'
 import { testFindLatestInLedgerBehaviour } from './ledger-contract/findLatestInLedger.contract.js'
+import { testFindLatestInLedgerBeforeBehaviour } from './ledger-contract/findLatestInLedgerBefore.contract.js'
 import { testFindLatestInLedgerByKindBehaviour } from './ledger-contract/findLatestInLedgerByKind.contract.js'
 import { testFindEventsByPrnIdAfterBehaviour } from './ledger-contract/findEventsByPrnIdAfter.contract.js'
 import { testFindAllInLedgerBehaviour } from './ledger-contract/findAllInLedger.contract.js'
@@ -8,6 +9,7 @@ import { testDeleteAllInLedgerBehaviour } from './ledger-contract/deleteAllInLed
 export const testLedgerRepositoryContract = (it) => {
   testAppendEventsBehaviour(it)
   testFindLatestInLedgerBehaviour(it)
+  testFindLatestInLedgerBeforeBehaviour(it)
   testFindLatestInLedgerByKindBehaviour(it)
   testFindEventsByPrnIdAfterBehaviour(it)
   testFindAllInLedgerBehaviour(it)

--- a/src/waste-balances/repository/ledger-port.js
+++ b/src/waste-balances/repository/ledger-port.js
@@ -110,6 +110,10 @@ export class LedgerSequenceError extends Error {
  * @property {(ledgerId: WasteBalanceLedgerId) => Promise<LedgerEvent | null>} findLatestInLedger
  *   Return the highest-numbered event for the ledger, or `null`
  *   if none exist.
+ * @property {(ledgerId: WasteBalanceLedgerId, cutoff: Date) => Promise<LedgerEvent | null>} findLatestInLedgerBefore
+ *   Return the highest-numbered event for the ledger whose `createdAt` is
+ *   strictly before `cutoff`, or `null` if no event precedes it. An event
+ *   created at exactly `cutoff` does not count as before it.
  * @property {(ledgerId: WasteBalanceLedgerId, kind: import('./ledger-schema.js').LedgerEventKind) => Promise<LedgerEvent | null>} findLatestInLedgerByKind
  *   Return the highest-numbered event of the given kind for the ledger,
  *   or `null` if none of that kind exist.

--- a/src/waste-balances/routes/index.js
+++ b/src/waste-balances/routes/index.js
@@ -1,1 +1,2 @@
 export { wasteBalanceGet } from './get.js'
+export { wasteBalanceReportGet } from './report.js'

--- a/src/waste-balances/routes/report.js
+++ b/src/waste-balances/routes/report.js
@@ -1,0 +1,53 @@
+import { StatusCodes } from 'http-status-codes'
+import Joi from 'joi'
+
+import { SCOPES } from '#common/helpers/auth/constants.js'
+import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
+import { generateWasteBalanceReport } from '../application/waste-balance-report.js'
+import { wasteBalanceReportResponseSchema } from './report.schema.js'
+
+/** @import { HapiRequest, HapiResponseToolkit } from '#common/hapi-types.js' */
+
+export const wasteBalanceReportPath = '/v1/admin/waste-balances/report'
+
+/**
+ * Admin report of every live accreditation's waste balance as it stood at a
+ * cutoff instant, with per-material totals across reprocessors and across
+ * exporters. The endpoint is not month-aware: the cutoff is an arbitrary
+ * instant, and month semantics live with the caller (the admin frontend).
+ */
+export const wasteBalanceReportGet = {
+  method: 'GET',
+  path: wasteBalanceReportPath,
+  options: {
+    auth: getAuthConfig([SCOPES.adminRead]),
+    tags: ['api', 'admin'],
+    validate: {
+      query: Joi.object({
+        cutoff: Joi.date().iso().required()
+      })
+    },
+    response: {
+      schema: wasteBalanceReportResponseSchema
+    }
+  },
+  /**
+   * @param {HapiRequest & { query: { cutoff: Date } }} request
+   * @param {HapiResponseToolkit} h
+   */
+  handler: async (request, h) => {
+    const { cutoff } = request.query
+
+    const report = await generateWasteBalanceReport(
+      {
+        organisationsRepository: request.organisationsRepository,
+        ledgerRepository: request.ledgerRepository
+      },
+      cutoff
+    )
+
+    return h
+      .response({ cutoff: cutoff.toISOString(), ...report })
+      .code(StatusCodes.OK)
+  }
+}

--- a/src/waste-balances/routes/report.schema.js
+++ b/src/waste-balances/routes/report.schema.js
@@ -1,0 +1,20 @@
+import Joi from 'joi'
+
+const totalSchema = Joi.object({
+  material: Joi.string().required(),
+  wasteProcessingType: Joi.string().required(),
+  amount: Joi.number().required(),
+  availableAmount: Joi.number().required()
+})
+
+const accreditationSchema = totalSchema.keys({
+  orgId: Joi.string().required(),
+  registrationNumber: Joi.string().required(),
+  accreditationNumber: Joi.string().required()
+})
+
+export const wasteBalanceReportResponseSchema = Joi.object({
+  cutoff: Joi.string().isoDate().required(),
+  totals: Joi.array().items(totalSchema).required(),
+  accreditations: Joi.array().items(accreditationSchema).required()
+})

--- a/src/waste-balances/routes/report.test.js
+++ b/src/waste-balances/routes/report.test.js
@@ -1,0 +1,214 @@
+import { StatusCodes } from 'http-status-codes'
+
+import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
+import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
+import { createTestServer } from '#test/create-test-server.js'
+import { asServiceMaintainer, asOperator } from '#test/inject-auth.js'
+import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+
+import { wasteBalanceReportPath } from './report.js'
+
+const CUTOFF_QUERY = '?cutoff=2026-06-30T23:00:00Z'
+
+const orgWithAccreditation = ({
+  id,
+  orgId,
+  registrationId,
+  accreditationId,
+  registrationNumber,
+  accreditationNumber,
+  material,
+  wasteProcessingType
+}) => ({
+  id,
+  orgId,
+  registrations: [
+    {
+      id: registrationId,
+      accreditationId,
+      registrationNumber,
+      material,
+      wasteProcessingType
+    }
+  ],
+  accreditations: [
+    {
+      id: accreditationId,
+      status: 'approved',
+      accreditationNumber,
+      material,
+      wasteProcessingType
+    }
+  ]
+})
+
+/**
+ * @param {{ organisations?: object[], events?: object[] }} [options]
+ */
+const createServerWithRepos = async ({
+  organisations = [],
+  events = []
+} = {}) => {
+  const ledgerRepository = createInMemoryLedgerRepository()()
+  for (const event of events) {
+    await ledgerRepository.appendEvents([buildLedgerEvent(event)])
+  }
+
+  return createTestServer({
+    repositories: {
+      ledgerRepository,
+      organisationsRepository: () => ({
+        findAll: vi.fn().mockResolvedValue(organisations)
+      })
+    }
+  })
+}
+
+describe(`GET ${wasteBalanceReportPath}`, () => {
+  setupAuthContext()
+
+  describe('route metadata', () => {
+    it('lives at the documented admin path', () => {
+      expect(wasteBalanceReportPath).toBe('/v1/admin/waste-balances/report')
+    })
+  })
+
+  describe('happy path', () => {
+    it('returns the documented shape: echoed cutoff, per-material totals, per-accreditation rows', async () => {
+      const server = await createServerWithRepos({
+        organisations: [
+          orgWithAccreditation({
+            id: 'org-a',
+            orgId: 500001,
+            registrationId: 'reg-a',
+            accreditationId: 'acc-a',
+            registrationNumber: 'REG-123',
+            accreditationNumber: 'ACC-456',
+            material: 'plastic',
+            wasteProcessingType: 'reprocessor'
+          })
+        ],
+        events: [
+          {
+            organisationId: 'org-a',
+            registrationId: 'reg-a',
+            accreditationId: 'acc-a',
+            number: 1,
+            closingBalance: { amount: 700, availableAmount: 500 },
+            createdAt: new Date('2026-06-15T10:00:00.000Z')
+          }
+        ]
+      })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `${wasteBalanceReportPath}${CUTOFF_QUERY}`,
+        ...asServiceMaintainer()
+      })
+
+      await server.stop()
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(response.payload)).toEqual({
+        cutoff: '2026-06-30T23:00:00.000Z',
+        totals: [
+          {
+            material: 'plastic',
+            wasteProcessingType: 'reprocessor',
+            amount: 700,
+            availableAmount: 500
+          }
+        ],
+        accreditations: [
+          {
+            orgId: '500001',
+            registrationNumber: 'REG-123',
+            accreditationNumber: 'ACC-456',
+            material: 'plastic',
+            wasteProcessingType: 'reprocessor',
+            amount: 700,
+            availableAmount: 500
+          }
+        ]
+      })
+    })
+
+    it('returns empty totals and accreditations when no organisations exist', async () => {
+      const server = await createServerWithRepos()
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `${wasteBalanceReportPath}${CUTOFF_QUERY}`,
+        ...asServiceMaintainer()
+      })
+
+      await server.stop()
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(response.payload)).toEqual({
+        cutoff: '2026-06-30T23:00:00.000Z',
+        totals: [],
+        accreditations: []
+      })
+    })
+  })
+
+  describe('cutoff validation', () => {
+    it('rejects a missing cutoff', async () => {
+      const server = await createServerWithRepos()
+
+      const response = await server.inject({
+        method: 'GET',
+        url: wasteBalanceReportPath,
+        ...asServiceMaintainer()
+      })
+
+      await server.stop()
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+    })
+
+    it('rejects a malformed cutoff', async () => {
+      const server = await createServerWithRepos()
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `${wasteBalanceReportPath}?cutoff=not-a-date`,
+        ...asServiceMaintainer()
+      })
+
+      await server.stop()
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+    })
+  })
+
+  describe('auth', () => {
+    it('returns 401 when no credentials are supplied', async () => {
+      const server = await createServerWithRepos()
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `${wasteBalanceReportPath}${CUTOFF_QUERY}`
+      })
+
+      await server.stop()
+
+      expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+    })
+
+    it('returns 403 when the caller is a standard user', async () => {
+      const server = await createServerWithRepos()
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `${wasteBalanceReportPath}${CUTOFF_QUERY}`,
+        ...asOperator()
+      })
+
+      await server.stop()
+
+      expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Backend for the monthly waste balance report (PAE-1676, PRN market supply): a back-office admin endpoint returning, for an arbitrary cutoff instant, every live accreditation's waste balance as it stood at that cutoff, plus per-material totals across all UK reprocessors and across all UK exporters — the supply-side signal for the PRN market.

- **`GET /v1/admin/waste-balances/report?cutoff=<ISO date-time>`** — `adminRead` auth (matching the other admin read endpoints), Joi-validated `cutoff`, Joi response schema. Deliberately not month-aware: month→cutoff mapping lives in the admin frontend (see DEFRA/epr-re-ex-admin-frontend#475).
- **Per accreditation:** the closing balance of the last ledger event created strictly before the cutoff, via a new contract-tested repository method `findLatestInLedgerBefore`; an accreditation with no ledger history before the cutoff is included with a zero balance. Balances carry over — the qualifying event need not fall within the selected month.
- **Totals** are summed per material × reprocessor/exporter with exact decimal arithmetic (`decimal-utils`), matching the ledger's own summation pattern.
- **Scope rules:** suspended accreditations included; created/rejected/cancelled excluded; registered-only ledger partitions (`accreditationId: null`) out of scope; test organisations excluded. Rows carry the organisation's external `orgId` (as a string), registration number and accreditation number.

Notes for reviewers:

- The service uses `resolveAccreditation(registration, org)` rather than `isRegistrationAccredited` — repository `findAll` does not hydrate `registration.accreditation` (only `findRegistrationById` does); `resolveAccreditation` applies the same approved/suspended filter over exactly the shape `findAll` returns, as the waste-records export already does.
- Missing/malformed `cutoff` returns **422** (not 400): the server-level `failAction` converts all Joi validation errors to `Boom.badData`, the codebase-wide convention.
- No new MongoDB index: the existing `partition_number` index covers the partition filter and `number` sort, with the `createdAt` bound applied as a filter; per-partition event counts are small.

Consolidates #1504 and #1505 (closed) — one commit per layer:

1. `cbd78fe9` — repository method (port, contract tests, MongoDB + in-memory adapters)
2. `6faad022` — aggregation service
3. `4d3bd809` — admin route

## Changes

- `src/waste-balances/repository/ledger-port.js` — port typedef gains `findLatestInLedgerBefore(ledgerId, cutoff)` with strictly-before semantics documented (an event created at exactly the cutoff does not count).
- `src/waste-balances/repository/ledger-mongodb.js` / `ledger-inmemory.js` — the two adapter implementations (`findOne` on `ledgerFilter` + `createdAt: { $lt: cutoff }`, sorted `number: -1`; the in-memory equivalent).
- `src/waste-balances/repository/ledger-contract/findLatestInLedgerBefore.contract.js` + `ledger-port.contract.js` — nine contract tests both adapters must satisfy: strictly-before (exact-cutoff excluded), latest-of-several, highest-numbered wins over latest-created when the orders disagree, carry-over, no-events → null, ledger/organisation isolation, null vs non-null `accreditationId`.
- `src/waste-balances/application/waste-balance-report.js` + test — `generateWasteBalanceReport({ organisationsRepository, ledgerRepository }, cutoff)`; 7 behaviour tests (totals arithmetic, exact decimal summation, zero-balance inclusion, carry-over, suspended in / dead states out, registered-only ignored, test orgs excluded).
- `src/waste-balances/routes/report.js` + `report.schema.js` + test + `routes/index.js` — the admin route, response schema, and 7 route tests (shape end-to-end, empty state, 422 validation, 401/403 auth).
