### PR TITLE
PAE-000: Untrack the impeccable hook cache

### DIFF
--- a/.impeccable/hook.cache.json
+++ b/.impeccable/hook.cache.json
@@ -1,1 +1,0 @@
-{ "version": 1, "sessions": {} }


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
`.impeccable/hook.cache.json` is a local editor-tooling cache that was committed by accident in [#1434](https://github.com/DEFRA/epr-backend/pull/1434), swept up alongside that PR's wide-ranging renames. It holds no repository state — its committed content is an empty `{ "version": 1, "sessions": {} }`.

Because the file is tracked, ignore rules don't apply to it, so it regenerates and shows as an uncommitted change in every worktree. That churn blocks fast-forward pulls and has produced spurious conflict errors during rebases.

Untracking it leaves the file on disk, where developers' ignore rules cover it normally.
