### PR TITLE
PAE-1697: remove closed-period-adjustments feature flag

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -346,12 +346,6 @@ const baseConfig = {
     }
   },
   featureFlags: {
-    closedPeriodAdjustments: {
-      doc: 'Feature Flag: Flag submitted reports as requiring resubmission when a later summary log restates a closed period',
-      format: Boolean,
-      default: false,
-      env: 'FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS'
-    },
     devEndpoints: {
       doc: 'Feature Flag: Enable development endpoints',
       format: Boolean,
@@ -371,7 +365,7 @@ const baseConfig = {
       env: 'FEATURE_FLAG_PRE_CPA_RESUBMISSION_REPORT'
     },
     preCpaResubmissionBackfill: {
-      doc: 'Feature Flag: Backfill requires-resubmission on stale pre-CPA submitted reports on startup (PAE-1768). Only takes effect when closedPeriodAdjustments is also enabled.',
+      doc: 'Feature Flag: Backfill requires-resubmission on stale pre-CPA submitted reports on startup (PAE-1768).',
       format: Boolean,
       default: false,
       env: 'FEATURE_FLAG_PRE_CPA_RESUBMISSION_BACKFILL'
@@ -527,13 +521,4 @@ function getConfig(overrides = {}) {
 
 const isProductionEnvironment = () => config.get('cdpEnvironment') === 'prod'
 const isLocalEnvironment = () => config.get('cdpEnvironment') === 'local'
-const isClosedPeriodAdjustmentsEnabled = () =>
-  config.get('featureFlags.closedPeriodAdjustments')
-
-export {
-  config,
-  getConfig,
-  isClosedPeriodAdjustmentsEnabled,
-  isLocalEnvironment,
-  isProductionEnvironment
-}
+export { config, getConfig, isLocalEnvironment, isProductionEnvironment }

--- a/src/reports/application/create-report-validation.js
+++ b/src/reports/application/create-report-validation.js
@@ -3,7 +3,6 @@ import { generateAllPeriodsForYear } from '#reports/domain/generate-reporting-pe
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
 import { isResubmissionRequired } from '#reports/domain/resubmission.js'
 import { errorCodes } from '#reports/enums/error-codes.js'
-import { isClosedPeriodAdjustmentsEnabled } from '#root/config.js'
 import { findSubmissionByNumber } from './submission-lookup.js'
 
 /**
@@ -156,10 +155,6 @@ export const assertResubmissionAllowed = (
         payload: { reason }
       }
     )
-
-  if (!isClosedPeriodAdjustmentsEnabled()) {
-    throw reject(errorCodes.resubmissionFeatureDisabled)
-  }
 
   const previous = findSubmissionByNumber(
     periodicReports,

--- a/src/reports/application/resubmission-service.js
+++ b/src/reports/application/resubmission-service.js
@@ -7,7 +7,6 @@ import {
 } from '#reports/domain/resubmission.js'
 import { REPORT_STATUS } from '#reports/domain/report-status.js'
 import { errorCodes } from '#reports/enums/error-codes.js'
-import { isClosedPeriodAdjustmentsEnabled } from '#root/config.js'
 import { findSubmissionByNumber } from './submission-lookup.js'
 
 /**
@@ -100,9 +99,6 @@ export function isLatestSubmissionOf(
  * @returns {import('#reports/repository/port.js').ResubmissionIneligibleReason}
  */
 export function resubmissionEligibility(periodicReports, target) {
-  if (!isClosedPeriodAdjustmentsEnabled()) {
-    return RESUBMISSION_INELIGIBLE_REASON.FEATURE_DISABLED
-  }
   if (target.status !== REPORT_STATUS.SUBMITTED) {
     return RESUBMISSION_INELIGIBLE_REASON.NOT_SUBMITTED
   }

--- a/src/reports/application/resubmission-service.test.js
+++ b/src/reports/application/resubmission-service.test.js
@@ -1,5 +1,4 @@
 import { ObjectId } from 'mongodb'
-import { config } from '#root/config.js'
 import {
   REPORT_STATUS,
   REPORT_STATUS_SLOT
@@ -116,14 +115,6 @@ describe('resubmission-service', () => {
   })
 
   describe('canRequestResubmission', () => {
-    beforeEach(() => {
-      config.set('featureFlags.closedPeriodAdjustments', true)
-    })
-
-    afterEach(() => {
-      config.set('featureFlags.closedPeriodAdjustments', false)
-    })
-
     const buildReport = (overrides = {}) => ({
       year: 2024,
       cadence: /** @type {import('#reports/domain/cadence.js').Cadence} */ (
@@ -236,30 +227,10 @@ describe('resubmission-service', () => {
 
       expect(canRequestResubmission(periodicReports, report)).toBe(false)
     })
-
-    it('returns false when closedPeriodAdjustments is disabled', () => {
-      config.set('featureFlags.closedPeriodAdjustments', false)
-      const report = buildReport()
-      const periodicReports = periodicReportsWith({
-        id: 'report-1',
-        submissionNumber: 1,
-        status: REPORT_STATUS.SUBMITTED
-      })
-
-      expect(canRequestResubmission(periodicReports, report)).toBe(false)
-    })
   })
 
   describe('requestOperatorResubmission', () => {
     const REQUESTED_BY = { id: 'user-1', name: 'Alice', position: 'Officer' }
-
-    beforeEach(() => {
-      config.set('featureFlags.closedPeriodAdjustments', true)
-    })
-
-    afterEach(() => {
-      config.set('featureFlags.closedPeriodAdjustments', false)
-    })
 
     it('flags the report and returns the flagged result', async () => {
       const reportsRepository = createInMemoryReportsRepository()()
@@ -349,31 +320,6 @@ describe('resubmission-service', () => {
           requestedBy: REQUESTED_BY
         })
       ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 404 } })
-    })
-
-    it('throws 409 when closedPeriodAdjustments is disabled', async () => {
-      const reportsRepository = createInMemoryReportsRepository()()
-      const params = defaultParams()
-      await createAndSubmitReport(reportsRepository, {
-        organisationId: params.organisationId,
-        registrationId: params.registrationId,
-        submissionNumber: 1
-      })
-
-      config.set('featureFlags.closedPeriodAdjustments', false)
-
-      await expect(
-        requestOperatorResubmission({
-          reportsRepository,
-          organisationId: params.organisationId,
-          registrationId: params.registrationId,
-          year: 2024,
-          cadence: 'monthly',
-          period: 1,
-          submissionNumber: 1,
-          requestedBy: REQUESTED_BY
-        })
-      ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 409 } })
     })
 
     it('throws 409 when the report is not submitted', async () => {

--- a/src/reports/application/summary-log-events.js
+++ b/src/reports/application/summary-log-events.js
@@ -1,4 +1,3 @@
-import { isClosedPeriodAdjustmentsEnabled } from '#root/config.js'
 import { logger } from '#common/helpers/logging/logger.js'
 import {
   auditMarkReportsStale,
@@ -77,10 +76,6 @@ export const createOnSummaryLogUploaded =
       logger.info({
         message: `No active report marked stale for ${organisationId}/${registrationId} summaryLogId=${summaryLogId} (none active, or already flagged by an earlier trigger)`
       })
-    }
-
-    if (!isClosedPeriodAdjustmentsEnabled()) {
-      return
     }
 
     const reportsRequiringResubmission =

--- a/src/reports/application/summary-log-events.test.js
+++ b/src/reports/application/summary-log-events.test.js
@@ -1,6 +1,5 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
-import { config } from '#root/config.js'
 import {
   buildCreateReportParams,
   DEFAULT_ORG_ID,
@@ -21,8 +20,6 @@ import {
 /**
  * @import { SummaryLogUploadedParams, SummaryLogUploadedRepositories } from './summary-log-events.js'
  */
-
-const CLOSED_PERIOD_ADJUSTMENTS = 'featureFlags.closedPeriodAdjustments'
 
 const mockAuditMarkReportsStale = vi.fn()
 const mockAuditMarkReportsRequiringResubmission = vi.fn()
@@ -68,7 +65,6 @@ const closedPeriod = {
 beforeEach(() => {
   vi.useFakeTimers()
   vi.setSystemTime(new Date(FIXED_NOW))
-  config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
   mockAuditMarkReportsStale.mockResolvedValue(undefined)
   mockAuditMarkReportsRequiringResubmission.mockResolvedValue(undefined)
 })
@@ -76,7 +72,6 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers()
   vi.clearAllMocks()
-  config.set(CLOSED_PERIOD_ADJUSTMENTS, false)
 })
 
 describe('onSummaryLogUploaded', () => {
@@ -271,27 +266,6 @@ describe('onSummaryLogUploaded', () => {
       organisationId: DEFAULT_ORG_ID,
       registrationId: DEFAULT_REG_ID,
       summaryLogId: DEFAULT_SL_ID,
-      reportsRepository: reportsRepositoryFactory(),
-      systemLogsRepository: buildSystemLogsRepository()
-    })
-
-    const unchanged = await reportsRepositoryFactory().findReportById(reportId)
-    expect(unchanged.resubmissionRequired).toBeUndefined()
-    expect(mockAuditMarkReportsRequiringResubmission).not.toHaveBeenCalled()
-  })
-
-  it('does not flag resubmission when the closed-period-adjustments flag is off', async () => {
-    config.set(CLOSED_PERIOD_ADJUSTMENTS, false)
-    const reportsRepositoryFactory = createInMemoryReportsRepository()
-    const { id: reportId } = await createAndSubmitReport(
-      reportsRepositoryFactory()
-    )
-
-    await onSummaryLogUploaded({
-      organisationId: DEFAULT_ORG_ID,
-      registrationId: DEFAULT_REG_ID,
-      summaryLogId: DEFAULT_SL_ID,
-      closedPeriods: [closedPeriod],
       reportsRepository: reportsRepositoryFactory(),
       systemLogsRepository: buildSystemLogsRepository()
     })

--- a/src/reports/domain/resubmission.js
+++ b/src/reports/domain/resubmission.js
@@ -9,7 +9,6 @@ export const isResubmissionRequired = (resubmissionRequired) =>
 
 /** Reasons a submitted report may not be eligible for a manual resubmission request, plus `ELIGIBLE`. */
 export const RESUBMISSION_INELIGIBLE_REASON = Object.freeze({
-  FEATURE_DISABLED: 'feature-disabled',
   NOT_SUBMITTED: 'not-submitted',
   ALREADY_REQUESTED: 'already-requested',
   NOT_LATEST_SUBMISSION: 'not-latest-submission',
@@ -24,8 +23,6 @@ export const RESUBMISSION_INELIGIBLE_REASON = Object.freeze({
  */
 export const resubmissionIneligibleReasonToErrorCode = (reason) => {
   switch (reason) {
-    case RESUBMISSION_INELIGIBLE_REASON.FEATURE_DISABLED:
-      return errorCodes.resubmissionFeatureDisabled
     case RESUBMISSION_INELIGIBLE_REASON.NOT_SUBMITTED:
       return errorCodes.reportNotSubmitted
     case RESUBMISSION_INELIGIBLE_REASON.ALREADY_REQUESTED:

--- a/src/reports/domain/resubmission.test.js
+++ b/src/reports/domain/resubmission.test.js
@@ -38,14 +38,6 @@ describe('isResubmissionRequired', () => {
 })
 
 describe('resubmissionIneligibleReasonToErrorCode', () => {
-  it('maps FEATURE_DISABLED', () => {
-    expect(
-      resubmissionIneligibleReasonToErrorCode(
-        RESUBMISSION_INELIGIBLE_REASON.FEATURE_DISABLED
-      )
-    ).toBe('resubmission_feature_disabled')
-  })
-
   it('maps NOT_SUBMITTED', () => {
     expect(
       resubmissionIneligibleReasonToErrorCode(

--- a/src/reports/enums/error-codes.js
+++ b/src/reports/enums/error-codes.js
@@ -4,7 +4,6 @@ export const errorCodes = {
   invalidPeriod: 'invalid_period',
   periodNotEnded: 'period_not_ended',
   reportAlreadyExists: 'report_already_exists',
-  resubmissionFeatureDisabled: 'resubmission_feature_disabled',
   resubmissionNotPermitted: 'resubmission_not_permitted',
   reportNotSubmitted: 'report_not_submitted',
   reportNotLatestSubmission: 'report_not_latest_submission',

--- a/src/reports/routes/get-detail.test.js
+++ b/src/reports/routes/get-detail.test.js
@@ -1,6 +1,5 @@
 import { ObjectId } from 'mongodb'
 import { StatusCodes } from 'http-status-codes'
-import { config } from '#root/config.js'
 import { createTestServer } from '#test/create-test-server.js'
 import { asServiceMaintainer, asOperator } from '#test/inject-auth.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
@@ -1322,14 +1321,6 @@ describe(`GET ${reportsGetDetailPath}`, () => {
       })
 
       describe('canRequestResubmission field', () => {
-        beforeEach(() => {
-          config.set('featureFlags.closedPeriodAdjustments', true)
-        })
-
-        afterEach(() => {
-          config.set('featureFlags.closedPeriodAdjustments', false)
-        })
-
         const createSubmittedReport = async (
           reportsRepositoryFactory,
           organisationId,
@@ -1434,36 +1425,6 @@ describe(`GET ${reportsGetDetailPath}`, () => {
 
           expect(response.statusCode).toBe(StatusCodes.OK)
           expect(payload.canRequestResubmission).toBe(true)
-        })
-
-        it('is false when closedPeriodAdjustments is disabled', async () => {
-          const {
-            server,
-            organisationId,
-            registrationId,
-            reportsRepositoryFactory
-          } = await createServerWithReports({
-            wasteProcessingType: 'reprocessor',
-            accreditationId: undefined
-          })
-
-          await createSubmittedReport(
-            reportsRepositoryFactory,
-            organisationId,
-            registrationId
-          )
-
-          config.set('featureFlags.closedPeriodAdjustments', false)
-
-          const response = await makeRequest(
-            server,
-            organisationId,
-            registrationId
-          )
-          const payload = JSON.parse(response.payload)
-
-          expect(response.statusCode).toBe(StatusCodes.OK)
-          expect(payload.canRequestResubmission).toBe(false)
         })
 
         it('is false once resubmissionRequired.operatorRequested is already set', async () => {

--- a/src/reports/routes/post.test.js
+++ b/src/reports/routes/post.test.js
@@ -16,7 +16,6 @@ import {
   REPORT_STATUS,
   REPORT_STATUS_SLOT
 } from '#reports/domain/report-status.js'
-import { config } from '#root/config.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
 import { buildAwaitingAcceptancePrn } from '#packaging-recycling-notes/repository/contract/test-data.js'
 import {
@@ -690,12 +689,7 @@ describe(`POST ${reportsPostPath}`, () => {
   })
 
   describe('resubmission submissions (submissionNumber > 1)', () => {
-    const CLOSED_PERIOD_ADJUSTMENTS = 'featureFlags.closedPeriodAdjustments'
     const changedBy = { id: 'user-1', name: 'Test', position: 'Officer' }
-
-    afterEach(() => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, false)
-    })
 
     const buildSubmission = (
       organisationId,
@@ -786,8 +780,7 @@ describe(`POST ${reportsPostPath}`, () => {
         n
       )
 
-    it('creates submission 2 when the flag is on and submission 1 is submitted and flagged', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
+    it('creates submission 2 when submission 1 is submitted and flagged', async () => {
       const { server, organisationId, registrationId, repo } = await setup()
 
       const { id } = await repo.createReport(
@@ -807,30 +800,7 @@ describe(`POST ${reportsPostPath}`, () => {
       expect(JSON.parse(response.payload).submissionNumber).toBe(2)
     })
 
-    it('rejects submission 2 with 409 resubmission_feature_disabled when the flag is off', async () => {
-      const { server, organisationId, registrationId, repo } = await setup()
-
-      const { id } = await repo.createReport(
-        buildSubmission(organisationId, registrationId, 1)
-      )
-      await submitReport(repo, id)
-      await flagPeriod(repo, organisationId, registrationId)
-
-      const response = await postSubmission(
-        server,
-        organisationId,
-        registrationId,
-        2
-      )
-
-      expect(response.statusCode).toBe(StatusCodes.CONFLICT)
-      expect(JSON.parse(response.payload).reason).toBe(
-        'resubmission_feature_disabled'
-      )
-    })
-
     it('rejects submission 2 with 409 resubmission_not_permitted when submission 1 is submitted but not flagged', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
       const { server, organisationId, registrationId, repo } = await setup()
 
       const { id } = await repo.createReport(
@@ -852,7 +822,6 @@ describe(`POST ${reportsPostPath}`, () => {
     })
 
     it('rejects submission 2 with 409 resubmission_not_permitted when submission 1 is still in progress', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
       const { server, organisationId, registrationId, repo } = await setup()
 
       await repo.createReport(
@@ -873,7 +842,6 @@ describe(`POST ${reportsPostPath}`, () => {
     })
 
     it('rejects submission 2 with 409 resubmission_not_permitted when no submission 1 exists', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
       const { server, organisationId, registrationId } = await setup()
 
       const response = await postSubmission(
@@ -890,7 +858,6 @@ describe(`POST ${reportsPostPath}`, () => {
     })
 
     it('rejects submission 3 when submission 2 is not yet submitted', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
       const { server, organisationId, registrationId, repo } = await setup()
 
       const { id } = await repo.createReport(

--- a/src/reports/routes/request-resubmission.test.js
+++ b/src/reports/routes/request-resubmission.test.js
@@ -14,13 +14,10 @@ import {
   buildCreateReportParams,
   createAndSubmitReport
 } from '#reports/repository/contract/test-data.js'
-import { config } from '#root/config.js'
 import { reportsRequestResubmissionPath } from './request-resubmission.js'
 import * as reportAudit from '#reports/application/audit.js'
 
 /** @import { Registration } from '#domain/organisations/registration.js' */
-
-const CLOSED_PERIOD_ADJUSTMENTS = 'featureFlags.closedPeriodAdjustments'
 
 vi.mock('#reports/application/audit.js', () => ({
   auditReportRequestResubmission: vi.fn().mockResolvedValue(undefined)
@@ -79,12 +76,7 @@ describe(`POST ${reportsRequestResubmissionPath}`, () => {
   }
 
   beforeEach(() => {
-    config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
     vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    config.set(CLOSED_PERIOD_ADJUSTMENTS, false)
   })
 
   describe('successful request', () => {
@@ -354,22 +346,6 @@ describe(`POST ${reportsRequestResubmissionPath}`, () => {
       const response = await server.inject({
         method: 'POST',
         url: makeUrl(org.id, registration.id, 2024, 'monthly', 1, 1),
-        ...asOperator()
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.CONFLICT)
-    })
-  })
-
-  describe('feature flag disabled', () => {
-    it('returns 409 when closedPeriodAdjustments is disabled', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, false)
-      const { server, organisationId, registrationId } =
-        await buildServerWithSubmittedReport()
-
-      const response = await server.inject({
-        method: 'POST',
-        url: makeUrl(organisationId, registrationId),
         ...asOperator()
       })
 

--- a/src/server/run-pre-cpa-resubmission-backfill.js
+++ b/src/server/run-pre-cpa-resubmission-backfill.js
@@ -1,5 +1,4 @@
 import { logger } from '#common/helpers/logging/logger.js'
-import { isClosedPeriodAdjustmentsEnabled } from '#root/config.js'
 import {
   findPreCpaResubmissionReports,
   backfillPreCpaResubmissionReports,
@@ -193,18 +192,16 @@ const runBackfill = async (server) => {
  * The two steps are gated independently: the diagnostic (read-only sizing/
  * logging) runs when `preCpaResubmissionReport` is enabled; the backfill
  * (writes `resubmissionRequired.closedPeriodRestated`) runs when
- * `preCpaResubmissionBackfill` is enabled AND closed-period adjustments
- * itself is enabled -- CPA must already be live before its history is
- * backfilled. Either can run without the other. With both flags off, this
- * returns before touching the locker or any repository.
+ * `preCpaResubmissionBackfill` is enabled. Either can run without the other.
+ * With both flags off, this returns before touching the locker or any
+ * repository.
  *
  * @param {Object} server - Hapi server instance
  */
 export const runPreCpaResubmissionBackfill = async (server) => {
   const reportEnabled = server.featureFlags.isPreCpaResubmissionReportEnabled()
   const backfillEnabled =
-    server.featureFlags.isPreCpaResubmissionBackfillEnabled() &&
-    isClosedPeriodAdjustmentsEnabled()
+    server.featureFlags.isPreCpaResubmissionBackfillEnabled()
 
   if (!reportEnabled && !backfillEnabled) {
     return

--- a/src/server/run-pre-cpa-resubmission-backfill.test.js
+++ b/src/server/run-pre-cpa-resubmission-backfill.test.js
@@ -1,13 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 import { logger } from '#common/helpers/logging/logger.js'
-import { config } from '#root/config.js'
 import { runPreCpaResubmissionBackfill } from './run-pre-cpa-resubmission-backfill.js'
-
-const CLOSED_PERIOD_ADJUSTMENTS = 'featureFlags.closedPeriodAdjustments'
 
 vi.mock('#common/helpers/logging/logger.js', () => ({
   logger: {
@@ -171,11 +168,6 @@ const buildServer = (
 describe('runPreCpaResubmissionBackfill', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    config.set(CLOSED_PERIOD_ADJUSTMENTS, false)
-  })
-
-  afterEach(() => {
-    config.set(CLOSED_PERIOD_ADJUSTMENTS, false)
   })
 
   describe('diagnostic step (preCpaResubmissionReport)', () => {
@@ -349,9 +341,8 @@ describe('runPreCpaResubmissionBackfill', () => {
     })
   })
 
-  describe('backfill step (preCpaResubmissionBackfill, requires CPA enabled)', () => {
-    it('does not write when the backfill flag is off, even with findings and CPA on', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
+  describe('backfill step (preCpaResubmissionBackfill)', () => {
+    it('does not write when the backfill flag is off, even with findings', async () => {
       const app = oneFindingApp()
       const server = buildServer(app, {
         reportEnabled: false,
@@ -366,24 +357,7 @@ describe('runPreCpaResubmissionBackfill', () => {
       ).not.toHaveBeenCalled()
     })
 
-    it('does not write when CPA is off, even with the backfill flag on', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, false)
-      const app = oneFindingApp()
-      const server = buildServer(app, {
-        reportEnabled: false,
-        backfillEnabled: true
-      })
-
-      await runPreCpaResubmissionBackfill(server)
-
-      expect(server.locker.lock).not.toHaveBeenCalled()
-      expect(
-        app.reportsRepository.markSubmittedReportsRequiringResubmission
-      ).not.toHaveBeenCalled()
-    })
-
     it('runs the backfill even when the report (diagnostic) flag is off', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
       const app = oneFindingApp()
       app.reportsRepository.markSubmittedReportsRequiringResubmission = vi
         .fn()
@@ -440,7 +414,6 @@ describe('runPreCpaResubmissionBackfill', () => {
     })
 
     it('runs both steps under a single shared lock when both flags are on', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
       const app = oneFindingApp()
       const server = buildServer(app, {
         reportEnabled: true,
@@ -462,7 +435,6 @@ describe('runPreCpaResubmissionBackfill', () => {
     })
 
     it('logs a report already flagged by an earlier run as a no-op, not an error', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
       const app = oneFindingApp()
       app.reportsRepository.markSubmittedReportsRequiringResubmission = vi
         .fn()
@@ -483,7 +455,6 @@ describe('runPreCpaResubmissionBackfill', () => {
     })
 
     it('warns when a write flags a reportId the scan did not attribute the period to', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
       const app = oneFindingApp()
       app.reportsRepository.markSubmittedReportsRequiringResubmission = vi
         .fn()
@@ -519,7 +490,6 @@ describe('runPreCpaResubmissionBackfill', () => {
     })
 
     it('logs a failed group and still releases the lock, without aborting the whole run', async () => {
-      config.set(CLOSED_PERIOD_ADJUSTMENTS, true)
       const app = oneFindingApp()
       const writeError = new Error('mongo write failed')
       app.reportsRepository.markSubmittedReportsRequiringResubmission = vi


### PR DESCRIPTION
Ticket: [PAE-1697](https://eaflood.atlassian.net/browse/PAE-1697)
removes FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS now closed-period adjustments are live in prod.

- drops the convict entry and `isClosedPeriodAdjustmentsEnabled` from both frontend and backend config
- backend: requires-resubmission event emission, resubmission eligibility and resubmission validation are now unconditional; the pre-CPA backfill gate drops its CPA conjunct
- backend: removes `RESUBMISSION_INELIGIBLE_REASON.FEATURE_DISABLED` and `resubmissionFeatureDisabled`, unreachable once those guards go and unused by any consumer
- frontend: closed-period messaging on the check and confirmation pages, the requires-resubmission reports-list entries and the resubmission-variant screens all render without a flag check; removes `IS_CLOSED_PERIOD_ADJUSTMENT_STATUS`, which only expressed the flag-off filter
- deletes the flag-off tests and overrides; both suites stay at 100% coverage
- drops the flag from the journey-test and service compose wiring, along with the already-dead `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES`, `_BACKFILL` and `FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES` entries

the service compose change also removes FEATURE_FLAG_OPERATOR_INITIATED_RESUBMISSION, missed by the PR that removed that flag from code.

second of three PRs on PAE-1697. the frontend and journey-test branches stack on the operator-initiated-resubmission PR. the cdp-app-config env keys come out once both reach prod.


[PAE-1697]: https://eaflood.atlassian.net/browse/PAE-1697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ