### PR TITLE
PAE-1790: Add insert and orgId allocation to the form-submissions port

### DIFF
--- a/src/domain/form-submissions/submission-records.js
+++ b/src/domain/form-submissions/submission-records.js
@@ -1,0 +1,105 @@
+import deepmerge from 'deepmerge'
+import { SCHEMA_VERSION } from '#common/enums/index.js'
+
+/** @import { Answer } from '#common/helpers/apply/extract-answers.js' */
+
+/**
+ * @typedef {Object} OrganisationSubmission
+ * @property {number} schemaVersion
+ * @property {Date} createdAt
+ * @property {number} orgId
+ * @property {string} orgName
+ * @property {string} email
+ * @property {string|null} nations
+ * @property {Answer[]} answers
+ * @property {object} rawSubmissionData
+ */
+
+/**
+ * @typedef {Object} RegistrationSubmission
+ * @property {number} schemaVersion
+ * @property {Date} createdAt
+ * @property {number} orgId
+ * @property {string} referenceNumber
+ * @property {Answer[]} answers
+ * @property {object} rawSubmissionData
+ */
+
+/**
+ * @typedef {Object} AccreditationSubmission
+ * @property {number} schemaVersion
+ * @property {Date} createdAt
+ * @property {number} orgId
+ * @property {string} referenceNumber
+ * @property {Answer[]} answers
+ * @property {object} rawSubmissionData
+ */
+
+/**
+ * @typedef {Object} AgainstOrganisationFields
+ * @property {number} orgId
+ * @property {string} referenceNumber
+ * @property {Answer[]} answers
+ * @property {object} rawSubmissionData
+ */
+
+const emptySubmission = {
+  schemaVersion: SCHEMA_VERSION,
+  answers: {},
+  rawSubmissionData: {}
+}
+
+/**
+ * @param {{orgId: number, orgName: string, email: string, nations?: string|null, answers: Answer[], rawSubmissionData: object}} fields
+ * @returns {OrganisationSubmission}
+ */
+export function organisationSubmission({
+  orgId,
+  orgName,
+  email,
+  nations = null,
+  answers,
+  rawSubmissionData
+}) {
+  return deepmerge(emptySubmission, {
+    createdAt: new Date(),
+    orgId,
+    orgName,
+    email,
+    nations,
+    answers,
+    rawSubmissionData
+  })
+}
+
+/**
+ * Registrations and accreditations are both filed against an organisation that
+ * already holds an orgId, so they carry the same fields.
+ *
+ * @param {AgainstOrganisationFields} fields
+ */
+const againstOrganisation = ({
+  orgId,
+  referenceNumber,
+  answers,
+  rawSubmissionData
+}) =>
+  deepmerge(emptySubmission, {
+    createdAt: new Date(),
+    orgId,
+    referenceNumber,
+    answers,
+    rawSubmissionData
+  })
+
+/**
+ * @param {AgainstOrganisationFields} fields
+ * @returns {RegistrationSubmission}
+ */
+export const registrationSubmission = (fields) => againstOrganisation(fields)
+
+/**
+ * @param {AgainstOrganisationFields} fields
+ * @returns {AccreditationSubmission}
+ */
+export const accreditationSubmission = (fields) => againstOrganisation(fields)

--- a/src/repositories/form-submissions/contract/insert.contract.js
+++ b/src/repositories/form-submissions/contract/insert.contract.js
@@ -1,0 +1,211 @@
+import { describe, expect } from 'vitest'
+import { ORG_ID_START_NUMBER } from '#common/enums/index.js'
+import {
+  accreditationSubmission,
+  organisationSubmission,
+  registrationSubmission
+} from '#domain/form-submissions/submission-records.js'
+import { generateReferenceNumber } from './test-data.js'
+
+const anAnswer = {
+  shortDescription: 'Organisation name',
+  title: 'What is the name of your organisation?',
+  type: 'TextField',
+  value: 'ACME ltd'
+}
+
+export const testAllocateOrgIdBehaviour = (it) => {
+  describe('allocateOrgId', () => {
+    it('allocates above the organisation id start number', async ({
+      formSubmissionsRepository
+    }) => {
+      const repository = formSubmissionsRepository()
+
+      const orgId = await repository.allocateOrgId()
+
+      expect(orgId).toBeGreaterThan(ORG_ID_START_NUMBER)
+    })
+
+    it('allocates the next id on each call', async ({
+      formSubmissionsRepository
+    }) => {
+      const repository = formSubmissionsRepository()
+
+      const first = await repository.allocateOrgId()
+      const second = await repository.allocateOrgId()
+
+      expect(second).toBe(first + 1)
+    })
+
+    it('never hands the same id to two concurrent callers', async ({
+      formSubmissionsRepository
+    }) => {
+      const repository = formSubmissionsRepository()
+      const allocations = 20
+
+      const orgIds = await Promise.all(
+        Array.from({ length: allocations }, () => repository.allocateOrgId())
+      )
+
+      expect(new Set(orgIds).size).toBe(allocations)
+    })
+  })
+}
+
+export const testInsertBehaviour = (it) => {
+  describe('insertOrganisation', () => {
+    it('stores the organisation and returns its reference number', async ({
+      formSubmissionsRepository
+    }) => {
+      const repository = formSubmissionsRepository()
+      const orgId = await repository.allocateOrgId()
+      const submission = organisationSubmission({
+        orgId,
+        orgName: 'ACME ltd',
+        email: 'alice@foo.com',
+        answers: [anAnswer],
+        rawSubmissionData: { meta: { definition: { name: 'Apply (ea)' } } }
+      })
+
+      const referenceNumber = await repository.insertOrganisation(submission)
+
+      const stored = await repository.findOrganisationById(referenceNumber)
+      expect(stored.id).toBe(referenceNumber)
+      expect(stored.orgId).toBe(orgId)
+      expect(stored.rawSubmissionData).toEqual(submission.rawSubmissionData)
+    })
+
+    it('hands a distinct reference number to each organisation', async ({
+      formSubmissionsRepository
+    }) => {
+      const repository = formSubmissionsRepository()
+      const build = async () =>
+        repository.insertOrganisation(
+          organisationSubmission({
+            orgId: await repository.allocateOrgId(),
+            orgName: 'ACME ltd',
+            email: 'alice@foo.com',
+            answers: [anAnswer],
+            rawSubmissionData: {}
+          })
+        )
+
+      const first = await build()
+      const second = await build()
+
+      expect(first).not.toBe(second)
+    })
+
+    it('makes the organisation visible to findAllOrganisations', async ({
+      formSubmissionsRepository
+    }) => {
+      const repository = formSubmissionsRepository()
+      const orgId = await repository.allocateOrgId()
+
+      const referenceNumber = await repository.insertOrganisation(
+        organisationSubmission({
+          orgId,
+          orgName: 'ACME ltd',
+          email: 'alice@foo.com',
+          answers: [anAnswer],
+          rawSubmissionData: {}
+        })
+      )
+
+      const all = await repository.findAllOrganisations()
+      expect(all.map((org) => org.id)).toContain(referenceNumber)
+    })
+  })
+
+  describe('insertRegistration', () => {
+    it('stores the registration against its organisation and reference number', async ({
+      formSubmissionsRepository
+    }) => {
+      const repository = formSubmissionsRepository()
+      const orgId = await repository.allocateOrgId()
+      const referenceNumber = generateReferenceNumber()
+      const submission = registrationSubmission({
+        orgId,
+        referenceNumber,
+        answers: [anAnswer],
+        rawSubmissionData: { data: { main: { field: 'value' } } }
+      })
+
+      await repository.insertRegistration(submission)
+
+      const found =
+        await repository.findRegistrationsBySystemReference(referenceNumber)
+      expect(found).toHaveLength(1)
+      expect(found[0].orgId).toBe(orgId)
+      expect(found[0].referenceNumber).toBe(referenceNumber)
+      expect(found[0].rawSubmissionData).toEqual(submission.rawSubmissionData)
+    })
+
+    it('gives the stored registration an id that findRegistrationById resolves', async ({
+      formSubmissionsRepository
+    }) => {
+      const repository = formSubmissionsRepository()
+      const referenceNumber = generateReferenceNumber()
+
+      await repository.insertRegistration(
+        registrationSubmission({
+          orgId: await repository.allocateOrgId(),
+          referenceNumber,
+          answers: [anAnswer],
+          rawSubmissionData: {}
+        })
+      )
+
+      const [stored] =
+        await repository.findRegistrationsBySystemReference(referenceNumber)
+      const byId = await repository.findRegistrationById(stored.id)
+      expect(byId.id).toBe(stored.id)
+    })
+  })
+
+  describe('insertAccreditation', () => {
+    it('stores the accreditation against its organisation and reference number', async ({
+      formSubmissionsRepository
+    }) => {
+      const repository = formSubmissionsRepository()
+      const orgId = await repository.allocateOrgId()
+      const referenceNumber = generateReferenceNumber()
+      const submission = accreditationSubmission({
+        orgId,
+        referenceNumber,
+        answers: [anAnswer],
+        rawSubmissionData: { data: { main: { field: 'value' } } }
+      })
+
+      await repository.insertAccreditation(submission)
+
+      const found =
+        await repository.findAccreditationsBySystemReference(referenceNumber)
+      expect(found).toHaveLength(1)
+      expect(found[0].orgId).toBe(orgId)
+      expect(found[0].referenceNumber).toBe(referenceNumber)
+      expect(found[0].rawSubmissionData).toEqual(submission.rawSubmissionData)
+    })
+
+    it('gives the stored accreditation an id that findAccreditationById resolves', async ({
+      formSubmissionsRepository
+    }) => {
+      const repository = formSubmissionsRepository()
+      const referenceNumber = generateReferenceNumber()
+
+      await repository.insertAccreditation(
+        accreditationSubmission({
+          orgId: await repository.allocateOrgId(),
+          referenceNumber,
+          answers: [anAnswer],
+          rawSubmissionData: {}
+        })
+      )
+
+      const [stored] =
+        await repository.findAccreditationsBySystemReference(referenceNumber)
+      const byId = await repository.findAccreditationById(stored.id)
+      expect(byId.id).toBe(stored.id)
+    })
+  })
+}

--- a/src/repositories/form-submissions/contract/test-data.js
+++ b/src/repositories/form-submissions/contract/test-data.js
@@ -1,8 +1,11 @@
 import crypto from 'node:crypto'
 import { ObjectId } from 'mongodb'
+import { ORG_ID_START_NUMBER } from '#common/enums/index.js'
 
-const ORG_ID_START = 500000
-export const generateOrgId = () => ORG_ID_START + crypto.randomInt(0, 100000)
+export const generateOrgId = () =>
+  ORG_ID_START_NUMBER + crypto.randomInt(0, 100000)
+
+export const generateReferenceNumber = () => new ObjectId().toString()
 
 const buildFormSubmission = (overrides = {}) => {
   return {

--- a/src/repositories/form-submissions/inmemory.js
+++ b/src/repositories/form-submissions/inmemory.js
@@ -1,3 +1,61 @@
+import { ObjectId } from 'mongodb'
+import { ORG_ID_START_NUMBER } from '#common/enums/index.js'
+
+/**
+ * @import {
+ *   AccreditationSubmission,
+ *   OrganisationSubmission,
+ *   RegistrationSubmission
+ * } from '#domain/form-submissions/submission-records.js'
+ */
+
+/**
+ * Mirrors the store's orgId counter: seeded from the organisations already
+ * present, then handed out one at a time.
+ *
+ * @param {{orgId?: number}[]} organisations
+ * @returns {number}
+ */
+const highestOrgId = (organisations) =>
+  organisations.reduce(
+    (highest, { orgId }) => Math.max(highest, orgId ?? ORG_ID_START_NUMBER),
+    ORG_ID_START_NUMBER
+  )
+
+/**
+ * One collection of submissions, cloned on the way in and on the way out so a
+ * caller cannot reach the stored documents.
+ *
+ * @param {Object[]} initialItems
+ */
+const collectionOf = (initialItems) => {
+  const items = structuredClone(initialItems)
+
+  return {
+    /**
+     * @param {OrganisationSubmission | RegistrationSubmission | AccreditationSubmission} submission
+     * @returns {string}
+     */
+    insert(submission) {
+      const id = new ObjectId().toString()
+      items.push({ ...structuredClone(submission), id })
+      return id
+    },
+    findAll: () => structuredClone(items),
+    findById(id) {
+      if (!id || (id.trim && !id.trim())) {
+        return null
+      }
+      return structuredClone(items).find((item) => item.id === id) || null
+    },
+    findBySystemReference: (ref) =>
+      structuredClone(items).filter(
+        (item) => item.referenceNumber.toLowerCase() === ref.toLowerCase()
+      ),
+    ids: () => new Set(items.map((item) => item.id))
+  }
+}
+
 /**
  * @param {Object[]} [initialAccreditations=[]]
  * @param {Object[]} [initialRegistrations=[]]
@@ -9,56 +67,40 @@ export const createFormSubmissionsRepository = (
   initialRegistrations = [],
   initialOrganisations = []
 ) => {
-  const organisations = structuredClone(initialOrganisations)
-  const accreditations = structuredClone(initialAccreditations)
-  const registrations = structuredClone(initialRegistrations)
+  const organisations = collectionOf(initialOrganisations)
+  const accreditations = collectionOf(initialAccreditations)
+  const registrations = collectionOf(initialRegistrations)
+
+  let orgIdCounter = highestOrgId(initialOrganisations)
 
   return () => ({
-    async findAllAccreditations() {
-      return structuredClone(accreditations)
+    async allocateOrgId() {
+      orgIdCounter += 1
+      return orgIdCounter
     },
-    async findAccreditationsBySystemReference(ref) {
-      return structuredClone(accreditations).filter(
-        (acc) => acc.referenceNumber.toLowerCase() === ref.toLowerCase()
-      )
+    async insertOrganisation(submission) {
+      return organisations.insert(submission)
     },
-    async findAccreditationById(id) {
-      if (!id || (id.trim && !id.trim())) {
-        return null
-      }
-      return (
-        structuredClone(accreditations).find((org) => org.id === id) || null
-      )
+    async insertRegistration(submission) {
+      registrations.insert(submission)
     },
-    async findAllOrganisations() {
-      return structuredClone(organisations)
+    async insertAccreditation(submission) {
+      accreditations.insert(submission)
     },
-    async findOrganisationById(id) {
-      if (!id || (id.trim && !id.trim())) {
-        return null
-      }
-      return structuredClone(organisations).find((org) => org.id === id) || null
-    },
-    async findAllRegistrations() {
-      return structuredClone(registrations)
-    },
-    async findRegistrationsBySystemReference(ref) {
-      return structuredClone(registrations).filter(
-        (reg) => reg.referenceNumber.toLowerCase() === ref.toLowerCase()
-      )
-    },
-    async findRegistrationById(id) {
-      if (!id || (id.trim && !id.trim())) {
-        return null
-      }
-      return structuredClone(registrations).find((org) => org.id === id) || null
-    },
-    async findAllFormSubmissionIds() {
-      return {
-        organisations: new Set(organisations.map((org) => org.id)),
-        registrations: new Set(registrations.map((reg) => reg.id)),
-        accreditations: new Set(accreditations.map((acc) => acc.id))
-      }
-    }
+    findAllAccreditations: async () => accreditations.findAll(),
+    findAccreditationsBySystemReference: async (ref) =>
+      accreditations.findBySystemReference(ref),
+    findAccreditationById: async (id) => accreditations.findById(id),
+    findAllOrganisations: async () => organisations.findAll(),
+    findOrganisationById: async (id) => organisations.findById(id),
+    findAllRegistrations: async () => registrations.findAll(),
+    findRegistrationsBySystemReference: async (ref) =>
+      registrations.findBySystemReference(ref),
+    findRegistrationById: async (id) => registrations.findById(id),
+    findAllFormSubmissionIds: async () => ({
+      organisations: organisations.ids(),
+      registrations: registrations.ids(),
+      accreditations: accreditations.ids()
+    })
   })
 }

--- a/src/repositories/form-submissions/mongodb.js
+++ b/src/repositories/form-submissions/mongodb.js
@@ -2,6 +2,13 @@ import { ObjectId } from 'mongodb'
 import { ORG_ID_START_NUMBER } from '#common/enums/db.js'
 
 /** @import { TypedLogger } from '#common/hapi-types.js' */
+/**
+ * @import {
+ *   AccreditationSubmission,
+ *   OrganisationSubmission,
+ *   RegistrationSubmission
+ * } from '#domain/form-submissions/submission-records.js'
+ */
 
 const ACCREDITATIONS_COLLECTION = 'accreditation'
 const REGISTRATIONS_COLLECTION = 'registration'
@@ -53,6 +60,17 @@ async function findHighestOrgId(db) {
 }
 
 /**
+ * The counters collection keys its documents by name rather than by ObjectId.
+ *
+ * @param {import('mongodb').Db} db
+ * @returns {import('mongodb').Collection<{_id: string, seq: number}>}
+ */
+const countersCollection = (db) =>
+  /** @type {import('mongodb').Collection<{_id: string, seq: number}>} */ (
+    db.collection(COUNTERS_COLLECTION)
+  )
+
+/**
  * Seeds the orgId counter from existing data on first run.
  * Uses $setOnInsert so it only writes when the counter doesn't exist yet.
  *
@@ -62,15 +80,92 @@ async function findHighestOrgId(db) {
 async function seedOrgIdCounter(db, logger) {
   const seq = await findHighestOrgId(db)
 
-  await db
-    .collection(COUNTERS_COLLECTION)
-    .updateOne(
-      { _id: /** @type {*} */ ('orgId') },
-      { $setOnInsert: { seq } },
-      { upsert: true }
-    )
+  await countersCollection(db).updateOne(
+    { _id: 'orgId' },
+    { $setOnInsert: { seq } },
+    { upsert: true }
+  )
 
   logger.info({ message: `orgId counter seeded at ${seq}` })
+}
+
+/**
+ * @param {import('mongodb').Db} db
+ * @returns {() => Promise<number>}
+ */
+const allocateOrgId = (db) => async () => {
+  const result = await countersCollection(db).findOneAndUpdate(
+    { _id: 'orgId' },
+    { $inc: { seq: 1 } },
+    { returnDocument: 'after' }
+  )
+
+  if (result?.seq === undefined) {
+    throw new Error('Failed to generate orgId: counter returned invalid result')
+  }
+
+  return result.seq
+}
+
+/**
+ * The write error MongoDB raises when a document fails the collection's
+ * $jsonSchema validator.
+ *
+ * @typedef {Error & {
+ *   errInfo?: {
+ *     details?: {
+ *       schemaRulesNotSatisfied?: {
+ *         propertiesNotSatisfied?: {propertyName: string, description: string}[]
+ *       }[]
+ *     }
+ *   }
+ * }} MongoWriteError
+ */
+
+/**
+ * Decodes the fields a schema validator rejected onto the driver's own error,
+ * so the caller keeps the original error while gaining the field detail.
+ *
+ * @param {MongoWriteError} error
+ * @returns {import('./port.js').FormSubmissionInsertError}
+ */
+const withSchemaViolations = (error) =>
+  Object.assign(error, {
+    schemaViolations: (error?.errInfo?.details?.schemaRulesNotSatisfied ?? [])
+      .flatMap((rule) => rule.propertiesNotSatisfied ?? [])
+      .map((prop) => `${prop.propertyName} - ${prop.description}`)
+  })
+
+/**
+ * @param {import('mongodb').Db} db
+ * @param {string} collectionName
+ * @returns {(submission: OrganisationSubmission | RegistrationSubmission | AccreditationSubmission) => Promise<string>}
+ */
+const insertInto = (db, collectionName) => async (submission) => {
+  try {
+    const { insertedId } = await db
+      .collection(collectionName)
+      .insertOne(submission)
+    return insertedId.toString()
+  } catch (error) {
+    throw withSchemaViolations(error)
+  }
+}
+
+/**
+ * Registrations and accreditations already carry the reference number they were
+ * filed against, so the document id the store mints is of no use to the caller.
+ *
+ * @param {import('mongodb').Db} db
+ * @param {string} collectionName
+ * @returns {(submission: RegistrationSubmission | AccreditationSubmission) => Promise<void>}
+ */
+const insertDiscardingId = (db, collectionName) => {
+  const insert = insertInto(db, collectionName)
+
+  return async (submission) => {
+    await insert(submission)
+  }
 }
 
 const mapDocument = (doc) => {
@@ -207,7 +302,11 @@ export const createFormSubmissionsRepository = async (db, logger) => {
       findRegistrationById: performFindRegistrationById(db),
       findAllOrganisations: performFindAllOrganisations(db),
       findOrganisationById: performFindOrganisationById(db),
-      findAllFormSubmissionIds: findAllFormSubmissionIds(db)
+      findAllFormSubmissionIds: findAllFormSubmissionIds(db),
+      allocateOrgId: allocateOrgId(db),
+      insertOrganisation: insertInto(db, ORGANISATION_COLLECTION),
+      insertRegistration: insertDiscardingId(db, REGISTRATIONS_COLLECTION),
+      insertAccreditation: insertDiscardingId(db, ACCREDITATIONS_COLLECTION)
     }
   }
 }

--- a/src/repositories/form-submissions/mongodb.test.js
+++ b/src/repositories/form-submissions/mongodb.test.js
@@ -6,8 +6,11 @@ import { testFormSubmissionsRepositoryContract } from './port.contract.js'
 import {
   buildAccreditation,
   buildRegistration,
-  buildOrganisation
+  buildOrganisation,
+  generateReferenceNumber
 } from './contract/test-data.js'
+import { createOrUpdateRegistrationCollection } from '#common/helpers/collections/create-update-registration.js'
+import { registrationSubmission } from '#domain/form-submissions/submission-records.js'
 
 /**
  * @import { Collection, Db } from 'mongodb'
@@ -205,6 +208,94 @@ describe('MongoDB form submissions repository', () => {
 
       const counter = await countersCollection(db).findOne({ _id: 'orgId' })
       expect(counter?.seq).toBe(600000)
+    })
+  })
+
+  describe('allocateOrgId', () => {
+    it('fails rather than inventing an id when the counter is missing', async ({
+      mongoClient
+    }) => {
+      const db = mongoClient.db(DATABASE_NAME)
+      const repository = (
+        await createFormSubmissionsRepository(db, testLogger)
+      )()
+      await countersCollection(db).deleteMany({})
+
+      await expect(repository.allocateOrgId()).rejects.toThrow(
+        'Failed to generate orgId: counter returned invalid result'
+      )
+    })
+  })
+
+  describe('schema violations on insert', () => {
+    const withRegistrationValidator = async (db) => {
+      const collections = await db
+        .listCollections({}, { nameOnly: true })
+        .toArray()
+      await createOrUpdateRegistrationCollection(db, collections)
+    }
+
+    const removeRegistrationValidator = (db) =>
+      db.command({ collMod: 'registration', validator: {} })
+
+    it('names the property a document was rejected for', async ({
+      mongoClient
+    }) => {
+      const db = mongoClient.db(DATABASE_NAME)
+      await withRegistrationValidator(db)
+      const repository = (
+        await createFormSubmissionsRepository(db, testLogger)
+      )()
+
+      const belowMinimum = registrationSubmission({
+        orgId: 1,
+        referenceNumber: generateReferenceNumber(),
+        answers: [],
+        rawSubmissionData: {}
+      })
+
+      const error = await repository
+        .insertRegistration(belowMinimum)
+        .catch((thrown) => thrown)
+
+      expect(error.schemaViolations).toEqual([
+        expect.stringContaining('orgId - ')
+      ])
+
+      await removeRegistrationValidator(db)
+    })
+
+    it('reports no properties when the document breaks a non-property rule', async ({
+      mongoClient
+    }) => {
+      const db = mongoClient.db(DATABASE_NAME)
+      await withRegistrationValidator(db)
+      const repository = (
+        await createFormSubmissionsRepository(db, testLogger)
+      )()
+
+      const error = await repository
+        .insertRegistration(/** @type {*} */ ({ orgId: 500001 }))
+        .catch((thrown) => thrown)
+
+      expect(error.schemaViolations).toEqual([])
+
+      await removeRegistrationValidator(db)
+    })
+
+    it('reports no properties when the failure is not a schema violation', async ({
+      mongoClient
+    }) => {
+      const db = mongoClient.db(DATABASE_NAME)
+      const repository = (
+        await createFormSubmissionsRepository(db, testLogger)
+      )()
+
+      const error = await repository
+        .insertRegistration(/** @type {*} */ ('not-a-document'))
+        .catch((thrown) => thrown)
+
+      expect(error.schemaViolations).toEqual([])
     })
   })
 

--- a/src/repositories/form-submissions/port.contract.js
+++ b/src/repositories/form-submissions/port.contract.js
@@ -1,7 +1,13 @@
 import { testFindBehaviour } from './contract/find.contract.js'
 import { testFindAllFormSubmissionIdsBehaviour } from './contract/find-all-ids.contract.js'
+import {
+  testAllocateOrgIdBehaviour,
+  testInsertBehaviour
+} from './contract/insert.contract.js'
 
 export const testFormSubmissionsRepositoryContract = (repositoryFactory) => {
   testFindBehaviour(repositoryFactory)
   testFindAllFormSubmissionIdsBehaviour(repositoryFactory)
+  testAllocateOrgIdBehaviour(repositoryFactory)
+  testInsertBehaviour(repositoryFactory)
 }

--- a/src/repositories/form-submissions/port.js
+++ b/src/repositories/form-submissions/port.js
@@ -1,4 +1,12 @@
 /**
+ * @import {
+ *   AccreditationSubmission,
+ *   OrganisationSubmission,
+ *   RegistrationSubmission
+ * } from '#domain/form-submissions/submission-records.js'
+ */
+
+/**
  * @typedef {Object} AccreditationFormSubmission
  * @property {string} id - Document ID
  * @property {number} orgId - Organisation ID
@@ -22,6 +30,13 @@
  */
 
 /**
+ * Thrown by the insert operations. A store that validates documents against a
+ * schema decodes the violated rules into `schemaViolations` so callers can log
+ * which fields were rejected without knowing the store's error shape.
+ * @typedef {Error & { schemaViolations: string[] }} FormSubmissionInsertError
+ */
+
+/**
  * @typedef {Object} FormSubmissionIds
  * @property {Set<string>} organisations - Set of organisation IDs
  * @property {Set<string>} registrations - Set of registration IDs
@@ -39,6 +54,10 @@
  * @property {() => Promise<OrganisationFormSubmission[]>} findAllOrganisations - Find all organisations
  * @property {(id: string) => Promise<OrganisationFormSubmission | null>} findOrganisationById
  * @property {() => Promise<FormSubmissionIds>} findAllFormSubmissionIds - Find all form submission IDs
+ * @property {() => Promise<number>} allocateOrgId - Reserve the next organisation ID; no two callers ever receive the same one
+ * @property {(submission: OrganisationSubmission) => Promise<string>} insertOrganisation - Store an organisation submission, returning its reference number
+ * @property {(submission: RegistrationSubmission) => Promise<void>} insertRegistration
+ * @property {(submission: AccreditationSubmission) => Promise<void>} insertAccreditation
  */
 
 /**

--- a/src/test/mock-repositories.js
+++ b/src/test/mock-repositories.js
@@ -90,6 +90,10 @@ export const createMockFormSubmissionsRepository = (overrides = {}) => ({
   findAllOrganisations: vi.fn(),
   findOrganisationById: vi.fn(),
   findAllFormSubmissionIds: vi.fn(),
+  allocateOrgId: vi.fn(),
+  insertOrganisation: vi.fn(),
+  insertRegistration: vi.fn(),
+  insertAccreditation: vi.fn(),
   ...overrides
 })
 

--- a/src/test/mock-repositories.test.js
+++ b/src/test/mock-repositories.test.js
@@ -63,7 +63,11 @@ describe('mock-repositories', () => {
         'findRegistrationsBySystemReference',
         'findAllOrganisations',
         'findOrganisationById',
-        'findAllFormSubmissionIds'
+        'findAllFormSubmissionIds',
+        'allocateOrgId',
+        'insertOrganisation',
+        'insertRegistration',
+        'insertAccreditation'
       ]
     },
     createMockPackagingRecyclingNotesRepository: {


### PR DESCRIPTION
Ticket: [PAE-1790](https://eaflood.atlassian.net/browse/PAE-1790)
Adds `allocateOrgId`, `insertOrganisation`, `insertRegistration` and `insertAccreditation` to the form-submissions repository port, with the in-memory and MongoDB adapters, the submission constructors they take and contract tests covering both implementations — nothing calls them yet, so behaviour is unchanged.

[PAE-1790]: https://eaflood.atlassian.net/browse/PAE-1790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ