### PR TITLE
PAE-1573: bound the PRN tonnage report's ledger read fan-out

### DIFF
--- a/src/application/prn-tonnage/aggregate-prn-tonnage.js
+++ b/src/application/prn-tonnage/aggregate-prn-tonnage.js
@@ -1,5 +1,4 @@
 import Joi from 'joi'
-import chunk from 'lodash.chunk'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import {
   REPROCESSING_TYPE,
@@ -49,6 +48,10 @@ export const REGISTRATION_TYPE = Object.freeze({
   REPROCESSOR_OUTPUT: 'REPROCESSOR_OUTPUT',
   EXPORTER: 'EXPORTER'
 })
+
+/**
+ * @typedef {typeof REGISTRATION_TYPE[keyof typeof REGISTRATION_TYPE]} RegistrationType
+ */
 
 /**
  * How many ledger reads the report holds in flight at once. Every report row
@@ -300,11 +303,33 @@ const balancesFor = async (ledgerRepository, ledgerId) => {
 }
 
 /**
+ * A row as the report publishes it: the hierarchy read down from organisation
+ * to accreditation, then the balances it holds, then its PRN tonnage by status.
+ *
+ * @typedef {Object} ReportRow
+ * @property {string} organisationName
+ * @property {string} orgId
+ * @property {string} registrationNumber
+ * @property {RegistrationType} registrationType
+ * @property {string} accreditationNumber
+ * @property {string} material
+ * @property {string} tonnageBand
+ * @property {number} wasteBalance
+ * @property {number} availableWasteBalance
+ * @property {number} awaitingAuthorisationTonnage
+ * @property {number} awaitingAcceptanceTonnage
+ * @property {number} awaitingCancellationTonnage
+ * @property {number} acceptedTonnage
+ * @property {number} cancelledTonnage
+ */
+
+/**
  * Reads down the hierarchy — organisation, registration, accreditation — before
  * the figures, so the response carries the report's column order.
  *
  * @param {WasteBalanceLedgerRepository} ledgerRepository
  * @param {AggregatedRow} aggregatedRow
+ * @returns {Promise<ReportRow>}
  */
 const buildReportRow = async (
   ledgerRepository,
@@ -332,25 +357,38 @@ const buildReportRow = async (
 })
 
 /**
+ * @template T
+ * @param {number} size
+ * @param {T[]} items
+ * @returns {T[][]}
+ */
+const inBatchesOf = (size, items) =>
+  Array.from({ length: Math.ceil(items.length / size) }, (_, batch) =>
+    items.slice(batch * size, (batch + 1) * size)
+  )
+
+/**
  * Resolves the rows a batch at a time, so the report never has more than
  * `LEDGER_READ_CONCURRENCY` ledger reads outstanding however many
- * accreditations it covers.
+ * accreditations it covers. Awaiting the rows reported so far before touching
+ * the next batch is what holds each batch back until its predecessor lands.
  *
  * @param {WasteBalanceLedgerRepository} ledgerRepository
  * @param {AggregatedRow[]} aggregatedRows
  */
-const buildReportRows = async (ledgerRepository, aggregatedRows) => {
-  const rows = []
+const buildReportRows = (ledgerRepository, aggregatedRows) => {
+  /** @type {ReportRow[]} */
+  const nothingReportedYet = []
 
-  for (const batch of chunk(aggregatedRows, LEDGER_READ_CONCURRENCY)) {
-    rows.push(
-      ...(await Promise.all(
-        batch.map((row) => buildReportRow(ledgerRepository, row))
-      ))
-    )
-  }
-
-  return rows
+  return inBatchesOf(LEDGER_READ_CONCURRENCY, aggregatedRows).reduce(
+    async (reportedSoFar, batch) =>
+      (await reportedSoFar).concat(
+        await Promise.all(
+          batch.map((row) => buildReportRow(ledgerRepository, row))
+        )
+      ),
+    Promise.resolve(nothingReportedYet)
+  )
 }
 
 /**

--- a/src/application/prn-tonnage/aggregate-prn-tonnage.js
+++ b/src/application/prn-tonnage/aggregate-prn-tonnage.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import chunk from 'lodash.chunk'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import {
   REPROCESSING_TYPE,
@@ -48,6 +49,14 @@ export const REGISTRATION_TYPE = Object.freeze({
   REPROCESSOR_OUTPUT: 'REPROCESSOR_OUTPUT',
   EXPORTER: 'EXPORTER'
 })
+
+/**
+ * How many ledger reads the report holds in flight at once. Every report row
+ * needs its own ledger read, and a whole report's worth of them released
+ * together would check out the MongoDB driver's connection pool and queue
+ * every other request on the pod behind it.
+ */
+export const LEDGER_READ_CONCURRENCY = 10
 
 const ZERO_BALANCES = Object.freeze({
   wasteBalance: 0,
@@ -323,6 +332,28 @@ const buildReportRow = async (
 })
 
 /**
+ * Resolves the rows a batch at a time, so the report never has more than
+ * `LEDGER_READ_CONCURRENCY` ledger reads outstanding however many
+ * accreditations it covers.
+ *
+ * @param {WasteBalanceLedgerRepository} ledgerRepository
+ * @param {AggregatedRow[]} aggregatedRows
+ */
+const buildReportRows = async (ledgerRepository, aggregatedRows) => {
+  const rows = []
+
+  for (const batch of chunk(aggregatedRows, LEDGER_READ_CONCURRENCY)) {
+    rows.push(
+      ...(await Promise.all(
+        batch.map((row) => buildReportRow(ledgerRepository, row))
+      ))
+    )
+  }
+
+  return rows
+}
+
+/**
  * @param {import('mongodb').Db} db
  * @param {WasteBalanceLedgerRepository} ledgerRepository
  */
@@ -334,15 +365,13 @@ export const aggregatePrnTonnage = async (db, ledgerRepository) => {
     .aggregate(pipeline)
     .toArray()
 
-  const rows = await Promise.all(
+  const rows = await buildReportRows(
+    ledgerRepository,
     aggregatedRows.map((row) =>
-      buildReportRow(
-        ledgerRepository,
-        Joi.attempt(
-          row,
-          aggregatedRowSchema,
-          `Unreportable PRN tonnage row for accreditation ${row.ledgerId.accreditationId}:`
-        )
+      Joi.attempt(
+        row,
+        aggregatedRowSchema,
+        `Unreportable PRN tonnage row for accreditation ${row.ledgerId.accreditationId}:`
       )
     )
   )

--- a/src/application/prn-tonnage/aggregate-prn-tonnage.js
+++ b/src/application/prn-tonnage/aggregate-prn-tonnage.js
@@ -1,23 +1,33 @@
 import Joi from 'joi'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 import {
+  MATERIAL,
   REPROCESSING_TYPE,
+  TONNAGE_BAND,
   WASTE_PROCESSING_TYPE
 } from '#domain/organisations/model.js'
 
 /** @import { WasteBalanceLedgerRepository } from '#waste-balances/repository/ledger-port.js' */
 /** @import { WasteBalanceLedgerId } from '#waste-balances/repository/ledger-schema.js' */
-/** @import { WasteProcessingTypeValue, ReprocessingType } from '#domain/organisations/model.js' */
+/** @import { Material, ReprocessingType, TonnageBand } from '#domain/organisations/model.js' */
+
+/**
+ * @typedef {{ wasteProcessingType: typeof WASTE_PROCESSING_TYPE.EXPORTER }} ExporterProcessingTypes
+ */
+
+/**
+ * @typedef {{ wasteProcessingType: typeof WASTE_PROCESSING_TYPE.REPROCESSOR, reprocessingType: ReprocessingType }} ReprocessorProcessingTypes
+ */
 
 /**
  * The registration's own processing-type fields, the same shape
  * `AccreditationContext` takes in `#waste-balances/domain/credited-tonnage.js`.
- * An exporter registration is forbidden a reprocessing type, so it arrives
- * absent.
+ * An exporter registration is forbidden a reprocessing type and an approved
+ * reprocessor registration is required to carry one, so the two are separate
+ * shapes rather than one shape with an optional field — a reprocessor without
+ * a reprocessing type cannot be built.
  *
- * @typedef {Object} RegistrationProcessingTypes
- * @property {WasteProcessingTypeValue} wasteProcessingType
- * @property {ReprocessingType} [reprocessingType]
+ * @typedef {ExporterProcessingTypes | ReprocessorProcessingTypes} RegistrationProcessingTypes
  */
 
 /**
@@ -29,8 +39,8 @@ import {
  * @property {string} orgId
  * @property {string} registrationNumber
  * @property {string} accreditationNumber
- * @property {string} material
- * @property {string} tonnageBand
+ * @property {Material} material
+ * @property {TonnageBand} tonnageBand
  * @property {WasteBalanceLedgerId} ledgerId
  * @property {RegistrationProcessingTypes} registration
  * @property {number} awaitingAuthorisationTonnage
@@ -238,8 +248,12 @@ const aggregatedRowSchema = Joi.object({
   orgId: Joi.string().required(),
   registrationNumber: Joi.string().required(),
   accreditationNumber: Joi.string().required(),
-  material: Joi.string().required(),
-  tonnageBand: Joi.string().required(),
+  material: Joi.string()
+    .valid(...Object.values(MATERIAL))
+    .required(),
+  tonnageBand: Joi.string()
+    .valid(...Object.values(TONNAGE_BAND))
+    .required(),
   ledgerId: Joi.object({
     organisationId: Joi.string().required(),
     registrationId: Joi.string().required(),
@@ -272,14 +286,14 @@ const aggregatedRowSchema = Joi.object({
  *
  * @param {RegistrationProcessingTypes} registration
  */
-const registrationTypeFor = ({ wasteProcessingType, reprocessingType }) => {
-  if (wasteProcessingType === WASTE_PROCESSING_TYPE.EXPORTER) {
+const registrationTypeFor = (registration) => {
+  if (registration.wasteProcessingType === WASTE_PROCESSING_TYPE.EXPORTER) {
     return REGISTRATION_TYPE.EXPORTER
   }
-  if (reprocessingType === REPROCESSING_TYPE.OUTPUT) {
-    return REGISTRATION_TYPE.REPROCESSOR_OUTPUT
-  }
-  return REGISTRATION_TYPE.REPROCESSOR_INPUT
+
+  return registration.reprocessingType === REPROCESSING_TYPE.OUTPUT
+    ? REGISTRATION_TYPE.REPROCESSOR_OUTPUT
+    : REGISTRATION_TYPE.REPROCESSOR_INPUT
 }
 
 /**
@@ -312,8 +326,8 @@ const balancesFor = async (ledgerRepository, ledgerId) => {
  * @property {string} registrationNumber
  * @property {RegistrationType} registrationType
  * @property {string} accreditationNumber
- * @property {string} material
- * @property {string} tonnageBand
+ * @property {Material} material
+ * @property {TonnageBand} tonnageBand
  * @property {number} wasteBalance
  * @property {number} availableWasteBalance
  * @property {number} awaitingAuthorisationTonnage

--- a/src/application/prn-tonnage/integration.test.js
+++ b/src/application/prn-tonnage/integration.test.js
@@ -114,6 +114,10 @@ const organisationWithRegistration = (
   registrations: [registration]
 })
 
+/** @param {number} count */
+const accreditationNumbers = (count) =>
+  [...Array(count).keys()].map((index) => `ACC-${index}`)
+
 /**
  * An organisation holding `count` accreditations, each on its own registration
  * and each with one accepted PRN, so the report has `count` rows to resolve
@@ -430,7 +434,7 @@ describe('aggregatePrnTonnage - Integration', () => {
     ])
   })
 
-  it('holds no more ledger reads in flight at once than the pool can spare', async () => {
+  it('holds exactly LEDGER_READ_CONCURRENCY ledger reads in flight at once', async () => {
     const rowCount = LEDGER_READ_CONCURRENCY * 2 + 1
     const { organisation, prns } = organisationWithAccreditations(rowCount)
     await db.collection(ORGANISATIONS_COLLECTION).insertOne(organisation)
@@ -440,7 +444,20 @@ describe('aggregatePrnTonnage - Integration', () => {
     const { rows } = await aggregatePrnTonnage(db, repository)
 
     expect(rows).toHaveLength(rowCount)
-    expect(peak()).toBeLessThanOrEqual(LEDGER_READ_CONCURRENCY)
+    expect(peak()).toBe(LEDGER_READ_CONCURRENCY)
+  })
+
+  it('reports the rows in sorted order across batches', async () => {
+    const rowCount = LEDGER_READ_CONCURRENCY * 2 + 1
+    const { organisation, prns } = organisationWithAccreditations(rowCount)
+    await db.collection(ORGANISATIONS_COLLECTION).insertOne(organisation)
+    await db.collection(PRNS_COLLECTION).insertMany(prns)
+
+    const { rows } = await aggregatePrnTonnage(db, ledgerRepository)
+
+    expect(rows.map((row) => row.accreditationNumber)).toStrictEqual(
+      accreditationNumbers(rowCount).toSorted()
+    )
   })
 
   it('reports a reprocessor-input registration as REPROCESSOR_INPUT', async () => {

--- a/src/application/prn-tonnage/integration.test.js
+++ b/src/application/prn-tonnage/integration.test.js
@@ -165,20 +165,23 @@ const organisationWithAccreditations = (count) => {
 
 /**
  * Wraps a ledger repository to record how many of its reads were ever in
- * flight at once.
+ * flight at once, and how many it was asked for at all.
  *
  * @param {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} repository
  */
 const recordingPeakConcurrency = (repository) => {
   let inFlight = 0
   let peak = 0
+  let reads = 0
 
   return {
     peak: () => peak,
+    reads: () => reads,
     repository: {
       ...repository,
       /** @param {import('#waste-balances/repository/ledger-schema.js').WasteBalanceLedgerId} ledgerId */
       findLatestInLedger: async (ledgerId) => {
+        reads += 1
         inFlight += 1
         peak = Math.max(peak, inFlight)
         try {
@@ -445,6 +448,56 @@ describe('aggregatePrnTonnage - Integration', () => {
 
     expect(rows).toHaveLength(rowCount)
     expect(peak()).toBe(LEDGER_READ_CONCURRENCY)
+  })
+
+  it('spends no ledger reads when a later row is unreportable', async () => {
+    await db.collection(ORGANISATIONS_COLLECTION).insertOne({
+      ...organisationWithRegistration(),
+      accreditations: [
+        {
+          id: accId,
+          accreditationNumber: 'ACC-1',
+          material: MATERIAL.PLASTIC,
+          prnIssuance: { tonnageBand: TONNAGE_BAND.UP_TO_5000 }
+        },
+        {
+          id: 'acc-2',
+          accreditationNumber: 'ACC-2',
+          material: MATERIAL.PLASTIC,
+          prnIssuance: { tonnageBand: TONNAGE_BAND.UP_TO_5000 }
+        }
+      ],
+      registrations: [
+        reprocessorRegistration(REPROCESSING_TYPE.INPUT),
+        {
+          ...reprocessorRegistration(REPROCESSING_TYPE.INPUT),
+          id: 'reg-2',
+          registrationNumber: null,
+          accreditationId: 'acc-2'
+        }
+      ]
+    })
+    await db.collection(PRNS_COLLECTION).insertMany([
+      prnWithStatus(PRN_STATUS.ACCEPTED, 40),
+      buildPrn({
+        registrationId: 'reg-2',
+        organisation: { id: organisationId, name: 'Acme Reprocessing' },
+        accreditation: buildAccreditation({
+          id: 'acc-2',
+          accreditationNumber: 'ACC-2',
+          material: MATERIAL.PLASTIC
+        }),
+        tonnage: 10,
+        status: withStatus(PRN_STATUS.ACCEPTED)
+      })
+    ])
+    const { reads, repository } = recordingPeakConcurrency(ledgerRepository)
+
+    await expect(aggregatePrnTonnage(db, repository)).rejects.toThrow(
+      'registrationNumber'
+    )
+
+    expect(reads()).toBe(0)
   })
 
   it('reports the rows in sorted order across batches', async () => {

--- a/src/application/prn-tonnage/integration.test.js
+++ b/src/application/prn-tonnage/integration.test.js
@@ -3,6 +3,7 @@ import { ObjectId } from 'mongodb'
 import { it, DATABASE_NAME } from '#vite/fixtures/mongo-client.js'
 import {
   aggregatePrnTonnage,
+  LEDGER_READ_CONCURRENCY,
   REGISTRATION_TYPE
 } from './aggregate-prn-tonnage.js'
 import {
@@ -112,6 +113,79 @@ const organisationWithRegistration = (
   ],
   registrations: [registration]
 })
+
+/**
+ * An organisation holding `count` accreditations, each on its own registration
+ * and each with one accepted PRN, so the report has `count` rows to resolve
+ * balances for.
+ *
+ * @param {number} count
+ */
+const organisationWithAccreditations = (count) => {
+  const indices = [...Array(count).keys()]
+
+  return {
+    organisation: {
+      _id: new ObjectId(organisationId),
+      orgId,
+      companyDetails: { name: 'Acme Reprocessing' },
+      accreditations: indices.map((index) => ({
+        id: `acc-${index}`,
+        accreditationNumber: `ACC-${index}`,
+        material: MATERIAL.PLASTIC,
+        prnIssuance: { tonnageBand: TONNAGE_BAND.UP_TO_5000 }
+      })),
+      registrations: indices.map((index) => ({
+        id: `reg-${index}`,
+        registrationNumber: `REG-${index}`,
+        accreditationId: `acc-${index}`,
+        wasteProcessingType: WASTE_PROCESSING_TYPE.REPROCESSOR,
+        reprocessingType: REPROCESSING_TYPE.INPUT
+      }))
+    },
+    prns: indices.map((index) =>
+      buildPrn({
+        registrationId: `reg-${index}`,
+        organisation: { id: organisationId, name: 'Acme Reprocessing' },
+        accreditation: buildAccreditation({
+          id: `acc-${index}`,
+          accreditationNumber: `ACC-${index}`,
+          material: MATERIAL.PLASTIC
+        }),
+        tonnage: 40,
+        status: withStatus(PRN_STATUS.ACCEPTED)
+      })
+    )
+  }
+}
+
+/**
+ * Wraps a ledger repository to record how many of its reads were ever in
+ * flight at once.
+ *
+ * @param {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} repository
+ */
+const recordingPeakConcurrency = (repository) => {
+  let inFlight = 0
+  let peak = 0
+
+  return {
+    peak: () => peak,
+    repository: {
+      ...repository,
+      /** @param {import('#waste-balances/repository/ledger-schema.js').WasteBalanceLedgerId} ledgerId */
+      findLatestInLedger: async (ledgerId) => {
+        inFlight += 1
+        peak = Math.max(peak, inFlight)
+        try {
+          return await repository.findLatestInLedger(ledgerId)
+        } finally {
+          inFlight -= 1
+        }
+      }
+    }
+  }
+}
 
 const expectedRow = (overrides = {}) => ({
   organisationName: 'Acme Reprocessing',
@@ -354,6 +428,19 @@ describe('aggregatePrnTonnage - Integration', () => {
     expect(rows).toStrictEqual([
       expectedRow({ registrationType: REGISTRATION_TYPE.EXPORTER })
     ])
+  })
+
+  it('holds no more ledger reads in flight at once than the pool can spare', async () => {
+    const rowCount = LEDGER_READ_CONCURRENCY * 2 + 1
+    const { organisation, prns } = organisationWithAccreditations(rowCount)
+    await db.collection(ORGANISATIONS_COLLECTION).insertOne(organisation)
+    await db.collection(PRNS_COLLECTION).insertMany(prns)
+    const { peak, repository } = recordingPeakConcurrency(ledgerRepository)
+
+    const { rows } = await aggregatePrnTonnage(db, repository)
+
+    expect(rows).toHaveLength(rowCount)
+    expect(peak()).toBeLessThanOrEqual(LEDGER_READ_CONCURRENCY)
   })
 
   it('reports a reprocessor-input registration as REPROCESSOR_INPUT', async () => {


### PR DESCRIPTION
Ticket: [PAE-1573](https://eaflood.atlassian.net/browse/PAE-1573)
The PRN tonnage report gives every row its own waste-balance ledger read, and used to release them all at once. `mongoOptions` sets no `maxPoolSize`, so the MongoDB driver's default of 100 applies. The public register currently lists around 370 reprocessor and exporter registrations, so a report covering them already asks for several times the pool in one go: it checks out every connection and every other request on the pod queues behind it. Reads now go out ten at a time.

## Bounding the reads

Rows resolve in batches of ten, one batch after another, so the report holds a fixed number of connections however many accreditations it covers.

The bound is per invocation, not per process: ten concurrent calls to this route would still reach the pool ceiling. That is an accepted limit rather than an oversight. This is an admin-scoped report, and a process-wide guarantee would want a lock or a cached result rather than a larger constant.

The trade is latency. Each wave costs the slowest of its ten reads, so the report gets slower by roughly the number of waves times a point-lookup round trip. The route sets no timeout, so if the report ever grows enough for that to matter it will fail as an undiagnosed 500 — worth a timeout and a measurement before the row count grows much further, rather than something this change settles.

## Validating before reading, not during

Row validation now happens up front, before any ledger read is spent. Previously an unreportable row threw out of the `.map` after earlier rows had already started their reads, leaving those unawaited: wasted work in the ordinary case, and an unhandled rejection in the case where one of them also failed. The report still rejects the same row with the same message.

## Making unreportable rows unrepresentable

Two shapes the module could describe but could never legitimately hold:

`material` and `tonnageBand` were typed as bare strings even though the response schema already constrains both to the domain's finite sets — the inbound parse was weaker than the outbound one, so a bad value failed late at response validation rather than early with its accreditation named. Both are now the domain types, and the inbound schema constrains them to match.

A registration's processing types were one shape with an optional reprocessing type, which made "reprocessor carrying no reprocessing type" representable — the exact combination the schema already forbids, and one the type-of-registration derivation quietly folded into reprocessor-input. Exporter and reprocessor are now separate shapes, so that combination cannot be built and the reprocessor branch is exhaustive by construction.

## Why the reads stay behind the port

The alternative is to resolve the balances inside the aggregation, with a correlated `$lookup` that sorts each partition by event number and takes one. The adjacent waste balance availability report already does exactly that, in one round trip, and it would very likely be faster here too.

It is not done here because that report reaches past the ledger's repository port and imports the events collection name from the Mongo adapter directly. Copying that would spread a layering breach there is already work open to remove. Bringing the same shape behind the port — a bulk latest-per-ledger read the adapter implements — is the version worth having, and it is a fair follow-up to this change rather than a reason to hold it: it is a performance decision that wants measurements, and this change is what stops the report exhausting the pool in the meantime.

<details>
<summary>How the bound is held, and how it is guarded</summary>

`inBatchesOf` splits the rows immutably and an async `reduce` folds the batches. Awaiting the rows reported so far *before* touching the next batch is what holds each batch back: `reduce` invokes every reducer synchronously, so each one must suspend on its predecessor before calling `batch.map`, or all batches launch at once.

Three guards, each confirmed to fail against the mistake it describes. The first wraps the real Mongo ledger repository in a recorder and asserts the peak in-flight count is exactly the bound, so it fails against an unbounded fan-out, against fully sequential reads, and against a flipped fold. The second asserts row order survives the batching, which the old `Promise.all` gave for free. The third asserts no ledger read is spent at all when a later row fails validation, which fails if validation moves back inside the fan-out.

`lodash.chunk` would have been the house helper here, but it ships no type declarations and made both the batch and its rows implicitly `any` under the strict type-check configuration, in a file that was otherwise clean. The repo carries no `@types/*` dependencies, so the split is written out instead.

The type changes were checked by poisoning each edge and confirming it reddens, since `noImplicitAny` is off in this repo and a green run proves little on its own. One limit remains: `Joi.attempt` returns `any`, so the agreement between the row schema and its typedef is maintained by hand — everything downstream of that assertion is checked, the assertion itself is not. That is the existing pattern across the repo rather than anything this branch introduces.
</details>


[PAE-1573]: https://eaflood.atlassian.net/browse/PAE-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ