### PR TITLE
PAE-1618 PAE-1623: accreditation reject and reopen transitions

### DIFF
--- a/src/routes/v1/organisations/accreditation-status-history.schema.js
+++ b/src/routes/v1/organisations/accreditation-status-history.schema.js
@@ -44,12 +44,27 @@ const createdToApprovedSchema = Joi.object({
   accreditationNumber: Joi.string().trim().min(1).required()
 })
 
+// Refusing a non-compliant application (PAE-1618): the operator stays
+// registered-only, so no number or validity dates are involved.
+const createdToRejectedSchema = Joi.object({
+  fromStatus: Joi.string().valid(ACCREDITATION_STATUS.CREATED).required(),
+  toStatus: Joi.string().valid(ACCREDITATION_STATUS.REJECTED).required()
+})
+
+// Reopening a rejected application for rework (PAE-1623).
+const rejectedToCreatedSchema = Joi.object({
+  fromStatus: Joi.string().valid(ACCREDITATION_STATUS.REJECTED).required(),
+  toStatus: Joi.string().valid(ACCREDITATION_STATUS.CREATED).required()
+})
+
 export const accreditationStatusHistoryPayloadSchema = Joi.alternatives()
   .try(
     approvedToSuspendedSchema,
     suspendedToApprovedSchema,
     suspendedToCancelledSchema,
     cancelledToApprovedSchema,
-    createdToApprovedSchema
+    createdToApprovedSchema,
+    createdToRejectedSchema,
+    rejectedToCreatedSchema
   )
   .required()

--- a/src/routes/v1/organisations/accreditation-status-history.test.js
+++ b/src/routes/v1/organisations/accreditation-status-history.test.js
@@ -113,6 +113,8 @@ const grantPayload = {
   appliesFrom: '2026-08-01',
   accreditationNumber: 'ACC999999'
 }
+const rejectPayload = { fromStatus: 'created', toStatus: 'rejected' }
+const reopenPayload = { fromStatus: 'rejected', toStatus: 'created' }
 
 describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/status-history', () => {
   setupAuthContext()
@@ -696,6 +698,144 @@ describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}
         /Cannot transition accreditation from created: its status is suspended/
       )
     })
+  })
+
+  describe('rejecting a created accreditation', () => {
+    it('rejects a created accreditation and returns 200 with { status: "rejected" }', async () => {
+      const ctx = await seedOrg('created')
+
+      const response = await server.inject({
+        method: 'POST',
+        url: statusHistoryUrl(ctx),
+        payload: rejectPayload,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(response.payload)).toEqual({ status: 'rejected' })
+    })
+
+    it('appends a rejected statusHistory entry, preserving earlier entries', async () => {
+      const ctx = await seedOrg('created')
+
+      await server.inject({
+        method: 'POST',
+        url: statusHistoryUrl(ctx),
+        payload: rejectPayload,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      const getResponse = await server.inject({
+        method: 'GET',
+        url: `/v1/organisations/${ctx.organisationId}`,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      const updatedOrg = JSON.parse(getResponse.payload)
+      const accreditation = updatedOrg.accreditations.find(
+        (a) => a.id === ctx.accreditationId
+      )
+
+      expect(accreditation.status).toBe('rejected')
+      expect(accreditation.statusHistory.map((e) => e.status)).toEqual([
+        'created',
+        'rejected'
+      ])
+
+      const otherAccreditation = updatedOrg.accreditations.find(
+        (a) => a.id === ctx.otherAccreditationId
+      )
+      expect(otherAccreditation.status).toBe('created')
+    })
+
+    it.each(['approved', 'suspended', 'rejected', 'cancelled'])(
+      'returns 422 when rejecting an accreditation that is currently %s',
+      async (status) => {
+        const ctx = await seedOrg(status)
+
+        const response = await server.inject({
+          method: 'POST',
+          url: statusHistoryUrl(ctx),
+          payload: rejectPayload,
+          headers: { Authorization: `Bearer ${validToken}` }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+        const body = JSON.parse(response.payload)
+        expect(body.message).toMatch(
+          new RegExp(
+            `Cannot transition accreditation from created: its status is ${status}`
+          )
+        )
+      }
+    )
+  })
+
+  describe('reopening a rejected accreditation', () => {
+    it('reopens a rejected accreditation and returns 200 with { status: "created" }', async () => {
+      const ctx = await seedOrg('rejected')
+
+      const response = await server.inject({
+        method: 'POST',
+        url: statusHistoryUrl(ctx),
+        payload: reopenPayload,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(response.payload)).toEqual({ status: 'created' })
+    })
+
+    it('appends a created statusHistory entry, preserving the rejection gap', async () => {
+      const ctx = await seedOrg('rejected')
+
+      await server.inject({
+        method: 'POST',
+        url: statusHistoryUrl(ctx),
+        payload: reopenPayload,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      const getResponse = await server.inject({
+        method: 'GET',
+        url: `/v1/organisations/${ctx.organisationId}`,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      const updatedOrg = JSON.parse(getResponse.payload)
+      const accreditation = updatedOrg.accreditations.find(
+        (a) => a.id === ctx.accreditationId
+      )
+
+      expect(accreditation.status).toBe('created')
+      expect(accreditation.statusHistory.map((e) => e.status)).toEqual([
+        'created',
+        'rejected',
+        'created'
+      ])
+    })
+
+    it.each(['approved', 'suspended', 'created', 'cancelled'])(
+      'returns 422 when reopening an accreditation that is currently %s',
+      async (status) => {
+        const ctx = await seedOrg(status)
+
+        const response = await server.inject({
+          method: 'POST',
+          url: statusHistoryUrl(ctx),
+          payload: reopenPayload,
+          headers: { Authorization: `Bearer ${validToken}` }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+        const body = JSON.parse(response.payload)
+        expect(body.message).toMatch(
+          new RegExp(
+            `Cannot transition accreditation from rejected: its status is ${status}`
+          )
+        )
+      }
+    )
   })
 
   describe('payload validation', () => {


### PR DESCRIPTION
## Summary

- Adds two accreditation status transitions to the status-history endpoint: `created → rejected` (Reject accreditation, PAE-1618) and `rejected → created` (Reopen rejected accreditation, PAE-1623).
- Both edges already exist in the domain transition map (`VALID_ACC_TRANSITIONS`), so the change is confined to the payload schema: two new arms in the discriminated union. No handler, repository or domain changes.
- Neither transition takes extra parameters — rejected/created accreditations carry no number or validity dates.
- Resulting operator state (no PRN issuing, registered-only template, no waste-balance contribution, quarterly reporting) is derived from the accreditation not being approved: `rejected` is only reachable from `created`, so such accreditations were never granted a number/`validFrom`, and `isAccreditedAtDates` excludes their rows from any PRN-issuable balance.

Jira: [PAE-1618](https://eaflood.atlassian.net/browse/PAE-1618), [PAE-1623](https://eaflood.atlassian.net/browse/PAE-1623)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAE-1618]: https://eaflood.atlassian.net/browse/PAE-1618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PAE-1623]: https://eaflood.atlassian.net/browse/PAE-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ