### PR TITLE
PAE-1755: enrich report response-validation logging

### DIFF
--- a/src/common/enums/event.js
+++ b/src/common/enums/event.js
@@ -37,7 +37,9 @@ export const LOGGING_EVENT_ACTIONS = {
   SUMMARY_LOG_VALIDATION_COMPLETED: 'summary_log_validation_completed',
   COMPENSATION_FAILURE: 'compensation_failure',
   COMPENSATION_SUCCESS: 'compensation_success',
-  WASTE_BALANCE_UPDATED: 'waste_balance_updated'
+  WASTE_BALANCE_UPDATED: 'waste_balance_updated',
+  REPORT_RESPONSE_SCHEMA_VIOLATION: 'report_response_schema_violation',
+  LEGACY_STALE_SHAPE_NORMALISED: 'legacy_stale_shape_normalised'
 }
 
 export const AUDIT_EVENT_CATEGORIES = {

--- a/src/reports/domain/stale.js
+++ b/src/reports/domain/stale.js
@@ -44,34 +44,27 @@ export const staleReasons = (stale) => {
 }
 
 /**
- * Normalises a report's `stale` field to the current nested shape. Old
- * documents (written before the PRN-cancellation trigger existed) carry a
- * flat `{ uploadedAt, reason, summaryLogId }` object; new writes only ever
- * produce `{ summaryLogChanged?, prnCancelled? }`. Applied at the repository
- * read boundary so every caller sees the current shape regardless of when
- * the document was written — no bulk migration needed, since `stale` only
- * ever applies to active drafts, which are short-lived by construction.
+ * Normalises a report's `stale` field to the current nested shape.
+ * Upgrading the legacy flat shape (`{ uploadedAt, reason, summaryLogId }`) where needed.
  *
- * @param {Record<string, unknown> | undefined} stale
+ * @param {any} stale
  * @returns {import('#reports/repository/port.js').ReportStale | undefined}
  */
 export const normaliseStale = (stale) => {
-  if (!stale) {
-    return undefined
+  if (!stale) return undefined
+
+  const { summaryLogChanged, prnCancelled, reason: _reason, ...rest } = stale
+
+  // If we have either of the new structured fields, extract and return them
+  if (summaryLogChanged || prnCancelled) {
+    return {
+      ...(summaryLogChanged && { summaryLogChanged }),
+      ...(prnCancelled && { prnCancelled })
+    }
   }
-  if ('summaryLogChanged' in stale || 'prnCancelled' in stale) {
-    return /** @type {import('#reports/repository/port.js').ReportStale} */ (
-      stale
-    )
-  }
-  // Old flat shape: the only reason that existed before this change.
-  const { reason: _reason, ...rest } = stale
-  return {
-    summaryLogChanged:
-      /** @type {import('#reports/repository/port.js').StaleSummaryLogChanged} */ (
-        rest
-      )
-  }
+
+  // Fallback for the old flat shape (everything except 'reason' goes into summaryLogChanged)
+  return { summaryLogChanged: rest }
 }
 
 /**

--- a/src/reports/domain/stale.js
+++ b/src/reports/domain/stale.js
@@ -67,6 +67,20 @@ export const normaliseStale = (stale) => {
   return { summaryLogChanged: rest }
 }
 
+const KNOWN_STALE_KEYS = new Set(['summaryLogChanged', 'prnCancelled'])
+
+/**
+ * Lists the top-level `stale` keys that `normaliseStale` would drop: the legacy
+ * flat fields left on a document written (or re-flagged) in the old shape. Empty
+ * for a clean nested-shape `stale`. Lets the read boundary flag which documents
+ * still carry the legacy shape so the migration tail is observable (PAE-1755).
+ *
+ * @param {Record<string, unknown> | undefined} stale
+ * @returns {string[]}
+ */
+export const legacyStaleKeys = (stale) =>
+  stale ? Object.keys(stale).filter((key) => !KNOWN_STALE_KEYS.has(key)) : []
+
 /**
  * Asserts `reasons` matches the 409 payload's `code` contract, so the shape
  * `staleReasons` produces is verified rather than just assumed by callers

--- a/src/reports/domain/stale.test.js
+++ b/src/reports/domain/stale.test.js
@@ -107,6 +107,56 @@ describe('normaliseStale', () => {
       }
     })
   })
+
+  it('strips legacy flat siblings left behind by a dot-path $set onto an old-shape document', () => {
+    // A doc first written in the old flat shape, then later `$set` with a
+    // dot-path (e.g. `stale.summaryLogChanged`) merges rather than replaces,
+    // leaving the legacy top-level keys alongside the new nested key.
+    const mixed = {
+      uploadedAt: '2025-01-01T00:00:00.000Z',
+      reason: 'summary_log_changed',
+      summaryLogId: 'sl-1',
+      summaryLogChanged: {
+        uploadedAt: '2025-02-01T00:00:00.000Z',
+        summaryLogId: 'sl-2'
+      }
+    }
+
+    expect(normaliseStale(mixed)).toEqual({
+      summaryLogChanged: {
+        uploadedAt: '2025-02-01T00:00:00.000Z',
+        summaryLogId: 'sl-2'
+      }
+    })
+  })
+
+  it('strips legacy flat siblings alongside a nested prnCancelled key', () => {
+    const mixed = {
+      uploadedAt: '2025-01-01T00:00:00.000Z',
+      reason: 'summary_log_changed',
+      summaryLogId: 'sl-1',
+      prnCancelled: buildPrnCancelled()
+    }
+
+    expect(normaliseStale(mixed)).toEqual({
+      prnCancelled: buildPrnCancelled()
+    })
+  })
+
+  it('preserves both reasons when both nested keys are present alongside legacy siblings', () => {
+    const mixed = {
+      uploadedAt: '2025-01-01T00:00:00.000Z',
+      reason: 'summary_log_changed',
+      summaryLogId: 'sl-1',
+      summaryLogChanged: buildSummaryLogChanged(),
+      prnCancelled: buildPrnCancelled()
+    }
+
+    expect(normaliseStale(mixed)).toEqual({
+      summaryLogChanged: buildSummaryLogChanged(),
+      prnCancelled: buildPrnCancelled()
+    })
+  })
 })
 
 describe('assertNotStale', () => {

--- a/src/reports/domain/stale.test.js
+++ b/src/reports/domain/stale.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   assertNotStale,
   assertValidStaleReasonsCode,
+  legacyStaleKeys,
   normaliseStale,
   STALE_REASON,
   staleReasons
@@ -156,6 +157,42 @@ describe('normaliseStale', () => {
       summaryLogChanged: buildSummaryLogChanged(),
       prnCancelled: buildPrnCancelled()
     })
+  })
+})
+
+describe('legacyStaleKeys', () => {
+  it('returns [] for undefined', () => {
+    expect(legacyStaleKeys(undefined)).toEqual([])
+  })
+
+  it('returns [] for the current nested shape', () => {
+    expect(
+      legacyStaleKeys({
+        summaryLogChanged: buildSummaryLogChanged(),
+        prnCancelled: buildPrnCancelled()
+      })
+    ).toEqual([])
+  })
+
+  it('returns every flat key for the old flat shape', () => {
+    expect(
+      legacyStaleKeys({
+        uploadedAt: '2025-01-01T00:00:00.000Z',
+        reason: 'summary_log_changed',
+        summaryLogId: 'sl-1'
+      })
+    ).toEqual(['uploadedAt', 'reason', 'summaryLogId'])
+  })
+
+  it('returns only the stray siblings for a hybrid shape', () => {
+    expect(
+      legacyStaleKeys({
+        uploadedAt: '2025-01-01T00:00:00.000Z',
+        reason: 'summary_log_changed',
+        summaryLogId: 'sl-1',
+        summaryLogChanged: buildSummaryLogChanged()
+      })
+    ).toEqual(['uploadedAt', 'reason', 'summaryLogId'])
   })
 })
 

--- a/src/reports/repository/helpers.js
+++ b/src/reports/repository/helpers.js
@@ -16,9 +16,10 @@ const BARE_DATE_LENGTH = 10
 
 /**
  * Normalises a report's `stale` field to the current nested shape on read.
- * Warns when the document still carries the legacy flat shape, so the number
- * of un-migrated documents is observable — the back-compat branch in
- * `normaliseStale` is safe to remove once this stops firing (PAE-1755).
+ * Logs at info when the document still carries the legacy flat shape, so the
+ * number of un-migrated documents is observable — the back-compat branch in
+ * `normaliseStale` is safe to remove once this stops firing (PAE-1755). Info,
+ * not warn: old documents are expected, so this must not raise alerts.
  *
  * @template {{ id?: string, stale?: Record<string, unknown> }} T
  * @param {T} report
@@ -30,7 +31,7 @@ export const mapReport = (report) => {
   }
   const strippedKeys = legacyStaleKeys(report.stale)
   if (strippedKeys.length > 0) {
-    logger.warn({
+    logger.info({
       message: 'Normalised legacy stale shape on report read',
       event: {
         category: LOGGING_EVENT_CATEGORIES.DB,

--- a/src/reports/repository/helpers.js
+++ b/src/reports/repository/helpers.js
@@ -4,18 +4,43 @@ import {
   REPORT_STATUS_SLOT
 } from '#reports/domain/report-status.js'
 import { periodKey } from '#reports/domain/period-key.js'
-import { normaliseStale } from '#reports/domain/stale.js'
+import { legacyStaleKeys, normaliseStale } from '#reports/domain/stale.js'
+import { logger } from '#common/helpers/logging/logger.js'
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/event.js'
 import { randomUUID } from 'node:crypto'
 
 const BARE_DATE_LENGTH = 10
 
 /**
- * @template {{ stale?: Record<string, unknown> }} T
+ * Normalises a report's `stale` field to the current nested shape on read.
+ * Warns when the document still carries the legacy flat shape, so the number
+ * of un-migrated documents is observable — the back-compat branch in
+ * `normaliseStale` is safe to remove once this stops firing (PAE-1755).
+ *
+ * @template {{ id?: string, stale?: Record<string, unknown> }} T
  * @param {T} report
  * @returns {T}
  */
-export const mapReport = (report) =>
-  report.stale ? { ...report, stale: normaliseStale(report.stale) } : report
+export const mapReport = (report) => {
+  if (!report.stale) {
+    return report
+  }
+  const strippedKeys = legacyStaleKeys(report.stale)
+  if (strippedKeys.length > 0) {
+    logger.warn({
+      message: 'Normalised legacy stale shape on report read',
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.DB,
+        action: LOGGING_EVENT_ACTIONS.LEGACY_STALE_SHAPE_NORMALISED,
+        reason: `reportId=${report.id} strippedKeys=${strippedKeys.join(',')}`
+      }
+    })
+  }
+  return { ...report, stale: normaliseStale(report.stale) }
+}
 
 /**
  * Only reports persisted before the bare-date schema fix carry a full ISO

--- a/src/reports/repository/helpers.test.js
+++ b/src/reports/repository/helpers.test.js
@@ -37,7 +37,7 @@ describe('mapReport', () => {
   })
 
   it('does not log for a clean nested-shape stale', () => {
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+    const info = vi.spyOn(logger, 'info').mockImplementation(() => logger)
 
     mapReport(
       buildReport({
@@ -48,11 +48,11 @@ describe('mapReport', () => {
       })
     )
 
-    expect(warn).not.toHaveBeenCalled()
+    expect(info).not.toHaveBeenCalled()
   })
 
-  it('warns with the report id and stripped keys when normalising a legacy stale shape', () => {
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+  it('logs at info with the report id and stripped keys when normalising a legacy stale shape', () => {
+    const info = vi.spyOn(logger, 'info').mockImplementation(() => logger)
 
     mapReport(
       buildReport({
@@ -66,7 +66,7 @@ describe('mapReport', () => {
       })
     )
 
-    expect(warn).toHaveBeenCalledWith(
+    expect(info).toHaveBeenCalledWith(
       expect.objectContaining({
         event: expect.objectContaining({
           action: LOGGING_EVENT_ACTIONS.LEGACY_STALE_SHAPE_NORMALISED,

--- a/src/reports/repository/helpers.test.js
+++ b/src/reports/repository/helpers.test.js
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { mapReport } from './helpers.js'
+import { logger } from '#common/helpers/logging/logger.js'
+import { LOGGING_EVENT_ACTIONS } from '#common/enums/event.js'
+
+const buildReport = (stale) => ({
+  id: 'report-1',
+  version: 1,
+  ...(stale ? { stale } : {})
+})
+
+describe('mapReport', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the report unchanged when there is no stale field', () => {
+    const report = buildReport()
+
+    expect(mapReport(report)).toBe(report)
+  })
+
+  it('normalises the stale field to the nested shape', () => {
+    const report = buildReport({
+      uploadedAt: '2025-01-01T00:00:00.000Z',
+      reason: 'summary_log_changed',
+      summaryLogId: 'sl-1'
+    })
+
+    expect(mapReport(report).stale).toEqual({
+      summaryLogChanged: {
+        uploadedAt: '2025-01-01T00:00:00.000Z',
+        summaryLogId: 'sl-1'
+      }
+    })
+  })
+
+  it('does not log for a clean nested-shape stale', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+
+    mapReport(
+      buildReport({
+        summaryLogChanged: {
+          uploadedAt: '2025-01-01T00:00:00.000Z',
+          summaryLogId: 'sl-1'
+        }
+      })
+    )
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('warns with the report id and stripped keys when normalising a legacy stale shape', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+
+    mapReport(
+      buildReport({
+        uploadedAt: '2025-01-01T00:00:00.000Z',
+        reason: 'summary_log_changed',
+        summaryLogId: 'sl-1',
+        summaryLogChanged: {
+          uploadedAt: '2025-02-01T00:00:00.000Z',
+          summaryLogId: 'sl-2'
+        }
+      })
+    )
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          action: LOGGING_EVENT_ACTIONS.LEGACY_STALE_SHAPE_NORMALISED,
+          reason:
+            'reportId=report-1 strippedKeys=uploadedAt,reason,summaryLogId'
+        })
+      })
+    )
+  })
+})

--- a/src/reports/routes/get-detail.js
+++ b/src/reports/routes/get-detail.js
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 import { fetchOrGenerateReportForPeriod } from '#reports/application/report-service.js'
 import { periodParamsSchema, withRegistrationDetails } from './shared.js'
 import { reportDetailResponseSchema } from './response.schema.js'
+import { reportResponseFailAction } from './response-fail-action.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { SCOPES } from '#common/helpers/auth/constants.js'
 
@@ -31,7 +32,7 @@ export const reportsGetDetail = {
     },
     response: {
       schema: reportDetailResponseSchema,
-      failAction: 'error'
+      failAction: reportResponseFailAction
     }
   },
   /**

--- a/src/reports/routes/post.js
+++ b/src/reports/routes/post.js
@@ -16,6 +16,7 @@ import {
   withRegistrationDetails
 } from './shared.js'
 import { reportDetailResponseSchema } from './response.schema.js'
+import { reportResponseFailAction } from './response-fail-action.js'
 
 /**
  * @import { HapiRequest, HapiResponseToolkit, TypedLogger } from '#common/hapi-types.js'
@@ -62,7 +63,7 @@ export const reportsPost = {
     },
     response: {
       schema: reportDetailResponseSchema,
-      failAction: 'error'
+      failAction: reportResponseFailAction
     }
   },
   /**

--- a/src/reports/routes/response-fail-action.js
+++ b/src/reports/routes/response-fail-action.js
@@ -2,6 +2,7 @@ import { internal } from '#common/helpers/logging/cdp-boom.js'
 import { LOGGING_EVENT_ACTIONS } from '#common/enums/event.js'
 
 /**
+ * @import { ValidationError } from 'joi'
  * @import { HapiRequest, HapiResponseToolkit } from '#common/hapi-types.js'
  */
 
@@ -11,17 +12,14 @@ const MAX_LOGGED_VIOLATIONS = 5
  * Summarises a Joi validation error into PII-safe descriptors: the failing
  * field path and the rule type it broke, never the offending value.
  *
- * @param {unknown} err
+ * @param {ValidationError} err
  * @returns {string}
  */
-const summariseViolations = (err) => {
-  const details =
-    /** @type {import('joi').ValidationError} */ (err)?.details ?? []
-  return details
+const summariseViolations = (err) =>
+  err.details
     .slice(0, MAX_LOGGED_VIOLATIONS)
     .map((detail) => `${detail.path.join('.')}:${detail.type}`)
     .join(' ')
-}
 
 /**
  * Response-validation failAction for the report routes. Hapi's built-in
@@ -36,14 +34,15 @@ const summariseViolations = (err) => {
  *
  * @param {HapiRequest} request
  * @param {HapiResponseToolkit} _h
- * @param {Error} err
+ * @param {Error} err - always the Joi ValidationError from response validation
  * @returns {never}
  */
 export const reportResponseFailAction = (request, _h, err) => {
+  const violations = summariseViolations(/** @type {ValidationError} */ (err))
   throw internal(err.message, 'report_response_schema_violation', {
     event: {
       action: LOGGING_EVENT_ACTIONS.REPORT_RESPONSE_SCHEMA_VIOLATION,
-      reason: `params=${JSON.stringify(request.params)} violations=${summariseViolations(err)}`
+      reason: `params=${JSON.stringify(request.params)} violations=${violations}`
     }
   })
 }

--- a/src/reports/routes/response-fail-action.js
+++ b/src/reports/routes/response-fail-action.js
@@ -1,0 +1,49 @@
+import { internal } from '#common/helpers/logging/cdp-boom.js'
+import { LOGGING_EVENT_ACTIONS } from '#common/enums/event.js'
+
+/**
+ * @import { HapiRequest, HapiResponseToolkit } from '#common/hapi-types.js'
+ */
+
+const MAX_LOGGED_VIOLATIONS = 5
+
+/**
+ * Summarises a Joi validation error into PII-safe descriptors: the failing
+ * field path and the rule type it broke, never the offending value.
+ *
+ * @param {unknown} err
+ * @returns {string}
+ */
+const summariseViolations = (err) => {
+  const details =
+    /** @type {import('joi').ValidationError} */ (err)?.details ?? []
+  return details
+    .slice(0, MAX_LOGGED_VIOLATIONS)
+    .map((detail) => `${detail.path.join('.')}:${detail.type}`)
+    .join(' ')
+}
+
+/**
+ * Response-validation failAction for the report routes. Hapi's built-in
+ * `'error'` mode surfaces only the first Joi message, dropping the report
+ * identity and the failing field — leaving a bare `"stale.uploadedAt" is not
+ * allowed` in the logs (PAE-1755). This throws a CdpBoom enriched with a
+ * searchable `code` and `event`, so `boom-error-logger` indexes which report
+ * failed and where.
+ *
+ * PII-safe: logs the route params (resource identifiers, already present in
+ * `url.path`) and the Joi field-paths + rule types, never the offending values.
+ *
+ * @param {HapiRequest} request
+ * @param {HapiResponseToolkit} _h
+ * @param {Error} err
+ * @returns {never}
+ */
+export const reportResponseFailAction = (request, _h, err) => {
+  throw internal(err.message, 'report_response_schema_violation', {
+    event: {
+      action: LOGGING_EVENT_ACTIONS.REPORT_RESPONSE_SCHEMA_VIOLATION,
+      reason: `params=${JSON.stringify(request.params)} violations=${summariseViolations(err)}`
+    }
+  })
+}

--- a/src/reports/routes/response-fail-action.js
+++ b/src/reports/routes/response-fail-action.js
@@ -34,11 +34,11 @@ const summariseViolations = (err) =>
  *
  * @param {HapiRequest} request
  * @param {HapiResponseToolkit} _h
- * @param {Error} err - always the Joi ValidationError from response validation
+ * @param {ValidationError} err
  * @returns {never}
  */
 export const reportResponseFailAction = (request, _h, err) => {
-  const violations = summariseViolations(/** @type {ValidationError} */ (err))
+  const violations = summariseViolations(err)
   throw internal(err.message, 'report_response_schema_violation', {
     event: {
       action: LOGGING_EVENT_ACTIONS.REPORT_RESPONSE_SCHEMA_VIOLATION,

--- a/src/reports/routes/response-fail-action.test.js
+++ b/src/reports/routes/response-fail-action.test.js
@@ -19,25 +19,7 @@ const buildValidationError = (schema, value) => {
 }
 
 describe('reportResponseFailAction', () => {
-  it('throws a 500 boom enriched with a searchable code and event action', () => {
-    const error = buildValidationError(
-      Joi.object({ summaryLogChanged: Joi.object() }),
-      { uploadedAt: '2025-01-01T00:00:00.000Z' }
-    )
-
-    expect(() => reportResponseFailAction(buildRequest(), h, error)).toThrow(
-      expect.objectContaining({
-        isBoom: true,
-        code: 'report_response_schema_violation',
-        output: expect.objectContaining({ statusCode: 500 }),
-        event: expect.objectContaining({
-          action: LOGGING_EVENT_ACTIONS.REPORT_RESPONSE_SCHEMA_VIOLATION
-        })
-      })
-    )
-  })
-
-  it('records the report params and the failing field-path with rule type', () => {
+  it('throws a 500 boom carrying the original message, code, and full event', () => {
     const params = {
       organisationId: 'org-1',
       registrationId: 'reg-1',
@@ -51,37 +33,19 @@ describe('reportResponseFailAction', () => {
       { uploadedAt: '2025-01-01T00:00:00.000Z' }
     )
 
-    let thrown
-    try {
+    expect(() =>
       reportResponseFailAction(buildRequest(params), h, error)
-    } catch (err) {
-      thrown = err
-    }
-
-    expect(thrown.event.reason).toBe(
-      `params=${JSON.stringify(params)} violations=uploadedAt:object.unknown`
-    )
-  })
-
-  it('records empty violations when the error carries no Joi details', () => {
-    let thrown
-    try {
-      reportResponseFailAction(buildRequest(), h, new Error('boom'))
-    } catch (err) {
-      thrown = err
-    }
-
-    expect(thrown.event.reason).toBe('params={} violations=')
-  })
-
-  it('preserves the original Joi message on the boom', () => {
-    const error = buildValidationError(
-      Joi.object({ summaryLogChanged: Joi.object() }),
-      { uploadedAt: '2025-01-01T00:00:00.000Z' }
-    )
-
-    expect(() => reportResponseFailAction(buildRequest(), h, error)).toThrow(
-      '"uploadedAt" is not allowed'
+    ).toThrow(
+      expect.objectContaining({
+        isBoom: true,
+        message: '"uploadedAt" is not allowed',
+        code: 'report_response_schema_violation',
+        output: expect.objectContaining({ statusCode: 500 }),
+        event: {
+          action: LOGGING_EVENT_ACTIONS.REPORT_RESPONSE_SCHEMA_VIOLATION,
+          reason: `params=${JSON.stringify(params)} violations=uploadedAt:object.unknown`
+        }
+      })
     )
   })
 })

--- a/src/reports/routes/response-fail-action.test.js
+++ b/src/reports/routes/response-fail-action.test.js
@@ -1,0 +1,87 @@
+import Joi from 'joi'
+import { describe, expect, it } from 'vitest'
+
+import { reportResponseFailAction } from './response-fail-action.js'
+import { LOGGING_EVENT_ACTIONS } from '#common/enums/event.js'
+
+/**
+ * @import { HapiRequest, HapiResponseToolkit } from '#common/hapi-types.js'
+ */
+
+const buildRequest = (params = {}) =>
+  /** @type {HapiRequest} */ (/** @type {unknown} */ ({ params }))
+
+const h = /** @type {HapiResponseToolkit} */ (/** @type {unknown} */ ({}))
+
+const buildValidationError = (schema, value) => {
+  const { error } = schema.validate(value, { abortEarly: false })
+  return error
+}
+
+describe('reportResponseFailAction', () => {
+  it('throws a 500 boom enriched with a searchable code and event action', () => {
+    const error = buildValidationError(
+      Joi.object({ summaryLogChanged: Joi.object() }),
+      { uploadedAt: '2025-01-01T00:00:00.000Z' }
+    )
+
+    expect(() => reportResponseFailAction(buildRequest(), h, error)).toThrow(
+      expect.objectContaining({
+        isBoom: true,
+        code: 'report_response_schema_violation',
+        output: expect.objectContaining({ statusCode: 500 }),
+        event: expect.objectContaining({
+          action: LOGGING_EVENT_ACTIONS.REPORT_RESPONSE_SCHEMA_VIOLATION
+        })
+      })
+    )
+  })
+
+  it('records the report params and the failing field-path with rule type', () => {
+    const params = {
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      year: 2026,
+      cadence: 'monthly',
+      period: 4,
+      submissionNumber: 1
+    }
+    const error = buildValidationError(
+      Joi.object({ summaryLogChanged: Joi.object() }),
+      { uploadedAt: '2025-01-01T00:00:00.000Z' }
+    )
+
+    let thrown
+    try {
+      reportResponseFailAction(buildRequest(params), h, error)
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown.event.reason).toBe(
+      `params=${JSON.stringify(params)} violations=uploadedAt:object.unknown`
+    )
+  })
+
+  it('records empty violations when the error carries no Joi details', () => {
+    let thrown
+    try {
+      reportResponseFailAction(buildRequest(), h, new Error('boom'))
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown.event.reason).toBe('params={} violations=')
+  })
+
+  it('preserves the original Joi message on the boom', () => {
+    const error = buildValidationError(
+      Joi.object({ summaryLogChanged: Joi.object() }),
+      { uploadedAt: '2025-01-01T00:00:00.000Z' }
+    )
+
+    expect(() => reportResponseFailAction(buildRequest(), h, error)).toThrow(
+      '"uploadedAt" is not allowed'
+    )
+  })
+})

--- a/src/reports/routes/submissions.js
+++ b/src/reports/routes/submissions.js
@@ -4,6 +4,7 @@ import { SCOPES } from '#common/helpers/auth/constants.js'
 import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
 import { REGULATOR_DISPLAY } from '#domain/organisations/model.js'
 import { generateReportSubmissions } from '#reports/application/report-submissions.js'
+import { reportResponseFailAction } from './response-fail-action.js'
 
 /**
  * @import { HapiRequest } from '#common/hapi-types.js'
@@ -69,7 +70,7 @@ export const getReportSubmissions = {
           )
           .required()
       }),
-      failAction: 'error'
+      failAction: reportResponseFailAction
     }
   },
   /**


### PR DESCRIPTION
Ticket: [PAE-1755](https://eaflood.atlassian.net/browse/PAE-1755)

stacked on #1518 (the fix). two observability outcomes from the `stale.uploadedAt` 500:

- **A — response-validation failures:** report GET/POST routes used Hapi's built-in `failAction: 'error'`, which logs only the first Joi message (`"stale.uploadedAt" is not allowed`) — no report id, no failing field. added a shared `reportResponseFailAction` that throws a `CdpBoom` carrying a searchable `code` + `event.action` and a PII-safe `reason` (route params + Joi field-path:rule-type). wired into `get-detail`, `post`, `submissions`.
- **B — legacy-stale read signal:** `mapReport` now warns when it normalises a legacy/hybrid `stale` doc on read (`legacy_stale_shape_normalised`, with report id + stripped keys), so the migration tail is observable and the back-compat branch in `normaliseStale` is safe to time for removal.

pure detector `legacyStaleKeys` added to the stale domain. new event actions in `common/enums/event.js`.

[PAE-1755]: https://eaflood.atlassian.net/browse/PAE-1755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ