### PR TITLE
PAE-1765: Classify the waste records export live at read time

### DIFF
--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -6,6 +6,8 @@ import { resolveAccreditation } from '#domain/organisations/registration-utils.j
 import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/index.js'
 import { coerceRowData } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { latestSubmittedSummaryLogId } from '#waste-balances/application/latest-submitted-summary-log-id.js'
+import { toWasteRecordState } from '#waste-records/application/read-summary-log-row-states.js'
+import { reclassifyWasteRecordStates } from '#waste-records/application/reclassify-waste-record-states.js'
 import {
   buildHeaderRow,
   buildDataRow,
@@ -60,7 +62,7 @@ const sortRowStates = (a, b) => {
  * top-level field on the row state, is merged back onto the data both to select
  * the schema and to fill its metadata column.
  *
- * @param {SummaryLogRowState} rowState
+ * @param {Pick<SummaryLogRowState, 'data' | 'processingType' | 'wasteRecordType'>} rowState
  * @returns {Record<string, any>}
  */
 const coerceForExport = ({ data, processingType, wasteRecordType }) => {
@@ -148,17 +150,34 @@ async function* streamRegistrationRows({
   const summaryLogEntry = summaryLogMap.get(latestSummaryLogId) ?? null
 
   const rowStatesSorted = [...rowStates].sort(sortRowStates)
+  const [firstRowState] = rowStatesSorted
+  if (!firstRowState) {
+    return
+  }
 
-  for (const rowState of rowStatesSorted) {
+  // One summary log is one uploaded workbook, so every row in it reports under
+  // that workbook's template, and the rows record which one.
+  const { processingType } = firstRowState
+
+  // The extract's other columns read the accreditation and overseas sites as
+  // they stand now, so its waste-balance columns have to be derived from the
+  // same context — a classification stamped at submission would contradict the
+  // Accredited and OSR columns beside it as soon as either changed.
+  const liveStates = reclassifyWasteRecordStates(
+    rowStatesSorted.map(toWasteRecordState),
+    { processingType, accreditation, overseasSites }
+  )
+
+  for (const state of liveStates) {
     yield await encodeRow(
       buildDataRow({
         org,
         registration,
         accreditation,
-        data: coerceForExport(rowState),
-        wasteRecordType: rowState.wasteRecordType,
-        rowId: rowState.rowId,
-        classification: rowState.classification,
+        data: coerceForExport({ ...state, processingType }),
+        wasteRecordType: state.wasteRecordType,
+        rowId: state.rowId,
+        classification: state.classification,
         summaryLogEntry,
         overseasSites,
         dataFieldColumns

--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -141,6 +141,9 @@ async function* streamRegistrationRows({
       ledgerId,
       latestSummaryLogId
     )
+  if (rowStates.length === 0) {
+    return
+  }
 
   const summaryLogMap = await loadSummaryLogMap(
     summaryLogsRepository,
@@ -150,34 +153,29 @@ async function* streamRegistrationRows({
   const summaryLogEntry = summaryLogMap.get(latestSummaryLogId) ?? null
 
   const rowStatesSorted = [...rowStates].sort(sortRowStates)
-  const [firstRowState] = rowStatesSorted
-  if (!firstRowState) {
-    return
-  }
 
   // One summary log is one uploaded workbook, so every row in it reports under
   // that workbook's template, and the rows record which one.
-  const { processingType } = firstRowState
+  const [{ processingType }] = rowStatesSorted
 
-  // The extract's other columns read the accreditation and overseas sites as
-  // they stand now, so its waste-balance columns have to be derived from the
-  // same context — a classification stamped at submission would contradict the
-  // Accredited and OSR columns beside it as soon as either changed.
+  // The waste-balance columns answer as of the same moment as the Accredited
+  // and OSR columns beside them, which read the accreditation and the
+  // registration's overseas sites as they stand at export time.
   const liveStates = reclassifyWasteRecordStates(
     rowStatesSorted.map(toWasteRecordState),
     { processingType, accreditation, overseasSites }
   )
 
-  for (const state of liveStates) {
+  for (const [index, rowState] of rowStatesSorted.entries()) {
     yield await encodeRow(
       buildDataRow({
         org,
         registration,
         accreditation,
-        data: coerceForExport({ ...state, processingType }),
-        wasteRecordType: state.wasteRecordType,
-        rowId: state.rowId,
-        classification: state.classification,
+        data: coerceForExport(rowState),
+        wasteRecordType: rowState.wasteRecordType,
+        rowId: rowState.rowId,
+        classification: liveStates[index].classification,
         summaryLogEntry,
         overseasSites,
         dataFieldColumns

--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -7,7 +7,7 @@ import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/
 import { coerceRowData } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { latestSubmittedSummaryLogId } from '#waste-balances/application/latest-submitted-summary-log-id.js'
 import { toWasteRecordState } from '#waste-records/application/read-summary-log-row-states.js'
-import { reclassifyWasteRecordStates } from '#waste-records/application/reclassify-waste-record-states.js'
+import { reclassifyWasteRecordState } from '#waste-records/application/reclassify-waste-record-states.js'
 import {
   buildHeaderRow,
   buildDataRow,
@@ -158,15 +158,15 @@ async function* streamRegistrationRows({
   // that workbook's template, and the rows record which one.
   const [{ processingType }] = rowStatesSorted
 
-  // The waste-balance columns answer as of the same moment as the Accredited
-  // and OSR columns beside them, which read the accreditation and the
-  // registration's overseas sites as they stand at export time.
-  const liveStates = reclassifyWasteRecordStates(
-    rowStatesSorted.map(toWasteRecordState),
-    { processingType, accreditation, overseasSites }
-  )
+  for (const rowState of rowStatesSorted) {
+    // The waste-balance columns answer as of the same moment as the Accredited
+    // and OSR columns beside them, which read the accreditation and the
+    // registration's overseas sites as they stand at export time.
+    const { classification } = reclassifyWasteRecordState(
+      toWasteRecordState(rowState),
+      { processingType, accreditation, overseasSites }
+    )
 
-  for (const [index, rowState] of rowStatesSorted.entries()) {
     yield await encodeRow(
       buildDataRow({
         org,
@@ -175,7 +175,7 @@ async function* streamRegistrationRows({
         data: coerceForExport(rowState),
         wasteRecordType: rowState.wasteRecordType,
         rowId: rowState.rowId,
-        classification: liveStates[index].classification,
+        classification,
         summaryLogEntry,
         overseasSites,
         dataFieldColumns

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -372,17 +372,6 @@ describe('streamCsvExport', () => {
     expect(out[3]).toContain('received')
     expect(out[4]).toContain('sentOn')
     expect(out[4]).toContain('Other Co')
-
-    // Each row reports the processing type it was committed under, so the sort
-    // above cannot shuffle a row onto another row's metadata.
-    const processingTypeOf = (line) =>
-      line.trim().split(',')[METADATA_COL_INDEX['Operator Processing Type']]
-    expect(out.slice(1).map(processingTypeOf)).toEqual([
-      PROCESSING_TYPES.EXPORTER,
-      PROCESSING_TYPES.REPROCESSOR_OUTPUT,
-      PROCESSING_TYPES.REPROCESSOR_INPUT,
-      PROCESSING_TYPES.EXPORTER
-    ])
   })
 
   it('builds the ORS context once per registration from the pre-loaded sites map', async () => {

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -372,6 +372,17 @@ describe('streamCsvExport', () => {
     expect(out[3]).toContain('received')
     expect(out[4]).toContain('sentOn')
     expect(out[4]).toContain('Other Co')
+
+    // Each row reports the processing type it was committed under, so the sort
+    // above cannot shuffle a row onto another row's metadata.
+    const processingTypeOf = (line) =>
+      line.trim().split(',')[METADATA_COL_INDEX['Operator Processing Type']]
+    expect(out.slice(1).map(processingTypeOf)).toEqual([
+      PROCESSING_TYPES.EXPORTER,
+      PROCESSING_TYPES.REPROCESSOR_OUTPUT,
+      PROCESSING_TYPES.REPROCESSOR_INPUT,
+      PROCESSING_TYPES.EXPORTER
+    ])
   })
 
   it('builds the ORS context once per registration from the pre-loaded sites map', async () => {

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -807,7 +807,7 @@ describe('streamCsvExport', () => {
     expect(out[2].trim().split(',')[METADATA_COL_INDEX['Row ID']]).toBe('10')
   })
 
-  it('renders a stamped NOT_APPLICABLE classification as NA with blank reason and tonnage', async () => {
+  it('renders a row with no active accreditation as NA with blank reason and tonnage', async () => {
     const deps = await buildDeps({
       orgs: [baseOrg({ registrations: [baseRegistration()] })],
       seeds: [{ rows: [receivedRowState()] }]

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -56,15 +56,74 @@ const naClassification = () => ({
   transactionAmount: 0
 })
 
-// A committed row-state entry (upsert shape). Defaults to an NA-outcome
-// reprocessor received row — inclusion is now read from the stamped
-// classification rather than recomputed, so tests set the outcome directly.
+// A committed row-state entry (upsert shape). Defaults to a reprocessor
+// received row whose data cannot classify — the export re-derives inclusion
+// from the row's data and the current context, so a row that should classify
+// carries `completeReceivedData` instead.
 const receivedRowState = (overrides = {}) => ({
   rowId: '1001',
   wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
   processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
   data: { DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01' },
   classification: naClassification(),
+  ...overrides
+})
+
+// Every field the reprocessor-input received schema needs to reach a per-row
+// waste-balance outcome, so the only thing left deciding the outcome is the
+// accreditation the export resolves at read time.
+const completeReceivedData = (overrides = {}) => ({
+  DATE_RECEIVED_FOR_REPROCESSING: '2026-06-15',
+  EWC_CODE: '03 03 08',
+  DESCRIPTION_WASTE: 'Paper - other',
+  WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+  GROSS_WEIGHT: 100,
+  TARE_WEIGHT: 5,
+  PALLET_WEIGHT: 5,
+  NET_WEIGHT: 90,
+  BAILING_WIRE_PROTOCOL: 'No',
+  HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'AAIG percentage',
+  WEIGHT_OF_NON_TARGET_MATERIALS: 10,
+  RECYCLABLE_PROPORTION_PERCENTAGE: 0.8,
+  TONNAGE_RECEIVED_FOR_RECYCLING: 50.5,
+  ...overrides
+})
+
+// The exporter equivalent of `completeReceivedData` — everything the
+// received-loads-for-export schema needs before the overseas site's approval
+// date is what decides the outcome.
+const completeExportedData = (overrides = {}) => ({
+  DATE_RECEIVED_FOR_EXPORT: '2026-06-01',
+  EWC_CODE: '03 03 08',
+  DESCRIPTION_WASTE: 'Paper - other',
+  WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: 'No',
+  GROSS_WEIGHT: 100,
+  TARE_WEIGHT: 5,
+  PALLET_WEIGHT: 5,
+  NET_WEIGHT: 90,
+  BAILING_WIRE_PROTOCOL: 'No',
+  HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'AAIG percentage',
+  WEIGHT_OF_NON_TARGET_MATERIALS: 10,
+  RECYCLABLE_PROPORTION_PERCENTAGE: 0.8,
+  TONNAGE_RECEIVED_FOR_EXPORT: 72,
+  TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 60.5,
+  DATE_OF_EXPORT: '2026-06-15',
+  BASEL_EXPORT_CODE: 'B1010',
+  CUSTOMS_CODES: 'HS123',
+  CONTAINER_NUMBER: 'CONT001',
+  DATE_RECEIVED_BY_OSR: '2026-06-20',
+  OSR_ID: '001',
+  DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE: 'No',
+  ...overrides
+})
+
+const approvedAccreditation = (overrides = {}) => ({
+  id: 'acc-1',
+  status: 'approved',
+  accreditationNumber: 'ACC-777',
+  validFrom: '2026-01-01',
+  validTo: '2026-12-31',
+  statusHistory: [],
   ...overrides
 })
 
@@ -317,15 +376,7 @@ describe('streamCsvExport', () => {
 
   it('builds the ORS context once per registration from the pre-loaded sites map', async () => {
     const org = baseOrg({
-      accreditations: [
-        {
-          id: 'acc-1',
-          status: 'approved',
-          validFrom: '2026-01-01',
-          validTo: '2026-12-31',
-          statusHistory: []
-        }
-      ],
+      accreditations: [approvedAccreditation()],
       registrations: [
         baseRegistration({
           accreditation: null,
@@ -347,12 +398,8 @@ describe('streamCsvExport', () => {
               rowId: '4001',
               wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
               processingType: PROCESSING_TYPES.EXPORTER,
-              data: { OSR_ID: '001', DATE_OF_EXPORT: '2026-03-01' },
-              classification: {
-                outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
-                reasons: [],
-                transactionAmount: 9
-              }
+              data: completeExportedData(),
+              classification: naClassification()
             }
           ]
         }
@@ -365,6 +412,48 @@ describe('streamCsvExport', () => {
     expect(findAll).toHaveBeenCalledTimes(1)
     const cells = out[1].trim().split(',')
     expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('true')
+  })
+
+  it('excludes an exported row whose overseas site is not yet approved on the export date', async () => {
+    const org = baseOrg({
+      accreditations: [approvedAccreditation()],
+      registrations: [
+        baseRegistration({
+          accreditation: null,
+          accreditationId: 'acc-1',
+          overseasSites: { '001': { overseasSiteId: 'site-a' } }
+        })
+      ]
+    })
+    const deps = await buildDeps({
+      orgs: [org],
+      sites: [{ id: 'site-a', validFrom: new Date('2026-09-01') }],
+      seeds: [
+        {
+          accreditationId: 'acc-1',
+          rows: [
+            {
+              rowId: '4001',
+              wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+              processingType: PROCESSING_TYPES.EXPORTER,
+              data: completeExportedData(),
+              classification: {
+                outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
+                reasons: [],
+                transactionAmount: 60.5
+              }
+            }
+          ]
+        }
+      ]
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const cells = out[1].trim().split(',')
+    expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('false')
+    expect(
+      cells[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]
+    ).toContain('ORS_NOT_APPROVED')
   })
 
   it('populates the derived OSR columns from the approved overseas site matched by OSR_ID', async () => {
@@ -420,15 +509,23 @@ describe('streamCsvExport', () => {
     expect(cells[header.indexOf(OSR_NAME_REVISED)]).toBe('')
   })
 
-  it('renders a stamped EXCLUDED classification as false with its reason and blank tonnage', async () => {
+  it('includes a row the stamped classification ignored once the accreditation covers its date', async () => {
+    const org = baseOrg({
+      accreditations: [approvedAccreditation()],
+      registrations: [
+        baseRegistration({ accreditation: null, accreditationId: 'acc-1' })
+      ]
+    })
     const deps = await buildDeps({
-      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      orgs: [org],
       seeds: [
         {
+          accreditationId: 'acc-1',
           rows: [
             receivedRowState({
+              data: completeReceivedData(),
               classification: {
-                outcome: WASTE_BALANCE_OUTCOME.EXCLUDED,
+                outcome: WASTE_BALANCE_OUTCOME.IGNORED,
                 reasons: [{ code: 'OUTSIDE_ACCREDITATION_PERIOD' }],
                 transactionAmount: 0
               }
@@ -440,6 +537,48 @@ describe('streamCsvExport', () => {
 
     const out = await collect(streamCsvExport(deps))
     const cells = out[1].trim().split(',')
+    expect(cells[METADATA_COL_INDEX['Accredited']]).toBe('Yes')
+    expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('true')
+    expect(cells[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toBe('')
+    expect(Number(cells[METADATA_COL_INDEX['Waste Balance Tonnage']])).toBe(
+      50.5
+    )
+  })
+
+  it('ignores a row the stamped classification included once the accreditation no longer covers its date', async () => {
+    const org = baseOrg({
+      accreditations: [
+        approvedAccreditation({
+          validFrom: '2026-01-01',
+          validTo: '2026-03-31'
+        })
+      ],
+      registrations: [
+        baseRegistration({ accreditation: null, accreditationId: 'acc-1' })
+      ]
+    })
+    const deps = await buildDeps({
+      orgs: [org],
+      seeds: [
+        {
+          accreditationId: 'acc-1',
+          rows: [
+            receivedRowState({
+              data: completeReceivedData(),
+              classification: {
+                outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
+                reasons: [],
+                transactionAmount: 50.5
+              }
+            })
+          ]
+        }
+      ]
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const cells = out[1].trim().split(',')
+    expect(cells[METADATA_COL_INDEX['Accredited']]).toBe('Yes')
     expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('false')
     expect(
       cells[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]
@@ -447,25 +586,48 @@ describe('streamCsvExport', () => {
     expect(cells[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe('')
   })
 
-  it('renders a stamped EXCLUDED reason with a field as "code: field"', async () => {
+  it('renders a row missing a waste-balance field as false with blank tonnage', async () => {
+    const { TONNAGE_RECEIVED_FOR_RECYCLING: _omitted, ...withoutTonnage } =
+      completeReceivedData()
     const deps = await buildDeps({
-      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      orgs: [
+        baseOrg({
+          accreditations: [approvedAccreditation()],
+          registrations: [
+            baseRegistration({ accreditation: null, accreditationId: 'acc-1' })
+          ]
+        })
+      ],
       seeds: [
         {
-          rows: [
-            receivedRowState({
-              classification: {
-                outcome: WASTE_BALANCE_OUTCOME.EXCLUDED,
-                reasons: [
-                  {
-                    code: 'MISSING_REQUIRED_FIELD',
-                    field: 'TONNAGE_RECEIVED_FOR_RECYCLING'
-                  }
-                ],
-                transactionAmount: 0
-              }
-            })
+          accreditationId: 'acc-1',
+          rows: [receivedRowState({ data: withoutTonnage })]
+        }
+      ]
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const cells = out[1].trim().split(',')
+    expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('false')
+    expect(cells[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe('')
+  })
+
+  it('renders an exclusion reason that names a field as "code: field"', async () => {
+    const { TONNAGE_RECEIVED_FOR_RECYCLING: _omitted, ...withoutTonnage } =
+      completeReceivedData()
+    const deps = await buildDeps({
+      orgs: [
+        baseOrg({
+          accreditations: [approvedAccreditation()],
+          registrations: [
+            baseRegistration({ accreditation: null, accreditationId: 'acc-1' })
           ]
+        })
+      ],
+      seeds: [
+        {
+          accreditationId: 'acc-1',
+          rows: [receivedRowState({ data: withoutTonnage })]
         }
       ]
     })
@@ -476,20 +638,20 @@ describe('streamCsvExport', () => {
     )
   })
 
-  it('renders a stamped INCLUDED classification as true with its tonnage and blank reason', async () => {
+  it('renders an included row as true with its tonnage and blank reason', async () => {
     const deps = await buildDeps({
-      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      orgs: [
+        baseOrg({
+          accreditations: [approvedAccreditation()],
+          registrations: [
+            baseRegistration({ accreditation: null, accreditationId: 'acc-1' })
+          ]
+        })
+      ],
       seeds: [
         {
-          rows: [
-            receivedRowState({
-              classification: {
-                outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
-                reasons: [],
-                transactionAmount: 9
-              }
-            })
-          ]
+          accreditationId: 'acc-1',
+          rows: [receivedRowState({ data: completeReceivedData() })]
         }
       ]
     })
@@ -498,7 +660,9 @@ describe('streamCsvExport', () => {
     const cells = out[1].trim().split(',')
     expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('true')
     expect(cells[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toBe('')
-    expect(Number(cells[METADATA_COL_INDEX['Waste Balance Tonnage']])).toBe(9)
+    expect(Number(cells[METADATA_COL_INDEX['Waste Balance Tonnage']])).toBe(
+      50.5
+    )
   })
 
   it('reads Accredited "Yes" with the number for a suspended accreditation', async () => {
@@ -654,6 +818,16 @@ describe('streamCsvExport', () => {
     expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('NA')
     expect(cells[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]).toBe('')
     expect(cells[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe('')
+  })
+
+  it('contributes no rows for a submitted summary log that committed none', async () => {
+    const deps = await buildDeps({
+      orgs: [baseOrg({ registrations: [baseRegistration()] })],
+      seeds: [{ rows: [] }]
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    expect(out).toHaveLength(1) // header only
   })
 
   it('contributes no rows for a registration with no submitted summary log', async () => {

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -597,6 +597,47 @@ describe('streamCsvExport', () => {
     expect(cells[METADATA_COL_INDEX['Waste Balance Tonnage']]).toBe('')
   })
 
+  it('gives each row of a summary log its own live outcome', async () => {
+    const { TONNAGE_RECEIVED_FOR_RECYCLING: _omitted, ...withoutTonnage } =
+      completeReceivedData()
+    const org = baseOrg({
+      accreditations: [approvedAccreditation()],
+      registrations: [
+        baseRegistration({ accreditation: null, accreditationId: 'acc-1' })
+      ]
+    })
+    const deps = await buildDeps({
+      orgs: [org],
+      seeds: [
+        {
+          accreditationId: 'acc-1',
+          rows: [
+            receivedRowState({ rowId: '1001', data: completeReceivedData() }),
+            receivedRowState({ rowId: '1002', data: withoutTonnage })
+          ]
+        }
+      ]
+    })
+
+    const out = await collect(streamCsvExport(deps))
+    const included = out[1].trim().split(',')
+    const excluded = out[2].trim().split(',')
+    expect(included[METADATA_COL_INDEX['Row ID']]).toBe('1001')
+    expect(included[METADATA_COL_INDEX['Included in Waste Balance']]).toBe(
+      'true'
+    )
+    expect(Number(included[METADATA_COL_INDEX['Waste Balance Tonnage']])).toBe(
+      50.5
+    )
+    expect(excluded[METADATA_COL_INDEX['Row ID']]).toBe('1002')
+    expect(excluded[METADATA_COL_INDEX['Included in Waste Balance']]).toBe(
+      'false'
+    )
+    expect(
+      excluded[METADATA_COL_INDEX['Waste Balance Exclusion Reason']]
+    ).toContain('TONNAGE_RECEIVED_FOR_RECYCLING')
+  })
+
   it('renders a row missing a waste-balance field as false with blank tonnage', async () => {
     const { TONNAGE_RECEIVED_FOR_RECYCLING: _omitted, ...withoutTonnage } =
       completeReceivedData()

--- a/src/waste-records-export/domain/csv-columns.js
+++ b/src/waste-records-export/domain/csv-columns.js
@@ -167,7 +167,7 @@ const buildWasteBalanceCells = (classification) => {
  * @property {Record<string, any>} data - Coerced committed row data, carrying `processingType`.
  * @property {WasteRecordType} wasteRecordType
  * @property {string} rowId
- * @property {RowClassification} classification - The row's stamped waste-balance classification.
+ * @property {RowClassification} classification - The row's waste-balance classification.
  * @property {{ submittedAt: string } | null | undefined} summaryLogEntry
  * @property {Record<string, import('./overseas-sites-context.js').OverseasSiteContextEntry>} [overseasSites]
  * @property {string[]} dataFieldColumns
@@ -179,9 +179,9 @@ const buildWasteBalanceCells = (classification) => {
  * numbers so they serialise unquoted; string cells are formula-injection
  * sanitised.
  *
- * Inclusion, reasons and tonnage come from the classification stamped on the
- * row state when its summary log was submitted — not recomputed — so the export
- * reflects exactly what counted toward the waste balance at submission.
+ * Inclusion, reasons and tonnage are rendered from the classification the
+ * caller supplies; which reading that is — the one stamped at submission or one
+ * derived against current context — is the caller's decision.
  *
  * The derived OSR columns (OSR_COUNTRY_REVISED / OSR_NAME_REVISED) sit at the
  * end of the metadata prefix and are looked up from the approved

--- a/src/waste-records/application/reclassify-waste-record-states.js
+++ b/src/waste-records/application/reclassify-waste-record-states.js
@@ -23,6 +23,9 @@ import { classifyRecordForWasteBalance } from '#waste-balances/domain/waste-bala
  * submits again. Reads that answer current-state questions call this so that
  * context changes show up without waiting for a submission.
  *
+ * Returns one state per input, in the same order, so a caller may pair the
+ * results back to the states it passed in by position.
+ *
  * @param {WasteRecordState[]} states
  * @param {ReclassificationContext} context
  * @returns {WasteRecordState[]}

--- a/src/waste-records/application/reclassify-waste-record-states.js
+++ b/src/waste-records/application/reclassify-waste-record-states.js
@@ -12,8 +12,8 @@ import { classifyRecordForWasteBalance } from '#waste-balances/domain/waste-bala
  */
 
 /**
- * Re-derive each row's waste-balance classification against the given context,
- * in place of the classification stamped when the row was submitted.
+ * Re-derive a row's waste-balance classification against the given context, in
+ * place of the classification stamped when the row was submitted.
  *
  * A stamped classification records the reading that produced the credit its
  * submission committed, so it is the right answer for reproducing that credit.
@@ -23,23 +23,29 @@ import { classifyRecordForWasteBalance } from '#waste-balances/domain/waste-bala
  * submits again. Reads that answer current-state questions call this so that
  * context changes show up without waiting for a submission.
  *
- * Returns one state per input, in the same order, so a caller may pair the
- * results back to the states it passed in by position.
+ * @param {WasteRecordState} state
+ * @param {ReclassificationContext} context
+ * @returns {WasteRecordState}
+ */
+export const reclassifyWasteRecordState = (
+  state,
+  { processingType, accreditation, overseasSites }
+) => ({
+  ...state,
+  classification: classifyRecordForWasteBalance(
+    { type: state.wasteRecordType, data: state.data },
+    processingType,
+    accreditation,
+    overseasSites
+  )
+})
+
+/**
+ * Reclassify a whole partition's row states against one shared context.
  *
  * @param {WasteRecordState[]} states
  * @param {ReclassificationContext} context
  * @returns {WasteRecordState[]}
  */
-export const reclassifyWasteRecordStates = (
-  states,
-  { processingType, accreditation, overseasSites }
-) =>
-  states.map((state) => ({
-    ...state,
-    classification: classifyRecordForWasteBalance(
-      { type: state.wasteRecordType, data: state.data },
-      processingType,
-      accreditation,
-      overseasSites
-    )
-  }))
+export const reclassifyWasteRecordStates = (states, context) =>
+  states.map((state) => reclassifyWasteRecordState(state, context))


### PR DESCRIPTION
Ticket: [PAE-1765](https://eaflood.atlassian.net/browse/PAE-1765)
The waste records CSV/FOI export resolves the accreditation and the registration's overseas sites as they stand at export time, but since it moved onto the summary log row states collection it rendered the waste-balance classification stamped when each row was submitted. The two drift apart: amend an accreditation's validity period or approve an overseas site, and a row can read "Accredited: Yes" beside "Included in Waste Balance: false — OUTSIDE_ACCREDITATION_PERIOD", contradicting itself within one line of the extract.

Each row's classification is now re-derived through `reclassifyWasteRecordStates` against the same context the surrounding columns read, so the whole row answers as of the same moment. No rows are added or dropped — the classification feeds the three waste-balance columns rather than a filter, so only their values change. The stamped classification stays in the collection as the record of the credit each submission committed.

The registration's processing type is hoisted once as classification context, since one summary log is one uploaded workbook, but every rendered column continues to read the row's own value. `coerceForExport` is narrowed to the three fields it actually reads, and `reclassifyWasteRecordStates` now states that it returns one state per input in order — the property that lets the export pair a classification back to its row.

Two behaviours the export documented but did not pin are now covered: the Operator Processing Type column against a summary log holding several types, and a submitted summary log that committed no rows.


[PAE-1765]: https://eaflood.atlassian.net/browse/PAE-1765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ