### PR TITLE
PAE-1660: Retain original submission date on the public register

### DIFF
--- a/src/reports/application/report-compliance.js
+++ b/src/reports/application/report-compliance.js
@@ -1,7 +1,10 @@
 import { CADENCE } from '#reports/domain/cadence.js'
 import { periodKey } from '#reports/domain/period-key.js'
 import { generateReportingPeriods } from '#reports/domain/generate-reporting-periods.js'
-import { mergeReportingPeriods } from '#reports/domain/merge-reporting-periods.js'
+import {
+  mergeReportingPeriods,
+  selectSubmittedReports
+} from '#reports/domain/merge-reporting-periods.js'
 import { generateComplianceReportingPeriods } from '#reports/domain/compliance-reporting-periods.js'
 import {
   activeAccreditationValidFrom,
@@ -28,6 +31,25 @@ import {
  *   entries: Map<string, ReportComplianceEntry>;
  * }} ReportComplianceData
  */
+
+/**
+ * The date the public register shows for a period. It retains the ORIGINAL
+ * submitted date: resubmissions are not reflected externally.
+ * `selectSubmittedReports` orders by submissionNumber ascending, so its first
+ * entry is the earliest submission — never the in-flight draft in `report`, nor
+ * a later correction. A period with nothing submitted yields no entry, so
+ * resolves to null.
+ *
+ * @param {import('#reports/domain/merge-reporting-periods.js').MergedPeriod} mergedPeriod
+ * @returns {string | null}
+ */
+function originalSubmittedDate(mergedPeriod) {
+  const [original] = selectSubmittedReports({
+    current: mergedPeriod.report,
+    previousSubmissions: mergedPeriod.previousSubmissions
+  })
+  return original?.submittedAt?.slice(0, 10) ?? null
+}
 
 /**
  * Groups all periodic reports by `${organisationId}::${registrationId}`.
@@ -111,7 +133,7 @@ export async function generateReportCompliance(
             cadence,
             period: mergedPeriod.period
           }),
-          mergedPeriod.report?.submittedAt?.slice(0, 10) ?? null
+          originalSubmittedDate(mergedPeriod)
         )
       }
     }

--- a/src/reports/application/report-compliance.js
+++ b/src/reports/application/report-compliance.js
@@ -35,10 +35,17 @@ import {
 /**
  * The date the public register shows for a period. It retains the ORIGINAL
  * submitted date: resubmissions are not reflected externally.
- * `selectSubmittedReports` orders by submissionNumber ascending, so its first
- * entry is the earliest submission — never the in-flight draft in `report`, nor
- * a later correction. A period with nothing submitted yields no entry, so
- * resolves to null.
+ *
+ * `selectSubmittedReports` returns the period's submitted reports ordered by
+ * submissionNumber ascending, so its first entry is the lowest-numbered
+ * submission. That is the original submission, because the write model only
+ * permits unsubmitting the latest submission (`isLatestSubmission` in
+ * report-service.js), so an earlier submission's `submittedAt` is never
+ * re-stamped after a later one exists. Keying on a retained `submittedAt`
+ * rather than the current status means a submitted-then-unsubmitted period
+ * keeps its date instead of blanking. A period with nothing submitted yields
+ * no entry, so resolves to null (never the in-flight draft in `report`, nor a
+ * later correction).
  *
  * @param {import('#reports/domain/merge-reporting-periods.js').MergedPeriod} mergedPeriod
  * @returns {string | null}

--- a/src/reports/application/report-compliance.test.js
+++ b/src/reports/application/report-compliance.test.js
@@ -4,6 +4,7 @@ import { createInMemoryOrganisationsRepository } from '#repositories/organisatio
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import { buildApprovedOrg } from '#vite/helpers/build-approved-org.js'
 import { buildSubmittedReport } from '#vite/helpers/build-submitted-report.js'
+import { seedInFlightResubmission } from '#vite/helpers/seed-inflight-resubmission.js'
 import {
   ORGANISATION_STATUS,
   REG_ACC_STATUS,
@@ -362,6 +363,97 @@ describe('generateReportCompliance', () => {
             submittedDates: new Map([
               ['2026:monthly:1', null],
               ['2026:monthly:2', SUBMITTED_DATE],
+              ['2026:monthly:3', null]
+            ])
+          }
+        ]
+      ])
+    })
+  })
+
+  it('retains the original submitted date while a resubmission is in progress', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    const org = await buildApprovedOrg(orgRepo, undefined, FULL_YEAR_RANGE)
+    const reg = org.registrations[0]
+
+    // Submission 1 submitted, with an in-flight submission 2 draft over it. The
+    // draft is the current report but carries no submitted date, so reading it
+    // would transiently blank a period that has in fact been submitted.
+    await seedInFlightResubmission(reportsRepo, {
+      organisationId: org.id,
+      registrationId: reg.id,
+      year: 2026,
+      cadence: 'monthly',
+      period: 1
+    })
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
+    // The public register keeps showing submission 1's date, not a blank.
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          reg.id,
+          {
+            registrationId: reg.id,
+            organisationId: org.id,
+            submittedDates: new Map([
+              ['2026:monthly:1', SUBMITTED_DATE],
+              ['2026:monthly:2', null],
+              ['2026:monthly:3', null]
+            ])
+          }
+        ]
+      ])
+    })
+  })
+
+  it('keeps the original submitted date after a resubmission is completed', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    const org = await buildApprovedOrg(orgRepo, undefined, FULL_YEAR_RANGE)
+    const reg = org.registrations[0]
+
+    // Submission 1 submitted on 17 Apr.
+    await buildSubmittedReport(reportsRepo, {
+      organisationId: org.id,
+      registrationId: reg.id,
+      year: 2026,
+      cadence: 'monthly',
+      period: 1
+    })
+
+    // Submission 2, a correction, itself submitted the next day. April has not
+    // yet ended, so the applicable period set is unchanged.
+    vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
+    await buildSubmittedReport(reportsRepo, {
+      organisationId: org.id,
+      registrationId: reg.id,
+      year: 2026,
+      cadence: 'monthly',
+      period: 1,
+      submissionNumber: 2
+    })
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
+    // Resubmissions are not reflected externally: the register still shows the
+    // original submission date (17 Apr), not the correction's (18 Apr).
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          reg.id,
+          {
+            registrationId: reg.id,
+            organisationId: org.id,
+            submittedDates: new Map([
+              ['2026:monthly:1', SUBMITTED_DATE],
+              ['2026:monthly:2', null],
               ['2026:monthly:3', null]
             ])
           }

--- a/src/reports/application/report-compliance.test.js
+++ b/src/reports/application/report-compliance.test.js
@@ -372,108 +372,50 @@ describe('generateReportCompliance', () => {
     })
   })
 
-  it('retains the original submitted date while a resubmission is in progress', async () => {
+  // The register date is the original submission date, stable across every
+  // state of the resubmission lifecycle: an in-flight redraft, a completed
+  // correction, and an unsubmit all leave period 1 showing its 17 Apr date.
+  // Production keys the date on submittedAt truthiness (via
+  // selectSubmittedReports), never on status, so each seeded state must yield
+  // the identical baseline result below. The retention invariant itself is
+  // owned at the domain layer (merge-reporting-periods.test.js).
+  it.for([
+    {
+      // Submission 1 submitted, with an in-flight submission 2 draft over it.
+      // The draft is the current report but carries no submitted date, so
+      // reading it naively would blank a period that has in fact been submitted.
+      state: 'a resubmission is in progress',
+      seed: (reportsRepo, ids) => seedInFlightResubmission(reportsRepo, ids)
+    },
+    {
+      // Submission 1 submitted on 17 Apr, then a correction (submission 2) itself
+      // submitted the next day. April has not yet ended, so the applicable period
+      // set is unchanged and the register must still show the original 17 Apr.
+      state: 'a resubmission has completed the next day',
+      seed: async (reportsRepo, ids) => {
+        await buildSubmittedReport(reportsRepo, ids)
+        vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
+        await buildSubmittedReport(reportsRepo, {
+          ...ids,
+          submissionNumber: 2
+        })
+      }
+    },
+    {
+      // A submitted period a service maintainer then unsubmits for correction:
+      // status reverts to ready_to_submit but the submitted date is retained.
+      // Keying on status rather than the retained submittedAt would blank it.
+      state: 'a submitted period is unsubmitted for correction',
+      seed: (reportsRepo, ids) => buildUnsubmittedReport(reportsRepo, ids)
+    }
+  ])('shows the original submitted date given $state', async ({ seed }) => {
     const orgRepo = createInMemoryOrganisationsRepository()()
     const reportsRepo = createInMemoryReportsRepository()()
 
     const org = await buildApprovedOrg(orgRepo, undefined, FULL_YEAR_RANGE)
     const reg = org.registrations[0]
 
-    // Submission 1 submitted, with an in-flight submission 2 draft over it. The
-    // draft is the current report but carries no submitted date, so reading it
-    // would transiently blank a period that has in fact been submitted.
-    await seedInFlightResubmission(reportsRepo, {
-      organisationId: org.id,
-      registrationId: reg.id,
-      year: 2026,
-      cadence: 'monthly',
-      period: 1
-    })
-
-    const result = await generateReportCompliance(orgRepo, reportsRepo)
-
-    // The public register keeps showing submission 1's date, not a blank.
-    expect(result).toEqual({
-      periods: EXPECTED_PERIODS,
-      entries: new Map([
-        [
-          reg.id,
-          {
-            registrationId: reg.id,
-            organisationId: org.id,
-            submittedDates: new Map([
-              ['2026:monthly:1', SUBMITTED_DATE],
-              ['2026:monthly:2', null],
-              ['2026:monthly:3', null]
-            ])
-          }
-        ]
-      ])
-    })
-  })
-
-  it('keeps the original submitted date after a resubmission is completed', async () => {
-    const orgRepo = createInMemoryOrganisationsRepository()()
-    const reportsRepo = createInMemoryReportsRepository()()
-
-    const org = await buildApprovedOrg(orgRepo, undefined, FULL_YEAR_RANGE)
-    const reg = org.registrations[0]
-
-    // Submission 1 submitted on 17 Apr.
-    await buildSubmittedReport(reportsRepo, {
-      organisationId: org.id,
-      registrationId: reg.id,
-      year: 2026,
-      cadence: 'monthly',
-      period: 1
-    })
-
-    // Submission 2, a correction, itself submitted the next day. April has not
-    // yet ended, so the applicable period set is unchanged.
-    vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
-    await buildSubmittedReport(reportsRepo, {
-      organisationId: org.id,
-      registrationId: reg.id,
-      year: 2026,
-      cadence: 'monthly',
-      period: 1,
-      submissionNumber: 2
-    })
-
-    const result = await generateReportCompliance(orgRepo, reportsRepo)
-
-    // Resubmissions are not reflected externally: the register still shows the
-    // original submission date (17 Apr), not the correction's (18 Apr).
-    expect(result).toEqual({
-      periods: EXPECTED_PERIODS,
-      entries: new Map([
-        [
-          reg.id,
-          {
-            registrationId: reg.id,
-            organisationId: org.id,
-            submittedDates: new Map([
-              ['2026:monthly:1', SUBMITTED_DATE],
-              ['2026:monthly:2', null],
-              ['2026:monthly:3', null]
-            ])
-          }
-        ]
-      ])
-    })
-  })
-
-  it('retains the submitted date after a submitted period is unsubmitted', async () => {
-    const orgRepo = createInMemoryOrganisationsRepository()()
-    const reportsRepo = createInMemoryReportsRepository()()
-
-    const org = await buildApprovedOrg(orgRepo, undefined, FULL_YEAR_RANGE)
-    const reg = org.registrations[0]
-
-    // A submitted period a service maintainer then unsubmits for correction:
-    // status reverts to ready_to_submit but the submitted date is retained.
-    // Keying on status rather than the retained submittedAt would blank it.
-    await buildUnsubmittedReport(reportsRepo, {
+    await seed(reportsRepo, {
       organisationId: org.id,
       registrationId: reg.id,
       year: 2026,

--- a/src/reports/application/report-compliance.test.js
+++ b/src/reports/application/report-compliance.test.js
@@ -5,6 +5,7 @@ import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js
 import { buildApprovedOrg } from '#vite/helpers/build-approved-org.js'
 import { buildSubmittedReport } from '#vite/helpers/build-submitted-report.js'
 import { seedInFlightResubmission } from '#vite/helpers/seed-inflight-resubmission.js'
+import { buildUnsubmittedReport } from '#vite/helpers/build-unsubmitted-report.js'
 import {
   ORGANISATION_STATUS,
   REG_ACC_STATUS,
@@ -443,6 +444,45 @@ describe('generateReportCompliance', () => {
 
     // Resubmissions are not reflected externally: the register still shows the
     // original submission date (17 Apr), not the correction's (18 Apr).
+    expect(result).toEqual({
+      periods: EXPECTED_PERIODS,
+      entries: new Map([
+        [
+          reg.id,
+          {
+            registrationId: reg.id,
+            organisationId: org.id,
+            submittedDates: new Map([
+              ['2026:monthly:1', SUBMITTED_DATE],
+              ['2026:monthly:2', null],
+              ['2026:monthly:3', null]
+            ])
+          }
+        ]
+      ])
+    })
+  })
+
+  it('retains the submitted date after a submitted period is unsubmitted', async () => {
+    const orgRepo = createInMemoryOrganisationsRepository()()
+    const reportsRepo = createInMemoryReportsRepository()()
+
+    const org = await buildApprovedOrg(orgRepo, undefined, FULL_YEAR_RANGE)
+    const reg = org.registrations[0]
+
+    // A submitted period a service maintainer then unsubmits for correction:
+    // status reverts to ready_to_submit but the submitted date is retained.
+    // Keying on status rather than the retained submittedAt would blank it.
+    await buildUnsubmittedReport(reportsRepo, {
+      organisationId: org.id,
+      registrationId: reg.id,
+      year: 2026,
+      cadence: 'monthly',
+      period: 1
+    })
+
+    const result = await generateReportCompliance(orgRepo, reportsRepo)
+
     expect(result).toEqual({
       periods: EXPECTED_PERIODS,
       entries: new Map([


### PR DESCRIPTION
Ticket: [PAE-1660](https://eaflood.atlassian.net/browse/PAE-1660)
## What

The public register embeds a submitted date per reporting period. It previously read the period's *current* report (`mergedPeriod.report`). While a period is being resubmitted the current report is an unsubmitted draft carrying no submitted date, so a period that had in fact been submitted transiently blanked on a public-facing artefact — and once a resubmission completed, the register showed the correction's date rather than the original.

This derives the register date from the **earliest** submitted report for the period instead of the current one:

- adds `originalSubmittedDate()`, which takes the first entry from `selectSubmittedReports` (ordered by submission number ascending)
- a period with an in-flight resubmission keeps showing its original submitted date instead of blanking
- a completed resubmission still shows the original submitted date, not the correction's
- a never-submitted period remains blank, unchanged

## Why

The business decision on PAE-1660 is that the public register retains the original submission date: resubmissions are not reflected externally, while a complete record of all resubmissions continues to be maintained in the backend (the report-submissions feed) for auditability. This may be revisited in future.

[PAE-1660]: https://eaflood.atlassian.net/browse/PAE-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ