### PR TITLE
PAE-1767: Deduct only sent-on loads that debited the waste balance [PARKED — premise unconfirmed]

### DIFF
--- a/src/waste-balances/domain/credited-tonnage.js
+++ b/src/waste-balances/domain/credited-tonnage.js
@@ -52,8 +52,8 @@ const YES = 'Yes'
  * @typedef {Object} MonthlyCreditedTonnage
  * @property {string} month - `YYYY-MM`
  * @property {number} totalCredited - gross tonnage on crediting rows, 2dp
- * @property {number} eligibleForWasteBalance - tonnage that credited the balance (persisted INCLUDED classification), 2dp
- * @property {number} sentOnDeductions - tonnage that debited the balance on sent-on rows (persisted INCLUDED classification), positive, reprocessor input only, 2dp
+ * @property {number} eligibleForWasteBalance - tonnage that credits the balance (INCLUDED classification), 2dp
+ * @property {number} sentOnDeductions - tonnage that debits the balance on sent-on rows (INCLUDED classification), sign-flipped to match the credit figure, reprocessor input only, 2dp
  */
 
 /**
@@ -194,15 +194,16 @@ const contributionFor = (rowState, processingType) => {
  *
  * Each contributing row lands in at most one month, bucketed by its
  * month-assignment date. Crediting rows add their tonnage column to
- * `totalCredited` gross — every row regardless of classification — and add the
- * persisted `classification.transactionAmount` to `eligibleForWasteBalance`
- * when the row's persisted outcome is `INCLUDED`. Sent-on rows on a
- * reprocessor-input accreditation add the negation of that same amount to
- * `sentOnDeductions`, so the report deducts what the balance was actually
- * debited and a row the classification never applied deducts nothing. Rows
- * whose month-assignment date is missing,
- * unparseable, or outside the range are dropped and counted in
- * `skippedRowCount`. Sums are decimal-safe to 2dp.
+ * `totalCredited` gross — every row regardless of classification — and add
+ * `classification.transactionAmount` to `eligibleForWasteBalance` when the
+ * row's outcome is `INCLUDED`. Sent-on rows on a reprocessor-input
+ * accreditation add the negation of that same amount to `sentOnDeductions`, so
+ * the report deducts what actually debited the balance and a row the
+ * classification never applied deducts nothing. Netting `eligibleForWasteBalance`
+ * against `sentOnDeductions` therefore reconciles to the balance's own
+ * movement. Rows whose month-assignment date is missing, unparseable, or
+ * outside the range are dropped and counted in `skippedRowCount`. Sums are
+ * decimal-safe to 2dp.
  *
  * @param {WasteRecordState[]} rowStates
  * @param {AccreditationContext} accreditation

--- a/src/waste-balances/domain/credited-tonnage.js
+++ b/src/waste-balances/domain/credited-tonnage.js
@@ -53,7 +53,7 @@ const YES = 'Yes'
  * @property {string} month - `YYYY-MM`
  * @property {number} totalCredited - gross tonnage on crediting rows, 2dp
  * @property {number} eligibleForWasteBalance - tonnage that credited the balance (persisted INCLUDED classification), 2dp
- * @property {number} sentOnDeductions - sent-on tonnage, positive, reprocessor input only, 2dp
+ * @property {number} sentOnDeductions - tonnage that debited the balance on sent-on rows (persisted INCLUDED classification), positive, reprocessor input only, 2dp
  */
 
 /**
@@ -67,13 +67,14 @@ const YES = 'Yes'
  */
 
 /**
- * How a row contributes: which tonnage column feeds the gross figure, which
- * date buckets it into a month, and whether it credits or deducts.
+ * How a row contributes: which date buckets it into a month, and whether it
+ * credits or deducts. Only a crediting row names a tonnage column, because only
+ * the gross credited figure is read from the row's data — a deduction is taken
+ * from the classification's transaction amount instead.
  *
- * @typedef {Object} RowContribution
- * @property {string} dateField
- * @property {number} tonnage
- * @property {boolean} credits
+ * @typedef {{ dateField: string, credits: true, tonnage: number }} CreditingContribution
+ * @typedef {{ dateField: string, credits: false }} DeductingContribution
+ * @typedef {CreditingContribution | DeductingContribution} RowContribution
  */
 
 /**
@@ -181,7 +182,6 @@ const contributionFor = (rowState, processingType) => {
   if (wasteRecordType === WASTE_RECORD_TYPE.SENT_ON) {
     return {
       dateField: SENT_ON_LOADS_FIELDS.DATE_LOAD_LEFT_SITE,
-      tonnage: data[SENT_ON_LOADS_FIELDS.TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON],
       credits: false
     }
   }
@@ -197,8 +197,10 @@ const contributionFor = (rowState, processingType) => {
  * `totalCredited` gross — every row regardless of classification — and add the
  * persisted `classification.transactionAmount` to `eligibleForWasteBalance`
  * when the row's persisted outcome is `INCLUDED`. Sent-on rows on a
- * reprocessor-input accreditation add their tonnage to `sentOnDeductions`
- * as a positive number. Rows whose month-assignment date is missing,
+ * reprocessor-input accreditation add the negation of that same amount to
+ * `sentOnDeductions`, so the report deducts what the balance was actually
+ * debited and a row the classification never applied deducts nothing. Rows
+ * whose month-assignment date is missing,
  * unparseable, or outside the range are dropped and counted in
  * `skippedRowCount`. Sums are decimal-safe to 2dp.
  *
@@ -240,11 +242,14 @@ export const creditedTonnageByMonth = (
       continue
     }
 
+    const includedInBalance =
+      rowState.classification.outcome === WASTE_BALANCE_OUTCOME.INCLUDED
+
     if (contribution.credits) {
       bucket.totalCredited = toNumber(
         addRounded(bucket.totalCredited, contribution.tonnage, 2)
       )
-      if (rowState.classification.outcome === WASTE_BALANCE_OUTCOME.INCLUDED) {
+      if (includedInBalance) {
         bucket.eligibleForWasteBalance = toNumber(
           addRounded(
             bucket.eligibleForWasteBalance,
@@ -253,9 +258,13 @@ export const creditedTonnageByMonth = (
           )
         )
       }
-    } else {
+    } else if (includedInBalance) {
       bucket.sentOnDeductions = toNumber(
-        addRounded(bucket.sentOnDeductions, contribution.tonnage, 2)
+        addRounded(
+          bucket.sentOnDeductions,
+          -rowState.classification.transactionAmount,
+          2
+        )
       )
     }
   }

--- a/src/waste-balances/domain/credited-tonnage.js
+++ b/src/waste-balances/domain/credited-tonnage.js
@@ -250,16 +250,21 @@ export const creditedTonnageByMonth = (
       bucket.totalCredited = toNumber(
         addRounded(bucket.totalCredited, contribution.tonnage, 2)
       )
-      if (includedInBalance) {
-        bucket.eligibleForWasteBalance = toNumber(
-          addRounded(
-            bucket.eligibleForWasteBalance,
-            rowState.classification.transactionAmount,
-            2
-          )
+    }
+
+    if (!includedInBalance) {
+      continue
+    }
+
+    if (contribution.credits) {
+      bucket.eligibleForWasteBalance = toNumber(
+        addRounded(
+          bucket.eligibleForWasteBalance,
+          rowState.classification.transactionAmount,
+          2
         )
-      }
-    } else if (includedInBalance) {
+      )
+    } else {
       bucket.sentOnDeductions = toNumber(
         addRounded(
           bucket.sentOnDeductions,

--- a/src/waste-balances/domain/credited-tonnage.test.js
+++ b/src/waste-balances/domain/credited-tonnage.test.js
@@ -40,14 +40,19 @@ const receivedRow = (rowId, date, tonnage, classification) => ({
   classification
 })
 
-const sentOnRow = (rowId, date, tonnage) => ({
+const sentOnRow = (
+  rowId,
+  date,
+  tonnage,
+  classification = included(-tonnage)
+) => ({
   rowId,
   wasteRecordType: WASTE_RECORD_TYPE.SENT_ON,
   data: {
     DATE_LOAD_LEFT_SITE: date,
     TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON: tonnage
   },
-  classification: included(-tonnage)
+  classification
 })
 
 const processedRow = (rowId, date, tonnage, classification) => ({
@@ -220,6 +225,71 @@ describe('creditedTonnageByMonth', () => {
         totalCredited: 100,
         eligibleForWasteBalance: 90
       })
+    })
+  })
+
+  describe('deductions restricted to sent-on rows that debited the balance', () => {
+    it('leaves a sent-on row ignored for falling outside the accreditation period out of sentOnDeductions', () => {
+      const result = creditedTonnageByMonth(
+        [
+          sentOnRow(
+            '5000',
+            '2026-02-04',
+            40,
+            notIncluded(WASTE_BALANCE_OUTCOME.IGNORED)
+          )
+        ],
+        REPROCESSOR_INPUT,
+        RANGE
+      )
+
+      expect(monthFor(result, '2026-02').sentOnDeductions).toBe(0)
+    })
+
+    it('leaves a sent-on row excluded for missing waste-balance fields out of sentOnDeductions', () => {
+      const result = creditedTonnageByMonth(
+        [
+          sentOnRow(
+            '5000',
+            '2026-02-04',
+            40,
+            notIncluded(WASTE_BALANCE_OUTCOME.EXCLUDED)
+          )
+        ],
+        REPROCESSOR_INPUT,
+        RANGE
+      )
+
+      expect(monthFor(result, '2026-02').sentOnDeductions).toBe(0)
+    })
+
+    it('deducts only the INCLUDED rows when a month mixes debiting and ignored sent-on loads', () => {
+      const result = creditedTonnageByMonth(
+        [
+          sentOnRow('5000', '2026-02-04', 40),
+          sentOnRow(
+            '5001',
+            '2026-02-05',
+            25,
+            notIncluded(WASTE_BALANCE_OUTCOME.IGNORED)
+          ),
+          sentOnRow('5002', '2026-02-06', 10)
+        ],
+        REPROCESSOR_INPUT,
+        RANGE
+      )
+
+      expect(monthFor(result, '2026-02').sentOnDeductions).toBe(50)
+    })
+
+    it('reads the deduction from the persisted classification, not the tonnage column', () => {
+      const result = creditedTonnageByMonth(
+        [sentOnRow('5000', '2026-02-04', 40, included(-32.5))],
+        REPROCESSOR_INPUT,
+        RANGE
+      )
+
+      expect(monthFor(result, '2026-02').sentOnDeductions).toBe(32.5)
     })
   })
 

--- a/src/waste-balances/domain/credited-tonnage.test.js
+++ b/src/waste-balances/domain/credited-tonnage.test.js
@@ -92,7 +92,7 @@ describe('creditedTonnageByMonth', () => {
       })
     })
 
-    it('buckets reprocessor-input sent-on loads by DATE_LOAD_LEFT_SITE using TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON into sentOnDeductions as a positive number', () => {
+    it('buckets reprocessor-input sent-on loads by DATE_LOAD_LEFT_SITE into sentOnDeductions, flipping the debiting amount to a positive number', () => {
       const result = creditedTonnageByMonth(
         [sentOnRow('5000', '2026-03-01', 7.25)],
         REPROCESSOR_INPUT,
@@ -254,6 +254,23 @@ describe('creditedTonnageByMonth', () => {
             '2026-02-04',
             40,
             notIncluded(WASTE_BALANCE_OUTCOME.EXCLUDED)
+          )
+        ],
+        REPROCESSOR_INPUT,
+        RANGE
+      )
+
+      expect(monthFor(result, '2026-02').sentOnDeductions).toBe(0)
+    })
+
+    it('leaves a sent-on row on a registration with no accreditation out of sentOnDeductions', () => {
+      const result = creditedTonnageByMonth(
+        [
+          sentOnRow(
+            '5000',
+            '2026-02-04',
+            40,
+            notIncluded(WASTE_BALANCE_OUTCOME.NOT_APPLICABLE)
           )
         ],
         REPROCESSOR_INPUT,
@@ -524,6 +541,40 @@ describe('creditedTonnageByMonth', () => {
 
       expect(totalEligible).toBeCloseTo(totalTransactionAmount, 10)
       expect(totalEligible).toBe(69.12)
+    })
+
+    it('nets eligible against deductions to the total transactionAmount of a reprocessor-input mix of credits and sent-on loads', () => {
+      const rowStates = [
+        receivedRow('1000', '2026-01-10', 100, included(100)),
+        receivedRow(
+          '1001',
+          '2026-01-11',
+          70,
+          notIncluded(WASTE_BALANCE_OUTCOME.EXCLUDED)
+        ),
+        sentOnRow('5000', '2026-02-10', 12.34),
+        sentOnRow(
+          '5001',
+          '2026-03-10',
+          45,
+          notIncluded(WASTE_BALANCE_OUTCOME.IGNORED)
+        )
+      ]
+
+      const result = creditedTonnageByMonth(rowStates, REPROCESSOR_INPUT, RANGE)
+
+      const totalTransactionAmount = rowStates.reduce(
+        (sum, row) => sum + row.classification.transactionAmount,
+        0
+      )
+      const netMovement = result.months.reduce(
+        (sum, entry) =>
+          sum + entry.eligibleForWasteBalance - entry.sentOnDeductions,
+        0
+      )
+
+      expect(netMovement).toBeCloseTo(totalTransactionAmount, 10)
+      expect(netMovement).toBe(87.66)
     })
   })
 })


### PR DESCRIPTION
> [!WARNING]
> **Do not merge — the premise is unconfirmed.** Whether a sent-on load should always deduct from the waste balance regardless of its classification is a business question that has not been answered. This PR assumes it should not. If the business says sent-on always deducts, this PR is the wrong fix and should be closed — see "Which component is wrong" below.

Closes PAE-1767.

The credited-tonnage report treated sent-on loads as unconditional deductions. `creditedTonnageByMonth` summed the raw `TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON` column for every sent-on row without consulting `classification.outcome` at all, while the crediting side filtered on `INCLUDED` — so the two halves of the report were computed on different bases.

The reachable failure needs no admin action or data corruption: a sent-on load dated outside the accreditation's validity period is classified `IGNORED` by the table schema, so it never debits the waste balance, but the report still deducted its full tonnage. The reported figure understated supply, and the understatement grew with the number of such loads. The same applied to a sent-on row excluded for missing required waste-balance fields.

The deduction now reads the negation of `classification.transactionAmount`, mirroring how the crediting side reads that same amount. A row the classification never applied deducts nothing, and netting `eligibleForWasteBalance` against `sentOnDeductions` reconciles to the balance's own movement — an invariant this PR pins with a test, since it is the justification for the design.

## Which component is wrong

The report and the ledger disagree, and that much is not in question. `classifyRecordForWasteBalance` zeroes the transaction amount for every non-`INCLUDED` outcome, and `period-status.js:245` derives the ledger's `tonnageDelta` from that amount — so **the waste balance itself does not currently deduct an out-of-window sent-on load**, while the report deducts its full tonnage.

This PR resolves the disagreement by making the report follow the ledger. The alternative reading is that the ledger is the component in the wrong: if a sent-on load should always deduct, the defect is in `sent-on-loads.js` classifying an out-of-window load `IGNORED`, and correcting it would change real waste balances rather than only a report. That is a materially larger change and is not what this PR does.

Until the business confirms which behaviour is intended, this stays parked.

## The basis chosen for the deduction

The report carries a gross figure and a classification-filtered figure on the credit side, but only one figure on the deduction side, so the fix had to pick a basis for it. It now carries the filtered basis, which pairs with `eligibleForWasteBalance` and makes the net reconcile. The consequence is that `totalCredited - sentOnDeductions` is no longer gross-minus-gross, and the gross sent-on tonnage is no longer reported anywhere.

That is deliberate rather than incidental. The admin frontend renders all three figures verbatim — the table and the CSV builder both format them straight through with no arithmetic — so each figure stands alone and none of the pairings is computed for us. Restoring symmetry would mean a fourth `totalSentOn` field carrying the deduction-side data-quality signal, which nothing has asked for; noting it here so the asymmetry is a recorded decision rather than something rediscovered as a defect later.

Splitting `RowContribution` into crediting and deducting variants keeps the tonnage column on the only rows that still read it, so reading it on a deduction is a type error rather than a latent bug.

Two things guard the deduction now: the `INCLUDED` gate, and reading the transaction amount rather than the raw column. Given `classifyRecordForWasteBalance` coerces the transaction amount to zero for every non-`INCLUDED` outcome, either alone would fix the reported defect — they are redundant with each other while that invariant holds. Both are kept deliberately: the gate states the intent the crediting side already states, and the amount is what the balance was actually moved by, so a stored row that violates the coupling (the collection does hold rows from a since-removed one-shot backfill) still cannot deduct tonnage the balance never lost.

## Note on the ticket's second observation

The ticket asked that the `eligibleForWasteBalance`-is-credits-only point be confirmed as intended rather than fixed blind. This PR does not change it — the field stays credits-only — and by making the deduction classification-filtered it makes `eligibleForWasteBalance - sentOnDeductions` the meaningful pairing, which answers the question by construction. Flagging it explicitly so the answer is stated rather than left implicit in the diff.

## Interaction with PR #1535

[PR #1535](https://github.com/DEFRA/epr-backend/pull/1535) (PAE-1766) touches this file too, though only its doc comments — on the same lines this PR edits, so whichever lands second needs a trivial rebase. The two are complementary: this PR makes the deduction consult the classification, #1535 makes that classification live. The wording here deliberately avoids claiming whether the classification was stamped at submission or derived live, because the deduction rule holds either way.
