### PR TITLE
PAE-1766: Classify credited-tonnage rows against current reference data

### DIFF
--- a/src/waste-balances/application/credited-tonnage-report.js
+++ b/src/waste-balances/application/credited-tonnage-report.js
@@ -1,5 +1,6 @@
 import { creditedTonnageByMonth } from '#waste-balances/domain/credited-tonnage.js'
 import { liveClassifiedRowStates } from '#waste-records/application/live-classified-row-states.js'
+import { buildOverseasSitesContext } from '#waste-records-export/domain/overseas-sites-context.js'
 import { resolveDetailedMaterial } from '#domain/organisations/registration-utils.js'
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
 import { LOGGING_EVENT_CATEGORIES } from '#common/enums/index.js'
@@ -171,10 +172,13 @@ export const buildCreditedTonnageReport = async ({
     toMonth: /** @type {string} */ (monthKeyForDate(now, REPORT_TIME_ZONE))
   }
 
-  const [entries, organisations] = await Promise.all([
+  const [entries, organisations, allSites] = await Promise.all([
     ledgerRepository.findLatestSubmittedSummaryLogPerLedger(),
-    organisationsRepository.findAll()
+    organisationsRepository.findAll(),
+    overseasSitesRepository.findAll()
   ])
+
+  const sitesById = new Map(allSites.map((site) => [site.id, site]))
 
   // Credits only exist for accredited partitions; registered-only entries
   // (accreditationId null) carry zero-delta submissions and never appear in
@@ -214,10 +218,9 @@ export const buildCreditedTonnageReport = async ({
         ledgerId,
         summaryLogId
       )
-    const rowStates = await liveClassifiedRowStates(storedRowStates, {
-      registration,
+    const rowStates = liveClassifiedRowStates(storedRowStates, {
       accreditation,
-      overseasSitesRepository
+      overseasSites: buildOverseasSitesContext(registration, sitesById)
     })
 
     const { months, skippedRowCount } = creditedTonnageByMonth(

--- a/src/waste-balances/application/credited-tonnage-report.js
+++ b/src/waste-balances/application/credited-tonnage-report.js
@@ -1,5 +1,5 @@
 import { creditedTonnageByMonth } from '#waste-balances/domain/credited-tonnage.js'
-import { wasteRecordStatesForHead } from '#waste-records/application/read-summary-log-row-states.js'
+import { liveClassifiedRowStates } from '#waste-records/application/live-classified-row-states.js'
 import { resolveDetailedMaterial } from '#domain/organisations/registration-utils.js'
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
 import { LOGGING_EVENT_CATEGORIES } from '#common/enums/index.js'
@@ -9,6 +9,7 @@ import { monthKeyForDate } from '#common/helpers/dates/year-month.js'
  * @typedef {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} WasteBalanceLedgerRepository
  * @typedef {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} SummaryLogRowStateRepository
  * @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository
+ * @typedef {import('#overseas-sites/repository/port.js').OverseasSitesRepository} OverseasSitesRepository
  * @typedef {import('#domain/organisations/model.js').Organisation} Organisation
  * @typedef {import('#domain/organisations/model.js').WasteProcessingTypeValue} WasteProcessingTypeValue
  * @typedef {import('#common/hapi-types.js').TypedLogger} TypedLogger
@@ -136,17 +137,23 @@ const compareRows = (a, b) =>
  * accreditation's latest submitted summary log.
  *
  * The ledger query yields one entry per accredited partition with a submission,
- * so accreditations with no submission never appear. Each entry's row states
- * are read at that submission's head and aggregated by the pure domain
- * function; the organisation join attaches the external reference, accreditation
- * number, processing type and effective material, and drops test organisations.
- * Rows dropped for a bad month-assignment date are counted per accreditation in
- * a structured log line.
+ * so accreditations with no submission never appear. Each entry's row states are
+ * read at that submission's head, classified against today's accreditation and
+ * overseas-site data rather than the reading stamped at submission, and
+ * aggregated by the pure domain function; the organisation join attaches the
+ * external reference, accreditation number, processing type and effective
+ * material, and drops test organisations. Rows dropped for a bad
+ * month-assignment date are counted per accreditation in a structured log line.
+ *
+ * This report answers what an accreditation has credited as of now, so
+ * approving an overseas site or amending a validity period must move the
+ * figures without waiting for the operator to submit again.
  *
  * @param {Object} params
  * @param {WasteBalanceLedgerRepository} params.ledgerRepository
  * @param {SummaryLogRowStateRepository} params.summaryLogRowStateRepository
  * @param {OrganisationsRepository} params.organisationsRepository
+ * @param {OverseasSitesRepository} params.overseasSitesRepository
  * @param {TypedLogger} params.logger
  * @param {Date} params.now - clock reading supplied by the caller; the report's upper month bound
  * @returns {Promise<CreditedTonnageReport>}
@@ -155,6 +162,7 @@ export const buildCreditedTonnageReport = async ({
   ledgerRepository,
   summaryLogRowStateRepository,
   organisationsRepository,
+  overseasSitesRepository,
   logger,
   now
 }) => {
@@ -201,11 +209,16 @@ export const buildCreditedTonnageReport = async ({
 
     const { organisation, registration, accreditation } = context
 
-    const rowStates = await wasteRecordStatesForHead(
-      summaryLogRowStateRepository,
-      ledgerId,
-      summaryLogId
-    )
+    const storedRowStates =
+      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+        ledgerId,
+        summaryLogId
+      )
+    const rowStates = await liveClassifiedRowStates(storedRowStates, {
+      registration,
+      accreditation,
+      overseasSitesRepository
+    })
 
     const { months, skippedRowCount } = creditedTonnageByMonth(
       rowStates,

--- a/src/waste-balances/application/credited-tonnage-report.test.js
+++ b/src/waste-balances/application/credited-tonnage-report.test.js
@@ -2,6 +2,7 @@ import { buildCreditedTonnageReport } from './credited-tonnage-report.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import {
   MATERIAL,
   GLASS_RECYCLING_PROCESS,
@@ -120,8 +121,14 @@ const STAMPED_EXCLUDED = {
   transactionAmount: 0
 }
 
-// A received row holding every field the waste-balance classifier reads, so it
-// classifies from its own content.
+/**
+ * A received row holding every field the waste-balance classifier reads, so it
+ * classifies from its own content.
+ *
+ * @param {string} date
+ * @param {number} tonnage
+ * @param {import('#waste-records/repository/schema.js').RowClassification} [stamped]
+ */
 const receivedRow = (date, tonnage, stamped = STAMPED_EXCLUDED) => ({
   rowId: `row-${date}-${tonnage}`,
   processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
@@ -144,8 +151,14 @@ const receivedRow = (date, tonnage, stamped = STAMPED_EXCLUDED) => ({
   classification: stamped
 })
 
-// An exported row, likewise complete. The report buckets it by the date the
-// overseas reprocessor received it.
+/**
+ * An exported row, likewise complete. The report buckets it by the date the
+ * overseas reprocessor received it.
+ *
+ * @param {string} dateReceivedByOsr
+ * @param {number} tonnage
+ * @param {import('#waste-records/repository/schema.js').RowClassification} [stamped]
+ */
 const exportedRow = (
   dateReceivedByOsr,
   tonnage,
@@ -179,6 +192,32 @@ const exportedRow = (
   }
 })
 
+/**
+ * An overseas reprocessing site. Omit `validFrom` for a site that is registered
+ * but not yet approved.
+ *
+ * @param {{ id: string, validFrom?: Date }} options
+ * @returns {import('#overseas-sites/repository/port.js').OverseasSite}
+ */
+const overseasSite = ({ id, validFrom }) => ({
+  id,
+  name: `Site ${id}`,
+  address: { line1: '1 Dock Road', townOrCity: 'Rotterdam' },
+  country: 'Netherlands',
+  createdAt: new Date('2025-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2025-01-01T00:00:00.000Z'),
+  ...(validFrom && { validFrom })
+})
+
+/**
+ * @param {{
+ *   organisations: any[],
+ *   entries: any[],
+ *   rowStatesByAccreditationId?: Record<string, any[]>,
+ *   overseasSites?: import('#overseas-sites/repository/port.js').OverseasSite[],
+ *   now?: Date
+ * }} options
+ */
 const run = ({
   organisations,
   entries,
@@ -196,10 +235,8 @@ const run = ({
     ) => rowStatesByAccreditationId[ledgerId.accreditationId] ?? []
   }
   const organisationsRepository = { findAll: async () => organisations }
-  const overseasSitesRepository = {
-    findByIds: async (/** @type {string[]} */ ids) =>
-      overseasSites.filter((site) => ids.includes(site.id))
-  }
+  const overseasSitesRepository =
+    createInMemoryOverseasSitesRepository(overseasSites)()
 
   return {
     logger,
@@ -213,9 +250,7 @@ const run = ({
       organisationsRepository: /** @type {OrganisationsRepository} */ (
         /** @type {unknown} */ (organisationsRepository)
       ),
-      overseasSitesRepository: /** @type {OverseasSitesRepository} */ (
-        /** @type {unknown} */ (overseasSitesRepository)
-      ),
+      overseasSitesRepository,
       logger: /** @type {TypedLogger} */ (/** @type {unknown} */ (logger)),
       now
     })
@@ -761,7 +796,10 @@ describe('buildCreditedTonnageReport', () => {
         [accreditationId]: [exportedRow('2026-02-10', 60)]
       },
       overseasSites: [
-        { id: 'site-1', validFrom: new Date('2026-01-01T00:00:00.000Z') }
+        overseasSite({
+          id: 'site-1',
+          validFrom: new Date('2026-01-01T00:00:00.000Z')
+        })
       ]
     })
 
@@ -790,7 +828,7 @@ describe('buildCreditedTonnageReport', () => {
       rowStatesByAccreditationId: {
         [accreditationId]: [exportedRow('2026-02-10', 60, stampedIncluded(60))]
       },
-      overseasSites: [{ id: 'site-1', validFrom: null }]
+      overseasSites: [overseasSite({ id: 'site-1' })]
     })
 
     expect(

--- a/src/waste-balances/application/credited-tonnage-report.test.js
+++ b/src/waste-balances/application/credited-tonnage-report.test.js
@@ -1,9 +1,11 @@
 import { buildCreditedTonnageReport } from './credited-tonnage-report.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import {
   MATERIAL,
   GLASS_RECYCLING_PROCESS,
+  REG_ACC_STATUS,
   WASTE_PROCESSING_TYPE,
   REPROCESSING_TYPE
 } from '#domain/organisations/model.js'
@@ -12,6 +14,7 @@ import {
  * @typedef {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} LedgerRepository
  * @typedef {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} RowStateRepository
  * @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository
+ * @typedef {import('#overseas-sites/repository/port.js').OverseasSitesRepository} OverseasSitesRepository
  * @typedef {import('#common/hapi-types.js').TypedLogger} TypedLogger
  */
 
@@ -22,6 +25,16 @@ const TEST_ORG_ID = 999999
 // A fixed clock: January 2026 → March 2026 is the report window.
 const NOW = new Date('2026-03-15T12:00:00.000Z')
 
+// The window every fixture accreditation is valid across, unless a test names
+// its own — wide enough to cover the whole report range.
+const ACCREDITED_FROM = '2026-01-01'
+const ACCREDITED_TO = '2026-12-31'
+
+const approvedHistory = [
+  { status: REG_ACC_STATUS.CREATED, updatedAt: '2025-11-01' },
+  { status: REG_ACC_STATUS.APPROVED, updatedAt: '2025-12-01' }
+]
+
 /**
  * @param {{
  *   orgId: number,
@@ -30,7 +43,10 @@ const NOW = new Date('2026-03-15T12:00:00.000Z')
  *   wasteProcessingType?: string,
  *   reprocessingType?: string,
  *   accreditationNumber?: string | null,
- *   status?: string
+ *   status?: string,
+ *   statusHistory?: { status: string, updatedAt: string }[],
+ *   validFrom?: string,
+ *   validTo?: string
  * }} options - pass `accreditationNumber: null` to omit it entirely
  */
 const makeAccreditation = ({
@@ -40,7 +56,10 @@ const makeAccreditation = ({
   wasteProcessingType = WASTE_PROCESSING_TYPE.REPROCESSOR,
   reprocessingType = REPROCESSING_TYPE.INPUT,
   accreditationNumber,
-  status = 'approved'
+  status = 'approved',
+  statusHistory = approvedHistory,
+  validFrom = ACCREDITED_FROM,
+  validTo = ACCREDITED_TO
 }) => {
   const id = `org-uuid-${orgId}`
   const registrationId = `reg-${orgId}`
@@ -56,6 +75,9 @@ const makeAccreditation = ({
   const accreditation = {
     id: accreditationId,
     status,
+    statusHistory,
+    validFrom,
+    validTo,
     material,
     wasteProcessingType,
     reprocessingType,
@@ -83,24 +105,85 @@ const makeAccreditation = ({
   }
 }
 
-const receivedRow = (
-  date,
-  tonnage,
-  { outcome = WASTE_BALANCE_OUTCOME.INCLUDED, transactionAmount = tonnage } = {}
-) => ({
+// The classification each fixture row carries from its submission. Every test
+// stamps the opposite of the answer the live context gives, so a report that
+// read the stamp instead of re-deriving cannot produce the expected figures.
+const stampedIncluded = (transactionAmount) => ({
+  outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
+  reasons: [],
+  transactionAmount
+})
+
+const STAMPED_EXCLUDED = {
+  outcome: WASTE_BALANCE_OUTCOME.EXCLUDED,
+  reasons: [],
+  transactionAmount: 0
+}
+
+// A received row holding every field the waste-balance classifier reads, so it
+// classifies from its own content.
+const receivedRow = (date, tonnage, stamped = STAMPED_EXCLUDED) => ({
   rowId: `row-${date}-${tonnage}`,
+  processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   data: {
     DATE_RECEIVED_FOR_REPROCESSING: date,
+    EWC_CODE: '15 01 02',
+    DESCRIPTION_WASTE: 'Plastic packaging',
+    WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+    GROSS_WEIGHT: tonnage + 1,
+    TARE_WEIGHT: 1,
+    PALLET_WEIGHT: 0,
+    NET_WEIGHT: tonnage,
+    BAILING_WIRE_PROTOCOL: 'No',
+    HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
+    WEIGHT_OF_NON_TARGET_MATERIALS: 0,
+    RECYCLABLE_PROPORTION_PERCENTAGE: 100,
     TONNAGE_RECEIVED_FOR_RECYCLING: tonnage
   },
-  classification: { outcome, reasons: [], transactionAmount }
+  classification: stamped
+})
+
+// An exported row, likewise complete. The report buckets it by the date the
+// overseas reprocessor received it.
+const exportedRow = (
+  dateReceivedByOsr,
+  tonnage,
+  stamped = STAMPED_EXCLUDED
+) => ({
+  ...receivedRow(dateReceivedByOsr, tonnage, stamped),
+  processingType: PROCESSING_TYPES.EXPORTER,
+  wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+  data: {
+    DATE_RECEIVED_FOR_EXPORT: '2026-01-05',
+    EWC_CODE: '15 01 02',
+    DESCRIPTION_WASTE: 'Plastic packaging',
+    WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+    GROSS_WEIGHT: tonnage + 1,
+    TARE_WEIGHT: 1,
+    PALLET_WEIGHT: 0,
+    NET_WEIGHT: tonnage,
+    BAILING_WIRE_PROTOCOL: 'No',
+    HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
+    WEIGHT_OF_NON_TARGET_MATERIALS: 0,
+    RECYCLABLE_PROPORTION_PERCENTAGE: 100,
+    TONNAGE_RECEIVED_FOR_EXPORT: tonnage,
+    TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: tonnage,
+    DATE_OF_EXPORT: '2026-01-20',
+    BASEL_EXPORT_CODE: 'B3010',
+    CUSTOMS_CODES: '391510',
+    CONTAINER_NUMBER: 'CN-001',
+    DATE_RECEIVED_BY_OSR: dateReceivedByOsr,
+    OSR_ID: '099',
+    DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE: 'No'
+  }
 })
 
 const run = ({
   organisations,
   entries,
   rowStatesByAccreditationId = {},
+  overseasSites = [],
   now = NOW
 }) => {
   const logger = { info: vi.fn(), warn: vi.fn() }
@@ -113,6 +196,10 @@ const run = ({
     ) => rowStatesByAccreditationId[ledgerId.accreditationId] ?? []
   }
   const organisationsRepository = { findAll: async () => organisations }
+  const overseasSitesRepository = {
+    findByIds: async (/** @type {string[]} */ ids) =>
+      overseasSites.filter((site) => ids.includes(site.id))
+  }
 
   return {
     logger,
@@ -125,6 +212,9 @@ const run = ({
       ),
       organisationsRepository: /** @type {OrganisationsRepository} */ (
         /** @type {unknown} */ (organisationsRepository)
+      ),
+      overseasSitesRepository: /** @type {OverseasSitesRepository} */ (
+        /** @type {unknown} */ (overseasSitesRepository)
       ),
       logger: /** @type {TypedLogger} */ (/** @type {unknown} */ (logger)),
       now
@@ -597,6 +687,118 @@ describe('buildCreditedTonnageReport', () => {
     expect(await report).toEqual({
       meta: { generatedAt: NOW.toISOString() },
       data: []
+    })
+  })
+
+  it('credits a row the submission stamped as excluded once the accreditation period covers it', async () => {
+    const { organisation, accreditationId, ledgerEntry } = makeAccreditation({
+      orgId: 500001,
+      validFrom: '2026-02-01'
+    })
+
+    const { report } = run({
+      organisations: [organisation],
+      entries: [ledgerEntry],
+      rowStatesByAccreditationId: {
+        // Stamped EXCLUDED with a zero transaction amount when it was
+        // submitted; the widened period now covers it.
+        [accreditationId]: [receivedRow('2026-02-10', 100)]
+      }
+    })
+
+    expect(
+      (await report).data.find((row) => row.month === '2026-02')?.tonnage
+    ).toEqual({
+      totalCredited: 100,
+      eligibleForWasteBalance: 100,
+      sentOnDeductions: 0
+    })
+  })
+
+  it('stops crediting a row once the accreditation period no longer covers it', async () => {
+    const { organisation, accreditationId, ledgerEntry } = makeAccreditation({
+      orgId: 500001,
+      validFrom: '2026-03-01'
+    })
+
+    const { report } = run({
+      organisations: [organisation],
+      entries: [ledgerEntry],
+      rowStatesByAccreditationId: {
+        // Stamped INCLUDED for its full tonnage when it was submitted; the
+        // narrowed period no longer covers it.
+        [accreditationId]: [
+          receivedRow('2026-02-10', 100, stampedIncluded(100))
+        ]
+      }
+    })
+
+    // Gross tonnage is what the operator reported and does not move; only the
+    // balance-eligible figure follows the accreditation period.
+    expect(
+      (await report).data.find((row) => row.month === '2026-02')?.tonnage
+    ).toEqual({
+      totalCredited: 100,
+      eligibleForWasteBalance: 0,
+      sentOnDeductions: 0
+    })
+  })
+
+  it('credits an exported row once its overseas site approval covers the export date', async () => {
+    const { organisation, accreditationId, ledgerEntry } = makeAccreditation({
+      orgId: 500001,
+      wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+      reprocessingType: undefined
+    })
+    organisation.registrations[0].overseasSites = {
+      '099': { overseasSiteId: 'site-1' }
+    }
+
+    const { report } = run({
+      organisations: [organisation],
+      entries: [ledgerEntry],
+      rowStatesByAccreditationId: {
+        [accreditationId]: [exportedRow('2026-02-10', 60)]
+      },
+      overseasSites: [
+        { id: 'site-1', validFrom: new Date('2026-01-01T00:00:00.000Z') }
+      ]
+    })
+
+    expect(
+      (await report).data.find((row) => row.month === '2026-02')?.tonnage
+    ).toEqual({
+      totalCredited: 60,
+      eligibleForWasteBalance: 60,
+      sentOnDeductions: 0
+    })
+  })
+
+  it('withholds credit from an exported row whose overseas site is not yet approved', async () => {
+    const { organisation, accreditationId, ledgerEntry } = makeAccreditation({
+      orgId: 500001,
+      wasteProcessingType: WASTE_PROCESSING_TYPE.EXPORTER,
+      reprocessingType: undefined
+    })
+    organisation.registrations[0].overseasSites = {
+      '099': { overseasSiteId: 'site-1' }
+    }
+
+    const { report } = run({
+      organisations: [organisation],
+      entries: [ledgerEntry],
+      rowStatesByAccreditationId: {
+        [accreditationId]: [exportedRow('2026-02-10', 60, stampedIncluded(60))]
+      },
+      overseasSites: [{ id: 'site-1', validFrom: null }]
+    })
+
+    expect(
+      (await report).data.find((row) => row.month === '2026-02')?.tonnage
+    ).toEqual({
+      totalCredited: 60,
+      eligibleForWasteBalance: 0,
+      sentOnDeductions: 0
     })
   })
 

--- a/src/waste-balances/domain/credited-tonnage.js
+++ b/src/waste-balances/domain/credited-tonnage.js
@@ -52,7 +52,7 @@ const YES = 'Yes'
  * @typedef {Object} MonthlyCreditedTonnage
  * @property {string} month - `YYYY-MM`
  * @property {number} totalCredited - gross tonnage on crediting rows, 2dp
- * @property {number} eligibleForWasteBalance - tonnage that credited the balance (persisted INCLUDED classification), 2dp
+ * @property {number} eligibleForWasteBalance - tonnage that credits the balance (INCLUDED classification), 2dp
  * @property {number} sentOnDeductions - sent-on tonnage, positive, reprocessor input only, 2dp
  */
 
@@ -194,9 +194,9 @@ const contributionFor = (rowState, processingType) => {
  *
  * Each contributing row lands in at most one month, bucketed by its
  * month-assignment date. Crediting rows add their tonnage column to
- * `totalCredited` gross — every row regardless of classification — and add the
- * persisted `classification.transactionAmount` to `eligibleForWasteBalance`
- * when the row's persisted outcome is `INCLUDED`. Sent-on rows on a
+ * `totalCredited` gross — every row regardless of classification — and add
+ * `classification.transactionAmount` to `eligibleForWasteBalance` when the
+ * row's outcome is `INCLUDED`. Sent-on rows on a
  * reprocessor-input accreditation add their tonnage to `sentOnDeductions`
  * as a positive number. Rows whose month-assignment date is missing,
  * unparseable, or outside the range are dropped and counted in

--- a/src/waste-balances/routes/credited-tonnage-get.js
+++ b/src/waste-balances/routes/credited-tonnage-get.js
@@ -24,7 +24,8 @@ export const creditedTonnageGet = {
    * @param {HapiRequest & {
    *   ledgerRepository: import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository,
    *   summaryLogRowStatesRepository: import('#waste-records/repository/port.js').SummaryLogRowStateRepository,
-   *   organisationsRepository: import('#repositories/organisations/port.js').OrganisationsRepository
+   *   organisationsRepository: import('#repositories/organisations/port.js').OrganisationsRepository,
+   *   overseasSitesRepository: import('#overseas-sites/repository/port.js').OverseasSitesRepository
    * }} request
    * @param {HapiResponseToolkit} h
    * @returns {Promise<import('#common/hapi-types.js').HapiResponseObject>}
@@ -34,6 +35,7 @@ export const creditedTonnageGet = {
       ledgerRepository,
       summaryLogRowStatesRepository,
       organisationsRepository,
+      overseasSitesRepository,
       logger
     } = request
 
@@ -41,6 +43,7 @@ export const creditedTonnageGet = {
       ledgerRepository,
       summaryLogRowStateRepository: summaryLogRowStatesRepository,
       organisationsRepository,
+      overseasSitesRepository,
       logger,
       now: new Date()
     })

--- a/src/waste-balances/routes/credited-tonnage-get.test.js
+++ b/src/waste-balances/routes/credited-tonnage-get.test.js
@@ -91,6 +91,8 @@ describe(`GET ${creditedTonnageGetPath}`, () => {
 
     const linkedRegistration = org.registrations[0]
     const linkedAccreditation = org.accreditations[0]
+    linkedAccreditation.validFrom = '2026-01-01'
+    linkedAccreditation.validTo = '2026-12-31'
     const ledgerId = {
       organisationId: org.id,
       registrationId: linkedRegistration.id,
@@ -108,12 +110,25 @@ describe(`GET ${creditedTonnageGetPath}`, () => {
           processingType: 'REPROCESSOR_INPUT',
           data: {
             DATE_RECEIVED_FOR_REPROCESSING: '2026-02-10',
+            EWC_CODE: '15 01 02',
+            DESCRIPTION_WASTE: 'Plastic packaging',
+            WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+            GROSS_WEIGHT: 101,
+            TARE_WEIGHT: 1,
+            PALLET_WEIGHT: 0,
+            NET_WEIGHT: 100,
+            BAILING_WIRE_PROTOCOL: 'No',
+            HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
+            WEIGHT_OF_NON_TARGET_MATERIALS: 0,
+            RECYCLABLE_PROPORTION_PERCENTAGE: 100,
             TONNAGE_RECEIVED_FOR_RECYCLING: 100
           },
+          // Stamped as contributing nothing at submission; the report
+          // re-derives against the accreditation as it stands now.
           classification: {
-            outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
+            outcome: WASTE_BALANCE_OUTCOME.EXCLUDED,
             reasons: [],
-            transactionAmount: 100
+            transactionAmount: 0
           }
         })
       ],

--- a/src/waste-records/application/live-classified-row-states.js
+++ b/src/waste-records/application/live-classified-row-states.js
@@ -8,27 +8,26 @@ import { reclassifyWasteRecordStates } from './reclassify-waste-record-states.js
 
 /**
  * @import {WasteRecordState} from './read-summary-log-row-states.js'
- * @import {SummaryLogRowState} from '#waste-records/repository/schema.js'
+ * @import {SummaryLogRowStateEntry} from '#waste-records/repository/schema.js'
  */
 
 /**
  * Classify already-read row states against current rules and reference data
  * rather than the reading stamped when each row was submitted.
  *
- * The stored rows are the input, so a caller that has already resolved its own
- * head submission — a cross-partition report reading one head per partition —
- * shares this path without re-resolving it.
+ * Pure — the resolved context is the input, not the repositories it came from,
+ * so a caller reading many partitions loads the reference data once for the
+ * whole run instead of once per partition.
  *
- * @param {SummaryLogRowState[]} rowStates
+ * @param {SummaryLogRowStateEntry[]} rowStates
  * @param {Object} context
- * @param {import('#domain/organisations/registration.js').Registration} context.registration
  * @param {import('#domain/organisations/accreditation.js').Accreditation | null} context.accreditation
- * @param {import('#overseas-sites/repository/port.js').OverseasSitesRepository} context.overseasSitesRepository
- * @returns {Promise<WasteRecordState[]>}
+ * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} context.overseasSites
+ * @returns {WasteRecordState[]}
  */
-export const liveClassifiedRowStates = async (
+export const liveClassifiedRowStates = (
   rowStates,
-  { registration, accreditation, overseasSitesRepository }
+  { accreditation, overseasSites }
 ) => {
   if (rowStates.length === 0) {
     return []
@@ -37,16 +36,6 @@ export const liveClassifiedRowStates = async (
   // One summary log is one uploaded workbook, so every row in it reports under
   // that workbook's template, and the rows record which one.
   const [{ processingType }] = rowStates
-
-  const sites = await overseasSitesRepository.findByIds(
-    Object.values(registration.overseasSites ?? {}).map(
-      ({ overseasSiteId }) => overseasSiteId
-    )
-  )
-  const overseasSites = buildOverseasSitesContext(
-    registration,
-    new Map(sites.map((site) => [site.id, site]))
-  )
 
   return reclassifyWasteRecordStates(rowStates.map(toWasteRecordState), {
     processingType,
@@ -109,9 +98,15 @@ export const liveClassifiedRowStatesForRegistration = async ({
   // current pointer, so rows stay with the accreditation that credited them.
   const accreditation = resolveAccreditation({ accreditationId }, organisation)
 
-  return liveClassifiedRowStates(rowStates, {
+  const sites = await overseasSitesRepository.findByIds(
+    Object.values(registration.overseasSites ?? {}).map(
+      ({ overseasSiteId }) => overseasSiteId
+    )
+  )
+  const overseasSites = buildOverseasSitesContext(
     registration,
-    accreditation,
-    overseasSitesRepository
-  })
+    new Map(sites.map((site) => [site.id, site]))
+  )
+
+  return liveClassifiedRowStates(rowStates, { accreditation, overseasSites })
 }

--- a/src/waste-records/application/live-classified-row-states.js
+++ b/src/waste-records/application/live-classified-row-states.js
@@ -8,7 +8,52 @@ import { reclassifyWasteRecordStates } from './reclassify-waste-record-states.js
 
 /**
  * @import {WasteRecordState} from './read-summary-log-row-states.js'
+ * @import {SummaryLogRowState} from '#waste-records/repository/schema.js'
  */
+
+/**
+ * Classify already-read row states against current rules and reference data
+ * rather than the reading stamped when each row was submitted.
+ *
+ * The stored rows are the input, so a caller that has already resolved its own
+ * head submission — a cross-partition report reading one head per partition —
+ * shares this path without re-resolving it.
+ *
+ * @param {SummaryLogRowState[]} rowStates
+ * @param {Object} context
+ * @param {import('#domain/organisations/registration.js').Registration} context.registration
+ * @param {import('#domain/organisations/accreditation.js').Accreditation | null} context.accreditation
+ * @param {import('#overseas-sites/repository/port.js').OverseasSitesRepository} context.overseasSitesRepository
+ * @returns {Promise<WasteRecordState[]>}
+ */
+export const liveClassifiedRowStates = async (
+  rowStates,
+  { registration, accreditation, overseasSitesRepository }
+) => {
+  if (rowStates.length === 0) {
+    return []
+  }
+
+  // One summary log is one uploaded workbook, so every row in it reports under
+  // that workbook's template, and the rows record which one.
+  const [{ processingType }] = rowStates
+
+  const sites = await overseasSitesRepository.findByIds(
+    Object.values(registration.overseasSites ?? {}).map(
+      ({ overseasSiteId }) => overseasSiteId
+    )
+  )
+  const overseasSites = buildOverseasSitesContext(
+    registration,
+    new Map(sites.map((site) => [site.id, site]))
+  )
+
+  return reclassifyWasteRecordStates(rowStates.map(toWasteRecordState), {
+    processingType,
+    accreditation,
+    overseasSites
+  })
+}
 
 /**
  * A registration's committed row states at its latest submission, classified
@@ -52,10 +97,6 @@ export const liveClassifiedRowStatesForRegistration = async ({
     return []
   }
 
-  // One summary log is one uploaded workbook, so every row in it reports under
-  // that workbook's template, and the rows record which one.
-  const [{ processingType }] = rowStates
-
   const organisation = await organisationsRepository.findById(organisationId)
   const registration = organisation.registrations?.find(
     (candidate) => candidate.id === registrationId
@@ -68,19 +109,9 @@ export const liveClassifiedRowStatesForRegistration = async ({
   // current pointer, so rows stay with the accreditation that credited them.
   const accreditation = resolveAccreditation({ accreditationId }, organisation)
 
-  const sites = await overseasSitesRepository.findByIds(
-    Object.values(registration.overseasSites ?? {}).map(
-      ({ overseasSiteId }) => overseasSiteId
-    )
-  )
-  const overseasSites = buildOverseasSitesContext(
+  return liveClassifiedRowStates(rowStates, {
     registration,
-    new Map(sites.map((site) => [site.id, site]))
-  )
-
-  return reclassifyWasteRecordStates(rowStates.map(toWasteRecordState), {
-    processingType,
     accreditation,
-    overseasSites
+    overseasSitesRepository
   })
 }

--- a/src/waste-records/application/live-classified-row-states.test.js
+++ b/src/waste-records/application/live-classified-row-states.test.js
@@ -380,10 +380,21 @@ describe('liveClassifiedRowStates', () => {
   })
 
   it('replaces each stamped classification with one derived from the given context', () => {
-    const [state] = liveClassifiedRowStates([rowStateEntry()], {
-      accreditation: accreditedThroughout,
-      overseasSites: {}
-    })
+    const [state] = liveClassifiedRowStates(
+      [
+        rowStateEntry({
+          classification: {
+            outcome: WASTE_BALANCE_OUTCOME.EXCLUDED,
+            reasons: [],
+            transactionAmount: 0
+          }
+        })
+      ],
+      {
+        accreditation: accreditedThroughout,
+        overseasSites: {}
+      }
+    )
 
     expect(state.classification).toEqual({
       outcome: WASTE_BALANCE_OUTCOME.INCLUDED,

--- a/src/waste-records/application/live-classified-row-states.test.js
+++ b/src/waste-records/application/live-classified-row-states.test.js
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest'
 
-import { liveClassifiedRowStatesForRegistration } from './live-classified-row-states.js'
+import {
+  liveClassifiedRowStates,
+  liveClassifiedRowStatesForRegistration
+} from './live-classified-row-states.js'
 import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
@@ -332,6 +335,17 @@ describe('liveClassifiedRowStatesForRegistration', () => {
     expect(states).toEqual([])
   })
 
+  it('returns nothing for a submission with no rows even when the organisation no longer holds the registration', async () => {
+    const scenario = reprocessorAccreditedFrom('2026-01-01')
+    scenario.organisation.registrations = []
+
+    // A partition with nothing committed answers with nothing; it does not
+    // reach the registration lookup and turn into a 404.
+    await expect(readLiveStates({ ...scenario, entries: [] })).resolves.toEqual(
+      []
+    )
+  })
+
   it('fails when the ledger names a registration the organisation does not hold', async () => {
     const scenario = reprocessorAccreditedFrom('2026-01-01')
     scenario.organisation.registrations = []
@@ -354,5 +368,62 @@ describe('liveClassifiedRowStatesForRegistration', () => {
     expect(state.classification.outcome).toBe(
       WASTE_BALANCE_OUTCOME.NOT_APPLICABLE
     )
+  })
+})
+
+describe('liveClassifiedRowStates', () => {
+  const accreditedThroughout = partialMock({
+    id: ACCREDITATION_ID,
+    validFrom: '2026-01-01',
+    validTo: '2027-01-01',
+    statusHistory: approvedHistory
+  })
+
+  it('replaces each stamped classification with one derived from the given context', () => {
+    const [state] = liveClassifiedRowStates([rowStateEntry()], {
+      accreditation: accreditedThroughout,
+      overseasSites: {}
+    })
+
+    expect(state.classification).toEqual({
+      outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
+      reasons: [],
+      transactionAmount: 9
+    })
+  })
+
+  it('withholds inclusion from a row the accreditation period does not cover', () => {
+    const [state] = liveClassifiedRowStates([rowStateEntry()], {
+      accreditation: partialMock({
+        ...accreditedThroughout,
+        validFrom: '2026-03-01'
+      }),
+      overseasSites: {}
+    })
+
+    expect(state.classification.outcome).toBe(WASTE_BALANCE_OUTCOME.IGNORED)
+  })
+
+  it('drops the storage artifacts, keeping the row to its domain content', () => {
+    const [state] = liveClassifiedRowStates([rowStateEntry()], {
+      accreditation: accreditedThroughout,
+      overseasSites: {}
+    })
+
+    expect(Object.keys(state).sort()).toEqual([
+      'classification',
+      'data',
+      'rowId',
+      'wasteRecordType'
+    ])
+  })
+
+  it('returns nothing when given no rows, so no template can be read from them', () => {
+    expect(
+      liveClassifiedRowStates([], {
+        accreditation: accreditedThroughout,
+        overseasSites: {}
+      })
+    ).toEqual([])
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1766](https://eaflood.atlassian.net/browse/PAE-1766)
## Why

The credited tonnage report gated rows on the classification stamped onto each summary log row state at submission, and summed the stamped `transactionAmount`.

Approve an overseas site, or amend an accreditation's validity period, and the affected rows kept the classification stamped when the operator last submitted. Reported credited tonnage for those months stayed wrong until that operator submitted again — for an accreditation that has finished submitting for the year, indefinitely.

This report is the supply-side signal for PRN market pricing and feeds regulator and policy reporting, so a stale figure there is expensive.

## What

The report now classifies each row against today's accreditation and overseas-site data instead of reading the stamp. It shares the live reclassification path added in #1533 rather than carrying its own copy of the inclusion rules — `credited-tonnage.js` only consumes `classification.outcome` and `transactionAmount`, and there remains exactly one implementation of what counts.

`liveClassifiedRowStates` is extracted from `liveClassifiedRowStatesForRegistration` so a caller that has already resolved its own head submission — this report resolves one per ledger partition from `findLatestSubmittedSummaryLogPerLedger` — reuses the classification step without re-resolving it. It takes the resolved overseas-sites context rather than the repository, so it stays pure and the report loads every site once for the whole run alongside its other opening reads, following the same shape as `stream-csv-export.js`. Its parameter names the row fields it actually reads rather than the full stored shape.

Gross `totalCredited` is unaffected: it is what the operator reported and does not move with reference data. Only `eligibleForWasteBalance` follows the current rules.

`overseasSitesRepository` is now injected into the report route.

## Notes for reviewers

The report suite's fixtures deliberately carry a stamped classification that contradicts the live answer in both directions, so reading the stamp instead of re-deriving cannot produce the expected figures. Verified by mutation rather than by inspection: replacing the live call with the stamped projection fails 7 of the 25 tests across the two credited-tonnage suites.

Two behaviours worth a second opinion:

- A registration's `overseasSites` are now resolved from a single `findAll()` map instead of `findByIds`. A malformed `overseasSiteId` therefore classifies as not-approved rather than throwing. It cannot be persisted through the supported write path (`put-by-id.js` rejects unknown and malformed ids), and the tolerant reading matches `admin-list.js` and `accreditation-list.js`, but the two live-classification paths now differ on that edge. Tracked separately.
- Where the template processing type and the accreditation are sourced from is unchanged from #1533; the divergence between that and `credited-tonnage.js`'s own `processingTypeFor` derivation is pre-existing and tracked separately, since collapsing them changes output and needs a decision.


[PAE-1766]: https://eaflood.atlassian.net/browse/PAE-1766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ