### PR TITLE
PAE-1405: point journey tests at consolidated epr-re-ex-journey-tests repo

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -141,7 +141,7 @@ jobs:
         id: journey-branch
         run: |
           BRANCH="${{ github.head_ref }}"
-          if git ls-remote --heads https://github.com/DEFRA/epr-backend-journey-tests.git "$BRANCH" | grep -q .; then
+          if git ls-remote --heads https://github.com/DEFRA/epr-re-ex-journey-tests.git "$BRANCH" | grep -q .; then
             echo "ref=$BRANCH" >> "$GITHUB_OUTPUT"
           else
             echo "ref=main" >> "$GITHUB_OUTPUT"
@@ -158,12 +158,13 @@ jobs:
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Run journey tests on ${{ steps.journey-branch.outputs.ref }}
-        uses: DEFRA/epr-backend-journey-tests/run-journey-tests@main
+        uses: DEFRA/epr-re-ex-journey-tests/run-journey-tests@main
         with:
           epr-backend: ${{github.sha}}
           branch: ${{ steps.journey-branch.outputs.ref }}
           waste-record-states: ${{ matrix.waste-record-states }}
           artifact-suffix: -waste-record-states-${{ matrix.waste-record-states }}
+          test-scope: all
 
       - name: Write journey test summary
         if: always()


### PR DESCRIPTION
Ticket: [PAE-1405](https://eaflood.atlassian.net/browse/PAE-1405)
## Summary
- `epr-backend-journey-tests` has been consolidated into `epr-re-ex-journey-tests`; branch-matching and the journey-test action call now target that repo, mirroring [epr-frontend#970](https://github.com/DEFRA/epr-frontend/commit/c792c1192e67066460ffda20d816a86a5cdb4ec0)
- Passes `test-scope: all` so backend PRs keep exercising the full journey suite (not scoped to a single service's specs)

## Test plan
- [ ] CI's journey-test job picks up `DEFRA/epr-re-ex-journey-tests/run-journey-tests@main` and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PAE-1405]: https://eaflood.atlassian.net/browse/PAE-1405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ