### PR TITLE
PAE-1705: make the split status enums enforceable by the type system

### DIFF
--- a/src/application/public-register/public-register-transformer.js
+++ b/src/application/public-register/public-register-transformer.js
@@ -3,6 +3,8 @@
  */
 
 /** @import {AccreditationStatus, Organisation, RegistrationStatus} from '#domain/organisations/model.js' */
+/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
+/** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {PublicRegisterRow} from './types.js' */
 /** @import {ReportComplianceData} from '#reports/application/report-compliance.js' */
 
@@ -101,14 +103,22 @@ function getLastStatusUpdateDate(item) {
     : null
 }
 
+/**
+ * @param {Registration} registration
+ * @param {Accreditation[]} accreditations
+ * @returns {Accreditation | null}
+ */
 function getLinkedAccreditation(registration, accreditations) {
-  return registration.accreditationId
-    ? accreditations.find(
-        (acc) =>
-          acc.id === registration.accreditationId &&
-          isAccreditationInPublishableState(acc)
-      )
-    : null
+  if (!registration.accreditationId) {
+    return null
+  }
+  return (
+    accreditations.find(
+      (acc) =>
+        acc.id === registration.accreditationId &&
+        isAccreditationInPublishableState(acc)
+    ) ?? null
+  )
 }
 
 /** @param {{ status: RegistrationStatus }} item */

--- a/src/application/public-register/public-register-transformer.js
+++ b/src/application/public-register/public-register-transformer.js
@@ -2,7 +2,7 @@
  * Transforms organisation entities into public register row objects
  */
 
-/** @import {Organisation} from '#domain/organisations/model.js' */
+/** @import {AccreditationStatus, Organisation, RegistrationStatus} from '#domain/organisations/model.js' */
 /** @import {PublicRegisterRow} from './types.js' */
 /** @import {ReportComplianceData} from '#reports/application/report-compliance.js' */
 
@@ -25,12 +25,14 @@ import { config } from '#root/config.js'
 
 // A registration's own status can never be suspended (suspension is an
 // accreditation-only concept), so suspended is excluded here.
+/** @type {Set<RegistrationStatus>} */
 const REGISTRATION_INCLUDED_STATUSES = new Set([
   REGISTRATION_STATUS.APPROVED,
   REGISTRATION_STATUS.CANCELLED
 ])
 
 // Cancelled and suspended accreditations remain on the public register (BR-E8).
+/** @type {Set<AccreditationStatus>} */
 const ACCREDITATION_INCLUDED_STATUSES = new Set([
   ACCREDITATION_STATUS.APPROVED,
   ACCREDITATION_STATUS.SUSPENDED,
@@ -109,10 +111,12 @@ function getLinkedAccreditation(registration, accreditations) {
     : null
 }
 
+/** @param {{ status: RegistrationStatus }} item */
 function isRegistrationInPublishableState(item) {
   return REGISTRATION_INCLUDED_STATUSES.has(item.status)
 }
 
+/** @param {{ status: AccreditationStatus }} item */
 function isAccreditationInPublishableState(item) {
   return ACCREDITATION_INCLUDED_STATUSES.has(item.status)
 }

--- a/src/common/helpers/dates/accreditation.js
+++ b/src/common/helpers/dates/accreditation.js
@@ -4,6 +4,10 @@ import { ACCREDITATION_STATUS } from '#domain/organisations/model.js'
 /** @import {AccreditationStatus} from '#domain/organisations/model.js' */
 
 /**
+ * @typedef {{ updatedAt: number, status: AccreditationStatus }} StatusHistoryDateTime
+ */
+
+/**
  * Checks if all dates are accredited
  * @param { (Date|string)[] } dates - The date to check
  * @param { Accreditation | null | undefined } accreditation
@@ -28,7 +32,7 @@ export function isAccreditedAtDates(dates, accreditation) {
 /**
  * Convert dates to numbers and sort descending
  * @param { StatusHistoryEntry[] } statusHistory - Accreditation status history
- * @returns {{ updatedAt: number; status: AccreditationStatus; }[]} Sorted list
+ * @returns {StatusHistoryDateTime[]} Sorted list
  */
 export function getStatusHistoryDateTimes(statusHistory) {
   const statusDates = statusHistory.map((s) => ({
@@ -64,7 +68,7 @@ export function isWithinAccreditationDateRange(date, accreditation) {
  * is never altered by these transitions.
  *
  * @param {string|Date} date - The date to check
- * @param {{ updatedAt: number; status: AccreditationStatus; }[]} statusHistory - Accreditation status history in descending date order
+ * @param {StatusHistoryDateTime[]} statusHistory - Accreditation status history in descending date order
  * @returns {boolean} True if the accreditation was suspended or cancelled at the given date
  */
 export function isSuspendedOrCancelledAtDate(date, statusHistory) {

--- a/src/common/helpers/dates/accreditation.js
+++ b/src/common/helpers/dates/accreditation.js
@@ -1,5 +1,7 @@
-/** @import {Accreditation, StatusHistoryEntry} from '#domain/organisations/accreditation.js' */
 import { ACCREDITATION_STATUS } from '#domain/organisations/model.js'
+
+/** @import {Accreditation, StatusHistoryEntry} from '#domain/organisations/accreditation.js' */
+/** @import {AccreditationStatus} from '#domain/organisations/model.js' */
 
 /**
  * Checks if all dates are accredited
@@ -26,7 +28,7 @@ export function isAccreditedAtDates(dates, accreditation) {
 /**
  * Convert dates to numbers and sort descending
  * @param { StatusHistoryEntry[] } statusHistory - Accreditation status history
- * @returns {{ updatedAt: number; status: string; }[]} Sorted list
+ * @returns {{ updatedAt: number; status: AccreditationStatus; }[]} Sorted list
  */
 export function getStatusHistoryDateTimes(statusHistory) {
   const statusDates = statusHistory.map((s) => ({
@@ -62,7 +64,7 @@ export function isWithinAccreditationDateRange(date, accreditation) {
  * is never altered by these transitions.
  *
  * @param {string|Date} date - The date to check
- * @param {{ updatedAt: number; status: string; }[]} statusHistory - Accreditation status history in descending date order
+ * @param {{ updatedAt: number; status: AccreditationStatus; }[]} statusHistory - Accreditation status history in descending date order
  * @returns {boolean} True if the accreditation was suspended or cancelled at the given date
  */
 export function isSuspendedOrCancelledAtDate(date, statusHistory) {

--- a/src/common/helpers/dates/accreditation.test.js
+++ b/src/common/helpers/dates/accreditation.test.js
@@ -7,7 +7,7 @@ import {
 } from './accreditation.js'
 
 /** @import {Accreditation, StatusHistoryEntry} from '#domain/organisations/accreditation.js' */
-/** @import {AccreditationStatus} from '#domain/organisations/model.js' */
+/** @import {StatusHistoryDateTime} from './accreditation.js' */
 
 describe('accreditation date helpers', () => {
   describe('isWithinAccreditationDateRange', () => {
@@ -110,7 +110,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return false when most recent status is approved', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'approved',
@@ -128,7 +128,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return true when accreditation was suspended at the given date', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'suspended',
@@ -150,7 +150,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return false when accreditation was re-approved after suspension', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'approved',
@@ -176,7 +176,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return true when date falls within a suspension period before re-approval', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'approved',
@@ -202,7 +202,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return false when date is before any status history entries', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'approved',
@@ -216,7 +216,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return true on the exact date of suspension', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'suspended',
@@ -238,7 +238,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return false when most recent status is created', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'created',
@@ -252,7 +252,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return true with a single suspended entry', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'suspended',
@@ -266,7 +266,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should use the first entry when multiple share the same timestamp', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'suspended',
@@ -287,7 +287,7 @@ describe('accreditation date helpers', () => {
       ).toBe(true)
     })
     it('should return true when the most recent status is cancelled', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'cancelled',
@@ -309,7 +309,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return true on the exact date of cancellation', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'cancelled',
@@ -327,7 +327,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return false for a date before cancellation while still approved', () => {
-      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
+      /** @type {StatusHistoryDateTime[]} */
       const statusHistory = [
         {
           status: 'cancelled',

--- a/src/common/helpers/dates/accreditation.test.js
+++ b/src/common/helpers/dates/accreditation.test.js
@@ -7,6 +7,7 @@ import {
 } from './accreditation.js'
 
 /** @import {Accreditation, StatusHistoryEntry} from '#domain/organisations/accreditation.js' */
+/** @import {AccreditationStatus} from '#domain/organisations/model.js' */
 
 describe('accreditation date helpers', () => {
   describe('isWithinAccreditationDateRange', () => {
@@ -109,6 +110,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return false when most recent status is approved', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'approved',
@@ -126,6 +128,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return true when accreditation was suspended at the given date', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'suspended',
@@ -147,6 +150,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return false when accreditation was re-approved after suspension', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'approved',
@@ -172,6 +176,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return true when date falls within a suspension period before re-approval', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'approved',
@@ -197,6 +202,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return false when date is before any status history entries', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'approved',
@@ -210,6 +216,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return true on the exact date of suspension', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'suspended',
@@ -231,6 +238,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return false when most recent status is created', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'created',
@@ -244,6 +252,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return true with a single suspended entry', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'suspended',
@@ -257,6 +266,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should use the first entry when multiple share the same timestamp', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'suspended',
@@ -277,6 +287,7 @@ describe('accreditation date helpers', () => {
       ).toBe(true)
     })
     it('should return true when the most recent status is cancelled', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'cancelled',
@@ -298,6 +309,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return true on the exact date of cancellation', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'cancelled',
@@ -315,6 +327,7 @@ describe('accreditation date helpers', () => {
     })
 
     it('should return false for a date before cancellation while still approved', () => {
+      /** @type {Array<{ status: AccreditationStatus, updatedAt: number }>} */
       const statusHistory = [
         {
           status: 'cancelled',

--- a/src/domain/organisations/model.js
+++ b/src/domain/organisations/model.js
@@ -35,6 +35,12 @@ export const ACCREDITATION_STATUS = Object.freeze({
  * @typedef {RegistrationStatus | AccreditationStatus} RegOrAccStatus
  */
 
+/** @type {ReadonlySet<AccreditationStatus>} */
+export const ACTIVE_ACCREDITATION_STATUSES = new Set([
+  ACCREDITATION_STATUS.APPROVED,
+  ACCREDITATION_STATUS.SUSPENDED
+])
+
 /**
  * Status values for organisations
  * @typedef {typeof ORGANISATION_STATUS[keyof typeof ORGANISATION_STATUS]} OrganisationStatus

--- a/src/domain/organisations/registration-utils.js
+++ b/src/domain/organisations/registration-utils.js
@@ -67,10 +67,9 @@ export function resolveAccreditationNumber(registration, org) {
  * @returns {boolean}
  */
 export function isRegistrationAccredited({ accreditation }) {
-  return (
-    accreditation !== null &&
-    ACTIVE_ACCREDITATION_STATUSES.has(accreditation.status)
-  )
+  return accreditation
+    ? ACTIVE_ACCREDITATION_STATUSES.has(accreditation.status)
+    : false
 }
 
 /**

--- a/src/domain/organisations/registration-utils.js
+++ b/src/domain/organisations/registration-utils.js
@@ -1,5 +1,5 @@
 import {
-  ACCREDITATION_STATUS,
+  ACTIVE_ACCREDITATION_STATUSES,
   REGISTRATION_STATUS
 } from '#domain/organisations/model.js'
 import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.js'
@@ -14,12 +14,6 @@ const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 const REPORTABLE_STATUSES = new Set([
   REGISTRATION_STATUS.APPROVED,
   REGISTRATION_STATUS.CANCELLED
-])
-
-/** @type {Set<AccreditationStatus>} */
-const ACTIVE_ACCREDITATION_STATUSES = new Set([
-  ACCREDITATION_STATUS.APPROVED,
-  ACCREDITATION_STATUS.SUSPENDED
 ])
 
 /**
@@ -90,8 +84,7 @@ export function isRegistrationAccredited({ accreditation }) {
 export function activeAccreditationValidFrom(accreditation) {
   if (
     accreditation &&
-    (accreditation.status === ACCREDITATION_STATUS.APPROVED ||
-      accreditation.status === ACCREDITATION_STATUS.SUSPENDED)
+    ACTIVE_ACCREDITATION_STATUSES.has(accreditation.status)
   ) {
     return accreditation.validFrom ?? null
   }

--- a/src/domain/organisations/registration-utils.js
+++ b/src/domain/organisations/registration-utils.js
@@ -10,13 +10,17 @@ import { TEST_ORGANISATION_IDS } from '#common/helpers/parse-test-organisations.
 
 const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 
-const REPORTABLE_STATUSES = /** @type {Set<RegistrationStatus>} */ (
-  new Set([REGISTRATION_STATUS.APPROVED, REGISTRATION_STATUS.CANCELLED])
-)
+/** @type {Set<RegistrationStatus>} */
+const REPORTABLE_STATUSES = new Set([
+  REGISTRATION_STATUS.APPROVED,
+  REGISTRATION_STATUS.CANCELLED
+])
 
-const ACTIVE_ACCREDITATION_STATUSES = /** @type {Set<AccreditationStatus>} */ (
-  new Set([ACCREDITATION_STATUS.APPROVED, ACCREDITATION_STATUS.SUSPENDED])
-)
+/** @type {Set<AccreditationStatus>} */
+const ACTIVE_ACCREDITATION_STATUSES = new Set([
+  ACCREDITATION_STATUS.APPROVED,
+  ACCREDITATION_STATUS.SUSPENDED
+])
 
 /**
  * Returns all reportable (approved/cancelled) registrations across all non-test organisations.
@@ -63,13 +67,15 @@ export function resolveAccreditationNumber(registration, org) {
  * sufficient — an accreditation in 'created', 'rejected', or 'cancelled'
  * state has never been active and must be treated as registered-only.
  *
- * @param {{ accreditation: { status?: string } | null }} registration
+ * @param {{
+ *   accreditation: { status: AccreditationStatus } | null
+ * }} registration
  * @returns {boolean}
  */
-export function isRegistrationAccredited(registration) {
-  const status = registration.accreditation?.status
-  return ACTIVE_ACCREDITATION_STATUSES.has(
-    /** @type {AccreditationStatus} */ (status)
+export function isRegistrationAccredited({ accreditation }) {
+  return (
+    accreditation !== null &&
+    ACTIVE_ACCREDITATION_STATUSES.has(accreditation.status)
   )
 }
 

--- a/src/domain/organisations/registration-utils.js
+++ b/src/domain/organisations/registration-utils.js
@@ -56,14 +56,16 @@ export function resolveAccreditationNumber(registration, org) {
 }
 
 /**
+ * @typedef {{ accreditation: { status: AccreditationStatus } | null }} AccreditationLink
+ */
+
+/**
  * Returns true when the registration is linked to an accreditation that is
  * live (approved or suspended). Presence of accreditationId alone is not
  * sufficient — an accreditation in 'created', 'rejected', or 'cancelled'
  * state has never been active and must be treated as registered-only.
  *
- * @param {{
- *   accreditation: { status: AccreditationStatus } | null
- * }} registration
+ * @param {AccreditationLink} registration
  * @returns {boolean}
  */
 export function isRegistrationAccredited({ accreditation }) {

--- a/src/domain/organisations/registration-utils.test.js
+++ b/src/domain/organisations/registration-utils.test.js
@@ -9,7 +9,7 @@ import {
 } from './registration-utils.js'
 import { ACCREDITATION_STATUS } from '#domain/organisations/model.js'
 
-/** @import { Organisation } from '#domain/organisations/model.js' */
+/** @import { AccreditationStatus, Organisation } from '#domain/organisations/model.js' */
 /** @import { Registration } from '#domain/organisations/registration.js' */
 
 const userFixture = {
@@ -134,13 +134,16 @@ describe('getReportableRegistrations', () => {
 // ---------------------------------------------------------------------------
 
 describe('isRegistrationAccredited', () => {
-  it.each([
+  /** @type {Array<{ status: AccreditationStatus, expected: boolean }>} */
+  const linkedAccreditations = [
     { status: 'approved', expected: true },
     { status: 'suspended', expected: true },
     { status: 'created', expected: false },
     { status: 'rejected', expected: false },
     { status: 'cancelled', expected: false }
-  ])(
+  ]
+
+  it.each(linkedAccreditations)(
     'returns $expected when linked accreditation status is $status',
     ({ status, expected }) => {
       expect(isRegistrationAccredited({ accreditation: { status } })).toBe(

--- a/src/domain/organisations/status.js
+++ b/src/domain/organisations/status.js
@@ -71,9 +71,14 @@ export const assertOrgStatusTransitionValid = (fromStatus, toStatus) => {
 
 /**
  * @template {string} S
+ * @typedef {(fromStatus: S, toStatus: S) => void} StatusTransitionAsserter
+ */
+
+/**
+ * @template {string} S
  * @param {Record<S, S[]>} validTransitions
  * @param {'registration' | 'accreditation'} itemKind
- * @returns {(fromStatus: S, toStatus: S) => void}
+ * @returns {StatusTransitionAsserter<S>}
  */
 const makeAssertStatusTransitionValid = (validTransitions, itemKind) => {
   return (fromStatus, toStatus) => {

--- a/src/domain/organisations/status.js
+++ b/src/domain/organisations/status.js
@@ -5,6 +5,8 @@ import {
   REGISTRATION_STATUS
 } from '#domain/organisations/model.js'
 
+/** @import { AccreditationStatus, RegistrationStatus } from '#domain/organisations/model.js' */
+
 const VALID_ORG_TRANSITIONS = {
   [ORGANISATION_STATUS.CREATED]: [
     ORGANISATION_STATUS.APPROVED,
@@ -21,6 +23,7 @@ const VALID_ORG_TRANSITIONS = {
 // Registrations cannot be suspended (PAE-1705): a registration is either live
 // or terminated, so approved -> cancelled is direct and there is no suspended
 // node at all.
+/** @type {Record<RegistrationStatus, RegistrationStatus[]>} */
 const VALID_REG_TRANSITIONS = {
   [REGISTRATION_STATUS.CREATED]: [
     REGISTRATION_STATUS.APPROVED,
@@ -37,6 +40,7 @@ const VALID_REG_TRANSITIONS = {
 // Accreditations keep suspension and may only reach cancelled via suspended
 // (ADR 0042). The registration-cancellation cascade bypasses this table by
 // design — cancelling a registration force-cancels its linked accreditation.
+/** @type {Record<AccreditationStatus, AccreditationStatus[]>} */
 const VALID_ACC_TRANSITIONS = {
   [ACCREDITATION_STATUS.CREATED]: [
     ACCREDITATION_STATUS.APPROVED,
@@ -66,9 +70,15 @@ export const assertOrgStatusTransitionValid = (fromStatus, toStatus) => {
 }
 
 /**
- * @param {Record<string, string[]>} validTransitions
+ * The status parameters are typed to the entity's own status union, so a
+ * status the entity can never hold is a compile error at the call site. The
+ * `?? []` still guards the runtime path, where a status read from storage is
+ * only as trustworthy as the document it came from.
+ *
+ * @template {string} S
+ * @param {Record<S, S[]>} validTransitions
  * @param {'registration' | 'accreditation'} itemKind
- * @returns {(fromStatus: string, toStatus: string) => void}
+ * @returns {(fromStatus: S, toStatus: S) => void}
  */
 const makeAssertStatusTransitionValid = (validTransitions, itemKind) => {
   return (fromStatus, toStatus) => {

--- a/src/domain/organisations/status.js
+++ b/src/domain/organisations/status.js
@@ -70,11 +70,6 @@ export const assertOrgStatusTransitionValid = (fromStatus, toStatus) => {
 }
 
 /**
- * The status parameters are typed to the entity's own status union, so a
- * status the entity can never hold is a compile error at the call site. The
- * `?? []` still guards the runtime path, where a status read from storage is
- * only as trustworthy as the document it came from.
- *
  * @template {string} S
  * @param {Record<S, S[]>} validTransitions
  * @param {'registration' | 'accreditation'} itemKind

--- a/src/domain/organisations/status.test.js
+++ b/src/domain/organisations/status.test.js
@@ -11,12 +11,13 @@ import {
 } from './model.js'
 import Boom from '@hapi/boom'
 
-/** @import {AccreditationStatus, OrganisationStatus, RegOrAccStatus} from './model.js' */
+/** @import {AccreditationStatus, OrganisationStatus, RegistrationStatus} from './model.js' */
 
 /**
- * @param {(fromStatus: string, toStatus: string) => void} assertTransitionValid
+ * @template {string} S
+ * @param {(fromStatus: S, toStatus: S) => void} assertTransitionValid
  * @param {'registration' | 'accreditation'} itemKind
- * @param {[RegOrAccStatus, RegOrAccStatus, boolean][]} transitionTable
+ * @param {[S, S, boolean][]} transitionTable
  */
 const describeTransitionTable = (
   assertTransitionValid,
@@ -114,12 +115,11 @@ describe('assertOrgStatusTransitionValid', () => {
 })
 
 describe('assertRegistrationStatusTransitionValid', () => {
-  /** @type {[RegOrAccStatus, RegOrAccStatus, boolean][]} */
+  /** @type {[RegistrationStatus, RegistrationStatus, boolean][]} */
   const transitionTable = [
     // From CREATED
     [REGISTRATION_STATUS.CREATED, REGISTRATION_STATUS.APPROVED, true],
     [REGISTRATION_STATUS.CREATED, REGISTRATION_STATUS.REJECTED, true],
-    [REGISTRATION_STATUS.CREATED, ACCREDITATION_STATUS.SUSPENDED, false],
     [REGISTRATION_STATUS.CREATED, REGISTRATION_STATUS.CANCELLED, false],
     [REGISTRATION_STATUS.CREATED, REGISTRATION_STATUS.CREATED, false],
 
@@ -127,28 +127,18 @@ describe('assertRegistrationStatusTransitionValid', () => {
     // registration status (PAE-1705)
     [REGISTRATION_STATUS.APPROVED, REGISTRATION_STATUS.CREATED, true],
     [REGISTRATION_STATUS.APPROVED, REGISTRATION_STATUS.CANCELLED, true],
-    [REGISTRATION_STATUS.APPROVED, ACCREDITATION_STATUS.SUSPENDED, false],
     [REGISTRATION_STATUS.APPROVED, REGISTRATION_STATUS.REJECTED, false],
     [REGISTRATION_STATUS.APPROVED, REGISTRATION_STATUS.APPROVED, false],
-
-    // From SUSPENDED — not a registration status; nothing is reachable
-    [ACCREDITATION_STATUS.SUSPENDED, REGISTRATION_STATUS.APPROVED, false],
-    [ACCREDITATION_STATUS.SUSPENDED, REGISTRATION_STATUS.CANCELLED, false],
-    [ACCREDITATION_STATUS.SUSPENDED, REGISTRATION_STATUS.CREATED, false],
-    [ACCREDITATION_STATUS.SUSPENDED, REGISTRATION_STATUS.REJECTED, false],
-    [ACCREDITATION_STATUS.SUSPENDED, ACCREDITATION_STATUS.SUSPENDED, false],
 
     // From CANCELLED — reinstatement only
     [REGISTRATION_STATUS.CANCELLED, REGISTRATION_STATUS.APPROVED, true],
     [REGISTRATION_STATUS.CANCELLED, REGISTRATION_STATUS.CREATED, false],
     [REGISTRATION_STATUS.CANCELLED, REGISTRATION_STATUS.REJECTED, false],
-    [REGISTRATION_STATUS.CANCELLED, ACCREDITATION_STATUS.SUSPENDED, false],
     [REGISTRATION_STATUS.CANCELLED, REGISTRATION_STATUS.CANCELLED, false],
 
     // From REJECTED
     [REGISTRATION_STATUS.REJECTED, REGISTRATION_STATUS.CREATED, true],
     [REGISTRATION_STATUS.REJECTED, REGISTRATION_STATUS.APPROVED, false],
-    [REGISTRATION_STATUS.REJECTED, ACCREDITATION_STATUS.SUSPENDED, false],
     [REGISTRATION_STATUS.REJECTED, REGISTRATION_STATUS.CANCELLED, false],
     [REGISTRATION_STATUS.REJECTED, REGISTRATION_STATUS.REJECTED, false]
   ]
@@ -158,6 +148,41 @@ describe('assertRegistrationStatusTransitionValid', () => {
     'registration',
     transitionTable
   )
+
+  // A typed caller can no longer pass suspended, so the table above cannot
+  // express these. What remains worth testing is the runtime guard for a
+  // status read from storage: one case per branch, source and target.
+  describe('suspended, which is not a registration status', () => {
+    const suspended = /** @type {RegistrationStatus} */ (
+      ACCREDITATION_STATUS.SUSPENDED
+    )
+
+    it('rejects a transition out of suspended', () => {
+      expect(() =>
+        assertRegistrationStatusTransitionValid(
+          suspended,
+          REGISTRATION_STATUS.CANCELLED
+        )
+      ).toThrow(
+        Boom.badData(
+          'Cannot transition registration status from suspended to cancelled'
+        )
+      )
+    })
+
+    it('rejects a transition into suspended', () => {
+      expect(() =>
+        assertRegistrationStatusTransitionValid(
+          REGISTRATION_STATUS.APPROVED,
+          suspended
+        )
+      ).toThrow(
+        Boom.badData(
+          'Cannot transition registration status from approved to suspended'
+        )
+      )
+    })
+  })
 })
 
 describe('assertAccreditationStatusTransitionValid', () => {

--- a/src/domain/organisations/status.test.js
+++ b/src/domain/organisations/status.test.js
@@ -149,9 +149,6 @@ describe('assertRegistrationStatusTransitionValid', () => {
     transitionTable
   )
 
-  // A typed caller can no longer pass suspended, so the table above cannot
-  // express these. What remains worth testing is the runtime guard for a
-  // status read from storage: one case per branch, source and target.
   describe('suspended, which is not a registration status', () => {
     const suspended = /** @type {RegistrationStatus} */ (
       ACCREDITATION_STATUS.SUSPENDED

--- a/src/domain/organisations/status.test.js
+++ b/src/domain/organisations/status.test.js
@@ -12,10 +12,11 @@ import {
 import Boom from '@hapi/boom'
 
 /** @import {AccreditationStatus, OrganisationStatus, RegistrationStatus} from './model.js' */
+/** @import {StatusTransitionAsserter} from './status.js' */
 
 /**
  * @template {string} S
- * @param {(fromStatus: S, toStatus: S) => void} assertTransitionValid
+ * @param {StatusTransitionAsserter<S>} assertTransitionValid
  * @param {'registration' | 'accreditation'} itemKind
  * @param {[S, S, boolean][]} transitionTable
  */
@@ -115,6 +116,11 @@ describe('assertOrgStatusTransitionValid', () => {
 })
 
 describe('assertRegistrationStatusTransitionValid', () => {
+  // Only reachable from a status read from storage, never from a typed caller.
+  const suspended = /** @type {RegistrationStatus} */ (
+    ACCREDITATION_STATUS.SUSPENDED
+  )
+
   /** @type {[RegistrationStatus, RegistrationStatus, boolean][]} */
   const transitionTable = [
     // From CREATED
@@ -140,7 +146,11 @@ describe('assertRegistrationStatusTransitionValid', () => {
     [REGISTRATION_STATUS.REJECTED, REGISTRATION_STATUS.CREATED, true],
     [REGISTRATION_STATUS.REJECTED, REGISTRATION_STATUS.APPROVED, false],
     [REGISTRATION_STATUS.REJECTED, REGISTRATION_STATUS.CANCELLED, false],
-    [REGISTRATION_STATUS.REJECTED, REGISTRATION_STATUS.REJECTED, false]
+    [REGISTRATION_STATUS.REJECTED, REGISTRATION_STATUS.REJECTED, false],
+
+    // Suspended is not a registration status
+    [suspended, REGISTRATION_STATUS.CANCELLED, false],
+    [REGISTRATION_STATUS.APPROVED, suspended, false]
   ]
 
   describeTransitionTable(
@@ -148,38 +158,6 @@ describe('assertRegistrationStatusTransitionValid', () => {
     'registration',
     transitionTable
   )
-
-  describe('suspended, which is not a registration status', () => {
-    const suspended = /** @type {RegistrationStatus} */ (
-      ACCREDITATION_STATUS.SUSPENDED
-    )
-
-    it('rejects a transition out of suspended', () => {
-      expect(() =>
-        assertRegistrationStatusTransitionValid(
-          suspended,
-          REGISTRATION_STATUS.CANCELLED
-        )
-      ).toThrow(
-        Boom.badData(
-          'Cannot transition registration status from suspended to cancelled'
-        )
-      )
-    })
-
-    it('rejects a transition into suspended', () => {
-      expect(() =>
-        assertRegistrationStatusTransitionValid(
-          REGISTRATION_STATUS.APPROVED,
-          suspended
-        )
-      ).toThrow(
-        Boom.badData(
-          'Cannot transition registration status from approved to suspended'
-        )
-      )
-    })
-  })
 })
 
 describe('assertAccreditationStatusTransitionValid', () => {

--- a/src/packaging-recycling-notes/domain/model.js
+++ b/src/packaging-recycling-notes/domain/model.js
@@ -2,6 +2,8 @@ import { ACCREDITATION_STATUS } from '#domain/organisations/model.js'
 
 export const PRN_NUMBER_MAX_LENGTH = 20
 
+/** @import {AccreditationStatus} from '#domain/organisations/model.js' */
+
 /**
  * Status values for Packaging Recycling Notes (PRNs)
  * @typedef {typeof PRN_STATUS[keyof typeof PRN_STATUS]} PrnStatus
@@ -128,7 +130,7 @@ export class AccreditationStatusError extends Error {
  * Asserts that an accreditation permits issuing a PRN. Issuing is blocked while
  * the accreditation is suspended (temporary) or cancelled (terminal). A PRN can
  * still be created (drafted) while suspended.
- * @param {{ status?: string } | null | undefined} accreditation
+ * @param {{ status: AccreditationStatus } | null | undefined} accreditation
  * @throws {AccreditationStatusError} when the accreditation is suspended or cancelled
  */
 export function assertAccreditationCanIssue(accreditation) {

--- a/src/packaging-recycling-notes/domain/model.test.js
+++ b/src/packaging-recycling-notes/domain/model.test.js
@@ -12,6 +12,7 @@ import {
   UnauthorisedTransitionError
 } from './model.js'
 
+/** @import {AccreditationStatus} from '#domain/organisations/model.js' */
 /** @import {PrnStatus} from './model.js' */
 
 describe('PRN_STATUS_TRANSITIONS', () => {
@@ -157,14 +158,20 @@ describe('validateTransition', () => {
 })
 
 describe('assertAccreditationCanIssue', () => {
-  it.each(['approved', 'created', 'rejected'])(
+  /** @type {AccreditationStatus[]} */
+  const issuableStatuses = ['approved', 'created', 'rejected']
+
+  /** @type {AccreditationStatus[]} */
+  const blockedStatuses = ['suspended', 'cancelled']
+
+  it.each(issuableStatuses)(
     'does not throw when accreditation is %s',
     (status) => {
       expect(() => assertAccreditationCanIssue({ status })).not.toThrow()
     }
   )
 
-  it.each(['suspended', 'cancelled'])(
+  it.each(blockedStatuses)(
     'throws AccreditationStatusError when accreditation is %s',
     (status) => {
       expect(() => assertAccreditationCanIssue({ status })).toThrow(

--- a/src/reports/application/assert-cadence.js
+++ b/src/reports/application/assert-cadence.js
@@ -4,6 +4,7 @@ import { isRegistrationAccredited } from '#domain/organisations/registration-uti
 import { errorCodes } from '#reports/enums/error-codes.js'
 
 /**
+ * @import { AccreditationStatus } from '#domain/organisations/model.js'
  * @import { Cadence } from '#reports/domain/cadence.js'
  */
 
@@ -13,7 +14,9 @@ import { errorCodes } from '#reports/enums/error-codes.js'
  * fields for indexed logging, and `output.payload.cadence` for API clients.
  *
  * @param {Cadence} cadence
- * @param {{ accreditation: { status?: string } | null }} registration
+ * @param {{
+ *   accreditation: { status: AccreditationStatus } | null
+ * }} registration
  * @returns {void}
  */
 export const assertCadence = (cadence, registration) => {

--- a/src/reports/application/assert-cadence.js
+++ b/src/reports/application/assert-cadence.js
@@ -4,7 +4,7 @@ import { isRegistrationAccredited } from '#domain/organisations/registration-uti
 import { errorCodes } from '#reports/enums/error-codes.js'
 
 /**
- * @import { AccreditationStatus } from '#domain/organisations/model.js'
+ * @import { AccreditationLink } from '#domain/organisations/registration-utils.js'
  * @import { Cadence } from '#reports/domain/cadence.js'
  */
 
@@ -14,9 +14,7 @@ import { errorCodes } from '#reports/enums/error-codes.js'
  * fields for indexed logging, and `output.payload.cadence` for API clients.
  *
  * @param {Cadence} cadence
- * @param {{
- *   accreditation: { status: AccreditationStatus } | null
- * }} registration
+ * @param {AccreditationLink} registration
  * @returns {void}
  */
 export const assertCadence = (cadence, registration) => {

--- a/src/reports/domain/operator-category.js
+++ b/src/reports/domain/operator-category.js
@@ -2,7 +2,7 @@ import { WASTE_PROCESSING_TYPE } from '#domain/organisations/model.js'
 import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
 
 /**
- * @import { WasteProcessingTypeValue } from '#domain/organisations/model.js'
+ * @import { AccreditationStatus, WasteProcessingTypeValue } from '#domain/organisations/model.js'
  */
 
 /**
@@ -42,7 +42,11 @@ const OPERATOR_CATEGORY_BY_WASTE_PROCESSING_TYPE = Object.freeze({
 /**
  * Derives the operator category from a registration.
  *
- * @param {{ wasteProcessingType: string, accreditationId?: string, accreditation: { status?: string } | null }} registration
+ * @param {{
+ *   accreditation: { status: AccreditationStatus } | null,
+ *   accreditationId?: string,
+ *   wasteProcessingType: string
+ * }} registration
  * @returns {OperatorCategory}
  */
 export function getOperatorCategory(registration) {

--- a/src/reports/domain/operator-category.js
+++ b/src/reports/domain/operator-category.js
@@ -2,7 +2,8 @@ import { WASTE_PROCESSING_TYPE } from '#domain/organisations/model.js'
 import { isRegistrationAccredited } from '#domain/organisations/registration-utils.js'
 
 /**
- * @import { AccreditationStatus, WasteProcessingTypeValue } from '#domain/organisations/model.js'
+ * @import { WasteProcessingTypeValue } from '#domain/organisations/model.js'
+ * @import { AccreditationLink } from '#domain/organisations/registration-utils.js'
  */
 
 /**
@@ -42,8 +43,7 @@ const OPERATOR_CATEGORY_BY_WASTE_PROCESSING_TYPE = Object.freeze({
 /**
  * Derives the operator category from a registration.
  *
- * @param {{
- *   accreditation: { status: AccreditationStatus } | null,
+ * @param {AccreditationLink & {
  *   accreditationId?: string,
  *   wasteProcessingType: string
  * }} registration

--- a/src/reports/domain/operator-category.test.js
+++ b/src/reports/domain/operator-category.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { OPERATOR_CATEGORY, getOperatorCategory } from './operator-category.js'
 
+/** @import {AccreditationStatus} from '#domain/organisations/model.js' */
+
 describe('OPERATOR_CATEGORY', () => {
   it('is frozen', () => {
     expect(Object.isFrozen(OPERATOR_CATEGORY)).toBe(true)
@@ -8,7 +10,18 @@ describe('OPERATOR_CATEGORY', () => {
 })
 
 describe('getOperatorCategory', () => {
-  it.each([
+  /**
+   * @type {Array<{
+   *   expected: string,
+   *   registration: {
+   *     accreditation: { status: AccreditationStatus } | null,
+   *     accreditationId?: string,
+   *     wasteProcessingType: string
+   *   },
+   *   scenario: string
+   * }>}
+   */
+  const categorisations = [
     {
       scenario: 'registered-only exporter (no accreditationId)',
       registration: { wasteProcessingType: 'exporter', accreditation: null },
@@ -118,9 +131,14 @@ describe('getOperatorCategory', () => {
       },
       expected: 'REPROCESSOR_REGISTERED_ONLY'
     }
-  ])('returns $expected for $scenario', ({ registration, expected }) => {
-    expect(getOperatorCategory(registration)).toBe(expected)
-  })
+  ]
+
+  it.each(categorisations)(
+    'returns $expected for $scenario',
+    ({ registration, expected }) => {
+      expect(getOperatorCategory(registration)).toBe(expected)
+    }
+  )
 
   it('throws for unknown wasteProcessingType', () => {
     expect(() => {

--- a/src/reports/domain/operator-category.test.js
+++ b/src/reports/domain/operator-category.test.js
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { OPERATOR_CATEGORY, getOperatorCategory } from './operator-category.js'
 
-/** @import {AccreditationStatus} from '#domain/organisations/model.js' */
-
 describe('OPERATOR_CATEGORY', () => {
   it('is frozen', () => {
     expect(Object.isFrozen(OPERATOR_CATEGORY)).toBe(true)
@@ -13,11 +11,7 @@ describe('getOperatorCategory', () => {
   /**
    * @type {Array<{
    *   expected: string,
-   *   registration: {
-   *     accreditation: { status: AccreditationStatus } | null,
-   *     accreditationId?: string,
-   *     wasteProcessingType: string
-   *   },
+   *   registration: Parameters<typeof getOperatorCategory>[0],
    *   scenario: string
    * }>}
    */

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -55,9 +55,10 @@ export const statusHistoryWithChanges = (updatedItem, existingItem) => {
 }
 
 /**
- * @param {Array<{ id: string, status: string }>} existingItems
- * @param {Array<{ id: string, status?: string }>} itemUpdates
- * @param {(fromStatus: string, toStatus: string) => void} assertStatusTransitionValid
+ * @template {string} S
+ * @param {Array<{ id: string, status: S }>} existingItems
+ * @param {Array<{ id: string, status?: S }>} itemUpdates
+ * @param {(fromStatus: S, toStatus: S) => void} assertStatusTransitionValid
  * @param {Set<string>} [systemAppliedItemIds] - items whose status change was
  *   applied by the system (the registration-cancellation cascade), exempt from
  *   the transition table

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -23,7 +23,7 @@ import { getCurrentStatus } from './status.js'
 
 /** @import { WithId } from 'mongodb' */
 /** @import { Organisation, OrganisationStatus } from '#domain/organisations/model.js' */
-/** @import { Registration } from '#domain/organisations/registration.js' */
+/** @import { StatusTransitionAsserter } from '#domain/organisations/status.js' */
 /** @import { FindPageForOverseasSitesAdminListParams } from './port.js' */
 
 export const createStatusHistoryEntry = (status) => ({
@@ -58,7 +58,7 @@ export const statusHistoryWithChanges = (updatedItem, existingItem) => {
  * @template {string} S
  * @param {Array<{ id: string, status: S }>} existingItems
  * @param {Array<{ id: string, status?: S }>} itemUpdates
- * @param {(fromStatus: S, toStatus: S) => void} assertStatusTransitionValid
+ * @param {StatusTransitionAsserter<S>} assertStatusTransitionValid
  * @param {Set<string>} [systemAppliedItemIds] - items whose status change was
  *   applied by the system (the registration-cancellation cascade), exempt from
  *   the transition table
@@ -112,8 +112,7 @@ export const mapDocumentWithCurrentStatuses = (org) => {
   rest.status = /** @type {OrganisationStatus} */ (getCurrentStatus(rest))
 
   for (const item of rest.registrations) {
-    // Greenfield: no stored registration history contains suspended (PAE-1705)
-    item.status = /** @type {Registration['status']} */ (getCurrentStatus(item))
+    item.status = getCurrentStatus(item)
     item.accreditation = item.accreditation ?? null
   }
 

--- a/src/repositories/organisations/schema/accreditation.js
+++ b/src/repositories/organisations/schema/accreditation.js
@@ -55,13 +55,7 @@ const prnIssuanceSchema = Joi.object({
 export const accreditationSchema = Joi.object({
   id: idSchema,
   status: Joi.string()
-    .valid(
-      ACCREDITATION_STATUS.CREATED,
-      ACCREDITATION_STATUS.APPROVED,
-      ACCREDITATION_STATUS.CANCELLED,
-      ACCREDITATION_STATUS.REJECTED,
-      ACCREDITATION_STATUS.SUSPENDED
-    )
+    .valid(...Object.values(ACCREDITATION_STATUS))
     .forbidden(),
   validFrom: dateRequiredWhenApprovedOrSuspended(),
   validTo: dateRequiredWhenApprovedOrSuspended(),

--- a/src/repositories/organisations/schema/registration.js
+++ b/src/repositories/organisations/schema/registration.js
@@ -71,12 +71,7 @@ const overseasSitesMapSchema = Joi.object().pattern(
 export const registrationSchema = Joi.object({
   id: idSchema,
   status: Joi.string()
-    .valid(
-      REGISTRATION_STATUS.CREATED,
-      REGISTRATION_STATUS.APPROVED,
-      REGISTRATION_STATUS.CANCELLED,
-      REGISTRATION_STATUS.REJECTED
-    )
+    .valid(...Object.values(REGISTRATION_STATUS))
     .forbidden(),
   registrationNumber: Joi.string()
     .when('status', requiredWhenApproved)

--- a/src/repositories/organisations/schema/status-transition.js
+++ b/src/repositories/organisations/schema/status-transition.js
@@ -8,6 +8,7 @@ import {
 } from '#domain/organisations/model.js'
 
 /** @import {Organisation} from '#domain/organisations/model.js' */
+/** @import {StatusTransitionAsserter} from '#domain/organisations/status.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 
@@ -71,7 +72,7 @@ export const assertOrgStatusTransition = (existing, updated) => {
  * @template {string} S
  * @param {{ status: S }} existing
  * @param {{ status?: S }} updated
- * @param {(fromStatus: S, toStatus: S) => void} assertStatusTransitionValid
+ * @param {StatusTransitionAsserter<S>} assertStatusTransitionValid
  * @returns {void}
  */
 export const assertAndHandleItemStateTransition = (

--- a/src/repositories/organisations/schema/status-transition.js
+++ b/src/repositories/organisations/schema/status-transition.js
@@ -67,9 +67,10 @@ export const assertOrgStatusTransition = (existing, updated) => {
 }
 
 /**
- * @param {{ status: string }} existing
- * @param {{ status?: string }} updated
- * @param {(fromStatus: string, toStatus: string) => void} assertStatusTransitionValid
+ * @template {string} S
+ * @param {{ status: S }} existing
+ * @param {{ status?: S }} updated
+ * @param {(fromStatus: S, toStatus: S) => void} assertStatusTransitionValid
  * @returns {void}
  */
 export const assertAndHandleItemStateTransition = (
@@ -91,9 +92,11 @@ const isRegistrationCancelled = (registration) =>
 // against the incoming payload status so that an attempt to reinstate a
 // cascade-cancelled accreditation (payload approved, registration still
 // cancelled) is also caught and held at cancelled.
-const CASCADEABLE_ACC_STATUSES = /** @type {Set<AccreditationStatus>} */ (
-  new Set([ACCREDITATION_STATUS.APPROVED, ACCREDITATION_STATUS.SUSPENDED])
-)
+/** @type {Set<AccreditationStatus>} */
+const CASCADEABLE_ACC_STATUSES = new Set([
+  ACCREDITATION_STATUS.APPROVED,
+  ACCREDITATION_STATUS.SUSPENDED
+])
 
 /**
  * Cancelling a registration force-cancels its linked accreditation, whether

--- a/src/repositories/organisations/schema/status-transition.js
+++ b/src/repositories/organisations/schema/status-transition.js
@@ -2,11 +2,12 @@ import Boom from '@hapi/boom'
 import { assertOrgStatusTransitionValid } from '#domain/organisations/status.js'
 import {
   ACCREDITATION_STATUS,
+  ACTIVE_ACCREDITATION_STATUSES,
   ORGANISATION_STATUS,
   REGISTRATION_STATUS
 } from '#domain/organisations/model.js'
 
-/** @import {AccreditationStatus, Organisation} from '#domain/organisations/model.js' */
+/** @import {Organisation} from '#domain/organisations/model.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
 /** @import {Accreditation} from '#domain/organisations/accreditation.js' */
 
@@ -88,16 +89,6 @@ export const assertAndHandleItemStateTransition = (
 const isRegistrationCancelled = (registration) =>
   registration.status === REGISTRATION_STATUS.CANCELLED
 
-// Only a live accreditation is force-cancelled by the cascade. The check runs
-// against the incoming payload status so that an attempt to reinstate a
-// cascade-cancelled accreditation (payload approved, registration still
-// cancelled) is also caught and held at cancelled.
-/** @type {Set<AccreditationStatus>} */
-const CASCADEABLE_ACC_STATUSES = new Set([
-  ACCREDITATION_STATUS.APPROVED,
-  ACCREDITATION_STATUS.SUSPENDED
-])
-
 /**
  * Cancelling a registration force-cancels its linked accreditation, whether
  * that accreditation is approved or suspended (PAE-1705 Scenario 5). An
@@ -129,7 +120,7 @@ export const applyRegistrationStatusToLinkedAccreditations = (
   const updatedAccreditations = accreditations.map((acc) => {
     if (
       linkedToCancelledRegistration.has(acc.id) &&
-      CASCADEABLE_ACC_STATUSES.has(acc.status)
+      ACTIVE_ACCREDITATION_STATUSES.has(acc.status)
     ) {
       cascadeCancelledIds.add(acc.id)
       return /** @type {Accreditation} */ ({

--- a/src/repositories/organisations/status.js
+++ b/src/repositories/organisations/status.js
@@ -1,6 +1,10 @@
-/** @import {RegOrAccStatus} from '#domain/organisations/model.js' */
-
 /**
- * @returns {RegOrAccStatus}
+ * The latest entry is the current status. `validateStatusHistory` enforces a
+ * non-empty history on every write, so the last entry is always present.
+ *
+ * @template {string} S
+ * @param {{ statusHistory: Array<{ status: S }> }} item
+ * @returns {S}
  */
-export const getCurrentStatus = (item) => item.statusHistory.at(-1).status
+export const getCurrentStatus = ({ statusHistory }) =>
+  statusHistory[statusHistory.length - 1].status


### PR DESCRIPTION
Ticket: [PAE-1705](https://eaflood.atlassian.net/browse/PAE-1705)

Follow-up to #1561 and #1564. The enums were split, but nothing enforced them — `assertRegistrationStatusTransitionValid('suspended', 'not-a-status')` compiled fine. This makes the split hold.

- casts (`/** @type {Set<X>} */ (new Set(...))`) replaced with annotations — a cast is mutually assignable, so it accepted any member
- public register status sets and their predicates were untyped, so `.has(any)` was unchecked
- transition asserters were generic over `string`; now generic over the entity's status union, with the tables typed `Record<RegistrationStatus, RegistrationStatus[]>` — which also makes enum key coverage a compile-time guarantee
- `getCurrentStatus` was `any` in, asserted union out, on the line every status flows through; now generic, removing three casts at call sites
- swept remaining `status: string` JSDoc in reg/acc code onto the per-entity unions
- deduped the active-accreditation set (approved/suspended), which existed three times: two sets and one inline `||`

Verified by injecting a non-member into each set and the asserter and confirming `lint:types` rejects all four.

Test fixtures that no longer typecheck are fixed test-side by annotating the tables, so literals are checked against the union. The nine `suspended` rows in the registration transition table are unrepresentable now, replaced by two tests for the runtime guard (source and target branches).

396 files, 7075 tests, 100% coverage.

[PAE-1705]: https://eaflood.atlassian.net/browse/PAE-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ