### PR TITLE
PAE-1773: export waste records from all ledger partitions

### DIFF
--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -5,7 +5,6 @@ import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.
 import { resolveAccreditation } from '#domain/organisations/registration-utils.js'
 import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/index.js'
 import { coerceRowData } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
-import { latestSubmittedSummaryLogId } from '#waste-balances/application/latest-submitted-summary-log-id.js'
 import { toWasteRecordState } from '#waste-records/application/read-summary-log-row-states.js'
 import { reclassifyWasteRecordState } from '#waste-records/application/reclassify-waste-record-states.js'
 import {
@@ -24,7 +23,7 @@ const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 /** @import {OverseasSite} from '#overseas-sites/repository/port.js' */
 /** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
 /** @import {SummaryLogRowStateRepository} from '#waste-records/repository/port.js' */
-/** @import {WasteBalanceLedgerRepository} from '#waste-balances/repository/ledger-port.js' */
+/** @import {WasteBalanceLedgerRepository, LatestSubmittedSummaryLogPerLedger} from '#waste-balances/repository/ledger-port.js' */
 /** @import {SummaryLogsRepository} from '#repositories/summary-logs/port.js' */
 /** @import {OverseasSitesRepository} from '#overseas-sites/repository/port.js' */
 
@@ -32,7 +31,7 @@ const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
  * @typedef {Object} StreamCsvExportDeps
  * @property {Pick<OrganisationsRepository, 'findAll' | 'findById'>} organisationsRepository
  * @property {Pick<SummaryLogRowStateRepository, 'findRowStatesForSummaryLog' | 'findDistinctDataKeys'>} summaryLogRowStatesRepository
- * @property {WasteBalanceLedgerRepository} ledgerRepository
+ * @property {Pick<WasteBalanceLedgerRepository, 'findLatestSubmittedSummaryLogPerLedger'>} ledgerRepository
  * @property {Pick<SummaryLogsRepository, 'findAllByOrgReg'>} summaryLogsRepository
  * @property {Pick<OverseasSitesRepository, 'findAll'>} overseasSitesRepository
  * @property {string} [organisationId] - When set, export only this organisation.
@@ -88,95 +87,102 @@ const encodeRow = async (cells) => {
   return `${line}\n`
 }
 
+// Deterministic partition order within a registration: registered-only
+// (null accreditation) first, then accreditation ids ascending.
+const sortEntriesByAccreditationId = (a, b) =>
+  String(a.ledgerId.accreditationId ?? '').localeCompare(
+    String(b.ledgerId.accreditationId ?? '')
+  )
+
 /**
- * Yield one CSV row per row state of a single (org, registration) pair. The
- * registration's current rows are the membership of its latest submitted
- * summary log, resolved once from the waste balance ledger; that submission's
- * timestamp is the "Submitted At" column shared by every row. A registration
- * with no submitted summary log contributes no rows.
+ * Yield one CSV row per row state of a single (org, registration) pair. A
+ * registration's rows are the membership of the latest submitted summary log
+ * of every ledger partition it has written to — one partition per
+ * accreditation it has been linked to, plus a null-accreditation partition for
+ * registered-only periods (PAE-1773). Each partition's submission timestamp is
+ * the "Submitted At" column shared by its rows. A registration with no
+ * submitted summary log contributes no rows.
  *
  * @param {Object} input
  * @param {Organisation} input.org
  * @param {Registration} input.registration
+ * @param {LatestSubmittedSummaryLogPerLedger[]} input.entries - The registration's per-partition latest submissions.
  * @param {Map<string, OverseasSite>} input.sitesById
  * @param {string[]} input.dataFieldColumns
  * @param {Pick<SummaryLogRowStateRepository, 'findRowStatesForSummaryLog'>} input.summaryLogRowStatesRepository
- * @param {WasteBalanceLedgerRepository} input.ledgerRepository
  * @param {Pick<SummaryLogsRepository, 'findAllByOrgReg'>} input.summaryLogsRepository
  * @returns {AsyncGenerator<string>}
  */
 async function* streamRegistrationRows({
   org,
   registration,
+  entries,
   sitesById,
   dataFieldColumns,
   summaryLogRowStatesRepository,
-  ledgerRepository,
   summaryLogsRepository
 }) {
-  const accreditation = resolveAccreditation(registration, org)
+  if (entries.length === 0) {
+    return
+  }
+
   const overseasSites = buildOverseasSitesContext(registration, sitesById)
-
-  // The ledger is keyed by the accreditation id stamped at submission —
-  // whatever its status — so the lookup uses the registration's raw
-  // accreditationId. resolveAccreditation is active-only (approved/suspended)
-  // and serves the Accredited columns; keying the ledger by it would drop
-  // every row submitted under a since-cancelled accreditation.
-  const ledgerId = {
-    organisationId: org.id,
-    registrationId: registration.id,
-    accreditationId: registration.accreditationId ?? null
-  }
-
-  const latestSummaryLogId = await latestSubmittedSummaryLogId(
-    ledgerRepository,
-    ledgerId
-  )
-  if (latestSummaryLogId === null) {
-    return
-  }
-
-  const rowStates =
-    await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
-      ledgerId,
-      latestSummaryLogId
-    )
-  if (rowStates.length === 0) {
-    return
-  }
-
   const summaryLogMap = await loadSummaryLogMap(
     summaryLogsRepository,
     org.id,
     registration.id
   )
-  const summaryLogEntry = summaryLogMap.get(latestSummaryLogId) ?? null
 
-  const rowStatesSorted = [...rowStates].sort(sortRowStates)
+  const entriesSorted = [...entries].sort(sortEntriesByAccreditationId)
 
-  for (const rowState of rowStatesSorted) {
-    // The waste-balance columns answer as of the same moment as the Accredited
-    // and OSR columns beside them, which read the accreditation and the
-    // registration's overseas sites as they stand at export time.
-    const { classification } = reclassifyWasteRecordState(
-      toWasteRecordState(rowState),
-      { accreditation, overseasSites }
+  for (const { ledgerId, summaryLogId } of entriesSorted) {
+    // The Accredited columns and the reclassification read the partition's own
+    // accreditation, resolved active-only (approved/suspended) as of export
+    // time — not the registration's current link. Rows submitted under a
+    // since-cancelled accreditation or a registered-only period render as not
+    // accredited but are still exported.
+    const accreditation = resolveAccreditation(
+      { accreditationId: ledgerId.accreditationId },
+      org
     )
 
-    yield await encodeRow(
-      buildDataRow({
-        org,
-        registration,
-        accreditation,
-        data: coerceForExport(rowState),
-        wasteRecordType: rowState.wasteRecordType,
-        rowId: rowState.rowId,
-        classification,
-        summaryLogEntry,
-        overseasSites,
-        dataFieldColumns
-      })
-    )
+    const rowStates =
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
+        ledgerId,
+        summaryLogId
+      )
+    if (rowStates.length === 0) {
+      continue
+    }
+
+    const summaryLogEntry = summaryLogMap.get(summaryLogId) ?? null
+
+    const rowStatesSorted = [...rowStates].sort(sortRowStates)
+
+    for (const rowState of rowStatesSorted) {
+      // The waste-balance columns answer as of the same moment as the
+      // Accredited and OSR columns beside them, which read the accreditation
+      // and the registration's overseas sites as they stand at export time.
+      const { classification } = reclassifyWasteRecordState(
+        toWasteRecordState(rowState),
+        { accreditation, overseasSites }
+      )
+
+      yield await encodeRow(
+        buildDataRow({
+          org,
+          registration,
+          accreditation,
+          data: coerceForExport(rowState),
+          wasteRecordType: rowState.wasteRecordType,
+          rowId: rowState.rowId,
+          classification,
+          summaryLogEntry,
+          overseasSites,
+          dataFieldColumns
+        })
+      )
+    }
   }
 }
 
@@ -188,9 +194,11 @@ async function* streamRegistrationRows({
  * field constants and any keys observed on stored row-state `data` objects.
  * Observed keys are discovered up-front via a server-side aggregation
  * (`findDistinctDataKeys`) so the export does not need to materialise any row
- * state to compose the header. Rows are then streamed one registration at a
- * time — memory is bounded by the largest single registration's row count, not
- * the total across the system.
+ * state to compose the header. Each registration's ledger partitions are
+ * resolved up-front from a single cross-ledger query
+ * (`findLatestSubmittedSummaryLogPerLedger`), then rows are streamed one
+ * partition at a time — memory is bounded by the largest single partition's
+ * row count, not the total across the system.
  *
  * @param {StreamCsvExportDeps} deps
  * @returns {AsyncGenerator<string>}
@@ -206,14 +214,17 @@ export async function* streamCsvExport(deps) {
     registrationId
   } = deps
 
-  const [allSites, observedKeys] = await Promise.all([
+  const [allSites, observedKeys, latestSubmittedEntries] = await Promise.all([
     overseasSitesRepository.findAll(),
-    summaryLogRowStatesRepository.findDistinctDataKeys()
+    summaryLogRowStatesRepository.findDistinctDataKeys(),
+    ledgerRepository.findLatestSubmittedSummaryLogPerLedger()
   ])
 
   const sitesById = new Map(allSites.map((s) => [s.id, s]))
   const dataFieldColumns = buildDataFieldColumns(observedKeys)
   yield await encodeRow(buildHeaderRow(dataFieldColumns))
+
+  const entriesByRegistration = groupByRegistration(latestSubmittedEntries)
 
   const orgsSorted = await resolveOrgs(organisationsRepository, organisationId)
   for (const org of orgsSorted) {
@@ -224,14 +235,50 @@ export async function* streamCsvExport(deps) {
       yield* streamRegistrationRows({
         org,
         registration,
+        entries:
+          entriesByRegistration.get(registrationKey(org.id, registration.id)) ??
+          [],
         sitesById,
         dataFieldColumns,
         summaryLogRowStatesRepository,
-        ledgerRepository,
         summaryLogsRepository
       })
     }
   }
+}
+
+/**
+ * @param {string} organisationId
+ * @param {string} registrationId
+ * @returns {string}
+ */
+const registrationKey = (organisationId, registrationId) =>
+  `${organisationId}::${registrationId}`
+
+/**
+ * Group the per-partition latest-submission entries by owning
+ * (organisation, registration) pair, so the per-registration streaming loop
+ * can pick up every ledger partition a registration has written to.
+ *
+ * @param {LatestSubmittedSummaryLogPerLedger[]} entries
+ * @returns {Map<string, LatestSubmittedSummaryLogPerLedger[]>}
+ */
+const groupByRegistration = (entries) => {
+  /** @type {Map<string, LatestSubmittedSummaryLogPerLedger[]>} */
+  const grouped = new Map()
+  for (const entry of entries) {
+    const key = registrationKey(
+      entry.ledgerId.organisationId,
+      entry.ledgerId.registrationId
+    )
+    const list = grouped.get(key)
+    if (list) {
+      list.push(entry)
+    } else {
+      grouped.set(key, [entry])
+    }
+  }
+  return grouped
 }
 
 /**

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -764,6 +764,175 @@ describe('streamCsvExport', () => {
     expect(cells[METADATA_COL_INDEX['Included in Waste Balance']]).toBe('NA')
   })
 
+  it('exports rows from every ledger partition, not just the current accreditation', async () => {
+    // A registration that submitted under acc-old before moving to acc-new
+    // holds two independently valid summary logs, one per ledger partition.
+    const org = baseOrg({
+      accreditations: [
+        approvedAccreditation({
+          id: 'acc-old',
+          accreditationNumber: 'ACC-OLD'
+        }),
+        approvedAccreditation({ id: 'acc-new', accreditationNumber: 'ACC-NEW' })
+      ],
+      registrations: [
+        baseRegistration({ accreditation: null, accreditationId: 'acc-new' })
+      ]
+    })
+    const deps = await buildDeps({
+      orgs: [org],
+      seeds: [
+        {
+          accreditationId: 'acc-old',
+          summaryLogId: 'sl-old',
+          rows: [receivedRowState({ rowId: '1001' })]
+        },
+        {
+          accreditationId: 'acc-new',
+          summaryLogId: 'sl-new',
+          rows: [receivedRowState({ rowId: '2002' })]
+        }
+      ]
+    })
+
+    const out = await collect(streamCsvExport(deps))
+
+    expect(out).toHaveLength(3)
+    const rowIds = out
+      .slice(1)
+      .map((line) => line.trim().split(',')[METADATA_COL_INDEX['Row ID']])
+    expect(rowIds).toContain('1001')
+    expect(rowIds).toContain('2002')
+  })
+
+  it('renders each partition against its own accreditation, not the current link', async () => {
+    const org = baseOrg({
+      accreditations: [
+        approvedAccreditation({
+          id: 'acc-old',
+          accreditationNumber: 'ACC-OLD'
+        }),
+        approvedAccreditation({ id: 'acc-new', accreditationNumber: 'ACC-NEW' })
+      ],
+      registrations: [
+        baseRegistration({ accreditation: null, accreditationId: 'acc-new' })
+      ]
+    })
+    const deps = await buildDeps({
+      orgs: [org],
+      seeds: [
+        {
+          accreditationId: 'acc-old',
+          summaryLogId: 'sl-old',
+          rows: [receivedRowState({ rowId: '1001' })]
+        },
+        {
+          accreditationId: 'acc-new',
+          summaryLogId: 'sl-new',
+          rows: [receivedRowState({ rowId: '2002' })]
+        }
+      ]
+    })
+
+    const out = await collect(streamCsvExport(deps))
+
+    expect(out).toHaveLength(3)
+    const byRowId = new Map(
+      out.slice(1).map((line) => {
+        const cells = line.trim().split(',')
+        return [cells[METADATA_COL_INDEX['Row ID']], cells]
+      })
+    )
+    expect(
+      byRowId.get('1001')[METADATA_COL_INDEX['Accreditation Number']]
+    ).toBe('ACC-OLD')
+    expect(
+      byRowId.get('2002')[METADATA_COL_INDEX['Accreditation Number']]
+    ).toBe('ACC-NEW')
+  })
+
+  it('exports a registered-only period alongside an accredited one, as Accredited "No"', async () => {
+    const org = baseOrg({
+      accreditations: [approvedAccreditation()],
+      registrations: [
+        baseRegistration({ accreditation: null, accreditationId: 'acc-1' })
+      ]
+    })
+    const deps = await buildDeps({
+      orgs: [org],
+      seeds: [
+        {
+          accreditationId: null,
+          summaryLogId: 'sl-registered-only',
+          rows: [receivedRowState({ rowId: '1001' })]
+        },
+        {
+          accreditationId: 'acc-1',
+          summaryLogId: 'sl-accredited',
+          rows: [receivedRowState({ rowId: '2002' })]
+        }
+      ]
+    })
+
+    const out = await collect(streamCsvExport(deps))
+
+    expect(out).toHaveLength(3)
+    const byRowId = new Map(
+      out.slice(1).map((line) => {
+        const cells = line.trim().split(',')
+        return [cells[METADATA_COL_INDEX['Row ID']], cells]
+      })
+    )
+    expect(byRowId.get('1001')[METADATA_COL_INDEX['Accredited']]).toBe('No')
+    expect(
+      byRowId.get('1001')[METADATA_COL_INDEX['Accreditation Number']]
+    ).toBe('')
+    expect(byRowId.get('2002')[METADATA_COL_INDEX['Accredited']]).toBe('Yes')
+    expect(
+      byRowId.get('2002')[METADATA_COL_INDEX['Accreditation Number']]
+    ).toBe('ACC-777')
+  })
+
+  it("orders a registration's partitions registered-only first, then by accreditation id", async () => {
+    const org = baseOrg({
+      accreditations: [
+        approvedAccreditation({ id: 'acc-a' }),
+        approvedAccreditation({ id: 'acc-b' })
+      ],
+      registrations: [
+        baseRegistration({ accreditation: null, accreditationId: 'acc-b' })
+      ]
+    })
+    const deps = await buildDeps({
+      orgs: [org],
+      seeds: [
+        {
+          accreditationId: 'acc-b',
+          summaryLogId: 'sl-b',
+          rows: [receivedRowState({ rowId: '3003' })]
+        },
+        {
+          accreditationId: null,
+          summaryLogId: 'sl-null',
+          rows: [receivedRowState({ rowId: '1001' })]
+        },
+        {
+          accreditationId: 'acc-a',
+          summaryLogId: 'sl-a',
+          rows: [receivedRowState({ rowId: '2002' })]
+        }
+      ]
+    })
+
+    const out = await collect(streamCsvExport(deps))
+
+    expect(out).toHaveLength(4)
+    const rowIds = out
+      .slice(1)
+      .map((line) => line.trim().split(',')[METADATA_COL_INDEX['Row ID']])
+    expect(rowIds).toEqual(['1001', '2002', '3003'])
+  })
+
   it('iterates organisations and registrations sorted by id for deterministic output', async () => {
     const orgB = baseOrg({
       id: 'org-b',


### PR DESCRIPTION
Ticket: [PAE-1773](https://eaflood.atlassian.net/browse/PAE-1773)
## Summary

- The admin waste-records CSV / FOI export emitted at most one summary log per registration: the one submitted under the registration's *current* accreditation link. Summary logs submitted under a previous accreditation, or during a registered-only (no accreditation) period, were silently omitted.
- The export now resolves every ledger partition a registration has written to via `findLatestSubmittedSummaryLogPerLedger()` (one cross-ledger query, the same pattern as the credited-tonnage report) and emits each partition's latest submitted summary log's rows.
- Each partition renders against its **own** accreditation, resolved active-only at export time: rows under a still-active older accreditation show that accreditation's number; rows under a since-cancelled accreditation or a registered-only period show `Accredited: No`. Read-time reclassification, the org/registration scoping filters, the test-organisation exclusion, and deterministic ordering are all preserved. Partitions within a registration order registered-only first, then by accreditation id.

## Changes

- `src/waste-records-export/application/stream-csv-export.js` — fetch the per-partition latest submissions once up front, group them by (organisation, registration), and stream each registration's partitions in turn instead of deriving a single ledger id from `registration.accreditationId`. The `ledgerRepository` dependency narrows to `Pick<..., 'findLatestSubmittedSummaryLogPerLedger'>`.
- `src/waste-records-export/application/stream-csv-export.test.js` — new tests: rows exported from every partition (the bug reproduction), per-partition accreditation rendering, registered-only period alongside an accredited one, and deterministic partition ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAE-1773]: https://eaflood.atlassian.net/browse/PAE-1773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ