### PR TITLE
PAE-1800: accreditation grant and reinstate require an approved registration

### DIFF
--- a/src/routes/v1/organisations/accreditation-status-history.js
+++ b/src/routes/v1/organisations/accreditation-status-history.js
@@ -2,6 +2,10 @@ import Boom from '@hapi/boom'
 import { SCOPES } from '#common/helpers/auth/constants.js'
 import { StatusCodes } from 'http-status-codes'
 import { auditOrganisationUpdate } from '#root/auditing/organisations.js'
+import {
+  ACCREDITATION_STATUS,
+  REGISTRATION_STATUS
+} from '#domain/organisations/model.js'
 import { assertAccreditationStatusTransitionValid } from '#domain/organisations/status.js'
 import { accreditationStatusHistoryPayloadSchema } from './accreditation-status-history.schema.js'
 
@@ -74,6 +78,21 @@ export const accreditationStatusHistory = {
     if (accreditation.status !== fromStatus) {
       throw Boom.badData(
         `Cannot transition accreditation from ${fromStatus}: its status is ${accreditation.status}`
+      )
+    }
+
+    // Both to-approved arms (grant and reinstate) require the linked
+    // registration to be approved (PAE-1800). Without this a cancelled
+    // registration's cascade-cancelled accreditation could be "reinstated":
+    // the repository cascade would hold it at cancelled while the endpoint
+    // returned 200 — this guard makes the rejection explicit. Granting gets
+    // the same clear message instead of validateApprovals' generic one.
+    if (
+      toStatus === ACCREDITATION_STATUS.APPROVED &&
+      registration.status !== REGISTRATION_STATUS.APPROVED
+    ) {
+      throw Boom.badData(
+        `Cannot transition accreditation to approved: its registration is ${registration.status}`
       )
     }
 

--- a/src/routes/v1/organisations/accreditation-status-history.js
+++ b/src/routes/v1/organisations/accreditation-status-history.js
@@ -17,6 +17,45 @@ import { accreditationStatusHistoryPayloadSchema } from './accreditation-status-
 export const accreditationStatusHistoryPath =
   '/v1/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/status-history'
 
+/**
+ * Grant-only validations. Granting sets validFrom to appliesFrom but leaves
+ * validTo (owned by the application data) untouched, so reject a window that
+ * would be inverted — when validTo is absent the replace 422s via the schema
+ * guard requiring it on approved accreditations. Granting also issues the
+ * accreditation number, which must not already be in use by any
+ * accreditation in any organisation, whatever its status. This uniqueness is
+ * enforced here only: there is no unique index on
+ * accreditations.accreditationNumber, so concurrent grants of the same
+ * number are not blocked by the database.
+ * @param {OrganisationsRepository} organisationsRepository
+ * @param {{ validTo?: string }} accreditation
+ * @param {{ appliesFrom: string, accreditationNumber: string }} grant
+ * @returns {Promise<void>}
+ */
+const assertGrantAllowed = async (
+  organisationsRepository,
+  accreditation,
+  grant
+) => {
+  if (
+    accreditation.validTo &&
+    new Date(grant.appliesFrom) > new Date(accreditation.validTo)
+  ) {
+    throw Boom.badData(
+      `Cannot grant accreditation: appliesFrom ${grant.appliesFrom} is after validTo ${accreditation.validTo}`
+    )
+  }
+
+  const holder = await organisationsRepository.findByAccreditationNumber(
+    grant.accreditationNumber
+  )
+  if (holder) {
+    throw Boom.badData(
+      `Accreditation number ${grant.accreditationNumber} is already in use`
+    )
+  }
+}
+
 export const accreditationStatusHistory = {
   method: 'POST',
   path: accreditationStatusHistoryPath,
@@ -103,32 +142,7 @@ export const accreditationStatusHistory = {
     assertAccreditationStatusTransitionValid(fromStatus, toStatus)
 
     if (grant) {
-      // Granting sets validFrom to appliesFrom but leaves validTo (owned by
-      // the application data) untouched, so reject a window that would be
-      // inverted. When validTo is absent the replace below 422s via the
-      // schema guard requiring it on approved accreditations.
-      if (
-        accreditation.validTo &&
-        new Date(grant.appliesFrom) > new Date(accreditation.validTo)
-      ) {
-        throw Boom.badData(
-          `Cannot grant accreditation: appliesFrom ${grant.appliesFrom} is after validTo ${accreditation.validTo}`
-        )
-      }
-
-      // Granting issues the accreditation number, which must not already be
-      // in use by any accreditation in any organisation, whatever its status.
-      // This uniqueness is enforced here only: there is no unique index on
-      // accreditations.accreditationNumber, so concurrent grants of the same
-      // number are not blocked by the database.
-      const holder = await organisationsRepository.findByAccreditationNumber(
-        grant.accreditationNumber
-      )
-      if (holder) {
-        throw Boom.badData(
-          `Accreditation number ${grant.accreditationNumber} is already in use`
-        )
-      }
+      await assertGrantAllowed(organisationsRepository, accreditation, grant)
     }
 
     const grantFields = grant

--- a/src/routes/v1/organisations/accreditation-status-history.test.js
+++ b/src/routes/v1/organisations/accreditation-status-history.test.js
@@ -36,8 +36,9 @@ vi.mock('@defra/cdp-auditing', () => ({
  * changing the target's status leaves other accreditations untouched.
  * The linked registration is 'created' by default; approving the
  * accreditation requires an approved registration, so tests opt in via
- * registrationStatus. accreditationOverrides lets grant tests shape the
- * target accreditation (e.g. no number yet).
+ * registrationStatus ('approved', 'rejected' or 'cancelled').
+ * accreditationOverrides lets grant tests shape the target accreditation
+ * (e.g. no number yet).
  * @param {string} status
  * @param {{ registrationStatus?: string, accreditationOverrides?: object }} [options]
  */
@@ -49,15 +50,16 @@ const buildOrgWithAccreditationStatus = (
   const registration = buildRegistration({
     accreditationId,
     reprocessingType: 'input',
-    ...(registrationStatus === 'approved' && {
-      // registrationNumber/validFrom/validTo are required once a
-      // registration has been approved or suspended.
+    ...(registrationStatus !== 'created' && {
+      // registrationNumber/validFrom/validTo are only required once a
+      // registration has been approved, but non-created registrations get
+      // them for realism (mirrors buildOrgWithRegistrationStatus).
       registrationNumber: 'REG123456',
       validFrom: '2024-01-01',
       validTo: '2025-01-01',
       statusHistory: [
         { status: 'created', updatedAt: '2024-01-01' },
-        { status: 'approved', updatedAt: '2024-01-15' }
+        { status: registrationStatus, updatedAt: '2024-01-15' }
       ]
     })
   })
@@ -371,8 +373,8 @@ describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}
 
       expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
       const body = JSON.parse(response.payload)
-      expect(body.message).toMatch(
-        /approved but not linked to an approved registration/
+      expect(body.message).toBe(
+        'Cannot transition accreditation to approved: its registration is created'
       )
     })
 
@@ -522,8 +524,8 @@ describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}
 
       expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
       const body = JSON.parse(response.payload)
-      expect(body.message).toMatch(
-        /approved but not linked to an approved registration/
+      expect(body.message).toBe(
+        'Cannot transition accreditation to approved: its registration is created'
       )
     })
 
@@ -659,8 +661,8 @@ describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}
 
       expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
       const body = JSON.parse(response.payload)
-      expect(body.message).toMatch(
-        /approved but not linked to an approved registration/
+      expect(body.message).toBe(
+        'Cannot transition accreditation to approved: its registration is created'
       )
     })
 
@@ -836,6 +838,37 @@ describe('POST /v1/organisations/{organisationId}/registrations/{registrationId}
         )
       }
     )
+  })
+
+  describe('to-approved transitions require an approved registration (PAE-1800)', () => {
+    const reinstatePayloadArm = {
+      fromStatus: 'cancelled',
+      toStatus: 'approved'
+    }
+
+    describe.each([
+      { arm: 'grant', accStatus: 'created', payload: grantPayload },
+      { arm: 'reinstate', accStatus: 'cancelled', payload: reinstatePayloadArm }
+    ])('$arm', ({ accStatus, payload }) => {
+      it.each(['created', 'rejected', 'cancelled'])(
+        'returns 422 when the linked registration is %s',
+        async (registrationStatus) => {
+          const ctx = await seedOrg(accStatus, { registrationStatus })
+
+          const response = await server.inject({
+            method: 'POST',
+            url: statusHistoryUrl(ctx),
+            payload,
+            headers: { Authorization: `Bearer ${validToken}` }
+          })
+
+          expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+          expect(JSON.parse(response.payload).message).toBe(
+            `Cannot transition accreditation to approved: its registration is ${registrationStatus}`
+          )
+        }
+      )
+    })
   })
 
   describe('payload validation', () => {


### PR DESCRIPTION
Ticket: [PAE-1800](https://eaflood.atlassian.net/browse/PAE-1800)
## Summary

Both to-approved arms of accreditation status transitions — grant (draft → approved) and reinstate (suspended → approved) — now require the linked registration to be approved. If the registration is not approved, the route returns an explicit `422 Bad Data` with a clear message instead of the previous behaviour:

- **Reinstate of a cascade-cancelled accreditation**: previously a silent `200` no-op, since the repository's cascade held the accreditation at `cancelled` while the endpoint reported success.
- **Grant**: previously fell through to `validateApprovals`'s generic repository-layer error message.

This also aligns the reapprove arm (suspended → approved) with the same clear message as grant, for consistency.

The repository-layer cascade cancellation is retained as defence in depth; this change adds an explicit route-level check so the API contract is unambiguous.

## Changes

- `src/routes/v1/organisations/accreditation-status-history.js` — new guard: when transitioning to `approved`, throw `Boom.badData` if the linked registration's status is not `approved`.
- `src/routes/v1/organisations/accreditation-status-history.test.js` — coverage for the new guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAE-1800]: https://eaflood.atlassian.net/browse/PAE-1800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ