### PR TITLE
PAE-1652: Block unsubmit on reports marked as requiring resubmission

### DIFF
--- a/src/reports/routes/unsubmit.js
+++ b/src/reports/routes/unsubmit.js
@@ -5,6 +5,7 @@ import { SCOPES } from '#common/helpers/auth/constants.js'
 import { auditReportStatusTransition } from '#reports/application/audit.js'
 import { fetchReportBySubmissionNumber } from '#reports/application/report-service.js'
 import { isLatestSubmission } from '#reports/application/resubmission-service.js'
+import { isResubmissionRequired } from '#reports/domain/resubmission.js'
 import {
   REPORT_STATUS,
   REPORT_STATUS_SLOT
@@ -60,6 +61,14 @@ export const reportsUnsubmit = {
     if (report.status.currentStatus !== REPORT_STATUS.SUBMITTED) {
       throw Boom.conflict(
         `Cannot unsubmit a report with status '${report.status.currentStatus}'`
+      )
+    }
+
+    // An operator has already been asked to resubmit this report. Unsubmitting
+    // it now would silently clear that outstanding requirement.
+    if (isResubmissionRequired(report.resubmissionRequired)) {
+      throw Boom.conflict(
+        `Cannot unsubmit submission ${submissionNumber}: it is marked as requiring resubmission`
       )
     }
 

--- a/src/reports/routes/unsubmit.test.js
+++ b/src/reports/routes/unsubmit.test.js
@@ -357,6 +357,34 @@ describe(`POST ${reportsUnsubmitPath}`, () => {
 
         expect(response.statusCode).toBe(StatusCodes.CONFLICT)
       })
+
+      it('returns 409 when report is marked as requiring resubmission', async () => {
+        const { server, organisationId, registrationId, reportsRepository } =
+          await buildServerWithSubmittedReport()
+
+        const flagged =
+          await reportsRepository.markSubmittedReportRequiringResubmissionByOperator(
+            {
+              organisationId,
+              registrationId,
+              year: 2024,
+              cadence: 'monthly',
+              period: 1,
+              submissionNumber: 1,
+              requestedBy: DEFAULT_CHANGED_BY,
+              requestedAt: new Date().toISOString()
+            }
+          )
+        expect(flagged).not.toBeNull()
+
+        const response = await server.inject({
+          method: 'POST',
+          url: makeUrl(organisationId, registrationId),
+          ...asServiceMaintainer()
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+      })
     })
 
     describe('superseded submission', () => {


### PR DESCRIPTION
Ticket: [PAE-1652](https://eaflood.atlassian.net/browse/PAE-1652)
- Reject unsubmit with 409 when the target submission has an outstanding operator-requested resubmission requirement, preventing that requirement from being silently cleared
- Add test coverage for the new conflict case

[PAE-1652]: https://eaflood.atlassian.net/browse/PAE-1652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ