### PR TITLE
PAE-1747: Fix pre-CPA resubmission diagnostic reading wrong summary-log id

### DIFF
--- a/src/reports/monitoring/pre-cpa-resubmission.js
+++ b/src/reports/monitoring/pre-cpa-resubmission.js
@@ -252,12 +252,16 @@ const resolveLedgers = async (
 
 /**
  * Submitted upload timeline for a registration, oldest-first. Only 'submitted'
- * logs committed row states; failure-status logs are excluded.
+ * logs committed row states; failure-status logs are excluded. Row-state
+ * membership is written against the uploaded file's id (`summaryLog.file.id`),
+ * not the summary-log document's own `id`, so `fileId` is carried separately
+ * for the row-state lookup while `id` (the document id, matching what live CPA
+ * writes to `resubmissionRequired.summaryLogId`) is kept for finding output.
  *
  * @param {SummaryLogsRepository} summaryLogsRepository
  * @param {string} organisationId
  * @param {string} registrationId
- * @returns {Promise<{ id: string, submittedAt: string }[]>}
+ * @returns {Promise<{ id: string, fileId: string, submittedAt: string }[]>}
  */
 const loadSubmittedLogTimeline = async (
   summaryLogsRepository,
@@ -276,6 +280,7 @@ const loadSubmittedLogTimeline = async (
     )
     .map(({ id, summaryLog }) => ({
       id,
+      fileId: summaryLog.file.id,
       submittedAt: /** @type {string} */ (summaryLog.submittedAt)
     }))
     .sort((a, b) => a.submittedAt.localeCompare(b.submittedAt))
@@ -308,8 +313,8 @@ const cadenceForRow = (row) =>
  *
  * @param {SummaryLogRowStateRepository} summaryLogRowStateRepository
  * @param {WasteBalanceLedgerId[]} ledgers
- * @param {{ id: string, submittedAt: string }[]} logs
- * @returns {Promise<{ id: string, submittedAt: string, rows: SummaryLogRowState[] }[]>}
+ * @param {{ id: string, fileId: string, submittedAt: string }[]} logs
+ * @returns {Promise<{ id: string, fileId: string, submittedAt: string, rows: SummaryLogRowState[] }[]>}
  */
 const loadSnapshots = async (summaryLogRowStateRepository, ledgers, logs) => {
   const snapshots = []
@@ -319,7 +324,7 @@ const loadSnapshots = async (summaryLogRowStateRepository, ledgers, logs) => {
       rows.push(
         ...(await summaryLogRowStateRepository.findRowStatesForSummaryLog(
           ledger,
-          log.id
+          log.fileId
         ))
       )
     }

--- a/src/reports/monitoring/pre-cpa-resubmission.test.js
+++ b/src/reports/monitoring/pre-cpa-resubmission.test.js
@@ -154,7 +154,8 @@ const buildRepos = async (registrations) => {
         summaryLogFactory.submitted({
           organisationId: reg.organisationId,
           registrationId: reg.registrationId,
-          submittedAt: log.submittedAt
+          submittedAt: log.submittedAt,
+          file: { id: log.id }
         })
       )
     }

--- a/src/server/run-pre-cpa-resubmission-report.test.js
+++ b/src/server/run-pre-cpa-resubmission-report.test.js
@@ -84,14 +84,16 @@ const oneFindingApp = ({
         id: 'sl-original',
         summaryLog: {
           status: 'submitted',
-          submittedAt: '2025-06-25T00:00:00.000Z'
+          submittedAt: '2025-06-25T00:00:00.000Z',
+          file: { id: 'sl-original' }
         }
       },
       {
         id: 'sl-restating',
         summaryLog: {
           status: 'submitted',
-          submittedAt: '2025-08-01T00:00:00.000Z'
+          submittedAt: '2025-08-01T00:00:00.000Z',
+          file: { id: 'sl-restating' }
         }
       }
     ])


### PR DESCRIPTION
Ticket: [PAE-1747](https://eaflood.atlassian.net/browse/PAE-1747)
## Summary
- `loadSubmittedLogTimeline` passed the summary-log document's own id into `findRowStatesForSummaryLog`, but row-state membership is written keyed by the uploaded file's id (`summaryLog.file.id`), so every snapshot loaded was empty and no restatements were ever detected
- Carry `fileId` separately for the row-state lookup while keeping `id` for finding output, consistent with the live CPA path's `resubmissionRequired.summaryLogId`

[PAE-1747]: https://eaflood.atlassian.net/browse/PAE-1747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ