### PR TITLE
PAE-1595: Derive row continuity from submitted row states

### DIFF
--- a/src/application/summary-logs/ledger-id.js
+++ b/src/application/summary-logs/ledger-id.js
@@ -1,0 +1,22 @@
+/** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {WasteBalanceLedgerId} from '#waste-balances/repository/ledger-schema.js' */
+/** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
+
+/**
+ * The ledger identity a summary log's reads and writes pivot on: the
+ * organisation and registration it belongs to, and the accreditation whose
+ * stream the submit path appended to — the summary log's own accreditationId
+ * when present, otherwise the registration's, or null in the registered-only
+ * phase. Carries the full ancestor chain so a read pivots on the same stream
+ * the write appended to, dropping no id above it.
+ *
+ * @param {SubmittedSummaryLog} summaryLog
+ * @param {Registration | undefined} registration
+ * @returns {WasteBalanceLedgerId}
+ */
+export const ledgerIdFor = (summaryLog, registration) => ({
+  organisationId: summaryLog.organisationId,
+  registrationId: summaryLog.registrationId,
+  accreditationId:
+    summaryLog.accreditationId ?? registration?.accreditationId ?? null
+})

--- a/src/application/summary-logs/transform-and-validate-data.js
+++ b/src/application/summary-logs/transform-and-validate-data.js
@@ -1,0 +1,82 @@
+import { transformFromSummaryLog } from '#application/waste-records/transform-from-summary-log.js'
+import { latestSubmittedSummaryLogRowStates } from '#waste-records/application/read-summary-log-row-states.js'
+import { validateDataBusiness } from './validations/data-business.js'
+import { ledgerIdFor } from './ledger-id.js'
+
+/** @import {ValidatedSummaryLog, ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
+/** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {WasteRecordsRepository} from '#repositories/waste-records/port.js' */
+/** @import {SummaryLogRowStateRepository} from '#waste-records/repository/port.js' */
+/** @import {WasteBalanceLedgerRepository} from '#waste-balances/repository/ledger-port.js' */
+/** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
+
+/**
+ * Transforms the upload's validated rows into waste records and runs data
+ * business validation against the previous submission. Both prior-state reads
+ * live here: the latest submitted summary log's row-state membership (the
+ * continuity baseline) and the registration's existing waste records (the
+ * transform's change/version reconciliation).
+ *
+ * @param {{
+ *   summaryLogId: string,
+ *   summaryLog: SubmittedSummaryLog,
+ *   validatedData: ValidatedSummaryLog,
+ *   registration: Registration | undefined,
+ *   wasteRecordsRepository: WasteRecordsRepository,
+ *   summaryLogRowStateRepository: SummaryLogRowStateRepository,
+ *   ledgerRepository: WasteBalanceLedgerRepository
+ * }} params
+ * @returns {Promise<{
+ *   wasteRecords: ValidatedWasteRecord[],
+ *   issues: ValidationIssuesCollector
+ * }>}
+ */
+export const transformAndValidateData = async ({
+  summaryLogId,
+  summaryLog,
+  validatedData,
+  registration,
+  wasteRecordsRepository,
+  summaryLogRowStateRepository,
+  ledgerRepository
+}) => {
+  const previousSubmission = await latestSubmittedSummaryLogRowStates({
+    ...ledgerIdFor(summaryLog, registration),
+    ledgerRepository,
+    summaryLogRowStateRepository
+  })
+
+  const existingWasteRecords = await wasteRecordsRepository.findByRegistration(
+    summaryLog.organisationId,
+    summaryLog.registrationId
+  )
+
+  const existingRecordsMap = new Map(
+    existingWasteRecords.map((record) => [
+      `${record.type}:${record.rowId}`,
+      record
+    ])
+  )
+
+  // Timestamp is required but won't be persisted during validation
+  /** @type {ValidatedWasteRecord[]} */
+  const wasteRecords = transformFromSummaryLog(
+    validatedData,
+    {
+      summaryLog: {
+        id: summaryLogId,
+        uri: summaryLog.file.uri
+      },
+      organisationId: summaryLog.organisationId,
+      registrationId: summaryLog.registrationId,
+      accreditationId: summaryLog.accreditationId,
+      timestamp: new Date().toISOString()
+    },
+    existingRecordsMap
+  )
+
+  const issues = validateDataBusiness({ wasteRecords, previousSubmission })
+
+  return { wasteRecords, issues }
+}

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -14,7 +14,10 @@ import {
 import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 
 import { transformFromSummaryLog } from '#application/waste-records/transform-from-summary-log.js'
-import { summaryLogRowStatesForRegistration } from '#waste-records/application/read-summary-log-row-states.js'
+import {
+  latestSubmittedSummaryLogRowStates,
+  summaryLogRowStatesForRegistration
+} from '#waste-records/application/read-summary-log-row-states.js'
 import { SUMMARY_LOG_META_FIELDS } from '#domain/summary-logs/meta-fields.js'
 import {
   findSchemaForProcessingType,
@@ -52,6 +55,7 @@ export { MAX_ACTUAL_LENGTH } from './cap-issues-for-storage.js'
 /** @import {WasteRecordsRepository} from '#repositories/waste-records/port.js' */
 /** @import {SummaryLogRowStateRepository} from '#waste-records/repository/port.js' */
 /** @import {WasteBalanceLedgerRepository} from '#waste-balances/repository/ledger-port.js' */
+/** @import {PreviousSubmission} from '#waste-records/application/read-summary-log-row-states.js' */
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 /** @import {SummaryLogExtractor} from './extractor.js' */
 /** @import {Loads} from './load-counts.js' */
@@ -87,11 +91,24 @@ const extractSummaryLog = async ({
 }
 
 /**
+ * The accreditation the ledger reads pivot on — the summary log's own
+ * accreditationId when present, otherwise the registration's — so a read pivots
+ * on the same stream the submit path appended to.
+ *
+ * @param {SubmittedSummaryLog} summaryLog
+ * @param {Registration | undefined} registration
+ * @returns {string | null}
+ */
+const ledgerAccreditationId = (summaryLog, registration) =>
+  summaryLog.accreditationId ?? registration?.accreditationId ?? null
+
+/**
  * @param {{
  *   summaryLogId: string,
  *   summaryLog: SubmittedSummaryLog,
  *   validatedData: ValidatedSummaryLog,
- *   wasteRecordsRepository: WasteRecordsRepository
+ *   wasteRecordsRepository: WasteRecordsRepository,
+ *   previousSubmission: PreviousSubmission | null
  * }} params
  * @returns {Promise<{
  *   wasteRecords: ValidatedWasteRecord[],
@@ -102,7 +119,8 @@ const transformAndValidateData = async ({
   summaryLogId,
   summaryLog,
   validatedData,
-  wasteRecordsRepository
+  wasteRecordsRepository,
+  previousSubmission
 }) => {
   // Fetch existing records and build lookup map for transformation
   const existingWasteRecords = await wasteRecordsRepository.findByRegistration(
@@ -136,7 +154,7 @@ const transformAndValidateData = async ({
   )
 
   // Data business validation using waste records
-  const issues = validateDataBusiness({ wasteRecords, existingWasteRecords })
+  const issues = validateDataBusiness({ wasteRecords, previousSubmission })
 
   return { wasteRecords, issues }
 }
@@ -290,6 +308,8 @@ const markIgnoredByDateRange = (
  *   summaryLogExtractor: SummaryLogExtractor,
  *   organisationsRepository: OrganisationsRepository,
  *   wasteRecordsRepository: WasteRecordsRepository,
+ *   summaryLogRowStateRepository: SummaryLogRowStateRepository,
+ *   ledgerRepository: WasteBalanceLedgerRepository,
  *   validateDataSyntax: (parsed: ParsedSummaryLog) => { issues: ValidationIssuesCollector, validatedData: ValidatedSummaryLog }
  * }} params
  * @returns {Promise<ValidationResult>}
@@ -302,6 +322,8 @@ const performValidationChecks = async ({
   summaryLogExtractor,
   organisationsRepository,
   wasteRecordsRepository,
+  summaryLogRowStateRepository,
+  ledgerRepository,
   validateDataSyntax
 }) => {
   const issues = createValidationIssues()
@@ -357,11 +379,20 @@ const performValidationChecks = async ({
       return { issues, wasteRecords, meta, registration }
     }
 
+    const previousSubmission = await latestSubmittedSummaryLogRowStates({
+      ledgerRepository,
+      summaryLogRowStateRepository,
+      organisationId: summaryLog.organisationId,
+      registrationId: summaryLog.registrationId,
+      accreditationId: ledgerAccreditationId(summaryLog, registration)
+    })
+
     const dataResult = await transformAndValidateData({
       summaryLogId,
       summaryLog,
       validatedData,
-      wasteRecordsRepository
+      wasteRecordsRepository,
+      previousSubmission
     })
 
     wasteRecords = dataResult.wasteRecords
@@ -572,8 +603,7 @@ const loadSubmittedRowStatesByKey = async ({
     summaryLogRowStateRepository,
     organisationId: summaryLog.organisationId,
     registrationId: summaryLog.registrationId,
-    accreditationId:
-      summaryLog.accreditationId ?? registration?.accreditationId ?? null
+    accreditationId: ledgerAccreditationId(summaryLog, registration)
   })
 
   return new Map(
@@ -707,6 +737,8 @@ export const createSummaryLogsValidator = ({
         summaryLogExtractor,
         organisationsRepository,
         wasteRecordsRepository,
+        summaryLogRowStateRepository,
+        ledgerRepository,
         validateDataSyntax
       })
 

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -13,11 +13,7 @@ import {
 } from '#domain/summary-logs/status.js'
 import { PermanentError } from '#server/queue-consumer/permanent-error.js'
 
-import { transformFromSummaryLog } from '#application/waste-records/transform-from-summary-log.js'
-import {
-  latestSubmittedSummaryLogRowStates,
-  summaryLogRowStatesForRegistration
-} from '#waste-records/application/read-summary-log-row-states.js'
+import { summaryLogRowStatesForRegistration } from '#waste-records/application/read-summary-log-row-states.js'
 import { SUMMARY_LOG_META_FIELDS } from '#domain/summary-logs/meta-fields.js'
 import {
   findSchemaForProcessingType,
@@ -32,11 +28,12 @@ import {
   resolveOverseasSitesContext
 } from './classify-and-persist.js'
 import { logValidationIssues } from './validate-issue-logging.js'
-import { validateDataBusiness } from './validations/data-business.js'
 import { createDataSyntaxValidator } from './validations/data-syntax.js'
 import { validateMetaBusiness } from './validations/meta-business.js'
 import { validateMetaSyntax } from './validations/meta-syntax.js'
 import { capIssuesForStorage } from './cap-issues-for-storage.js'
+import { transformAndValidateData } from './transform-and-validate-data.js'
+import { ledgerIdFor } from './ledger-id.js'
 
 export { MAX_VALIDATION_ISSUES } from './validate-issue-logging.js'
 export { MAX_ACTUAL_LENGTH } from './cap-issues-for-storage.js'
@@ -55,7 +52,6 @@ export { MAX_ACTUAL_LENGTH } from './cap-issues-for-storage.js'
 /** @import {WasteRecordsRepository} from '#repositories/waste-records/port.js' */
 /** @import {SummaryLogRowStateRepository} from '#waste-records/repository/port.js' */
 /** @import {WasteBalanceLedgerRepository} from '#waste-balances/repository/ledger-port.js' */
-/** @import {PreviousSubmission} from '#waste-records/application/read-summary-log-row-states.js' */
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 /** @import {SummaryLogExtractor} from './extractor.js' */
 /** @import {Loads} from './load-counts.js' */
@@ -88,75 +84,6 @@ const extractSummaryLog = async ({
   })
 
   return parsed
-}
-
-/**
- * The accreditation the ledger reads pivot on — the summary log's own
- * accreditationId when present, otherwise the registration's — so a read pivots
- * on the same stream the submit path appended to.
- *
- * @param {SubmittedSummaryLog} summaryLog
- * @param {Registration | undefined} registration
- * @returns {string | null}
- */
-const ledgerAccreditationId = (summaryLog, registration) =>
-  summaryLog.accreditationId ?? registration?.accreditationId ?? null
-
-/**
- * @param {{
- *   summaryLogId: string,
- *   summaryLog: SubmittedSummaryLog,
- *   validatedData: ValidatedSummaryLog,
- *   wasteRecordsRepository: WasteRecordsRepository,
- *   previousSubmission: PreviousSubmission | null
- * }} params
- * @returns {Promise<{
- *   wasteRecords: ValidatedWasteRecord[],
- *   issues: ValidationIssuesCollector
- * }>}
- */
-const transformAndValidateData = async ({
-  summaryLogId,
-  summaryLog,
-  validatedData,
-  wasteRecordsRepository,
-  previousSubmission
-}) => {
-  // Fetch existing records and build lookup map for transformation
-  const existingWasteRecords = await wasteRecordsRepository.findByRegistration(
-    summaryLog.organisationId,
-    summaryLog.registrationId
-  )
-
-  const existingRecordsMap = new Map(
-    existingWasteRecords.map((record) => [
-      `${record.type}:${record.rowId}`,
-      record
-    ])
-  )
-
-  // Transform validated rows into waste records (issues flow through)
-  // Timestamp is required but won't be persisted during validation
-  /** @type {ValidatedWasteRecord[]} */
-  const wasteRecords = transformFromSummaryLog(
-    validatedData,
-    {
-      summaryLog: {
-        id: summaryLogId,
-        uri: summaryLog.file.uri
-      },
-      organisationId: summaryLog.organisationId,
-      registrationId: summaryLog.registrationId,
-      accreditationId: summaryLog.accreditationId,
-      timestamp: new Date().toISOString()
-    },
-    existingRecordsMap
-  )
-
-  // Data business validation using waste records
-  const issues = validateDataBusiness({ wasteRecords, previousSubmission })
-
-  return { wasteRecords, issues }
 }
 
 /**
@@ -379,20 +306,14 @@ const performValidationChecks = async ({
       return { issues, wasteRecords, meta, registration }
     }
 
-    const previousSubmission = await latestSubmittedSummaryLogRowStates({
-      ledgerRepository,
-      summaryLogRowStateRepository,
-      organisationId: summaryLog.organisationId,
-      registrationId: summaryLog.registrationId,
-      accreditationId: ledgerAccreditationId(summaryLog, registration)
-    })
-
     const dataResult = await transformAndValidateData({
       summaryLogId,
       summaryLog,
       validatedData,
+      registration,
       wasteRecordsRepository,
-      previousSubmission
+      summaryLogRowStateRepository,
+      ledgerRepository
     })
 
     wasteRecords = dataResult.wasteRecords
@@ -580,10 +501,6 @@ const persistValidationResult = async ({
  * by `${wasteRecordType}:${rowId}` — the baseline the check-page projections
  * classify this upload's rows against.
  *
- * The accreditation is resolved the same way the submit path partitions the
- * ledger — the summary log's own accreditationId when present, otherwise the
- * registration's — so the read pivots on the same stream the write appended to.
- *
  * @param {{
  *   ledgerRepository: WasteBalanceLedgerRepository,
  *   summaryLogRowStateRepository: SummaryLogRowStateRepository,
@@ -599,11 +516,9 @@ const loadSubmittedRowStatesByKey = async ({
   registration
 }) => {
   const submittedRowStates = await summaryLogRowStatesForRegistration({
+    ...ledgerIdFor(summaryLog, registration),
     ledgerRepository,
-    summaryLogRowStateRepository,
-    organisationId: summaryLog.organisationId,
-    registrationId: summaryLog.registrationId,
-    accreditationId: ledgerAccreditationId(summaryLog, registration)
+    summaryLogRowStateRepository
   })
 
   return new Map(

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -13,9 +13,48 @@ import {
 import { createEmptyLoadValidity } from './load-counts.js'
 import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
+import { LEDGER_EVENT_KIND } from '#waste-balances/repository/ledger-schema.js'
+import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
 import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { buildSummaryLogRowStateEntry } from '#waste-records/repository/test-data.js'
 
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
+/** @import {WasteBalanceLedgerId} from '#waste-balances/repository/ledger-schema.js' */
+
+/**
+ * Seed a submitted summary log for a ledger: its row states and the
+ * SUMMARY_LOG_SUBMITTED ledger event that resolves it as the head.
+ *
+ * @param {Object} params
+ * @param {WasteBalanceLedgerId} params.ledgerId
+ * @param {string} params.summaryLogId
+ * @param {number} params.number - the submission's ledger position
+ * @param {Array<{ rowId: string, wasteRecordType?: string }>} params.rows
+ * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} params.summaryLogRowStateRepository
+ * @param {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} params.ledgerRepository
+ */
+const seedSubmittedSummaryLog = async ({
+  ledgerId,
+  summaryLogId,
+  number,
+  rows,
+  summaryLogRowStateRepository,
+  ledgerRepository
+}) => {
+  await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+    ledgerId,
+    rows.map((row) => buildSummaryLogRowStateEntry(row)),
+    summaryLogId
+  )
+  await ledgerRepository.appendEvents([
+    buildLedgerEvent({
+      ...ledgerId,
+      number,
+      kind: LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
+      payload: { summaryLogId, creditTotal: 0 }
+    })
+  ])
+}
 
 // ============================================================================
 // Test Builders
@@ -2087,12 +2126,27 @@ describe('SummaryLogsValidator', () => {
         })
       )
 
-      // An existing waste record whose ROW_ID is NOT in the current upload
+      // The legacy waste-records collection still feeds the transform's
+      // change/version reconciliation during the ADR-0037 transition.
+      wasteRecordsRepository.findByRegistration.mockResolvedValue([
+        buildExistingWasteRecord(buildReceivedLoadRow({ ROW_ID: 10000 }))
+      ])
+
+      // A previously submitted row whose ROW_ID is NOT in the current upload
       // triggers a fatal SEQUENTIAL_ROW_REMOVED error during data-business
       // validation — appended AFTER the 130+ non-fatal data-syntax issues.
-      wasteRecordsRepository.findByRegistration.mockResolvedValue([
-        buildExistingWasteRecord(buildReceivedLoadRow({ ROW_ID: 99999 }))
-      ])
+      await seedSubmittedSummaryLog({
+        ledgerId: {
+          organisationId: 'org-123',
+          registrationId: 'reg-123',
+          accreditationId: null
+        },
+        summaryLogId: 'previous-summary-log',
+        number: 1,
+        rows: [{ rowId: '99999' }],
+        summaryLogRowStateRepository,
+        ledgerRepository
+      })
 
       await validateSummaryLog(summaryLogId)
 
@@ -2112,6 +2166,98 @@ describe('SummaryLogsValidator', () => {
 
       // Status should be invalid (the fatal was detected pre-cap)
       expect(updateCall.status).toBe(SUMMARY_LOG_STATUS.INVALID)
+    })
+  })
+
+  describe('row continuity across submitted summary logs', () => {
+    const sequentialRowRemovedFatal = () => {
+      const updateCall = summaryLogsRepository.update.mock.calls[0][2]
+      return updateCall.validation.issues.find(
+        (issue) => issue.code === 'SEQUENTIAL_ROW_REMOVED'
+      )
+    }
+
+    it('rejects an upload that drops a row the latest submission carried, naming that submission', async () => {
+      await seedSubmittedSummaryLog({
+        ledgerId: {
+          organisationId: 'org-123',
+          registrationId: 'reg-123',
+          accreditationId: null
+        },
+        summaryLogId: 'previous-log',
+        number: 1,
+        rows: [{ rowId: 'A' }],
+        summaryLogRowStateRepository,
+        ledgerRepository
+      })
+
+      await validateSummaryLog(summaryLogId)
+
+      const fatal = sequentialRowRemovedFatal()
+      expect(fatal).toBeDefined()
+      expect(fatal.context.location.rowId).toBe('A')
+      expect(fatal.context.previousSummaryLog.id).toBe('previous-log')
+    })
+
+    it('resolves the previous submission on the accreditation the summary log was uploaded against', async () => {
+      summaryLog.accreditationId = 'acc-1'
+
+      await seedSubmittedSummaryLog({
+        ledgerId: {
+          organisationId: 'org-123',
+          registrationId: 'reg-123',
+          accreditationId: 'acc-1'
+        },
+        summaryLogId: 'previous-log',
+        number: 1,
+        rows: [{ rowId: 'A' }],
+        summaryLogRowStateRepository,
+        ledgerRepository
+      })
+
+      await validateSummaryLog(summaryLogId)
+
+      const fatal = sequentialRowRemovedFatal()
+      expect(fatal).toBeDefined()
+      expect(fatal.context.previousSummaryLog.id).toBe('previous-log')
+    })
+
+    it('names the latest submission, not the one that first wrote the row', async () => {
+      const ledgerId = {
+        organisationId: 'org-123',
+        registrationId: 'reg-123',
+        accreditationId: null
+      }
+      await seedSubmittedSummaryLog({
+        ledgerId,
+        summaryLogId: 'log-1',
+        number: 1,
+        rows: [{ rowId: 'A' }],
+        summaryLogRowStateRepository,
+        ledgerRepository
+      })
+      await seedSubmittedSummaryLog({
+        ledgerId,
+        summaryLogId: 'log-2',
+        number: 2,
+        rows: [{ rowId: 'A' }],
+        summaryLogRowStateRepository,
+        ledgerRepository
+      })
+
+      await validateSummaryLog(summaryLogId)
+
+      const fatal = sequentialRowRemovedFatal()
+      expect(fatal).toBeDefined()
+      expect(fatal.context.previousSummaryLog.id).toBe('log-2')
+    })
+
+    it('accepts an upload when the registration has never submitted', async () => {
+      await validateSummaryLog(summaryLogId)
+
+      expect(sequentialRowRemovedFatal()).toBeUndefined()
+      const updateCall = summaryLogsRepository.update.mock.calls[0][2]
+      expect(updateCall.status).toBe(SUMMARY_LOG_STATUS.VALIDATED)
     })
   })
 })

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -2126,8 +2126,9 @@ describe('SummaryLogsValidator', () => {
         })
       )
 
-      // The legacy waste-records collection still feeds the transform's
-      // change/version reconciliation during the ADR-0037 transition.
+      // The transform's change/version reconciliation reads the waste-records
+      // collection; the continuity check reads submitted row states. This test
+      // seeds both so the truncation assertion exercises the real transform.
       wasteRecordsRepository.findByRegistration.mockResolvedValue([
         buildExistingWasteRecord(buildReceivedLoadRow({ ROW_ID: 10000 }))
       ])

--- a/src/application/summary-logs/validations/data-business.js
+++ b/src/application/summary-logs/validations/data-business.js
@@ -3,7 +3,7 @@ import { validateRowContinuity } from './row-continuity.js'
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
-/** @import {WasteRecord} from '#domain/waste-records/model.js' */
+/** @import {PreviousSubmission} from '#waste-records/application/read-summary-log-row-states.js' */
 
 /**
  * Validates data business rules
@@ -22,13 +22,10 @@ import { validateRowContinuity } from './row-continuity.js'
  *
  * @param {Object} params
  * @param {ValidatedWasteRecord[]} params.wasteRecords - Waste records from the current upload
- * @param {WasteRecord[]} params.existingWasteRecords - Existing waste records from previous uploads
+ * @param {PreviousSubmission | null} params.previousSubmission - The latest submitted summary log with its row states, or null when the registration has never submitted
  * @returns {ValidationIssuesCollector} Validation issues object
  */
-export const validateDataBusiness = ({
-  wasteRecords,
-  existingWasteRecords
-}) => {
+export const validateDataBusiness = ({ wasteRecords, previousSubmission }) => {
   const issues = createValidationIssues()
 
   for (const validate of [
@@ -38,7 +35,7 @@ export const validateDataBusiness = ({
     // validateTonnageAccuracy,
     // etc.
   ]) {
-    issues.merge(validate({ wasteRecords, existingWasteRecords }))
+    issues.merge(validate({ wasteRecords, previousSubmission }))
   }
 
   return issues

--- a/src/application/summary-logs/validations/data-business.test.js
+++ b/src/application/summary-logs/validations/data-business.test.js
@@ -1,10 +1,10 @@
 import { validateDataBusiness } from './data-business.js'
-import {
-  VERSION_STATUS,
-  WASTE_RECORD_TYPE
-} from '#domain/waste-records/model.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 
 /** @import { ValidatedWasteRecord } from '#application/waste-records/transform-from-summary-log.js' */
+/** @import { PreviousSubmission, WasteRecordState } from '#waste-records/application/read-summary-log-row-states.js' */
 
 describe('validateDataBusiness', () => {
   /**
@@ -12,13 +12,11 @@ describe('validateDataBusiness', () => {
    * @param {Object} options
    * @param {string} options.rowId - The row ID
    * @param {string} [options.type] - The waste record type
-   * @param {Array} [options.issues] - Validation issues
    * @returns {ValidatedWasteRecord}
    */
   const createValidatedWasteRecord = ({
     rowId,
-    type = WASTE_RECORD_TYPE.RECEIVED,
-    issues = []
+    type = WASTE_RECORD_TYPE.RECEIVED
   }) =>
     /** @type {ValidatedWasteRecord} */ (
       /** @type {unknown} */ ({
@@ -33,66 +31,47 @@ describe('validateDataBusiness', () => {
             DATE_RECEIVED_FOR_REPROCESSING: '2024-01-15',
             GROSS_WEIGHT: 100
           },
-          versions: [
-            {
-              createdAt: new Date().toISOString(),
-              status: VERSION_STATUS.CREATED,
-              summaryLog: {
-                id: 'current-summary-log-id',
-                uri: 's3://bucket/current-file.xlsx'
-              },
-              data: {
-                ROW_ID: rowId,
-                DATE_RECEIVED_FOR_REPROCESSING: '2024-01-15',
-                GROSS_WEIGHT: 100
-              }
-            }
-          ]
+          versions: []
         },
-        issues
+        issues: []
       })
     )
 
   /**
-   * Creates an existing waste record for testing
-   * @param {string} rowId - The row ID
-   * @returns {Object} Waste record
+   * @param {string} rowId
+   * @returns {WasteRecordState}
    */
-  const createWasteRecord = (rowId) => ({
-    organisationId: 'org-456',
-    registrationId: 'reg-789',
-    accreditationId: 'acc-111',
+  const createWasteRecordState = (rowId) => ({
     rowId,
-    type: WASTE_RECORD_TYPE.RECEIVED,
+    wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+    processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
     data: {
-      ROW_ID: rowId,
       DATE_RECEIVED_FOR_REPROCESSING: '2024-01-15',
       GROSS_WEIGHT: 100
     },
-    versions: [
-      {
-        createdAt: '2024-01-15T10:00:00.000Z',
-        status: VERSION_STATUS.CREATED,
-        summaryLog: {
-          id: 'previous-summary-log-id',
-          uri: 's3://bucket/previous-file.xlsx'
-        },
-        data: {
-          ROW_ID: rowId,
-          DATE_RECEIVED_FOR_REPROCESSING: '2024-01-15',
-          GROSS_WEIGHT: 100
-        }
-      }
-    ]
+    classification: {
+      outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
+      reasons: [],
+      transactionAmount: 100
+    }
+  })
+
+  /**
+   * @param {WasteRecordState[]} wasteRecordStates
+   * @returns {PreviousSubmission}
+   */
+  const createPreviousSubmission = (wasteRecordStates) => ({
+    summaryLog: {
+      summaryLogId: 'previous-summary-log-id',
+      submittedAt: new Date('2024-01-15T10:00:00.000Z')
+    },
+    wasteRecordStates
   })
 
   it('returns valid result when validators pass', () => {
-    const wasteRecords = [createValidatedWasteRecord({ rowId: 'row-1' })]
-    const existingWasteRecords = []
-
     const result = validateDataBusiness({
-      wasteRecords,
-      existingWasteRecords
+      wasteRecords: [createValidatedWasteRecord({ rowId: 'row-1' })],
+      previousSubmission: null
     })
 
     expect(result.isValid()).toBe(true)
@@ -101,17 +80,12 @@ describe('validateDataBusiness', () => {
   })
 
   it('returns invalid result when validators fail', () => {
-    const wasteRecords = [
-      createValidatedWasteRecord({ rowId: 'row-2' }) // row-1 is missing
-    ]
-    const existingWasteRecords = [
-      createWasteRecord('row-1'),
-      createWasteRecord('row-2')
-    ]
-
     const result = validateDataBusiness({
-      wasteRecords,
-      existingWasteRecords
+      wasteRecords: [createValidatedWasteRecord({ rowId: 'row-2' })],
+      previousSubmission: createPreviousSubmission([
+        createWasteRecordState('row-1'),
+        createWasteRecordState('row-2')
+      ])
     })
 
     expect(result.isValid()).toBe(false)

--- a/src/application/summary-logs/validations/row-continuity.js
+++ b/src/application/summary-logs/validations/row-continuity.js
@@ -10,10 +10,17 @@ import {
 
 /** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
-/** @import {WasteRecord} from '#domain/waste-records/model.js' */
+/** @import {PreviousSubmission} from '#waste-records/application/read-summary-log-row-states.js' */
 
 /**
- * Validates that no rows from previous uploads have been removed
+ * @param {string} wasteRecordType
+ * @param {string} rowId
+ * @returns {string}
+ */
+const rowKey = (wasteRecordType, rowId) => `${wasteRecordType}:${rowId}`
+
+/**
+ * Validates that no rows from the previous submission have been removed
  *
  * This validation ensures data integrity across sequential summary log submissions.
  * Once a waste balance entry has been submitted, it cannot be removed in future uploads.
@@ -22,73 +29,56 @@ import {
  * - Updated (corrections to existing entries)
  * - Unchanged (carried forward as-is)
  *
- * Only applies to subsequent uploads (not first-time uploads).
- * Missing rows result in FATAL errors that block submission.
+ * The rows that must be carried forward are the row states of the registration's
+ * latest submitted summary log, and that summary log is the one the FATAL names.
+ * Only applies to subsequent uploads (not first-time uploads). Missing rows result
+ * in FATAL errors that block submission.
  *
  * @param {Object} params
  * @param {ValidatedWasteRecord[]} params.wasteRecords - Waste records from the current upload
- * @param {WasteRecord[] | null | undefined} params.existingWasteRecords - Existing waste records from previous uploads
+ * @param {PreviousSubmission | null} params.previousSubmission - The latest submitted summary log with its row states, or null when the registration has never submitted
  * @returns {ValidationIssuesCollector} Validation issues object
  */
-export const validateRowContinuity = ({
-  wasteRecords,
-  existingWasteRecords
-}) => {
+export const validateRowContinuity = ({ wasteRecords, previousSubmission }) => {
   const issues = createValidationIssues()
 
-  if (!existingWasteRecords || existingWasteRecords.length === 0) {
+  if (previousSubmission === null) {
     return issues
   }
 
-  const existingRowKeys = new Set(
-    existingWasteRecords.map((record) => `${record.type}:${record.rowId}`)
+  const { summaryLog, wasteRecordStates } = previousSubmission
+
+  const uploadedRowKeys = new Set(
+    wasteRecords.map(({ record }) => rowKey(record.type, String(record.rowId)))
   )
 
-  const existingRecordsMap = new Map(
-    existingWasteRecords.map((record) => [
-      `${record.type}:${record.rowId}`,
-      record
-    ])
+  const removedRowStates = wasteRecordStates.filter(
+    ({ wasteRecordType, rowId }) =>
+      !uploadedRowKeys.has(rowKey(wasteRecordType, rowId))
   )
 
-  const newRowKeys = new Set(
-    wasteRecords.map(({ record }) => `${record.type}:${record.rowId}`)
-  )
+  for (const { wasteRecordType, rowId } of removedRowStates) {
+    const match = findSchemaByWasteRecordType(
+      wasteRecordType,
+      PROCESSING_TYPE_TABLES
+    )
 
-  const missingRowKeys = [...existingRowKeys].filter(
-    (key) => !newRowKeys.has(key)
-  )
-
-  if (missingRowKeys.length > 0) {
-    for (const missingKey of missingRowKeys) {
-      const [type, rowId] = missingKey.split(':')
-      // Key came from existingRowKeys derived from same source as map, so guaranteed to exist
-      const originalRecord = /** @type {WasteRecord} */ (
-        existingRecordsMap.get(missingKey)
-      )
-
-      const lastVersion =
-        originalRecord.versions[originalRecord.versions.length - 1]
-
-      const match = findSchemaByWasteRecordType(type, PROCESSING_TYPE_TABLES)
-
-      issues.addFatal(
-        VALIDATION_CATEGORY.BUSINESS,
-        `Row '${rowId}' from a previous summary log submission cannot be removed. All previously submitted rows must be included in subsequent uploads.`,
-        VALIDATION_CODE.SEQUENTIAL_ROW_REMOVED,
-        {
-          location: {
-            sheet: match?.schema.sheetName ?? 'Unknown',
-            table: match?.tableName ?? 'Unknown',
-            rowId
-          },
-          previousSummaryLog: {
-            id: lastVersion.summaryLog.id,
-            submittedAt: lastVersion.createdAt
-          }
+    issues.addFatal(
+      VALIDATION_CATEGORY.BUSINESS,
+      `Row '${rowId}' from a previous summary log submission cannot be removed. All previously submitted rows must be included in subsequent uploads.`,
+      VALIDATION_CODE.SEQUENTIAL_ROW_REMOVED,
+      {
+        location: {
+          sheet: match?.schema.sheetName ?? 'Unknown',
+          table: match?.tableName ?? 'Unknown',
+          rowId
+        },
+        previousSummaryLog: {
+          id: summaryLog.summaryLogId,
+          submittedAt: summaryLog.submittedAt.toISOString()
         }
-      )
-    }
+      }
+    )
   }
 
   return issues

--- a/src/application/summary-logs/validations/row-continuity.js
+++ b/src/application/summary-logs/validations/row-continuity.js
@@ -49,7 +49,7 @@ export const validateRowContinuity = ({ wasteRecords, previousSubmission }) => {
   const { summaryLog, wasteRecordStates } = previousSubmission
 
   const uploadedRowKeys = new Set(
-    wasteRecords.map(({ record }) => rowKey(record.type, String(record.rowId)))
+    wasteRecords.map(({ record }) => rowKey(record.type, record.rowId))
   )
 
   const removedRowStates = wasteRecordStates.filter(

--- a/src/application/summary-logs/validations/row-continuity.test.js
+++ b/src/application/summary-logs/validations/row-continuity.test.js
@@ -295,6 +295,28 @@ describe('validateRowContinuity', () => {
       expect(fatals[0]?.context?.location?.sheet).toBe('Received')
     })
 
+    it('treats the same rowId under a different waste record type as a distinct row', () => {
+      const result = validateRowContinuity({
+        wasteRecords: [
+          createValidatedWasteRecord({
+            rowId: 'row-1',
+            type: WASTE_RECORD_TYPE.RECEIVED
+          })
+        ],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1', WASTE_RECORD_TYPE.PROCESSED)
+        ])
+      })
+
+      expect(result.isValid()).toBe(false)
+      expect(result.isFatal()).toBe(true)
+
+      const fatals = result.getIssuesBySeverity(VALIDATION_SEVERITY.FATAL)
+      expect(fatals).toHaveLength(1)
+      expect(fatals[0]?.context?.location?.rowId).toBe('row-1')
+      expect(fatals[0]?.context?.location?.sheet).toBe('Processed')
+    })
+
     it('correctly maps different waste record types to sheets and tables from the schema registry', () => {
       const testCases = [
         {

--- a/src/application/summary-logs/validations/row-continuity.test.js
+++ b/src/application/summary-logs/validations/row-continuity.test.js
@@ -4,75 +4,32 @@ import {
   VALIDATION_SEVERITY
 } from '#common/enums/validation.js'
 import {
-  VERSION_STATUS,
+  WASTE_RECORD_CHANGE,
   WASTE_RECORD_TYPE
 } from '#domain/waste-records/model.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 
-/**
- * @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js'
- * @import {WasteRecord} from '#domain/waste-records/model.js'
- *
- * @typedef {{ id: string, submittedAt: string }} PreviousSummaryLogRef
- */
+/** @import {ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
+/** @import {WasteRecordType} from '#domain/waste-records/model.js' */
+/** @import {PreviousSubmission, WasteRecordState} from '#waste-records/application/read-summary-log-row-states.js' */
+
+const PREVIOUS_SUMMARY_LOG_ID = 'previous-summary-log-id'
+const PREVIOUS_SUBMITTED_AT = new Date('2024-01-15T10:00:00.000Z')
 
 describe('validateRowContinuity', () => {
   /**
-   * Creates a transformed record for testing
-   * @param {Object} options
-   * @param {string} options.rowId - The row ID
-   * @param {string} [options.type] - The waste record type
-   * @param {Array} [options.issues] - Validation issues
+   * A transformed record from the upload under validation
+   *
+   * @param {{ rowId: string, type?: WasteRecordType }} options
    * @returns {ValidatedWasteRecord}
    */
   const createValidatedWasteRecord = ({
     rowId,
-    type = WASTE_RECORD_TYPE.RECEIVED,
-    issues = []
-  }) =>
-    /** @type {ValidatedWasteRecord} */ ({
-      record: {
-        organisationId: 'org-456',
-        registrationId: 'reg-789',
-        accreditationId: 'acc-111',
-        rowId,
-        type,
-        data: {
-          ROW_ID: rowId,
-          DATE_RECEIVED_FOR_REPROCESSING: '2024-01-15',
-          GROSS_WEIGHT: 100
-        },
-        versions: [
-          {
-            createdAt: new Date().toISOString(),
-            status: VERSION_STATUS.CREATED,
-            summaryLog: {
-              id: 'current-summary-log-id',
-              uri: 's3://bucket/current-file.xlsx'
-            },
-            data: {
-              ROW_ID: rowId,
-              DATE_RECEIVED_FOR_REPROCESSING: '2024-01-15',
-              GROSS_WEIGHT: 100
-            }
-          }
-        ]
-      },
-      issues
-    })
-
-  /**
-   * Creates an existing waste record for testing
-   * @param {string} rowId - The row ID
-   * @param {string} [type] - The waste record type
-   * @param {Object} [overrides] - Property overrides
-   * @returns {WasteRecord} Waste record
-   */
-  const createWasteRecord = (
-    rowId,
-    type = WASTE_RECORD_TYPE.RECEIVED,
-    overrides = {}
-  ) =>
-    /** @type {WasteRecord} */ ({
+    type = WASTE_RECORD_TYPE.RECEIVED
+  }) => ({
+    record: {
       organisationId: 'org-456',
       registrationId: 'reg-789',
       accreditationId: 'acc-111',
@@ -83,84 +40,76 @@ describe('validateRowContinuity', () => {
         DATE_RECEIVED_FOR_REPROCESSING: '2024-01-15',
         GROSS_WEIGHT: 100
       },
-      versions: [
-        {
-          createdAt: '2024-01-15T10:00:00.000Z',
-          status: VERSION_STATUS.CREATED,
-          summaryLog: {
-            id: 'previous-summary-log-id',
-            uri: 's3://bucket/previous-file.xlsx'
-          },
-          data: {
-            ROW_ID: rowId,
-            DATE_RECEIVED_FOR_REPROCESSING: '2024-01-15',
-            GROSS_WEIGHT: 100
-          }
-        }
-      ],
-      ...overrides
-    })
+      versions: []
+    },
+    issues: [],
+    outcome: ROW_OUTCOME.INCLUDED,
+    change: WASTE_RECORD_CHANGE.CREATED,
+    tableName: 'RECEIVED_LOADS_FOR_REPROCESSING',
+    wasteRecordType: type
+  })
 
-  describe('first-time uploads (no existing records)', () => {
-    it('returns valid result when no existing records exist', () => {
-      const wasteRecords = [createValidatedWasteRecord({ rowId: 'row-1' })]
-      const existingWasteRecords = []
+  /**
+   * A row state belonging to the latest submitted summary log
+   *
+   * @param {string} rowId
+   * @param {WasteRecordType} [wasteRecordType]
+   * @returns {WasteRecordState}
+   */
+  const createWasteRecordState = (
+    rowId,
+    wasteRecordType = WASTE_RECORD_TYPE.RECEIVED
+  ) => ({
+    rowId,
+    wasteRecordType,
+    processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+    data: {
+      DATE_RECEIVED_FOR_REPROCESSING: '2024-01-15',
+      GROSS_WEIGHT: 100
+    },
+    classification: {
+      outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
+      reasons: [],
+      transactionAmount: 100
+    }
+  })
 
+  /**
+   * @param {WasteRecordState[]} wasteRecordStates
+   * @returns {PreviousSubmission}
+   */
+  const createPreviousSubmission = (wasteRecordStates) => ({
+    summaryLog: {
+      summaryLogId: PREVIOUS_SUMMARY_LOG_ID,
+      submittedAt: PREVIOUS_SUBMITTED_AT
+    },
+    wasteRecordStates
+  })
+
+  describe('first-time uploads (no previously submitted summary log)', () => {
+    it('returns valid result when the registration has never submitted', () => {
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [createValidatedWasteRecord({ rowId: 'row-1' })],
+        previousSubmission: null
       })
 
       expect(result.isValid()).toBe(true)
       expect(result.isFatal()).toBe(false)
       expect(result.hasIssues()).toBe(false)
-    })
-
-    it('returns valid result when existingWasteRecords is null', () => {
-      const wasteRecords = [createValidatedWasteRecord({ rowId: 'row-1' })]
-      const existingWasteRecords = /** @type {WasteRecord[]} */ (
-        /** @type {unknown} */ (null)
-      )
-
-      const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
-      })
-
-      expect(result.isValid()).toBe(true)
-      expect(result.isFatal()).toBe(false)
-    })
-
-    it('returns valid result when existingWasteRecords is undefined', () => {
-      const wasteRecords = [createValidatedWasteRecord({ rowId: 'row-1' })]
-      const existingWasteRecords = /** @type {WasteRecord[]} */ (
-        /** @type {unknown} */ (undefined)
-      )
-
-      const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
-      })
-
-      expect(result.isValid()).toBe(true)
-      expect(result.isFatal()).toBe(false)
     })
   })
 
   describe('subsequent uploads with all rows present', () => {
-    it('returns valid result when all existing rows are present', () => {
-      const wasteRecords = [
-        createValidatedWasteRecord({ rowId: 'row-1' }),
-        createValidatedWasteRecord({ rowId: 'row-2' })
-      ]
-      const existingWasteRecords = [
-        createWasteRecord('row-1'),
-        createWasteRecord('row-2')
-      ]
-
+    it('returns valid result when all previously submitted rows are present', () => {
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [
+          createValidatedWasteRecord({ rowId: 'row-1' }),
+          createValidatedWasteRecord({ rowId: 'row-2' })
+        ],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1'),
+          createWasteRecordState('row-2')
+        ])
       })
 
       expect(result.isValid()).toBe(true)
@@ -168,15 +117,12 @@ describe('validateRowContinuity', () => {
       expect(result.hasIssues()).toBe(false)
     })
 
-    it('returns valid result when existing rows are present with updated values', () => {
-      const wasteRecords = [
-        createValidatedWasteRecord({ rowId: 'row-1' }) // Updated date and tonnage
-      ]
-      const existingWasteRecords = [createWasteRecord('row-1')]
-
+    it('returns valid result when previously submitted rows are present with updated values', () => {
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [createValidatedWasteRecord({ rowId: 'row-1' })],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1')
+        ])
       })
 
       expect(result.isValid()).toBe(true)
@@ -185,20 +131,17 @@ describe('validateRowContinuity', () => {
   })
 
   describe('subsequent uploads with new rows added', () => {
-    it('returns valid result when new rows are added alongside existing rows', () => {
-      const wasteRecords = [
-        createValidatedWasteRecord({ rowId: 'row-1' }), // Existing
-        createValidatedWasteRecord({ rowId: 'row-2' }), // Existing
-        createValidatedWasteRecord({ rowId: 'row-3' }) // New row added
-      ]
-      const existingWasteRecords = [
-        createWasteRecord('row-1'),
-        createWasteRecord('row-2')
-      ]
-
+    it('returns valid result when new rows are added alongside previously submitted rows', () => {
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [
+          createValidatedWasteRecord({ rowId: 'row-1' }),
+          createValidatedWasteRecord({ rowId: 'row-2' }),
+          createValidatedWasteRecord({ rowId: 'row-3' })
+        ],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1'),
+          createWasteRecordState('row-2')
+        ])
       })
 
       expect(result.isValid()).toBe(true)
@@ -206,16 +149,15 @@ describe('validateRowContinuity', () => {
     })
 
     it('returns valid result when only new rows are added', () => {
-      const wasteRecords = [
-        createValidatedWasteRecord({ rowId: 'row-1' }), // Existing
-        createValidatedWasteRecord({ rowId: 'row-3' }), // New
-        createValidatedWasteRecord({ rowId: 'row-4' }) // New
-      ]
-      const existingWasteRecords = [createWasteRecord('row-1')]
-
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [
+          createValidatedWasteRecord({ rowId: 'row-1' }),
+          createValidatedWasteRecord({ rowId: 'row-3' }),
+          createValidatedWasteRecord({ rowId: 'row-4' })
+        ],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1')
+        ])
       })
 
       expect(result.isValid()).toBe(true)
@@ -225,17 +167,12 @@ describe('validateRowContinuity', () => {
 
   describe('subsequent uploads with missing rows', () => {
     it('returns fatal business error when a single row is missing', () => {
-      const wasteRecords = [
-        createValidatedWasteRecord({ rowId: 'row-2' }) // row-1 is missing
-      ]
-      const existingWasteRecords = [
-        createWasteRecord('row-1'),
-        createWasteRecord('row-2')
-      ]
-
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [createValidatedWasteRecord({ rowId: 'row-2' })],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1'),
+          createWasteRecordState('row-2')
+        ])
       })
 
       expect(result.isValid()).toBe(false)
@@ -249,26 +186,16 @@ describe('validateRowContinuity', () => {
       expect(fatals[0]?.message).toContain('cannot be removed')
       expect(fatals[0]?.context?.location?.rowId).toBe('row-1')
       expect(fatals[0]?.context?.location?.sheet).toBe('Received')
-
-      const previousSummaryLog = /** @type {PreviousSummaryLogRef} */ (
-        fatals[0]?.context?.previousSummaryLog
-      )
-      expect(previousSummaryLog.id).toBe('previous-summary-log-id')
     })
 
     it('returns fatal errors for multiple missing rows', () => {
-      const wasteRecords = [
-        createValidatedWasteRecord({ rowId: 'row-2' }) // row-1 and row-3 are missing
-      ]
-      const existingWasteRecords = [
-        createWasteRecord('row-1'),
-        createWasteRecord('row-2'),
-        createWasteRecord('row-3')
-      ]
-
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [createValidatedWasteRecord({ rowId: 'row-2' })],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1'),
+          createWasteRecordState('row-2'),
+          createWasteRecordState('row-3')
+        ])
       })
 
       expect(result.isValid()).toBe(false)
@@ -283,18 +210,13 @@ describe('validateRowContinuity', () => {
       expect(missingRowIds).toEqual(['row-1', 'row-3'])
     })
 
-    it('returns fatal error when all existing rows are removed', () => {
-      const wasteRecords = [
-        createValidatedWasteRecord({ rowId: 'row-3' }) // All previous rows removed
-      ]
-      const existingWasteRecords = [
-        createWasteRecord('row-1'),
-        createWasteRecord('row-2')
-      ]
-
+    it('returns fatal error when all previously submitted rows are removed', () => {
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [createValidatedWasteRecord({ rowId: 'row-3' })],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1'),
+          createWasteRecordState('row-2')
+        ])
       })
 
       expect(result.isValid()).toBe(false)
@@ -306,29 +228,23 @@ describe('validateRowContinuity', () => {
   })
 
   describe('edge cases', () => {
-    it('returns valid result when upload has no data rows but no existing records either', () => {
-      const wasteRecords = []
-      const existingWasteRecords = []
-
+    it('returns valid result when upload has no data rows and there is no previous submission', () => {
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [],
+        previousSubmission: null
       })
 
       expect(result.isValid()).toBe(true)
       expect(result.isFatal()).toBe(false)
     })
 
-    it('returns fatal error when upload has no data rows but existing records exist', () => {
-      const wasteRecords = []
-      const existingWasteRecords = [
-        createWasteRecord('row-1'),
-        createWasteRecord('row-2')
-      ]
-
+    it('returns fatal error when upload has no data rows but a previous submission exists', () => {
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1'),
+          createWasteRecordState('row-2')
+        ])
       })
 
       expect(result.isValid()).toBe(false)
@@ -338,58 +254,36 @@ describe('validateRowContinuity', () => {
       expect(fatals).toHaveLength(2)
     })
 
-    it('includes previous summary log information in error context', () => {
-      const wasteRecords = []
-      const previousSummaryLogId = 'prev-123'
-      const previousSubmitTime = '2024-01-10T10:00:00.000Z'
-
-      const existingWasteRecords = [
-        createWasteRecord('row-1', WASTE_RECORD_TYPE.RECEIVED, {
-          versions: [
-            {
-              createdAt: previousSubmitTime,
-              status: VERSION_STATUS.CREATED,
-              summaryLog: {
-                id: previousSummaryLogId,
-                uri: 's3://bucket/prev.xlsx'
-              },
-              data: { ROW_ID: 'row-1' }
-            }
-          ]
-        })
-      ]
-
+    it('names the previous summary log and when it was submitted in the error context', () => {
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1')
+        ])
       })
 
       const fatals = result.getIssuesBySeverity(VALIDATION_SEVERITY.FATAL)
       expect(fatals).toHaveLength(1)
 
-      const previousSummaryLog = /** @type {PreviousSummaryLogRef} */ (
-        fatals[0]?.context?.previousSummaryLog
-      )
-      expect(previousSummaryLog.id).toBe(previousSummaryLogId)
-      expect(previousSummaryLog.submittedAt).toBe(previousSubmitTime)
+      expect(fatals[0]?.context?.previousSummaryLog).toEqual({
+        id: PREVIOUS_SUMMARY_LOG_ID,
+        submittedAt: PREVIOUS_SUBMITTED_AT.toISOString()
+      })
     })
   })
 
   describe('different waste record types', () => {
     it('validates rows across different waste record types', () => {
-      const wasteRecords = [
-        createValidatedWasteRecord({ rowId: 'row-1' }),
-        createValidatedWasteRecord({ rowId: 'row-2' })
-      ]
-      const existingWasteRecords = [
-        createWasteRecord('row-1', WASTE_RECORD_TYPE.RECEIVED),
-        createWasteRecord('row-2', WASTE_RECORD_TYPE.RECEIVED),
-        createWasteRecord('row-3', WASTE_RECORD_TYPE.RECEIVED) // Missing from upload
-      ]
-
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [
+          createValidatedWasteRecord({ rowId: 'row-1' }),
+          createValidatedWasteRecord({ rowId: 'row-2' })
+        ],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1', WASTE_RECORD_TYPE.RECEIVED),
+          createWasteRecordState('row-2', WASTE_RECORD_TYPE.RECEIVED),
+          createWasteRecordState('row-3', WASTE_RECORD_TYPE.RECEIVED)
+        ])
       })
 
       expect(result.isValid()).toBe(false)
@@ -401,7 +295,7 @@ describe('validateRowContinuity', () => {
       expect(fatals[0]?.context?.location?.sheet).toBe('Received')
     })
 
-    it('correctly maps different waste record types to sheets and tables from schema registry', () => {
+    it('correctly maps different waste record types to sheets and tables from the schema registry', () => {
       const testCases = [
         {
           type: WASTE_RECORD_TYPE.RECEIVED,
@@ -426,12 +320,11 @@ describe('validateRowContinuity', () => {
       ]
 
       for (const { type, expectedSheet, expectedTable } of testCases) {
-        const wasteRecords = []
-        const existingWasteRecords = [createWasteRecord('row-1', type)]
-
         const result = validateRowContinuity({
-          wasteRecords,
-          existingWasteRecords
+          wasteRecords: [],
+          previousSubmission: createPreviousSubmission([
+            createWasteRecordState('row-1', type)
+          ])
         })
 
         const fatals = result.getIssuesBySeverity(VALIDATION_SEVERITY.FATAL)
@@ -443,21 +336,17 @@ describe('validateRowContinuity', () => {
 
   describe('idempotent uploads (same file uploaded twice)', () => {
     it('returns valid result when exact same data is uploaded again', () => {
-      const wasteRecords = [
-        createValidatedWasteRecord({ rowId: 'row-1' }),
-        createValidatedWasteRecord({ rowId: 'row-2' })
-      ]
-      const existingWasteRecords = [
-        createWasteRecord('row-1'),
-        createWasteRecord('row-2')
-      ]
-
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [
+          createValidatedWasteRecord({ rowId: 'row-1' }),
+          createValidatedWasteRecord({ rowId: 'row-2' })
+        ],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState('row-1'),
+          createWasteRecordState('row-2')
+        ])
       })
 
-      // Should pass - idempotent upload contains all existing rows
       expect(result.isValid()).toBe(true)
       expect(result.isFatal()).toBe(false)
     })
@@ -465,12 +354,14 @@ describe('validateRowContinuity', () => {
 
   describe('unknown waste record types', () => {
     it('handles unknown waste record type with fallback sheet and table names', () => {
-      const wasteRecords = []
-      const existingWasteRecords = [createWasteRecord('row-1', 'unknownType')]
-
       const result = validateRowContinuity({
-        wasteRecords,
-        existingWasteRecords
+        wasteRecords: [],
+        previousSubmission: createPreviousSubmission([
+          createWasteRecordState(
+            'row-1',
+            /** @type {WasteRecordType} */ ('unknownType')
+          )
+        ])
       })
 
       expect(result.isValid()).toBe(false)

--- a/src/waste-records/application/read-summary-log-row-states.js
+++ b/src/waste-records/application/read-summary-log-row-states.js
@@ -1,4 +1,4 @@
-import { latestSubmittedSummaryLogId } from '#waste-balances/application/latest-submitted-summary-log-id.js'
+import { latestSubmittedSummaryLog } from '#waste-balances/application/latest-submitted-summary-log.js'
 
 /**
  * @typedef {import('#waste-records/repository/schema.js').SummaryLogRowState} SummaryLogRowState
@@ -73,18 +73,31 @@ export const wasteRecordStatesForHead = async (
 }
 
 /**
- * Waste record states of a registration at its latest submitted summary log.
- * The head resolves in one stream lookup against the ledger; the row states
- * are then read back for that same ledger at that submission, projected to
- * their domain content.
+ * A registration's latest submitted summary log together with the row states
+ * that belong to it — the baseline a subsequent upload is judged against.
  *
- * @param {import('#waste-balances/repository/ledger-schema.js').WasteBalanceLedgerId & {
+ * @typedef {Object} PreviousSubmission
+ * @property {{ summaryLogId: string, submittedAt: Date }} summaryLog
+ * @property {WasteRecordState[]} wasteRecordStates
+ */
+
+/**
+ * @typedef {import('#waste-balances/repository/ledger-schema.js').WasteBalanceLedgerId & {
  *   ledgerRepository: import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository,
  *   summaryLogRowStateRepository: import('#waste-records/repository/port.js').SummaryLogRowStateRepository
- * }} context
- * @returns {Promise<WasteRecordState[]>}
+ * }} RegistrationRowStateContext
  */
-export const summaryLogRowStatesForRegistration = async ({
+
+/**
+ * The registration's latest submitted summary log and its row states, or null
+ * when the registration has never submitted. The summary log resolves from the
+ * ledger in one stream lookup; the row states are then read back for that same
+ * ledger at that submission, projected to their domain content.
+ *
+ * @param {RegistrationRowStateContext} context
+ * @returns {Promise<PreviousSubmission | null>}
+ */
+export const latestSubmittedSummaryLogRowStates = async ({
   ledgerRepository,
   summaryLogRowStateRepository,
   organisationId,
@@ -93,7 +106,27 @@ export const summaryLogRowStatesForRegistration = async ({
 }) => {
   const ledgerId = { organisationId, registrationId, accreditationId }
 
-  const head = await latestSubmittedSummaryLogId(ledgerRepository, ledgerId)
+  const summaryLog = await latestSubmittedSummaryLog(ledgerRepository, ledgerId)
 
-  return wasteRecordStatesForHead(summaryLogRowStateRepository, ledgerId, head)
+  if (summaryLog === null) {
+    return null
+  }
+
+  const wasteRecordStates = await wasteRecordStatesForHead(
+    summaryLogRowStateRepository,
+    ledgerId,
+    summaryLog.summaryLogId
+  )
+
+  return { summaryLog, wasteRecordStates }
 }
+
+/**
+ * Waste record states of a registration at its latest submitted summary log,
+ * or an empty array when it has never submitted.
+ *
+ * @param {RegistrationRowStateContext} context
+ * @returns {Promise<WasteRecordState[]>}
+ */
+export const summaryLogRowStatesForRegistration = async (context) =>
+  (await latestSubmittedSummaryLogRowStates(context))?.wasteRecordStates ?? []

--- a/src/waste-records/application/read-summary-log-row-states.test.js
+++ b/src/waste-records/application/read-summary-log-row-states.test.js
@@ -11,7 +11,10 @@ import {
 } from '#waste-records/repository/test-data.js'
 import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
 import { partialMock } from '#test/type-helpers.js'
-import { summaryLogRowStatesForRegistration } from './read-summary-log-row-states.js'
+import {
+  latestSubmittedSummaryLogRowStates,
+  summaryLogRowStatesForRegistration
+} from './read-summary-log-row-states.js'
 
 /**
  * @import { LedgerEvent } from '#waste-balances/repository/ledger-schema.js'
@@ -20,13 +23,15 @@ import { summaryLogRowStatesForRegistration } from './read-summary-log-row-state
 /**
  * @param {number} number
  * @param {string} summaryLogId
+ * @param {Date} [submittedAt]
  * @returns {LedgerEvent}
  */
-const submissionEvent = (number, summaryLogId) =>
+const submissionEvent = (number, summaryLogId, submittedAt) =>
   partialMock(
     buildLedgerEvent({
       number,
-      payload: { summaryLogId, creditTotal: number * 10 }
+      payload: { summaryLogId, creditTotal: number * 10 },
+      ...(submittedAt && { createdAt: submittedAt })
     })
   )
 
@@ -144,6 +149,65 @@ describe('summaryLogRowStatesForRegistration', () => {
         reasons: [],
         transactionAmount: 10
       }
+    })
+  })
+})
+
+describe('latestSubmittedSummaryLogRowStates', () => {
+  it('returns null when the stream has no submission', async () => {
+    const previousSubmission = await latestSubmittedSummaryLogRowStates({
+      ledgerRepository: createInMemoryLedgerRepository()(),
+      summaryLogRowStateRepository:
+        createInMemorySummaryLogRowStateRepository()(),
+      ...registration
+    })
+
+    expect(previousSubmission).toBeNull()
+  })
+
+  it('names the latest submitted summary log with when it was submitted and its row states', async () => {
+    const summaryLogRowStateRepository =
+      createInMemorySummaryLogRowStateRepository()()
+    await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+      DEFAULT_LEDGER_ID,
+      [buildSummaryLogRowStateEntry({ rowId: 'row-1', data: { tonnage: 10 } })],
+      'log-1'
+    )
+    await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+      DEFAULT_LEDGER_ID,
+      [
+        buildSummaryLogRowStateEntry({ rowId: 'row-1', data: { tonnage: 99 } }),
+        buildSummaryLogRowStateEntry({ rowId: 'row-2', data: { tonnage: 20 } })
+      ],
+      'log-2'
+    )
+
+    const submittedAt = new Date('2026-02-20T09:30:00.000Z')
+    const ledgerRepository = createInMemoryLedgerRepository([
+      submissionEvent(1, 'log-1', new Date('2026-01-15T10:00:00.000Z')),
+      submissionEvent(2, 'log-2', submittedAt)
+    ])()
+
+    const previousSubmission = await latestSubmittedSummaryLogRowStates({
+      ledgerRepository,
+      summaryLogRowStateRepository,
+      ...registration
+    })
+
+    expect(previousSubmission?.summaryLog).toEqual({
+      summaryLogId: 'log-2',
+      submittedAt
+    })
+
+    const dataByRowId = Object.fromEntries(
+      (previousSubmission?.wasteRecordStates ?? []).map((state) => [
+        state.rowId,
+        state.data
+      ])
+    )
+    expect(dataByRowId).toEqual({
+      'row-1': { tonnage: 99 },
+      'row-2': { tonnage: 20 }
     })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1595](https://eaflood.atlassian.net/browse/PAE-1595)
## What

The sequential-row continuity check — which rejects an upload that drops a row present in the previous submission, preventing silent operator data loss — now derives the previous submission's rows from committed row-state membership instead of the legacy waste-records `versions` array.

`validateRowContinuity` takes a `previousSubmission`: the registration's latest submitted summary log together with the row states committed under it, resolved from that log's `SUMMARY_LOG_SUBMITTED` ledger event. `validate.js` loads this after the registration fetch and threads it through `validateDataBusiness`. The FATAL raised for a removed row now names that latest submitted summary log (`id` + `submittedAt`).

## Why

This removes the last read-consumer of the legacy waste-records collection in the continuity path, part of retiring that collection. The previous read walked `originalRecord.versions.at(-1)` to find the rows the previous submission wrote; the new read is the committed row-state membership of the latest submitted log.

This is a deliberate change of which submission the FATAL names. The old `versions`-based read named the submission that last *wrote* a given row; the new read names the submission immediately *before* this upload (the latest submitted). The row-removal rejection behaviour itself — which rows are rejected and how many FATALs are raised — is unchanged.

## Notes

The read resolves the ledger partition by the summary log's own `accreditationId`, falling back to the registration's, via a shared `ledgerAccreditationId` helper also used by the check-page row-state read. The transform's separate `findByRegistration` read (change/version reconciliation) is untouched — it belongs to the write-side retirement, tracked separately.

[PAE-1595]: https://eaflood.atlassian.net/browse/PAE-1595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ