### PR TITLE
PAE-1755: Fix report stale-status normalisation dropping legacy summary-log data

### DIFF
--- a/src/reports/domain/stale.js
+++ b/src/reports/domain/stale.js
@@ -2,6 +2,10 @@ import Boom from '@hapi/boom'
 import Joi from 'joi'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
 
+/**
+ * @import { ReportStale, StaleSummaryLogChanged } from '#reports/repository/port.js'
+ */
+
 export const STALE_REASON = Object.freeze({
   SUMMARY_LOG_CHANGED: 'summary_log_changed',
   PRN_CANCELLED: 'prn_cancelled'
@@ -44,34 +48,29 @@ export const staleReasons = (stale) => {
 }
 
 /**
- * Normalises a report's `stale` field to the current nested shape. Old
- * documents (written before the PRN-cancellation trigger existed) carry a
- * flat `{ uploadedAt, reason, summaryLogId }` object; new writes only ever
- * produce `{ summaryLogChanged?, prnCancelled? }`. Applied at the repository
- * read boundary so every caller sees the current shape regardless of when
- * the document was written — no bulk migration needed, since `stale` only
- * ever applies to active drafts, which are short-lived by construction.
+ * Normalises a report's `stale` field to the current nested shape
+ * (`{ summaryLogChanged?, prnCancelled? }`), upgrading the legacy flat
+ * shape (`{ uploadedAt, reason, summaryLogId }`) where needed.
  *
  * @param {Record<string, unknown> | undefined} stale
- * @returns {import('#reports/repository/port.js').ReportStale | undefined}
+ * @returns {ReportStale | undefined}
  */
 export const normaliseStale = (stale) => {
   if (!stale) {
     return undefined
   }
-  if ('summaryLogChanged' in stale || 'prnCancelled' in stale) {
-    return /** @type {import('#reports/repository/port.js').ReportStale} */ (
-      stale
-    )
+
+  const { summaryLogChanged, prnCancelled, reason: _reason, ...rest } = stale
+
+  if (summaryLogChanged || prnCancelled) {
+    return /** @type {ReportStale} */ ({
+      ...(summaryLogChanged ? { summaryLogChanged } : {}),
+      ...(prnCancelled ? { prnCancelled } : {})
+    })
   }
+
   // Old flat shape: the only reason that existed before this change.
-  const { reason: _reason, ...rest } = stale
-  return {
-    summaryLogChanged:
-      /** @type {import('#reports/repository/port.js').StaleSummaryLogChanged} */ (
-        rest
-      )
-  }
+  return { summaryLogChanged: /** @type {StaleSummaryLogChanged} */ (rest) }
 }
 
 /**

--- a/src/reports/domain/stale.test.js
+++ b/src/reports/domain/stale.test.js
@@ -107,6 +107,56 @@ describe('normaliseStale', () => {
       }
     })
   })
+
+  it('strips legacy flat siblings left behind by a dot-path $set onto an old-shape document', () => {
+    // A doc first written in the old flat shape, then later `$set` with a
+    // dot-path (e.g. `stale.summaryLogChanged`) merges rather than replaces,
+    // leaving the legacy top-level keys alongside the new nested key.
+    const mixed = {
+      uploadedAt: '2025-01-01T00:00:00.000Z',
+      reason: 'summary_log_changed',
+      summaryLogId: 'sl-1',
+      summaryLogChanged: {
+        uploadedAt: '2025-02-01T00:00:00.000Z',
+        summaryLogId: 'sl-2'
+      }
+    }
+
+    expect(normaliseStale(mixed)).toEqual({
+      summaryLogChanged: {
+        uploadedAt: '2025-02-01T00:00:00.000Z',
+        summaryLogId: 'sl-2'
+      }
+    })
+  })
+
+  it('strips legacy flat siblings alongside a nested prnCancelled key', () => {
+    const mixed = {
+      uploadedAt: '2025-01-01T00:00:00.000Z',
+      reason: 'summary_log_changed',
+      summaryLogId: 'sl-1',
+      prnCancelled: buildPrnCancelled()
+    }
+
+    expect(normaliseStale(mixed)).toEqual({
+      prnCancelled: buildPrnCancelled()
+    })
+  })
+
+  it('preserves both reasons when both nested keys are present alongside legacy siblings', () => {
+    const mixed = {
+      uploadedAt: '2025-01-01T00:00:00.000Z',
+      reason: 'summary_log_changed',
+      summaryLogId: 'sl-1',
+      summaryLogChanged: buildSummaryLogChanged(),
+      prnCancelled: buildPrnCancelled()
+    }
+
+    expect(normaliseStale(mixed)).toEqual({
+      summaryLogChanged: buildSummaryLogChanged(),
+      prnCancelled: buildPrnCancelled()
+    })
+  })
 })
 
 describe('assertNotStale', () => {


### PR DESCRIPTION
Ticket: [PAE-1755](https://eaflood.atlassian.net/browse/PAE-1755)
## Summary
- Fixes a prod 500 (`"stale.uploadedAt" is not allowed`) on report reads for reports marked stale before PAE-1698 (old flat `stale` shape) and then re-flagged afterwards, which left legacy fields sitting alongside the new nested shape.
- `normaliseStale` now correctly upgrades/strips the legacy flat shape (`{ uploadedAt, reason, summaryLogId }`) to the current nested shape (`{ summaryLogChanged?, prnCancelled? }`) wherever a report is read, so the strict response schema never sees the old fields.

Ref: PAE-1755

[PAE-1755]: https://eaflood.atlassian.net/browse/PAE-1755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ