### PR TITLE
PAE-1617: grant accreditation via status-history with explicit from/to

### DIFF
--- a/src/common/validation/iso-date-schema.js
+++ b/src/common/validation/iso-date-schema.js
@@ -1,0 +1,23 @@
+import Joi from 'joi'
+
+/**
+ * A calendar date as a YYYY-MM-DD string. The round-trip check rejects
+ * strings that match the pattern but name no real date (e.g. 2026-02-30),
+ * which Date parsing would otherwise silently roll into the next month.
+ * Callers add `.required()`, `.when(...)` etc. as the field needs.
+ * @returns {import('joi').StringSchema}
+ */
+export const isoDateString = () =>
+  Joi.string()
+    .pattern(/^\d{4}-\d{2}-\d{2}$/)
+    .custom((value, helpers) => {
+      const date = new Date(`${value}T00:00:00.000Z`)
+      if (
+        Number.isNaN(date.getTime()) ||
+        date.toISOString().slice(0, 10) !== value
+      ) {
+        return helpers.error('string.pattern.base')
+      }
+      return value
+    })
+    .messages({ 'string.pattern.base': 'Date must be in YYYY-MM-DD format' })

--- a/src/common/validation/iso-date-schema.test.js
+++ b/src/common/validation/iso-date-schema.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { isoDateString } from './iso-date-schema.js'
+import { expectValidationError } from './validation-test-helpers.js'
+
+describe('#isoDateString', () => {
+  it('accepts a real calendar date', () => {
+    const { error, value } = isoDateString().validate('2026-08-01')
+
+    expect(error).toBeUndefined()
+    expect(value).toBe('2026-08-01')
+  })
+
+  it('accepts 29 February in a leap year', () => {
+    const { error } = isoDateString().validate('2024-02-29')
+
+    expect(error).toBeUndefined()
+  })
+
+  it('rejects a value that is not in YYYY-MM-DD format', () => {
+    const [detail] = expectValidationError(isoDateString(), '01/08/2026')
+
+    expect(detail.message).toBe('Date must be in YYYY-MM-DD format')
+  })
+
+  it('rejects a month outside 01-12', () => {
+    const [detail] = expectValidationError(isoDateString(), '2026-13-01')
+
+    expect(detail.message).toBe('Date must be in YYYY-MM-DD format')
+  })
+
+  it.each(['2026-02-30', '2026-04-31', '2025-02-29'])(
+    'rejects %s, a day that does not exist in that month',
+    (value) => {
+      const [detail] = expectValidationError(isoDateString(), value)
+
+      expect(detail.message).toBe('Date must be in YYYY-MM-DD format')
+    }
+  )
+})

--- a/src/repositories/organisations/contract/find-by-accreditation-number.contract.js
+++ b/src/repositories/organisations/contract/find-by-accreditation-number.contract.js
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect } from 'vitest'
+import { buildAccreditation, buildOrganisation } from './test-data.js'
+
+export const testFindByAccreditationNumberBehaviour = (it) => {
+  describe('findByAccreditationNumber', () => {
+    let repository
+
+    beforeEach(
+      async (
+        /** @type {{ organisationsRepository: import("../port.js").OrganisationsRepositoryFactory }} */ {
+          organisationsRepository
+        }
+      ) => {
+        repository = await organisationsRepository()
+      }
+    )
+
+    it('returns null when no accreditation holds the number', async () => {
+      const org = buildOrganisation()
+      await repository.insert(org)
+
+      const result = await repository.findByAccreditationNumber('ACC000000')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns the organisation holding an accreditation with the number', async () => {
+      const accreditation = buildAccreditation({
+        accreditationNumber: 'ACC777777'
+      })
+      const org = buildOrganisation({ accreditations: [accreditation] })
+      const otherOrg = buildOrganisation()
+      await Promise.all([org, otherOrg].map((o) => repository.insert(o)))
+
+      const result = await repository.findByAccreditationNumber('ACC777777')
+
+      expect(result).toMatchObject({ id: org.id })
+    })
+
+    it('finds the number regardless of which accreditation on the organisation holds it', async () => {
+      const first = buildAccreditation()
+      const second = buildAccreditation({ accreditationNumber: 'ACC888888' })
+      const org = buildOrganisation({ accreditations: [first, second] })
+      await repository.insert(org)
+
+      const result = await repository.findByAccreditationNumber('ACC888888')
+
+      expect(result).toMatchObject({ id: org.id })
+    })
+  })
+}

--- a/src/repositories/organisations/inmemory.js
+++ b/src/repositories/organisations/inmemory.js
@@ -252,6 +252,21 @@ const performFindByLinkedDefraOrgId = (staleCache) => async (defraOrgId) => {
   return mapDocumentWithCurrentStatuses(structuredClone(found))
 }
 
+const performFindByAccreditationNumber =
+  (staleCache) => async (accreditationNumber) => {
+    const found = staleCache.find((org) =>
+      org.accreditations.some(
+        (acc) => acc.accreditationNumber === accreditationNumber
+      )
+    )
+
+    if (!found) {
+      return null
+    }
+
+    return mapDocumentWithCurrentStatuses(structuredClone(found))
+  }
+
 const caseInsensitiveEquals = (a, b) =>
   a.localeCompare(b, undefined, { sensitivity: 'accent' }) === 0
 
@@ -418,6 +433,7 @@ export const createInMemoryOrganisationsRepository = (
       findById,
       findByIds: performFindByIds(staleCache),
       findByLinkedDefraOrgId: performFindByLinkedDefraOrgId(staleCache),
+      findByAccreditationNumber: performFindByAccreditationNumber(staleCache),
       findAllLinkableForUser: performFindAllLinkableForUser(staleCache),
       findByOrgId: performFindByOrgId(staleCache),
       replaceRegistrationOverseasSites: performReplaceRegistrationOverseasSites(

--- a/src/repositories/organisations/mongodb.js
+++ b/src/repositories/organisations/mongodb.js
@@ -310,6 +310,19 @@ const performFindByLinkedDefraOrgId = (db) => async (defraOrgId) => {
   return mapDocumentWithCurrentStatuses(doc)
 }
 
+const performFindByAccreditationNumber =
+  (db) => async (accreditationNumber) => {
+    const doc = await db
+      .collection(COLLECTION_NAME)
+      .findOne({ 'accreditations.accreditationNumber': accreditationNumber })
+
+    if (!doc) {
+      return null
+    }
+
+    return mapDocumentWithCurrentStatuses(doc)
+  }
+
 const performFindAllLinkableForUser = (db) => async (email) => {
   const docs = await db
     .collection(COLLECTION_NAME)
@@ -468,6 +481,7 @@ export const createOrganisationsRepository = async (
       findByIds: performFindByIds(db),
       findAllIds: findAllIds(db),
       findByLinkedDefraOrgId: performFindByLinkedDefraOrgId(db),
+      findByAccreditationNumber: performFindByAccreditationNumber(db),
       findAllLinkableForUser: performFindAllLinkableForUser(db),
       findRegistrationById: performFindRegistrationById(findById),
       findAccreditationById: performFindAccreditationById(findById),

--- a/src/repositories/organisations/port.contract.js
+++ b/src/repositories/organisations/port.contract.js
@@ -5,6 +5,7 @@ import { testFindByIdsBehaviour } from './contract/find-by-ids.contract.js'
 import { testFindAllIdsBehaviour } from './contract/find-all-ids.contract.js'
 import { testFindAllLinkedBehaviour } from './contract/find-all-linked.contract.js'
 import { testFindByLinkedDefraOrgIdBehaviour } from './contract/find-by-linked-defra-org-id.contract.js'
+import { testFindByAccreditationNumberBehaviour } from './contract/find-by-accreditation-number.contract.js'
 import { testFindPageBehaviour } from './contract/find-page.contract.js'
 import { testInsertBehaviour } from './contract/insert.contract.js'
 import { testReplaceBehaviour } from './contract/replace.contract.js'
@@ -25,6 +26,7 @@ export const testOrganisationsRepositoryContract = (repositoryFactory) => {
   testFindAllBySchemaVersionBehaviour(repositoryFactory)
   testFindAllLinkedBehaviour(repositoryFactory)
   testFindByLinkedDefraOrgIdBehaviour(repositoryFactory)
+  testFindByAccreditationNumberBehaviour(repositoryFactory)
   testFindPageBehaviour(repositoryFactory)
   testFindRegistrationByIdBehaviour(repositoryFactory)
   testFindAccreditationByIdBehaviour(repositoryFactory)

--- a/src/repositories/organisations/port.js
+++ b/src/repositories/organisations/port.js
@@ -75,6 +75,7 @@
  * @property {(ids: string[]) => Promise<Organisation[]>} findByIds - Find organisations by array of IDs
  * @property {(id: string, minimumVersion?: number) => Promise<Organisation>} findById
  * @property {(defraOrgId: string) => Promise<Organisation|null>} findByLinkedDefraOrgId - Find organisation linked to a Defra organisation ID
+ * @property {(accreditationNumber: string) => Promise<Organisation|null>} findByAccreditationNumber - Find the organisation holding an accreditation with this number, regardless of the accreditation's status
  * @property {(filter?: { name?: string }) => Promise<Organisation[]>} findAllLinked - Find all organisations linked to a Defra organisation, optionally filtered by name
  * @property {(email: string) => Promise<Organisation[]>} findAllLinkableForUser - Find unlinked approved organisations where user is an initial user
  * @property {(organisationId: string, registrationId: string, minimumOrgVersion?: number) => Promise<Registration>} findRegistrationById

--- a/src/repositories/organisations/schema/helpers.js
+++ b/src/repositories/organisations/schema/helpers.js
@@ -9,6 +9,7 @@ import {
   isAccreditationForRegistration
 } from '#formsubmission/submission-keys.js'
 import Boom from '@hapi/boom'
+import { isoDateString } from '#common/validation/iso-date-schema.js'
 
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {RegistrationOrAccreditation} from '#domain/organisations/model.js' */
@@ -92,18 +93,7 @@ export const requiredWhenApprovedOrSuspended = {
 }
 
 export const dateRequiredWhenApprovedOrSuspended = () =>
-  Joi.string()
-    .pattern(/^\d{4}-\d{2}-\d{2}$/)
-    .custom((value, helpers) => {
-      const date = new Date(value + 'T00:00:00.000Z')
-      if (Number.isNaN(date.getTime())) {
-        return helpers.error('string.pattern.base')
-      }
-      return value
-    })
-    .messages({ 'string.pattern.base': 'Date must be in YYYY-MM-DD format' })
-    .when('status', requiredWhenApprovedOrSuspended)
-    .default(null)
+  isoDateString().when('status', requiredWhenApprovedOrSuspended).default(null)
 
 function findAccreditationsWithoutApprovedRegistration(
   accreditations,

--- a/src/routes/v1/organisations/accreditation-status-history.js
+++ b/src/routes/v1/organisations/accreditation-status-history.js
@@ -27,7 +27,12 @@ export const accreditationStatusHistory = {
   },
 
   /**
-   * @param {import('#common/hapi-types.js').HapiRequest<{ status: RegAccStatus }> & {
+   * @param {import('#common/hapi-types.js').HapiRequest<{
+   *    fromStatus: RegAccStatus,
+   *    toStatus: RegAccStatus,
+   *    appliesFrom?: string,
+   *    accreditationNumber?: string
+   * }> & {
    *    organisationsRepository: OrganisationsRepository,
    *    systemLogsRepository: SystemLogsRepository,
    *    params: { organisationId: string, registrationId: string, accreditationId: string }
@@ -38,7 +43,8 @@ export const accreditationStatusHistory = {
   handler: async (request, h) => {
     const { organisationsRepository } = request
     const { organisationId, registrationId, accreditationId } = request.params
-    const { status } = request.payload
+    const { fromStatus, toStatus, appliesFrom, accreditationNumber } =
+      request.payload
 
     const initial = await organisationsRepository.findById(organisationId)
 
@@ -58,11 +64,35 @@ export const accreditationStatusHistory = {
       )
     }
 
+    if (accreditation.status !== fromStatus) {
+      throw Boom.badData(
+        `Cannot transition accreditation from ${fromStatus}: its status is ${accreditation.status}`
+      )
+    }
+
     // Route-level check is required, not belt-and-braces: the repository's
     // assertAndHandleItemStateTransition skips validation when the status is
     // unchanged, so suspended -> suspended via replace() would otherwise be a
     // silent no-op instead of the required 422.
-    assertRegAccStatusTransitionValid(accreditation.status, status)
+    assertRegAccStatusTransitionValid(fromStatus, toStatus)
+
+    // Granting issues the accreditation number, which must not already be in
+    // use by any accreditation in any organisation.
+    if (accreditationNumber) {
+      const holder =
+        await organisationsRepository.findByAccreditationNumber(
+          accreditationNumber
+        )
+      if (holder) {
+        throw Boom.badData(
+          `Accreditation number ${accreditationNumber} is already in use`
+        )
+      }
+    }
+
+    const grantFields = accreditationNumber
+      ? { accreditationNumber, validFrom: appliesFrom }
+      : {}
 
     const { id, version, ...orgFields } = initial
 
@@ -73,7 +103,11 @@ export const accreditationStatusHistory = {
         acc.id === accreditationId
           ? // The transition assert above guarantees the requested status is
             // reachable from the current one, so the result is a valid item.
-            /** @type {typeof acc} */ ({ ...acc, status })
+            /** @type {typeof acc} */ ({
+              ...acc,
+              status: toStatus,
+              ...grantFields
+            })
           : acc
       )
     }
@@ -82,6 +116,6 @@ export const accreditationStatusHistory = {
     const updated = await organisationsRepository.findById(id, version + 1)
     await auditOrganisationUpdate(request, id, initial, updated)
 
-    return h.response({ status }).code(StatusCodes.OK)
+    return h.response({ status: toStatus }).code(StatusCodes.OK)
   }
 }

--- a/src/routes/v1/organisations/accreditation-status-history.js
+++ b/src/routes/v1/organisations/accreditation-status-history.js
@@ -76,9 +76,22 @@ export const accreditationStatusHistory = {
     // silent no-op instead of the required 422.
     assertRegAccStatusTransitionValid(fromStatus, toStatus)
 
-    // Granting issues the accreditation number, which must not already be in
-    // use by any accreditation in any organisation.
     if (accreditationNumber) {
+      // Granting sets validFrom to appliesFrom but leaves validTo (owned by
+      // the application data) untouched, so reject a window that would be
+      // inverted. When validTo is absent the replace below 422s via the
+      // schema guard requiring it on approved accreditations.
+      if (accreditation.validTo && appliesFrom > accreditation.validTo) {
+        throw Boom.badData(
+          `Cannot grant accreditation: appliesFrom ${appliesFrom} is after validTo ${accreditation.validTo}`
+        )
+      }
+
+      // Granting issues the accreditation number, which must not already be
+      // in use by any accreditation in any organisation, whatever its status.
+      // This uniqueness is enforced here only: there is no unique index on
+      // accreditations.accreditationNumber, so concurrent grants of the same
+      // number are not blocked by the database.
       const holder =
         await organisationsRepository.findByAccreditationNumber(
           accreditationNumber

--- a/src/routes/v1/organisations/accreditation-status-history.js
+++ b/src/routes/v1/organisations/accreditation-status-history.js
@@ -27,12 +27,15 @@ export const accreditationStatusHistory = {
   },
 
   /**
-   * @param {import('#common/hapi-types.js').HapiRequest<{
-   *    fromStatus: RegAccStatus,
-   *    toStatus: RegAccStatus,
-   *    appliesFrom?: string,
-   *    accreditationNumber?: string
-   * }> & {
+   * @param {import('#common/hapi-types.js').HapiRequest<
+   *    { fromStatus: RegAccStatus, toStatus: RegAccStatus } |
+   *    {
+   *      fromStatus: RegAccStatus,
+   *      toStatus: RegAccStatus,
+   *      appliesFrom: string,
+   *      accreditationNumber: string
+   *    }
+   * > & {
    *    organisationsRepository: OrganisationsRepository,
    *    systemLogsRepository: SystemLogsRepository,
    *    params: { organisationId: string, registrationId: string, accreditationId: string }
@@ -43,8 +46,12 @@ export const accreditationStatusHistory = {
   handler: async (request, h) => {
     const { organisationsRepository } = request
     const { organisationId, registrationId, accreditationId } = request.params
-    const { fromStatus, toStatus, appliesFrom, accreditationNumber } =
-      request.payload
+    const payload = request.payload
+    const { fromStatus, toStatus } = payload
+
+    // The created -> approved arm of the payload schema requires both grant
+    // fields; the other arms forbid them.
+    const grant = 'accreditationNumber' in payload ? payload : undefined
 
     const initial = await organisationsRepository.findById(organisationId)
 
@@ -76,14 +83,17 @@ export const accreditationStatusHistory = {
     // silent no-op instead of the required 422.
     assertRegAccStatusTransitionValid(fromStatus, toStatus)
 
-    if (accreditationNumber) {
+    if (grant) {
       // Granting sets validFrom to appliesFrom but leaves validTo (owned by
       // the application data) untouched, so reject a window that would be
       // inverted. When validTo is absent the replace below 422s via the
       // schema guard requiring it on approved accreditations.
-      if (accreditation.validTo && appliesFrom > accreditation.validTo) {
+      if (
+        accreditation.validTo &&
+        new Date(grant.appliesFrom) > new Date(accreditation.validTo)
+      ) {
         throw Boom.badData(
-          `Cannot grant accreditation: appliesFrom ${appliesFrom} is after validTo ${accreditation.validTo}`
+          `Cannot grant accreditation: appliesFrom ${grant.appliesFrom} is after validTo ${accreditation.validTo}`
         )
       }
 
@@ -92,19 +102,21 @@ export const accreditationStatusHistory = {
       // This uniqueness is enforced here only: there is no unique index on
       // accreditations.accreditationNumber, so concurrent grants of the same
       // number are not blocked by the database.
-      const holder =
-        await organisationsRepository.findByAccreditationNumber(
-          accreditationNumber
-        )
+      const holder = await organisationsRepository.findByAccreditationNumber(
+        grant.accreditationNumber
+      )
       if (holder) {
         throw Boom.badData(
-          `Accreditation number ${accreditationNumber} is already in use`
+          `Accreditation number ${grant.accreditationNumber} is already in use`
         )
       }
     }
 
-    const grantFields = accreditationNumber
-      ? { accreditationNumber, validFrom: appliesFrom }
+    const grantFields = grant
+      ? {
+          accreditationNumber: grant.accreditationNumber,
+          validFrom: grant.appliesFrom
+        }
       : {}
 
     const { id, version, ...orgFields } = initial

--- a/src/routes/v1/organisations/accreditation-status-history.schema.js
+++ b/src/routes/v1/organisations/accreditation-status-history.schema.js
@@ -1,22 +1,48 @@
 import Joi from 'joi'
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 
+const dateSchema = Joi.string()
+  .pattern(/^\d{4}-\d{2}-\d{2}$/)
+  .custom((value, helpers) => {
+    const date = new Date(`${value}T00:00:00.000Z`)
+    if (Number.isNaN(date.getTime())) {
+      return helpers.error('string.pattern.base')
+    }
+    return value
+  })
+  .messages({ 'string.pattern.base': 'Date must be in YYYY-MM-DD format' })
+
 /**
- * Discriminated union over the parameters each transition requires.
- * Suspension and reinstatement are supported so far; add an arm per
- * transition as they gain endpoints. Arms are named by transition, not by
- * target status: created -> approved (grant) will be a separate arm from
- * suspended -> approved (reinstate) because granting requires the
- * accreditation number, which is set on first approval.
+ * Discriminated union over the explicit from/to status pair: each supported
+ * transition declares its own arm with the parameters it requires, so the
+ * endpoint only accepts transitions that have been built. The handler still
+ * checks the accreditation really is in fromStatus and that the transition
+ * is in the domain map.
  */
 const approvedToSuspendedSchema = Joi.object({
-  status: Joi.string().valid(REG_ACC_STATUS.SUSPENDED).required()
+  fromStatus: Joi.string().valid(REG_ACC_STATUS.APPROVED).required(),
+  toStatus: Joi.string().valid(REG_ACC_STATUS.SUSPENDED).required()
 })
 
 const suspendedToApprovedSchema = Joi.object({
-  status: Joi.string().valid(REG_ACC_STATUS.APPROVED).required()
+  fromStatus: Joi.string().valid(REG_ACC_STATUS.SUSPENDED).required(),
+  toStatus: Joi.string().valid(REG_ACC_STATUS.APPROVED).required()
+})
+
+// Granting issues the accreditation number and sets validFrom to the supplied
+// appliesFrom date. validTo is owned by the application data and is not
+// changed by this transition.
+const createdToApprovedSchema = Joi.object({
+  fromStatus: Joi.string().valid(REG_ACC_STATUS.CREATED).required(),
+  toStatus: Joi.string().valid(REG_ACC_STATUS.APPROVED).required(),
+  appliesFrom: dateSchema.required(),
+  accreditationNumber: Joi.string().trim().min(1).required()
 })
 
 export const accreditationStatusHistoryPayloadSchema = Joi.alternatives()
-  .try(approvedToSuspendedSchema, suspendedToApprovedSchema)
+  .try(
+    approvedToSuspendedSchema,
+    suspendedToApprovedSchema,
+    createdToApprovedSchema
+  )
   .required()

--- a/src/routes/v1/organisations/accreditation-status-history.schema.js
+++ b/src/routes/v1/organisations/accreditation-status-history.schema.js
@@ -1,16 +1,6 @@
 import Joi from 'joi'
 import { REG_ACC_STATUS } from '#domain/organisations/model.js'
-
-const dateSchema = Joi.string()
-  .pattern(/^\d{4}-\d{2}-\d{2}$/)
-  .custom((value, helpers) => {
-    const date = new Date(`${value}T00:00:00.000Z`)
-    if (Number.isNaN(date.getTime())) {
-      return helpers.error('string.pattern.base')
-    }
-    return value
-  })
-  .messages({ 'string.pattern.base': 'Date must be in YYYY-MM-DD format' })
+import { isoDateString } from '#common/validation/iso-date-schema.js'
 
 /**
  * Discriminated union over the explicit from/to status pair: each supported
@@ -35,7 +25,7 @@ const suspendedToApprovedSchema = Joi.object({
 const createdToApprovedSchema = Joi.object({
   fromStatus: Joi.string().valid(REG_ACC_STATUS.CREATED).required(),
   toStatus: Joi.string().valid(REG_ACC_STATUS.APPROVED).required(),
-  appliesFrom: dateSchema.required(),
+  appliesFrom: isoDateString().required(),
   accreditationNumber: Joi.string().trim().min(1).required()
 })
 

--- a/src/routes/v1/organisations/accreditation-status-history.test.js
+++ b/src/routes/v1/organisations/accreditation-status-history.test.js
@@ -34,15 +34,16 @@ vi.mock('@defra/cdp-auditing', () => ({
  * accreditation whose statusHistory ends in the given status, plus an
  * unrelated second (unlinked, 'created') accreditation used to assert that
  * changing the target's status leaves other accreditations untouched.
- * The linked registration is 'created' by default; reinstating the
+ * The linked registration is 'created' by default; approving the
  * accreditation requires an approved registration, so tests opt in via
- * registrationStatus.
+ * registrationStatus. accreditationOverrides lets grant tests shape the
+ * target accreditation (e.g. no number yet).
  * @param {string} status
- * @param {{ registrationStatus?: string }} [options]
+ * @param {{ registrationStatus?: string, accreditationOverrides?: object }} [options]
  */
 const buildOrgWithAccreditationStatus = (
   status,
-  { registrationStatus = 'created' } = {}
+  { registrationStatus = 'created', accreditationOverrides = {} } = {}
 ) => {
   const accreditationId = new ObjectId().toString()
   const registration = buildRegistration({
@@ -77,7 +78,8 @@ const buildOrgWithAccreditationStatus = (
               { status: 'created', updatedAt: '2024-01-01' },
               { status, updatedAt: '2024-02-01' }
             ]
-      )
+      ),
+    ...accreditationOverrides
   })
   const otherAccreditation = buildAccreditation()
 
@@ -98,17 +100,24 @@ const statusHistoryUrl = ({
 }) =>
   `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/status-history`
 
-const suspendPayload = { status: 'suspended' }
-const reinstatePayload = { status: 'approved' }
+const suspendPayload = { fromStatus: 'approved', toStatus: 'suspended' }
+const reinstatePayload = { fromStatus: 'suspended', toStatus: 'approved' }
+const grantPayload = {
+  fromStatus: 'created',
+  toStatus: 'approved',
+  appliesFrom: '2026-08-01',
+  accreditationNumber: 'ACC999999'
+}
 
 describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/status-history', () => {
   setupAuthContext()
   let server
 
-  const seedOrg = async (status, options) => {
-    const fixture = buildOrgWithAccreditationStatus(status, options)
+  const seedOrg = async (status, options = {}) => {
+    const { extraOrgs = [], ...builderOptions } = options
+    const fixture = buildOrgWithAccreditationStatus(status, builderOptions)
     const organisationsRepositoryFactory =
-      createInMemoryOrganisationsRepository([fixture])
+      createInMemoryOrganisationsRepository([fixture, ...extraOrgs])
 
     server = await createTestServer({
       repositories: {
@@ -275,9 +284,9 @@ describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}
     })
   })
 
-  describe('invalid status transitions', () => {
+  describe('fromStatus mismatch', () => {
     it.each(['created', 'suspended', 'rejected', 'cancelled'])(
-      'returns 422 when the accreditation is currently %s',
+      'returns 422 when suspending an accreditation that is currently %s',
       async (status) => {
         const ctx = await seedOrg(status)
 
@@ -291,7 +300,9 @@ describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}
         expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
         const body = JSON.parse(response.payload)
         expect(body.message).toMatch(
-          new RegExp(`Cannot transition .* from ${status} to suspended`)
+          new RegExp(
+            `Cannot transition accreditation from approved: its status is ${status}`
+          )
         )
       }
     )
@@ -358,10 +369,7 @@ describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}
       )
     })
 
-    // Not exhaustive over statuses: the map also allows created -> approved
-    // (grant) and cancelled -> approved (reinstate after cancellation), which
-    // are separate stories exercised through the same endpoint.
-    it.each(['approved', 'rejected'])(
+    it.each(['approved', 'rejected', 'created'])(
       'returns 422 when the accreditation is currently %s',
       async (status) => {
         const ctx = await seedOrg(status, { registrationStatus: 'approved' })
@@ -376,19 +384,182 @@ describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}
         expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
         const body = JSON.parse(response.payload)
         expect(body.message).toMatch(
-          new RegExp(`Cannot transition .* from ${status} to approved`)
+          new RegExp(
+            `Cannot transition accreditation from suspended: its status is ${status}`
+          )
         )
       }
     )
   })
 
+  describe('granting a created accreditation', () => {
+    // A created accreditation has no number or validFrom yet; validTo is
+    // owned by the application data and must already be present.
+    const ungrantedAccreditation = {
+      accreditationNumber: null,
+      validFrom: null,
+      validTo: '2026-12-31'
+    }
+
+    const buildOrgHoldingNumber = (accreditationNumber) =>
+      /** @type {import('#domain/organisations/model.js').Organisation} */ (
+        /** @type {unknown} */ (
+          buildOrganisation({
+            accreditations: [buildAccreditation({ accreditationNumber })]
+          })
+        )
+      )
+
+    it('grants the accreditation, issuing the number and setting validFrom to appliesFrom', async () => {
+      const ctx = await seedOrg('created', {
+        registrationStatus: 'approved',
+        accreditationOverrides: ungrantedAccreditation
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: statusHistoryUrl(ctx),
+        payload: grantPayload,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(response.payload)).toEqual({ status: 'approved' })
+
+      const getResponse = await server.inject({
+        method: 'GET',
+        url: `/v1/organisations/${ctx.organisationId}`,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+      const updatedOrg = JSON.parse(getResponse.payload)
+      const accreditation = updatedOrg.accreditations.find(
+        (a) => a.id === ctx.accreditationId
+      )
+
+      expect(accreditation.status).toBe('approved')
+      expect(accreditation.accreditationNumber).toBe('ACC999999')
+      expect(accreditation.validFrom).toBe('2026-08-01')
+      expect(accreditation.validTo).toBe('2026-12-31')
+      expect(accreditation.statusHistory.map((e) => e.status)).toEqual([
+        'created',
+        'approved'
+      ])
+    })
+
+    it('returns 422 when the accreditation number is already in use by another organisation', async () => {
+      const ctx = await seedOrg('created', {
+        registrationStatus: 'approved',
+        accreditationOverrides: ungrantedAccreditation,
+        extraOrgs: [buildOrgHoldingNumber('ACC555555')]
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: statusHistoryUrl(ctx),
+        payload: { ...grantPayload, accreditationNumber: 'ACC555555' },
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      const body = JSON.parse(response.payload)
+      expect(body.message).toMatch(
+        /Accreditation number ACC555555 is already in use/
+      )
+    })
+
+    it('returns 422 when the linked registration is not approved', async () => {
+      const ctx = await seedOrg('created', {
+        accreditationOverrides: ungrantedAccreditation
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: statusHistoryUrl(ctx),
+        payload: grantPayload,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      const body = JSON.parse(response.payload)
+      expect(body.message).toMatch(
+        /approved but not linked to an approved registration/
+      )
+    })
+
+    it('returns 422 when the accreditation has no validTo, which granting does not set', async () => {
+      const ctx = await seedOrg('created', {
+        registrationStatus: 'approved',
+        accreditationOverrides: { ...ungrantedAccreditation, validTo: null }
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: statusHistoryUrl(ctx),
+        payload: grantPayload,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      const body = JSON.parse(response.payload)
+      expect(body.message).toMatch(/validTo/)
+    })
+
+    it('returns 422 when the accreditation is not currently created', async () => {
+      const ctx = await seedOrg('suspended', { registrationStatus: 'approved' })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: statusHistoryUrl(ctx),
+        payload: grantPayload,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      const body = JSON.parse(response.payload)
+      expect(body.message).toMatch(
+        /Cannot transition accreditation from created: its status is suspended/
+      )
+    })
+  })
+
   describe('payload validation', () => {
     it.each([
       ['payload is missing', undefined],
-      ['status is missing', {}],
-      ['status is not a supported transition target', { status: 'cancelled' }],
-      ['status is not a known status', { status: 'nonsense' }],
-      ['payload has unexpected fields', { status: 'suspended', reason: 'x' }]
+      ['payload is empty', {}],
+      ['payload uses the old status-only shape', { status: 'suspended' }],
+      [
+        'the from/to pair is not a supported transition',
+        { fromStatus: 'suspended', toStatus: 'cancelled' }
+      ],
+      [
+        'toStatus is not a known status',
+        { fromStatus: 'approved', toStatus: 'nonsense' }
+      ],
+      ['payload has unexpected fields', { ...suspendPayload, reason: 'x' }],
+      [
+        'a non-grant transition carries grant fields',
+        {
+          ...reinstatePayload,
+          appliesFrom: '2026-08-01',
+          accreditationNumber: 'ACC999999'
+        }
+      ],
+      [
+        'a grant is missing appliesFrom',
+        { ...grantPayload, appliesFrom: undefined }
+      ],
+      [
+        'a grant is missing the accreditation number',
+        { ...grantPayload, accreditationNumber: undefined }
+      ],
+      [
+        'a grant has an invalid appliesFrom date',
+        { ...grantPayload, appliesFrom: '2026-13-45' }
+      ],
+      [
+        'a grant has an empty accreditation number',
+        { ...grantPayload, accreditationNumber: ' ' }
+      ]
     ])('returns 422 when %s', async (_label, payload) => {
       const ctx = await seedOrg('approved')
 

--- a/src/routes/v1/organisations/accreditation-status-history.test.js
+++ b/src/routes/v1/organisations/accreditation-status-history.test.js
@@ -467,6 +467,26 @@ describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}
       )
     })
 
+    it('returns 422 when appliesFrom is after the accreditation validTo', async () => {
+      const ctx = await seedOrg('created', {
+        registrationStatus: 'approved',
+        accreditationOverrides: ungrantedAccreditation
+      })
+
+      const response = await server.inject({
+        method: 'POST',
+        url: statusHistoryUrl(ctx),
+        payload: { ...grantPayload, appliesFrom: '2027-06-01' },
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      const body = JSON.parse(response.payload)
+      expect(body.message).toMatch(
+        /appliesFrom 2027-06-01 is after validTo 2026-12-31/
+      )
+    })
+
     it('returns 422 when the linked registration is not approved', async () => {
       const ctx = await seedOrg('created', {
         accreditationOverrides: ungrantedAccreditation
@@ -555,6 +575,10 @@ describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}
       [
         'a grant has an invalid appliesFrom date',
         { ...grantPayload, appliesFrom: '2026-13-45' }
+      ],
+      [
+        'a grant has an appliesFrom day that does not exist in that month',
+        { ...grantPayload, appliesFrom: '2026-02-30' }
       ],
       [
         'a grant has an empty accreditation number',

--- a/src/test/mock-repositories.js
+++ b/src/test/mock-repositories.js
@@ -27,6 +27,7 @@ export const createMockOrganisationsRepository = (overrides = {}) => ({
   findByIds: vi.fn(),
   findById: vi.fn(),
   findByLinkedDefraOrgId: vi.fn(),
+  findByAccreditationNumber: vi.fn(),
   findAllLinked: vi.fn(),
   findAllLinkableForUser: vi.fn(),
   findRegistrationById: vi.fn(),

--- a/src/test/mock-repositories.test.js
+++ b/src/test/mock-repositories.test.js
@@ -24,6 +24,7 @@ describe('mock-repositories', () => {
         'findByIds',
         'findById',
         'findByLinkedDefraOrgId',
+        'findByAccreditationNumber',
         'findAllLinked',
         'findAllLinkableForUser',
         'findRegistrationById',


### PR DESCRIPTION
Ticket: [PAE-1617](https://eaflood.atlassian.net/browse/PAE-1617)
## Summary

- Extends the status-history endpoint with the `created → approved` (grant) transition. The payload union is now discriminated on an explicit `{ fromStatus, toStatus }` pair — each supported transition is its own arm, and the handler returns 422 when the accreditation is not actually in `fromStatus`
- The grant arm takes `appliesFrom` (YYYY-MM-DD) and `accreditationNumber` (non-empty). The number is issued at grant and must be unique across all organisations' accreditations — new `findByAccreditationNumber` port method (MongoDB + in-memory + contract tests); 422 when already in use. Uniqueness is app-enforced only (no unique index) — documented in the handler
- `validFrom` is set to `appliesFrom`; **`validTo` is not changed** — approval 422s via the existing schema guard if the accreditation data carries no `validTo`, and 422s when `appliesFrom` is after the existing `validTo` so an inverted validity window cannot be written
- Date strings are validated by a shared `isoDateString()` Joi schema with a round-trip check, so impossible calendar dates (e.g. `2026-02-30`, which `Date` silently rolls to March 2) are rejected. Used for both the `appliesFrom` payload field and the stored `validFrom`/`validTo` schema, replacing two duplicated validators


[PAE-1617]: https://eaflood.atlassian.net/browse/PAE-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
