### PR TITLE
PAE-1705: remove suspended status from registrations

### DIFF
--- a/src/application/public-register/public-register-transformer.js
+++ b/src/application/public-register/public-register-transformer.js
@@ -20,7 +20,15 @@ import chunk from 'lodash.chunk'
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
 import { config } from '#root/config.js'
 
-const INCLUDED_STATUSES = new Set([
+// A registration's own status can never be suspended (suspension is an
+// accreditation-only concept), so suspended is excluded here.
+const REGISTRATION_INCLUDED_STATUSES = new Set([
+  REG_ACC_STATUS.APPROVED,
+  REG_ACC_STATUS.CANCELLED
+])
+
+// Cancelled and suspended accreditations remain on the public register (BR-E8).
+const ACCREDITATION_INCLUDED_STATUSES = new Set([
   REG_ACC_STATUS.APPROVED,
   REG_ACC_STATUS.SUSPENDED,
   REG_ACC_STATUS.CANCELLED
@@ -92,13 +100,18 @@ function getLinkedAccreditation(registration, accreditations) {
   return registration.accreditationId
     ? accreditations.find(
         (acc) =>
-          acc.id === registration.accreditationId && isInPublishableState(acc)
+          acc.id === registration.accreditationId &&
+          isAccreditationInPublishableState(acc)
       )
     : null
 }
 
-function isInPublishableState(item) {
-  return INCLUDED_STATUSES.has(item.status)
+function isRegistrationInPublishableState(item) {
+  return REGISTRATION_INCLUDED_STATUSES.has(item.status)
+}
+
+function isAccreditationInPublishableState(item) {
+  return ACCREDITATION_INCLUDED_STATUSES.has(item.status)
 }
 
 function isTestOrg(org) {
@@ -115,22 +128,24 @@ function processBatch(batch, reportComplianceData) {
   return batch
     .filter((org) => !isTestOrg(org))
     .flatMap((org) =>
-      org.registrations.filter(isInPublishableState).map((registration) => {
-        const accreditation = getLinkedAccreditation(
-          registration,
-          org.accreditations
-        )
-        const entry = entries.get(registration.id)
-        const reportComplianceFields = entry
-          ? buildReportComplianceFields(periods, entry)
-          : {}
-        return transformRegAcc(
-          org,
-          registration,
-          accreditation,
-          reportComplianceFields
-        )
-      })
+      org.registrations
+        .filter(isRegistrationInPublishableState)
+        .map((registration) => {
+          const accreditation = getLinkedAccreditation(
+            registration,
+            org.accreditations
+          )
+          const entry = entries.get(registration.id)
+          const reportComplianceFields = entry
+            ? buildReportComplianceFields(periods, entry)
+            : {}
+          return transformRegAcc(
+            org,
+            registration,
+            accreditation,
+            reportComplianceFields
+          )
+        })
     )
 }
 

--- a/src/application/public-register/public-register-transformer.test.js
+++ b/src/application/public-register/public-register-transformer.test.js
@@ -215,17 +215,6 @@ describe('transform', () => {
     }
   )
 
-  it('should exclude suspended registrations', async () => {
-    const registration = createTestRegistration({
-      status: REG_ACC_STATUS.SUSPENDED
-    })
-    const org = createTestOrganisation({ registrations: [registration] })
-
-    const rows = await transform([org], { periods: [], entries: new Map() })
-
-    expect(rows).toHaveLength(0)
-  })
-
   it.each([
     {
       status: REG_ACC_STATUS.APPROVED,

--- a/src/application/public-register/public-register-transformer.test.js
+++ b/src/application/public-register/public-register-transformer.test.js
@@ -181,10 +181,6 @@ describe('transform', () => {
       expectedStatus: 'Approved'
     },
     {
-      status: REG_ACC_STATUS.SUSPENDED,
-      expectedStatus: 'Suspended'
-    },
-    {
       status: REG_ACC_STATUS.CANCELLED,
       expectedStatus: 'Cancelled'
     }
@@ -218,6 +214,17 @@ describe('transform', () => {
       ])
     }
   )
+
+  it('should exclude suspended registrations', async () => {
+    const registration = createTestRegistration({
+      status: REG_ACC_STATUS.SUSPENDED
+    })
+    const org = createTestOrganisation({ registrations: [registration] })
+
+    const rows = await transform([org], { periods: [], entries: new Map() })
+
+    expect(rows).toHaveLength(0)
+  })
 
   it.each([
     {

--- a/src/domain/organisations/registration-utils.js
+++ b/src/domain/organisations/registration-utils.js
@@ -8,11 +8,7 @@ import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.
 const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
 const REPORTABLE_STATUSES = /** @type {Set<RegAccStatus>} */ (
-  new Set([
-    REG_ACC_STATUS.APPROVED,
-    REG_ACC_STATUS.SUSPENDED,
-    REG_ACC_STATUS.CANCELLED
-  ])
+  new Set([REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.CANCELLED])
 )
 
 const ACTIVE_ACCREDITATION_STATUSES = /** @type {Set<RegAccStatus>} */ (
@@ -20,7 +16,7 @@ const ACTIVE_ACCREDITATION_STATUSES = /** @type {Set<RegAccStatus>} */ (
 )
 
 /**
- * Returns all reportable (approved/suspended/cancelled) registrations across all non-test organisations.
+ * Returns all reportable (approved/cancelled) registrations across all non-test organisations.
  *
  * @param {Organisation[]} orgs
  * @returns {Array<{ org: Organisation, registration: RegistrationApproved }>}

--- a/src/domain/organisations/registration-utils.js
+++ b/src/domain/organisations/registration-utils.js
@@ -2,7 +2,7 @@ import { REG_ACC_STATUS } from '#domain/organisations/model.js'
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
 
 /** @import { GlassRecyclingProcess, Material, Organisation, RegAccStatus } from '#domain/organisations/model.js' */
-/** @import { Registration, RegistrationApproved } from '#domain/organisations/registration.js' */
+/** @import { Registration, ReportableRegistration } from '#domain/organisations/registration.js' */
 /** @import { Accreditation } from '#domain/organisations/accreditation.js' */
 
 const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
@@ -19,7 +19,7 @@ const ACTIVE_ACCREDITATION_STATUSES = /** @type {Set<RegAccStatus>} */ (
  * Returns all reportable (approved/cancelled) registrations across all non-test organisations.
  *
  * @param {Organisation[]} orgs
- * @returns {Array<{ org: Organisation, registration: RegistrationApproved }>}
+ * @returns {Array<{ org: Organisation, registration: ReportableRegistration }>}
  */
 export function getReportableRegistrations(orgs) {
   return orgs
@@ -29,7 +29,7 @@ export function getReportableRegistrations(orgs) {
         .filter((registration) => REPORTABLE_STATUSES.has(registration.status))
         .map((registration) => ({
           org,
-          registration: /** @type {RegistrationApproved} */ (registration)
+          registration: /** @type {ReportableRegistration} */ (registration)
         }))
     )
 }

--- a/src/domain/organisations/registration-utils.test.js
+++ b/src/domain/organisations/registration-utils.test.js
@@ -80,29 +80,20 @@ describe('getReportableRegistrations', () => {
     expect(result[0].registration.status).toBe('approved')
   })
 
-  it('excludes suspended registrations', () => {
-    const org = buildOrg({ registrations: [buildReg({ status: 'suspended' })] })
-
-    expect(getReportableRegistrations([org])).toHaveLength(0)
-  })
-
   it('includes cancelled registrations', () => {
     const org = buildOrg({ registrations: [buildReg({ status: 'cancelled' })] })
 
     expect(getReportableRegistrations([org])).toHaveLength(1)
   })
 
-  it('excludes created registrations', () => {
-    const org = buildOrg({ registrations: [buildReg({ status: 'created' })] })
+  it.each(['suspended', 'created', 'rejected'])(
+    'excludes %s registrations',
+    (status) => {
+      const org = buildOrg({ registrations: [buildReg({ status })] })
 
-    expect(getReportableRegistrations([org])).toHaveLength(0)
-  })
-
-  it('excludes rejected registrations', () => {
-    const org = buildOrg({ registrations: [buildReg({ status: 'rejected' })] })
-
-    expect(getReportableRegistrations([org])).toHaveLength(0)
-  })
+      expect(getReportableRegistrations([org])).toHaveLength(0)
+    }
+  )
 
   it('excludes test organisations by orgId', () => {
     const testOrg = buildOrg({

--- a/src/domain/organisations/registration-utils.test.js
+++ b/src/domain/organisations/registration-utils.test.js
@@ -80,10 +80,10 @@ describe('getReportableRegistrations', () => {
     expect(result[0].registration.status).toBe('approved')
   })
 
-  it('includes suspended registrations', () => {
+  it('excludes suspended registrations', () => {
     const org = buildOrg({ registrations: [buildReg({ status: 'suspended' })] })
 
-    expect(getReportableRegistrations([org])).toHaveLength(1)
+    expect(getReportableRegistrations([org])).toHaveLength(0)
   })
 
   it('includes cancelled registrations', () => {

--- a/src/domain/organisations/registration.js
+++ b/src/domain/organisations/registration.js
@@ -52,7 +52,7 @@
 /**
  * @typedef {RegistrationBase & {
  *  registrationNumber: string;
- *  status: Extract<RegAccStatus, 'approved'|'suspended'>;
+ *  status: Extract<RegAccStatus, 'approved'>;
  *  validFrom: string;
  *  validTo: string;
  * }} RegistrationApproved

--- a/src/domain/organisations/registration.js
+++ b/src/domain/organisations/registration.js
@@ -72,4 +72,16 @@
  * @typedef {RegistrationApproved | RegistrationOther} Registration
  */
 
+/**
+ * A registration that appears in regulator reports: approved, or cancelled
+ * after approval. A cancelled registration was previously approved, so it
+ * carries its registration number and validity dates.
+ * @typedef {RegistrationBase & {
+ *  registrationNumber: string;
+ *  status: Extract<RegAccStatus, 'approved'|'cancelled'>;
+ *  validFrom: string;
+ *  validTo: string;
+ * }} ReportableRegistration
+ */
+
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/domain/organisations/status.js
+++ b/src/domain/organisations/status.js
@@ -17,7 +17,20 @@ const VALID_ORG_TRANSITIONS = {
   [ORGANISATION_STATUS.REJECTED]: [ORGANISATION_STATUS.CREATED]
 }
 
-const VALID_REG_ACC_TRANSITIONS = {
+// Registrations cannot be suspended (PAE-1705): a registration is either live
+// or terminated, so approved -> cancelled is direct and there is no suspended
+// node at all.
+const VALID_REG_TRANSITIONS = {
+  [REG_ACC_STATUS.CREATED]: [REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.REJECTED],
+  [REG_ACC_STATUS.APPROVED]: [REG_ACC_STATUS.CREATED, REG_ACC_STATUS.CANCELLED],
+  [REG_ACC_STATUS.CANCELLED]: [REG_ACC_STATUS.APPROVED],
+  [REG_ACC_STATUS.REJECTED]: [REG_ACC_STATUS.CREATED]
+}
+
+// Accreditations keep suspension and may only reach cancelled via suspended
+// (ADR 0042). The registration-cancellation cascade bypasses this table by
+// design — cancelling a registration force-cancels its linked accreditation.
+const VALID_ACC_TRANSITIONS = {
   [REG_ACC_STATUS.CREATED]: [REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.REJECTED],
   [REG_ACC_STATUS.APPROVED]: [REG_ACC_STATUS.SUSPENDED, REG_ACC_STATUS.CREATED],
   [REG_ACC_STATUS.SUSPENDED]: [
@@ -39,13 +52,26 @@ export const assertOrgStatusTransitionValid = (fromStatus, toStatus) => {
   }
 }
 
-export const assertRegAccStatusTransitionValid = (fromStatus, toStatus) => {
-  const allowedTransitions = VALID_REG_ACC_TRANSITIONS[fromStatus]
-  const isValid = allowedTransitions.includes(toStatus)
+/**
+ * @param {Record<string, string[]>} validTransitions
+ * @param {'registration' | 'accreditation'} itemKind
+ * @returns {(fromStatus: string, toStatus: string) => void}
+ */
+const makeAssertStatusTransitionValid = (validTransitions, itemKind) => {
+  return (fromStatus, toStatus) => {
+    const allowedTransitions = validTransitions[fromStatus] ?? []
+    const isValid = allowedTransitions.includes(toStatus)
 
-  if (!isValid) {
-    throw Boom.badData(
-      `Cannot transition registration/accreditation status from ${fromStatus} to ${toStatus}`
-    )
+    if (!isValid) {
+      throw Boom.badData(
+        `Cannot transition ${itemKind} status from ${fromStatus} to ${toStatus}`
+      )
+    }
   }
 }
+
+export const assertRegistrationStatusTransitionValid =
+  makeAssertStatusTransitionValid(VALID_REG_TRANSITIONS, 'registration')
+
+export const assertAccreditationStatusTransitionValid =
+  makeAssertStatusTransitionValid(VALID_ACC_TRANSITIONS, 'accreditation')

--- a/src/domain/organisations/status.test.js
+++ b/src/domain/organisations/status.test.js
@@ -1,12 +1,52 @@
 import { describe, expect, it } from 'vitest'
 import {
+  assertAccreditationStatusTransitionValid,
   assertOrgStatusTransitionValid,
-  assertRegAccStatusTransitionValid
+  assertRegistrationStatusTransitionValid
 } from './status.js'
 import { ORGANISATION_STATUS, REG_ACC_STATUS } from './model.js'
 import Boom from '@hapi/boom'
 
 /** @import {OrganisationStatus, RegAccStatus} from './model.js' */
+
+/**
+ * @param {(fromStatus: string, toStatus: string) => void} assertTransitionValid
+ * @param {'registration' | 'accreditation'} itemKind
+ * @param {[RegAccStatus, RegAccStatus, boolean][]} transitionTable
+ */
+const describeTransitionTable = (
+  assertTransitionValid,
+  itemKind,
+  transitionTable
+) => {
+  describe('valid transitions', () => {
+    const validTransitions = transitionTable.filter(([, , isValid]) => isValid)
+
+    it.each(validTransitions)(
+      'allows transition from %s to %s',
+      (fromStatus, toStatus) => {
+        expect(() => assertTransitionValid(fromStatus, toStatus)).not.toThrow()
+      }
+    )
+  })
+
+  describe('invalid transitions', () => {
+    const invalidTransitions = transitionTable.filter(
+      ([, , isValid]) => !isValid
+    )
+
+    it.each(invalidTransitions)(
+      'rejects transition from %s to %s with Boom error',
+      (fromStatus, toStatus) => {
+        expect(() => assertTransitionValid(fromStatus, toStatus)).toThrow(
+          Boom.badData(
+            `Cannot transition ${itemKind} status from ${fromStatus} to ${toStatus}`
+          )
+        )
+      }
+    )
+  })
+}
 
 describe('assertOrgStatusTransitionValid', () => {
   /** @type {[OrganisationStatus, OrganisationStatus, boolean][]} */
@@ -69,7 +109,7 @@ describe('assertOrgStatusTransitionValid', () => {
   })
 })
 
-describe('assertRegAccStatusTransitionValid', () => {
+describe('assertRegistrationStatusTransitionValid', () => {
   /** @type {[RegAccStatus, RegAccStatus, boolean][]} */
   const transitionTable = [
     // From CREATED
@@ -79,7 +119,55 @@ describe('assertRegAccStatusTransitionValid', () => {
     [REG_ACC_STATUS.CREATED, REG_ACC_STATUS.CANCELLED, false],
     [REG_ACC_STATUS.CREATED, REG_ACC_STATUS.CREATED, false],
 
-    // From APPROVED
+    // From APPROVED — direct cancellation is valid; suspension is not a
+    // registration status (PAE-1705)
+    [REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.CREATED, true],
+    [REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.CANCELLED, true],
+    [REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.SUSPENDED, false],
+    [REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.REJECTED, false],
+    [REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.APPROVED, false],
+
+    // From SUSPENDED — not a registration status; nothing is reachable
+    [REG_ACC_STATUS.SUSPENDED, REG_ACC_STATUS.APPROVED, false],
+    [REG_ACC_STATUS.SUSPENDED, REG_ACC_STATUS.CANCELLED, false],
+    [REG_ACC_STATUS.SUSPENDED, REG_ACC_STATUS.CREATED, false],
+    [REG_ACC_STATUS.SUSPENDED, REG_ACC_STATUS.REJECTED, false],
+    [REG_ACC_STATUS.SUSPENDED, REG_ACC_STATUS.SUSPENDED, false],
+
+    // From CANCELLED — reinstatement only
+    [REG_ACC_STATUS.CANCELLED, REG_ACC_STATUS.APPROVED, true],
+    [REG_ACC_STATUS.CANCELLED, REG_ACC_STATUS.CREATED, false],
+    [REG_ACC_STATUS.CANCELLED, REG_ACC_STATUS.REJECTED, false],
+    [REG_ACC_STATUS.CANCELLED, REG_ACC_STATUS.SUSPENDED, false],
+    [REG_ACC_STATUS.CANCELLED, REG_ACC_STATUS.CANCELLED, false],
+
+    // From REJECTED
+    [REG_ACC_STATUS.REJECTED, REG_ACC_STATUS.CREATED, true],
+    [REG_ACC_STATUS.REJECTED, REG_ACC_STATUS.APPROVED, false],
+    [REG_ACC_STATUS.REJECTED, REG_ACC_STATUS.SUSPENDED, false],
+    [REG_ACC_STATUS.REJECTED, REG_ACC_STATUS.CANCELLED, false],
+    [REG_ACC_STATUS.REJECTED, REG_ACC_STATUS.REJECTED, false]
+  ]
+
+  describeTransitionTable(
+    assertRegistrationStatusTransitionValid,
+    'registration',
+    transitionTable
+  )
+})
+
+describe('assertAccreditationStatusTransitionValid', () => {
+  /** @type {[RegAccStatus, RegAccStatus, boolean][]} */
+  const transitionTable = [
+    // From CREATED
+    [REG_ACC_STATUS.CREATED, REG_ACC_STATUS.APPROVED, true],
+    [REG_ACC_STATUS.CREATED, REG_ACC_STATUS.REJECTED, true],
+    [REG_ACC_STATUS.CREATED, REG_ACC_STATUS.SUSPENDED, false],
+    [REG_ACC_STATUS.CREATED, REG_ACC_STATUS.CANCELLED, false],
+    [REG_ACC_STATUS.CREATED, REG_ACC_STATUS.CREATED, false],
+
+    // From APPROVED — suspension stays an accreditation concept; direct
+    // cancellation stays forbidden (ADR 0042 — cancelled only from suspended)
     [REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.SUSPENDED, true],
     [REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.CREATED, true],
     [REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.REJECTED, false],
@@ -93,14 +181,14 @@ describe('assertRegAccStatusTransitionValid', () => {
     [REG_ACC_STATUS.SUSPENDED, REG_ACC_STATUS.REJECTED, false],
     [REG_ACC_STATUS.SUSPENDED, REG_ACC_STATUS.SUSPENDED, false],
 
-    // From CANCELLED
-    [REG_ACC_STATUS.CANCELLED, REG_ACC_STATUS.CREATED, false],
+    // From CANCELLED — reinstatement only
     [REG_ACC_STATUS.CANCELLED, REG_ACC_STATUS.APPROVED, true],
+    [REG_ACC_STATUS.CANCELLED, REG_ACC_STATUS.CREATED, false],
     [REG_ACC_STATUS.CANCELLED, REG_ACC_STATUS.REJECTED, false],
     [REG_ACC_STATUS.CANCELLED, REG_ACC_STATUS.SUSPENDED, false],
     [REG_ACC_STATUS.CANCELLED, REG_ACC_STATUS.CANCELLED, false],
 
-    // From REJECTED (no valid transitions)
+    // From REJECTED
     [REG_ACC_STATUS.REJECTED, REG_ACC_STATUS.CREATED, true],
     [REG_ACC_STATUS.REJECTED, REG_ACC_STATUS.APPROVED, false],
     [REG_ACC_STATUS.REJECTED, REG_ACC_STATUS.SUSPENDED, false],
@@ -108,35 +196,9 @@ describe('assertRegAccStatusTransitionValid', () => {
     [REG_ACC_STATUS.REJECTED, REG_ACC_STATUS.REJECTED, false]
   ]
 
-  describe('valid transitions', () => {
-    const validTransitions = transitionTable.filter(([, , isValid]) => isValid)
-
-    it.each(validTransitions)(
-      'allows transition from %s to %s',
-      (fromStatus, toStatus) => {
-        expect(() =>
-          assertRegAccStatusTransitionValid(fromStatus, toStatus)
-        ).not.toThrow()
-      }
-    )
-  })
-
-  describe('invalid transitions', () => {
-    const invalidTransitions = transitionTable.filter(
-      ([, , isValid]) => !isValid
-    )
-
-    it.each(invalidTransitions)(
-      'rejects transition from %s to %s with Boom error',
-      (fromStatus, toStatus) => {
-        expect(() =>
-          assertRegAccStatusTransitionValid(fromStatus, toStatus)
-        ).toThrow(
-          Boom.badData(
-            `Cannot transition registration/accreditation status from ${fromStatus} to ${toStatus}`
-          )
-        )
-      }
-    )
-  })
+  describeTransitionTable(
+    assertAccreditationStatusTransitionValid,
+    'accreditation',
+    transitionTable
+  )
 })

--- a/src/reports/application/report-compliance.js
+++ b/src/reports/application/report-compliance.js
@@ -73,7 +73,7 @@ function groupByRegistration(allPeriodicReports) {
 }
 
 /**
- * Builds a map of report compliance data for all approved/suspended registrations.
+ * Builds a map of report compliance data for all approved/cancelled registrations.
  *
  * Each entry in `entries` is keyed by `registrationId` and contains only the
  * periods that were actually submitted (`submittedDates`). The consumer can

--- a/src/reports/application/report-submissions.js
+++ b/src/reports/application/report-submissions.js
@@ -1,5 +1,5 @@
 /** @import { Organisation } from '#domain/organisations/model.js' */
-/** @import { RegistrationApproved } from '#domain/organisations/registration.js' */
+/** @import { ReportableRegistration } from '#domain/organisations/registration.js' */
 /** @import { MergedPeriod } from '#reports/domain/merge-reporting-periods.js' */
 
 import { CADENCE } from '#reports/domain/cadence.js'
@@ -133,7 +133,7 @@ function buildTonnageFields(report) {
 
 /**
  * @param {Organisation} org
- * @param {RegistrationApproved} registration
+ * @param {ReportableRegistration} registration
  * @param {string} cadence
  * @param {MergedPeriod} mergedPeriod
  * @param {string} accreditationNumber

--- a/src/reports/application/report-submissions.js
+++ b/src/reports/application/report-submissions.js
@@ -241,7 +241,7 @@ async function buildSubmissionRows(
 }
 
 /**
- * Generates a flat list of report submission rows across all approved/suspended
+ * Generates a flat list of report submission rows across all approved/cancelled
  * registrations for all organisations.
  *
  * @param {import('#repositories/organisations/port.js').OrganisationsRepository} organisationsRepository

--- a/src/repositories/organisations/contract/reg-acc-approval.contract.js
+++ b/src/repositories/organisations/contract/reg-acc-approval.contract.js
@@ -900,7 +900,7 @@ export const testRegAccApprovalValidation = (it) => {
           expect(updatedReg.validTo).toBe(VALID_TO)
         })
 
-        it('rejects update when registration status changes to suspended without registrationNumber', async () => {
+        it('rejects update when registration status changes to suspended (not an allowed registration status)', async () => {
           const organisation = buildOrganisation()
           await repository.insert(organisation)
           const inserted = await repository.findById(organisation.id)
@@ -908,9 +908,10 @@ export const testRegAccApprovalValidation = (it) => {
           const registrationToUpdate = {
             ...inserted.registrations[0],
             status: REG_ACC_STATUS.SUSPENDED,
-            registrationNumber: null,
+            registrationNumber: 'REG12345',
             validFrom: VALID_FROM,
-            validTo: VALID_TO
+            validTo: VALID_TO,
+            reprocessingType: REPROCESSING_TYPE.INPUT
           }
 
           await expect(
@@ -922,7 +923,7 @@ export const testRegAccApprovalValidation = (it) => {
               })
             )
           ).rejects.toThrow(
-            /Invalid organisation data: registrations\.0\.registrationNumber:.*contains an invalid value/
+            /Invalid organisation data: registrations\.0\.status/
           )
         })
       })
@@ -1399,61 +1400,7 @@ export const testRegAccApprovalValidation = (it) => {
           )
         })
 
-        it('rejects update when registration status changes to suspended without validFrom', async () => {
-          const organisation = buildOrganisation()
-          await repository.insert(organisation)
-          const inserted = await repository.findById(organisation.id)
-
-          const registrationToUpdate = {
-            ...inserted.registrations[0],
-            status: REG_ACC_STATUS.SUSPENDED,
-            registrationNumber: 'REG12345',
-            validFrom: null,
-            validTo: VALID_TO,
-            reprocessingType: REPROCESSING_TYPE.INPUT
-          }
-
-          await expect(
-            repository.replace(
-              organisation.id,
-              1,
-              prepareOrgUpdate(inserted, {
-                registrations: [registrationToUpdate]
-              })
-            )
-          ).rejects.toThrow(
-            /Invalid organisation data: registrations\.0\.validFrom:.*contains an invalid value/
-          )
-        })
-
-        it('rejects update when registration status changes to suspended without validTo', async () => {
-          const organisation = buildOrganisation()
-          await repository.insert(organisation)
-          const inserted = await repository.findById(organisation.id)
-
-          const registrationToUpdate = {
-            ...inserted.registrations[0],
-            status: REG_ACC_STATUS.SUSPENDED,
-            registrationNumber: 'REG12345',
-            validFrom: VALID_FROM,
-            validTo: null,
-            reprocessingType: REPROCESSING_TYPE.INPUT
-          }
-
-          await expect(
-            repository.replace(
-              organisation.id,
-              1,
-              prepareOrgUpdate(inserted, {
-                registrations: [registrationToUpdate]
-              })
-            )
-          ).rejects.toThrow(
-            /Invalid organisation data: registrations\.0\.validTo:.*contains an invalid value/
-          )
-        })
-
-        it('allows update when registration status is not approved or suspended without validFrom and validTo', async () => {
+        it('allows update when registration status is not approved without validFrom and validTo', async () => {
           const organisation = buildOrganisation()
           await repository.insert(organisation)
           const inserted = await repository.findById(organisation.id)

--- a/src/repositories/organisations/contract/reg-acc-status-transition.contract.js
+++ b/src/repositories/organisations/contract/reg-acc-status-transition.contract.js
@@ -322,6 +322,66 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
           expect(reinstatedReg.status).toBe(REG_ACC_STATUS.APPROVED)
         })
 
+        it('leaves a CREATED linked accreditation untouched when the registration is cancelled', async () => {
+          // A registration can be approved while its accreditation application
+          // is still pending — the cascade must not cancel a never-live
+          // accreditation
+          const orgData = buildOrganisation()
+          await repository.insert(orgData)
+          const inserted = await repository.findById(orgData.id)
+
+          const approvedReg = {
+            ...inserted.registrations[0],
+            status: REG_ACC_STATUS.APPROVED,
+            registrationNumber: 'REG12345',
+            validFrom: VALID_FROM,
+            validTo: VALID_TO,
+            reprocessingType: REPROCESSING_TYPE.INPUT,
+            accreditationId: inserted.accreditations[0].id
+          }
+
+          await repository.replace(
+            orgData.id,
+            1,
+            prepareOrgUpdate(inserted, {
+              registrations: [approvedReg],
+              accreditations: [
+                {
+                  ...inserted.accreditations[0],
+                  reprocessingType: REPROCESSING_TYPE.INPUT
+                }
+              ]
+            })
+          )
+
+          const afterApprovalOfReg = await repository.findById(orgData.id, 2)
+          const linkedReg = afterApprovalOfReg.registrations[0]
+          assert.strictEqual(
+            afterApprovalOfReg.accreditations[0].status,
+            REG_ACC_STATUS.CREATED
+          )
+
+          await repository.replace(
+            orgData.id,
+            2,
+            prepareOrgUpdate(afterApprovalOfReg, {
+              registrations: [
+                { ...linkedReg, status: REG_ACC_STATUS.CANCELLED }
+              ]
+            })
+          )
+
+          const result = await repository.findById(orgData.id, 3)
+          const untouchedAcc = result.accreditations.find(
+            (a) => a.id === inserted.accreditations[0].id
+          )
+
+          expect(untouchedAcc.status).toBe(REG_ACC_STATUS.CREATED)
+          expect(untouchedAcc.statusHistory.map((h) => h.status)).not.toContain(
+            REG_ACC_STATUS.CANCELLED
+          )
+        })
+
         it('does not reinstate the cascade-cancelled accreditation when the registration is reinstated', async () => {
           // Cancel directly — the cancellation force-cancels accreditation1
           await repository.replace(

--- a/src/repositories/organisations/contract/reg-acc-status-transition.contract.js
+++ b/src/repositories/organisations/contract/reg-acc-status-transition.contract.js
@@ -59,8 +59,10 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
             output: {
               statusCode: 422,
               payload: {
-                message: expect.stringContaining(
-                  `Cannot transition registration/accreditation status from ${REG_ACC_STATUS.CREATED} to ${REG_ACC_STATUS.SUSPENDED}`
+                // suspended is no longer an allowed registration status, so
+                // the schema rejects it before the transition table is consulted
+                message: expect.stringMatching(
+                  /Invalid organisation data: registrations\.0\.status/
                 )
               }
             }
@@ -145,30 +147,45 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
           assert.strictEqual(accreditation2.status, REG_ACC_STATUS.APPROVED)
         })
 
-        it('allows transition from APPROVED to SUSPENDED', async () => {
-          // Transition: APPROVED → SUSPENDED
-          const suspendedRegistration = {
-            ...registration1,
-            status: REG_ACC_STATUS.SUSPENDED
-          }
+        it('rejects transition from APPROVED to SUSPENDED (registrations cannot be suspended)', async () => {
+          const suspendedPayload = prepareOrgUpdate(afterApproval, {
+            registrations: [
+              {
+                ...registration1,
+                status: REG_ACC_STATUS.SUSPENDED
+              }
+            ]
+          })
 
-          await repository.replace(
-            organisation.id,
-            2,
-            prepareOrgUpdate(afterApproval, {
-              registrations: [suspendedRegistration]
-            })
+          await expect(
+            repository.replace(organisation.id, 2, suspendedPayload)
+          ).rejects.toMatchObject({
+            isBoom: true,
+            output: {
+              statusCode: 422,
+              payload: {
+                // suspended is no longer an allowed registration status, so
+                // the schema rejects it before the transition table is consulted
+                message: expect.stringMatching(
+                  /Invalid organisation data: registrations\.0\.status/
+                )
+              }
+            }
+          })
+
+          // The registration and its linked accreditation are untouched
+          const result = await repository.findById(organisation.id, 2)
+          const unchangedReg = result.registrations.find(
+            (r) => r.id === registration1.id
           )
-
-          const result = await repository.findById(organisation.id, 3)
-          const updatedReg = result.registrations.find(
-            (r) => r.id === suspendedRegistration.id
+          const unchangedAcc = result.accreditations.find(
+            (a) => a.id === accreditation1.id
           )
-
-          expect(updatedReg.status).toBe(REG_ACC_STATUS.SUSPENDED)
+          expect(unchangedReg.status).toBe(REG_ACC_STATUS.APPROVED)
+          expect(unchangedAcc.status).toBe(REG_ACC_STATUS.APPROVED)
         })
 
-        it('rejects transition from APPROVED to CANCELLED', async () => {
+        it('allows direct transition from APPROVED to CANCELLED', async () => {
           const cancelledPayload = prepareOrgUpdate(afterApproval, {
             registrations: [
               {
@@ -178,50 +195,9 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
             ]
           })
 
-          await expect(
-            repository.replace(organisation.id, 2, cancelledPayload)
-          ).rejects.toMatchObject({
-            isBoom: true,
-            output: {
-              statusCode: 422,
-              payload: {
-                message: expect.stringContaining(
-                  `Cannot transition registration/accreditation status from ${REG_ACC_STATUS.APPROVED} to ${REG_ACC_STATUS.CANCELLED}`
-                )
-              }
-            }
-          })
-        })
+          await repository.replace(organisation.id, 2, cancelledPayload)
 
-        it('allows transition from SUSPENDED to CANCELLED', async () => {
-          // First suspend
-          const suspendedRegistration = {
-            ...registration1,
-            status: REG_ACC_STATUS.SUSPENDED
-          }
-
-          await repository.replace(
-            organisation.id,
-            2,
-            prepareOrgUpdate(afterApproval, {
-              registrations: [suspendedRegistration]
-            })
-          )
-
-          // Now cancel
-          const cancelledRegistration = {
-            ...registration1,
-            status: REG_ACC_STATUS.CANCELLED
-          }
-          await repository.replace(
-            organisation.id,
-            3,
-            prepareOrgUpdate(afterApproval, {
-              registrations: [cancelledRegistration]
-            })
-          )
-
-          const result = await repository.findById(organisation.id, 4)
+          const result = await repository.findById(organisation.id, 3)
           const updatedReg = result.registrations.find(
             (r) => r.id === registration1.id
           )
@@ -229,58 +205,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
           expect(updatedReg.status).toBe(REG_ACC_STATUS.CANCELLED)
         })
 
-        it('cascades status to linked accreditation when registration moves to SUSPENDED', async () => {
-          // Transition registration1: APPROVED → SUSPENDED
-          const suspendedRegistration = {
-            ...registration1,
-            status: REG_ACC_STATUS.SUSPENDED
-          }
-
-          await repository.replace(
-            organisation.id,
-            2,
-            prepareOrgUpdate(afterApproval, {
-              registrations: [suspendedRegistration]
-            })
-          )
-
-          const result = await repository.findById(organisation.id, 3)
-          const updatedReg1 = result.registrations.find(
-            (r) => r.id === suspendedRegistration.id
-          )
-          const updatedAcc1 = result.accreditations.find(
-            (a) => a.id === accreditation1.id
-          )
-          const updatedReg2 = result.registrations.find(
-            (r) => r.id === registration2.id
-          )
-          const updatedAcc2 = result.accreditations.find(
-            (a) => a.id === accreditation2.id
-          )
-
-          // Verify registration1 and linked accreditation1 cascaded to SUSPENDED
-          expect(updatedReg1.status).toBe(REG_ACC_STATUS.SUSPENDED)
-          expect(updatedAcc1.status).toBe(REG_ACC_STATUS.SUSPENDED)
-
-          // Verify registration2 and accreditation2 remain APPROVED
-          expect(updatedReg2.status).toBe(REG_ACC_STATUS.APPROVED)
-          expect(updatedAcc2.status).toBe(REG_ACC_STATUS.APPROVED)
-        })
-
-        it('cascades status to linked accreditation when registration moves to CANCELLED', async () => {
-          const suspendedRegistration = {
-            ...registration1,
-            status: REG_ACC_STATUS.SUSPENDED
-          }
-
-          await repository.replace(
-            organisation.id,
-            2,
-            prepareOrgUpdate(afterApproval, {
-              registrations: [suspendedRegistration]
-            })
-          )
-
+        it('force-cancels the linked APPROVED accreditation when the registration is cancelled', async () => {
           const cancelledRegistration = {
             ...registration1,
             status: REG_ACC_STATUS.CANCELLED
@@ -288,13 +213,13 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
 
           await repository.replace(
             organisation.id,
-            3,
+            2,
             prepareOrgUpdate(afterApproval, {
               registrations: [cancelledRegistration]
             })
           )
 
-          const result = await repository.findById(organisation.id, 4)
+          const result = await repository.findById(organisation.id, 3)
           const finalReg1 = result.registrations.find(
             (r) => r.id === registration1.id
           )
@@ -308,29 +233,61 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
             (a) => a.id === accreditation2.id
           )
 
-          // Verify registration1 and linked accreditation1 cascaded to CANCELLED
+          // The accreditation is force-cancelled from APPROVED — the cascade
+          // bypasses the accreditation's suspended-first rule (Scenario 5)
           expect(finalReg1.status).toBe(REG_ACC_STATUS.CANCELLED)
           expect(finalAcc1.status).toBe(REG_ACC_STATUS.CANCELLED)
+          expect(finalAcc1.statusHistory.at(-1)).toMatchObject({
+            status: REG_ACC_STATUS.CANCELLED
+          })
 
           // Verify registration2 and accreditation2 remain APPROVED
           expect(finalReg2.status).toBe(REG_ACC_STATUS.APPROVED)
           expect(finalAcc2.status).toBe(REG_ACC_STATUS.APPROVED)
         })
 
-        it('allows transition from CANCELLED to APPROVED (reinstatement)', async () => {
-          // Suspend then cancel
+        it('cascades cancellation to the linked SUSPENDED accreditation when the registration is cancelled', async () => {
+          // Suspend the accreditation directly (suspension is an
+          // accreditation-only concept)
           await repository.replace(
             organisation.id,
             2,
             prepareOrgUpdate(afterApproval, {
-              registrations: [
-                { ...registration1, status: REG_ACC_STATUS.SUSPENDED }
+              accreditations: [
+                { ...accreditation1, status: REG_ACC_STATUS.SUSPENDED }
               ]
             })
           )
+
+          const afterSuspension = await repository.findById(organisation.id, 3)
+
           await repository.replace(
             organisation.id,
             3,
+            prepareOrgUpdate(afterSuspension, {
+              registrations: [
+                { ...registration1, status: REG_ACC_STATUS.CANCELLED }
+              ]
+            })
+          )
+
+          const result = await repository.findById(organisation.id, 4)
+          const finalReg1 = result.registrations.find(
+            (r) => r.id === registration1.id
+          )
+          const finalAcc1 = result.accreditations.find(
+            (a) => a.id === accreditation1.id
+          )
+
+          expect(finalReg1.status).toBe(REG_ACC_STATUS.CANCELLED)
+          expect(finalAcc1.status).toBe(REG_ACC_STATUS.CANCELLED)
+        })
+
+        it('allows transition from CANCELLED to APPROVED (reinstatement)', async () => {
+          // Cancel directly
+          await repository.replace(
+            organisation.id,
+            2,
             prepareOrgUpdate(afterApproval, {
               registrations: [
                 { ...registration1, status: REG_ACC_STATUS.CANCELLED }
@@ -341,7 +298,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
           // Reinstate
           const afterCancellation = await repository.findById(
             organisation.id,
-            4
+            3
           )
           const cancelledReg = afterCancellation.registrations.find(
             (r) => r.id === registration1.id
@@ -349,7 +306,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
 
           await repository.replace(
             organisation.id,
-            4,
+            3,
             prepareOrgUpdate(afterCancellation, {
               registrations: [
                 { ...cancelledReg, status: REG_ACC_STATUS.APPROVED }
@@ -357,7 +314,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
             })
           )
 
-          const result = await repository.findById(organisation.id, 5)
+          const result = await repository.findById(organisation.id, 4)
           const reinstatedReg = result.registrations.find(
             (r) => r.id === registration1.id
           )
@@ -366,19 +323,10 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
         })
 
         it('does not reinstate the cascade-cancelled accreditation when the registration is reinstated', async () => {
-          // Suspend then cancel — the cancellation cascades to accreditation1
+          // Cancel directly — the cancellation force-cancels accreditation1
           await repository.replace(
             organisation.id,
             2,
-            prepareOrgUpdate(afterApproval, {
-              registrations: [
-                { ...registration1, status: REG_ACC_STATUS.SUSPENDED }
-              ]
-            })
-          )
-          await repository.replace(
-            organisation.id,
-            3,
             prepareOrgUpdate(afterApproval, {
               registrations: [
                 { ...registration1, status: REG_ACC_STATUS.CANCELLED }
@@ -389,7 +337,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
           // Reinstate the registration only
           const afterCancellation = await repository.findById(
             organisation.id,
-            4
+            3
           )
           const cancelledReg = afterCancellation.registrations.find(
             (r) => r.id === registration1.id
@@ -397,7 +345,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
 
           await repository.replace(
             organisation.id,
-            4,
+            3,
             prepareOrgUpdate(afterCancellation, {
               registrations: [
                 { ...cancelledReg, status: REG_ACC_STATUS.APPROVED }
@@ -405,7 +353,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
             })
           )
 
-          const result = await repository.findById(organisation.id, 5)
+          const result = await repository.findById(organisation.id, 4)
           const reinstatedReg = result.registrations.find(
             (r) => r.id === registration1.id
           )
@@ -452,7 +400,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
               statusCode: 422,
               payload: {
                 message: expect.stringContaining(
-                  `Cannot transition registration/accreditation status from ${REG_ACC_STATUS.CREATED} to ${REG_ACC_STATUS.SUSPENDED}`
+                  `Cannot transition accreditation status from ${REG_ACC_STATUS.CREATED} to ${REG_ACC_STATUS.SUSPENDED}`
                 )
               }
             }
@@ -545,7 +493,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
               statusCode: 422,
               payload: {
                 message: expect.stringContaining(
-                  `Cannot transition registration/accreditation status from ${REG_ACC_STATUS.APPROVED} to ${REG_ACC_STATUS.CANCELLED}`
+                  `Cannot transition accreditation status from ${REG_ACC_STATUS.APPROVED} to ${REG_ACC_STATUS.CANCELLED}`
                 )
               }
             }
@@ -646,15 +594,6 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
             2,
             prepareOrgUpdate(afterApproval, {
               registrations: [
-                { ...registration, status: REG_ACC_STATUS.SUSPENDED }
-              ]
-            })
-          )
-          await repository.replace(
-            organisation.id,
-            3,
-            prepareOrgUpdate(afterApproval, {
-              registrations: [
                 { ...registration, status: REG_ACC_STATUS.CANCELLED }
               ]
             })
@@ -665,7 +604,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
           // accreditation is held at CANCELLED
           const afterCancellation = await repository.findById(
             organisation.id,
-            4
+            3
           )
           const cancelledAcc = afterCancellation.accreditations.find(
             (a) => a.id === accreditation.id
@@ -673,7 +612,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
 
           await repository.replace(
             organisation.id,
-            4,
+            3,
             prepareOrgUpdate(afterCancellation, {
               accreditations: [
                 { ...cancelledAcc, status: REG_ACC_STATUS.APPROVED }
@@ -681,7 +620,7 @@ export const testRegAccStatusTransitionBehaviour = (it) => {
             })
           )
 
-          const result = await repository.findById(organisation.id, 5)
+          const result = await repository.findById(organisation.id, 4)
           const heldAcc = result.accreditations.find(
             (a) => a.id === accreditation.id
           )

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -14,11 +14,16 @@ import {
   validateAccreditationLinkUniqueness,
   validateApprovals
 } from './schema/helpers.js'
+import {
+  assertAccreditationStatusTransitionValid,
+  assertRegistrationStatusTransitionValid
+} from '#domain/organisations/status.js'
 import { collateUsers } from './collate-users.js'
 import { getCurrentStatus } from './status.js'
 
 /** @import { WithId } from 'mongodb' */
 /** @import { Organisation, OrganisationStatus } from '#domain/organisations/model.js' */
+/** @import { Registration } from '#domain/organisations/registration.js' */
 /** @import { FindPageForOverseasSitesAdminListParams } from './port.js' */
 
 export const createStatusHistoryEntry = (status) => ({
@@ -49,7 +54,20 @@ export const statusHistoryWithChanges = (updatedItem, existingItem) => {
   return validateStatusHistory(statusHistory)
 }
 
-export const updateStatusHistoryForItems = (existingItems, itemUpdates) => {
+/**
+ * @param {Array<{ id: string, status: string }>} existingItems
+ * @param {Array<{ id: string, status?: string }>} itemUpdates
+ * @param {(fromStatus: string, toStatus: string) => void} assertStatusTransitionValid
+ * @param {Set<string>} [systemAppliedItemIds] - items whose status change was
+ *   applied by the system (the registration-cancellation cascade), exempt from
+ *   the transition table
+ */
+export const updateStatusHistoryForItems = (
+  existingItems,
+  itemUpdates,
+  assertStatusTransitionValid,
+  systemAppliedItemIds = new Set()
+) => {
   const existingItemsById = new Map(
     existingItems.map((item) => [item.id, item])
   )
@@ -59,7 +77,13 @@ export const updateStatusHistoryForItems = (existingItems, itemUpdates) => {
     if (existingItem) {
       existingItemsById.delete(updatedItem.id)
       // Validate status transition for registrations/accreditations
-      assertAndHandleItemStateTransition(existingItem, updatedItem)
+      if (!systemAppliedItemIds.has(updatedItem.id)) {
+        assertAndHandleItemStateTransition(
+          existingItem,
+          updatedItem,
+          assertStatusTransitionValid
+        )
+      }
       return {
         ...updatedItem,
         statusHistory: statusHistoryWithChanges(updatedItem, existingItem)
@@ -87,7 +111,8 @@ export const mapDocumentWithCurrentStatuses = (org) => {
   rest.status = /** @type {OrganisationStatus} */ (getCurrentStatus(rest))
 
   for (const item of rest.registrations) {
-    item.status = getCurrentStatus(item)
+    // Greenfield: no stored registration history contains suspended (PAE-1705)
+    item.status = /** @type {Registration['status']} */ (getCurrentStatus(item))
     item.accreditation = item.accreditation ?? null
   }
 
@@ -99,7 +124,7 @@ export const mapDocumentWithCurrentStatuses = (org) => {
 }
 
 function prepareRegAccForReplace(validated, existing) {
-  const accreditationsAfterUpdate =
+  const { accreditations: accreditationsAfterUpdate, cascadeCancelledIds } =
     applyRegistrationStatusToLinkedAccreditations(
       validated.registrations,
       validated.accreditations
@@ -116,12 +141,15 @@ function prepareRegAccForReplace(validated, existing) {
   validateApprovals(validated.registrations, accreditationsAfterUpdate)
   const registrations = updateStatusHistoryForItems(
     existing.registrations,
-    validated.registrations
+    validated.registrations,
+    assertRegistrationStatusTransitionValid
   )
 
   const accreditations = updateStatusHistoryForItems(
     existing.accreditations,
-    accreditationsAfterUpdate
+    accreditationsAfterUpdate,
+    assertAccreditationStatusTransitionValid,
+    cascadeCancelledIds
   )
   return { registrations, accreditations }
 }

--- a/src/repositories/organisations/schema/accreditation.js
+++ b/src/repositories/organisations/schema/accreditation.js
@@ -11,7 +11,7 @@ import {
   formFileUploadSchema,
   formSubmissionSchema,
   idSchema,
-  reprocessingTypeSchema,
+  makeReprocessingTypeSchema,
   userSchema
 } from './base.js'
 import {
@@ -68,7 +68,7 @@ export const accreditationSchema = Joi.object({
   accreditationNumber: Joi.string()
     .when('status', requiredWhenApprovedOrSuspended)
     .default(null),
-  reprocessingType: reprocessingTypeSchema,
+  reprocessingType: makeReprocessingTypeSchema(requiredWhenApprovedOrSuspended),
   submittedToRegulator: Joi.string()
     .valid(REGULATOR.EA, REGULATOR.NRW, REGULATOR.SEPA, REGULATOR.NIEA)
     .required(),

--- a/src/repositories/organisations/schema/base.js
+++ b/src/repositories/organisations/schema/base.js
@@ -9,7 +9,6 @@ import {
 } from '#domain/organisations/model.js'
 import Joi from 'joi'
 import { ObjectId } from 'mongodb'
-import { requiredWhenApprovedOrSuspended } from '#repositories/organisations/schema/helpers.js'
 
 export const idSchema = Joi.string()
   .required()
@@ -114,14 +113,15 @@ export const formFileUploadSchema = Joi.object({
   s3Uri: Joi.string().optional()
 })
 
-export const reprocessingTypeSchema = Joi.when('wasteProcessingType', {
-  is: WASTE_PROCESSING_TYPE.REPROCESSOR,
-  then: Joi.string()
-    .valid(REPROCESSING_TYPE.INPUT, REPROCESSING_TYPE.OUTPUT)
-    .when('status', requiredWhenApprovedOrSuspended)
-    .default(null),
-  otherwise: Joi.forbidden()
-})
+export const makeReprocessingTypeSchema = (requiredWhen) =>
+  Joi.when('wasteProcessingType', {
+    is: WASTE_PROCESSING_TYPE.REPROCESSOR,
+    then: Joi.string()
+      .valid(REPROCESSING_TYPE.INPUT, REPROCESSING_TYPE.OUTPUT)
+      .when('status', requiredWhen)
+      .default(null),
+    otherwise: Joi.forbidden()
+  })
 
 export const formSubmissionSchema = Joi.object({
   id: idSchema.required(),

--- a/src/repositories/organisations/schema/helpers.js
+++ b/src/repositories/organisations/schema/helpers.js
@@ -84,6 +84,9 @@ export const requiredForWasteExemptionAndReprocessor = (schema) =>
     otherwise: Joi.forbidden()
   })
 
+// Accreditations require their number and validity dates while approved or
+// suspended; registrations cannot be suspended (PAE-1705), so their variant
+// requires the fields when approved only.
 export const requiredWhenApprovedOrSuspended = {
   switch: [
     { is: REG_ACC_STATUS.APPROVED, then: Joi.required().invalid(null) },
@@ -92,8 +95,17 @@ export const requiredWhenApprovedOrSuspended = {
   otherwise: Joi.optional().allow(null)
 }
 
+export const requiredWhenApproved = {
+  is: REG_ACC_STATUS.APPROVED,
+  then: Joi.required().invalid(null),
+  otherwise: Joi.optional().allow(null)
+}
+
 export const dateRequiredWhenApprovedOrSuspended = () =>
   isoDateString().when('status', requiredWhenApprovedOrSuspended).default(null)
+
+export const dateRequiredWhenApproved = () =>
+  isoDateString().when('status', requiredWhenApproved).default(null)
 
 function findAccreditationsWithoutApprovedRegistration(
   accreditations,

--- a/src/repositories/organisations/schema/registration.js
+++ b/src/repositories/organisations/schema/registration.js
@@ -12,18 +12,18 @@ import {
   formFileUploadSchema,
   formSubmissionSchema,
   idSchema,
-  reprocessingTypeSchema,
+  makeReprocessingTypeSchema,
   userSchema
 } from './base.js'
 import { wasteManagementPermitSchema } from './waste-permits.js'
 import { yearlyMetricsSchema } from './metrics.js'
 import {
   CURRENT_SCHEMA_VERSION,
-  dateRequiredWhenApprovedOrSuspended,
+  dateRequiredWhenApproved,
   requiredForExporterOptionalForReprocessor,
   requiredForReprocessor,
   requiredForReprocessorOptionalForExporter,
-  requiredWhenApprovedOrSuspended,
+  requiredWhenApproved,
   whenExporter,
   whenMaterial,
   whenReprocessor
@@ -75,16 +75,15 @@ export const registrationSchema = Joi.object({
       REG_ACC_STATUS.CREATED,
       REG_ACC_STATUS.APPROVED,
       REG_ACC_STATUS.CANCELLED,
-      REG_ACC_STATUS.REJECTED,
-      REG_ACC_STATUS.SUSPENDED
+      REG_ACC_STATUS.REJECTED
     )
     .forbidden(),
   registrationNumber: Joi.string()
-    .when('status', requiredWhenApprovedOrSuspended)
+    .when('status', requiredWhenApproved)
     .default(null),
-  reprocessingType: reprocessingTypeSchema,
-  validFrom: dateRequiredWhenApprovedOrSuspended(),
-  validTo: dateRequiredWhenApprovedOrSuspended(),
+  reprocessingType: makeReprocessingTypeSchema(requiredWhenApproved),
+  validFrom: dateRequiredWhenApproved(),
+  validTo: dateRequiredWhenApproved(),
   submittedToRegulator: Joi.string()
     .valid(REGULATOR.EA, REGULATOR.NRW, REGULATOR.SEPA, REGULATOR.NIEA)
     .required(),

--- a/src/repositories/organisations/schema/status-transition.js
+++ b/src/repositories/organisations/schema/status-transition.js
@@ -1,14 +1,13 @@
 import Boom from '@hapi/boom'
-import {
-  assertOrgStatusTransitionValid,
-  assertRegAccStatusTransitionValid
-} from '#domain/organisations/status.js'
+import { assertOrgStatusTransitionValid } from '#domain/organisations/status.js'
 import {
   ORGANISATION_STATUS,
   REG_ACC_STATUS
 } from '#domain/organisations/model.js'
 
 /** @import {Organisation} from '#domain/organisations/model.js' */
+/** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 
 /**
  * @param {Organisation} existing
@@ -66,36 +65,59 @@ export const assertOrgStatusTransition = (existing, updated) => {
   }
 }
 
-export const assertAndHandleItemStateTransition = (existing, updated) => {
+/**
+ * @param {{ status: string }} existing
+ * @param {{ status?: string }} updated
+ * @param {(fromStatus: string, toStatus: string) => void} assertStatusTransitionValid
+ * @returns {void}
+ */
+export const assertAndHandleItemStateTransition = (
+  existing,
+  updated,
+  assertStatusTransitionValid
+) => {
   // If no status change requested (undefined or same), skip validation
   if (!updated.status || existing.status === updated.status) {
     return
   }
-  assertRegAccStatusTransitionValid(existing.status, updated.status)
+  assertStatusTransitionValid(existing.status, updated.status)
 }
 
-const isRegistrationCancelledOrSuspended = (registration) => {
-  return [REG_ACC_STATUS.SUSPENDED, REG_ACC_STATUS.CANCELLED].includes(
-    registration.status
-  )
-}
+const isRegistrationCancelled = (registration) =>
+  registration.status === REG_ACC_STATUS.CANCELLED
 
+/**
+ * Cancelling a registration force-cancels its linked accreditation, whether
+ * that accreditation is approved or suspended (PAE-1705 Scenario 5). The
+ * returned cascadeCancelledIds mark these as system-driven changes, exempt
+ * from the accreditation transition table — which deliberately has no direct
+ * approved -> cancelled arc for user-driven updates (ADR 0042).
+ * @param {Registration[]} registrations
+ * @param {Accreditation[]} accreditations
+ * @returns {{ accreditations: Accreditation[], cascadeCancelledIds: Set<string> }}
+ */
 export const applyRegistrationStatusToLinkedAccreditations = (
   registrations,
   accreditations
 ) => {
-  const statusUpdates = new Map()
+  /** @type {Set<string>} */
+  const cascadeCancelledIds = new Set()
 
   for (const reg of registrations) {
-    if (reg.accreditationId && isRegistrationCancelledOrSuspended(reg)) {
-      statusUpdates.set(reg.accreditationId, reg.status)
+    if (reg.accreditationId && isRegistrationCancelled(reg)) {
+      cascadeCancelledIds.add(reg.accreditationId)
     }
   }
 
-  return accreditations.map((acc) => {
-    if (statusUpdates.has(acc.id)) {
-      return { ...acc, status: statusUpdates.get(acc.id) }
+  const updatedAccreditations = accreditations.map((acc) => {
+    if (cascadeCancelledIds.has(acc.id)) {
+      return /** @type {Accreditation} */ ({
+        ...acc,
+        status: REG_ACC_STATUS.CANCELLED
+      })
     }
     return acc
   })
+
+  return { accreditations: updatedAccreditations, cascadeCancelledIds }
 }

--- a/src/repositories/organisations/schema/status-transition.js
+++ b/src/repositories/organisations/schema/status-transition.js
@@ -5,7 +5,7 @@ import {
   REG_ACC_STATUS
 } from '#domain/organisations/model.js'
 
-/** @import {Organisation} from '#domain/organisations/model.js' */
+/** @import {Organisation, RegAccStatus} from '#domain/organisations/model.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 
@@ -86,12 +86,22 @@ export const assertAndHandleItemStateTransition = (
 const isRegistrationCancelled = (registration) =>
   registration.status === REG_ACC_STATUS.CANCELLED
 
+// Only a live accreditation is force-cancelled by the cascade. The check runs
+// against the incoming payload status so that an attempt to reinstate a
+// cascade-cancelled accreditation (payload approved, registration still
+// cancelled) is also caught and held at cancelled.
+const CASCADEABLE_ACC_STATUSES = /** @type {Set<RegAccStatus>} */ (
+  new Set([REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.SUSPENDED])
+)
+
 /**
  * Cancelling a registration force-cancels its linked accreditation, whether
- * that accreditation is approved or suspended (PAE-1705 Scenario 5). The
- * returned cascadeCancelledIds mark these as system-driven changes, exempt
- * from the accreditation transition table — which deliberately has no direct
- * approved -> cancelled arc for user-driven updates (ADR 0042).
+ * that accreditation is approved or suspended (PAE-1705 Scenario 5). An
+ * accreditation that was never live (created or rejected) is left untouched.
+ * The returned cascadeCancelledIds mark the force-cancelled accreditations as
+ * system-driven changes, exempt from the accreditation transition table —
+ * which deliberately has no direct approved -> cancelled arc for user-driven
+ * updates (ADR 0042).
  * @param {Registration[]} registrations
  * @param {Accreditation[]} accreditations
  * @returns {{ accreditations: Accreditation[], cascadeCancelledIds: Set<string> }}
@@ -101,16 +111,23 @@ export const applyRegistrationStatusToLinkedAccreditations = (
   accreditations
 ) => {
   /** @type {Set<string>} */
-  const cascadeCancelledIds = new Set()
+  const linkedToCancelledRegistration = new Set()
 
   for (const reg of registrations) {
     if (reg.accreditationId && isRegistrationCancelled(reg)) {
-      cascadeCancelledIds.add(reg.accreditationId)
+      linkedToCancelledRegistration.add(reg.accreditationId)
     }
   }
 
+  /** @type {Set<string>} */
+  const cascadeCancelledIds = new Set()
+
   const updatedAccreditations = accreditations.map((acc) => {
-    if (cascadeCancelledIds.has(acc.id)) {
+    if (
+      linkedToCancelledRegistration.has(acc.id) &&
+      CASCADEABLE_ACC_STATUSES.has(acc.status)
+    ) {
+      cascadeCancelledIds.add(acc.id)
       return /** @type {Accreditation} */ ({
         ...acc,
         status: REG_ACC_STATUS.CANCELLED

--- a/src/repositories/organisations/schema/status-transition.test.js
+++ b/src/repositories/organisations/schema/status-transition.test.js
@@ -1,0 +1,90 @@
+import { applyRegistrationStatusToLinkedAccreditations } from './status-transition.js'
+import { REG_ACC_STATUS } from '#domain/organisations/model.js'
+import { partialMock } from '#test/type-helpers.js'
+
+/** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
+
+describe('applyRegistrationStatusToLinkedAccreditations', () => {
+  it.each([REG_ACC_STATUS.APPROVED, REG_ACC_STATUS.SUSPENDED])(
+    'cancels a linked %s accreditation and reports it as cascade-cancelled',
+    (status) => {
+      /** @type {Registration[]} */
+      const registrations = [
+        partialMock({
+          status: REG_ACC_STATUS.CANCELLED,
+          accreditationId: 'acc-1'
+        })
+      ]
+      /** @type {Accreditation[]} */
+      const accreditations = [partialMock({ id: 'acc-1', status })]
+
+      const result = applyRegistrationStatusToLinkedAccreditations(
+        registrations,
+        accreditations
+      )
+
+      expect(result.accreditations[0].status).toBe(REG_ACC_STATUS.CANCELLED)
+      expect(result.cascadeCancelledIds).toStrictEqual(new Set(['acc-1']))
+    }
+  )
+
+  it.each([REG_ACC_STATUS.CREATED, REG_ACC_STATUS.REJECTED])(
+    'leaves a linked %s accreditation untouched — it was never live',
+    (status) => {
+      /** @type {Registration[]} */
+      const registrations = [
+        partialMock({
+          status: REG_ACC_STATUS.CANCELLED,
+          accreditationId: 'acc-1'
+        })
+      ]
+      /** @type {Accreditation[]} */
+      const accreditations = [partialMock({ id: 'acc-1', status })]
+
+      const result = applyRegistrationStatusToLinkedAccreditations(
+        registrations,
+        accreditations
+      )
+
+      expect(result.accreditations[0].status).toBe(status)
+      expect(result.cascadeCancelledIds).toStrictEqual(new Set())
+    }
+  )
+
+  it('leaves accreditations untouched when the linked registration is not cancelled', () => {
+    /** @type {Registration[]} */
+    const registrations = [
+      partialMock({ status: REG_ACC_STATUS.APPROVED, accreditationId: 'acc-1' })
+    ]
+    /** @type {Accreditation[]} */
+    const accreditations = [
+      partialMock({ id: 'acc-1', status: REG_ACC_STATUS.APPROVED })
+    ]
+
+    const result = applyRegistrationStatusToLinkedAccreditations(
+      registrations,
+      accreditations
+    )
+
+    expect(result.accreditations[0].status).toBe(REG_ACC_STATUS.APPROVED)
+    expect(result.cascadeCancelledIds).toStrictEqual(new Set())
+  })
+
+  it('leaves accreditations untouched when the cancelled registration has no linked accreditation', () => {
+    /** @type {Registration[]} */
+    const registrations = [partialMock({ status: REG_ACC_STATUS.CANCELLED })]
+    /** @type {Accreditation[]} */
+    const accreditations = [
+      partialMock({ id: 'acc-1', status: REG_ACC_STATUS.APPROVED })
+    ]
+
+    const result = applyRegistrationStatusToLinkedAccreditations(
+      registrations,
+      accreditations
+    )
+
+    expect(result.accreditations[0].status).toBe(REG_ACC_STATUS.APPROVED)
+    expect(result.cascadeCancelledIds).toStrictEqual(new Set())
+  })
+})

--- a/src/routes/v1/organisations/accreditation-status-history.js
+++ b/src/routes/v1/organisations/accreditation-status-history.js
@@ -2,7 +2,7 @@ import Boom from '@hapi/boom'
 import { SCOPES } from '#common/helpers/auth/constants.js'
 import { StatusCodes } from 'http-status-codes'
 import { auditOrganisationUpdate } from '#root/auditing/organisations.js'
-import { assertRegAccStatusTransitionValid } from '#domain/organisations/status.js'
+import { assertAccreditationStatusTransitionValid } from '#domain/organisations/status.js'
 import { accreditationStatusHistoryPayloadSchema } from './accreditation-status-history.schema.js'
 
 /** @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository */
@@ -81,7 +81,7 @@ export const accreditationStatusHistory = {
     // assertAndHandleItemStateTransition skips validation when the status is
     // unchanged, so suspended -> suspended via replace() would otherwise be a
     // silent no-op instead of the required 422.
-    assertRegAccStatusTransitionValid(fromStatus, toStatus)
+    assertAccreditationStatusTransitionValid(fromStatus, toStatus)
 
     if (grant) {
       // Granting sets validFrom to appliesFrom but leaves validTo (owned by


### PR DESCRIPTION
Ticket: [PAE-1705](https://eaflood.atlassian.net/browse/PAE-1705)
## Summary

- Registrations can no longer be suspended (PAE-1705): the shared registration/accreditation status-transition table is split into `VALID_REG_TRANSITIONS`  and `VALID_ACC_TRANSITIONS` 
- Cancelling a registration now **force-cancels** its linked accreditation when that accreditation is approved or suspended; a linked accreditation that was never live (created/rejected) is left untouched
- Reports & public register: split the status sets so a registration's own status can never be included as suspended. `REPORTABLE_STATUSES` drops `suspended`, and the public register transformer now has separate registration and accreditation inclusion sets so cancelled/suspended linked accreditations stay published (BR-E8) while a registration is never included as suspended

## Production data check

Verified in prod: zero registrations have `suspended` as a current status and zero registrations carry a `suspended` entry in `statusHistory`, so removing `suspended` from the registration schema cannot break reads or replaces of existing documents.

[PAE-1705]: https://eaflood.atlassian.net/browse/PAE-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
