### PR TITLE
PAE-1790: Type the organisation update write path

### DIFF
--- a/src/domain/organisations/accreditation.js
+++ b/src/domain/organisations/accreditation.js
@@ -93,4 +93,17 @@
  * @typedef {AccreditationApproved | AccreditationOther} Accreditation
  */
 
+/**
+ * An accreditation as a validated update carries it. Status is optional, since
+ * it is derived from statusHistory on read, and statusHistory does not come
+ * from the caller.
+ *
+ * @typedef {Omit<AccreditationBase, 'statusHistory'> & {
+ *  accreditationNumber?: string | null;
+ *  status?: AccreditationStatus;
+ *  validFrom?: string;
+ *  validTo?: string;
+ * }} AccreditationUpdate
+ */
+
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/domain/organisations/model.js
+++ b/src/domain/organisations/model.js
@@ -1,5 +1,5 @@
-/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
-/** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {Accreditation, AccreditationUpdate} from '#domain/organisations/accreditation.js' */
+/** @import {Registration, RegistrationUpdate} from '#domain/organisations/registration.js' */
 
 /**
  * @typedef {Registration | Accreditation} RegistrationOrAccreditation
@@ -297,4 +297,20 @@ export const USER_ROLES = Object.freeze({
  *   version: number;
  *   wasteProcessingTypes: WasteProcessingTypeValue[];
  * }} Organisation
+ */
+
+/**
+ * An organisation as it arrives on the write path: what a validated update
+ * carries, which is not an `Organisation`. `id` cannot be updated, `status` is
+ * optional because most updates leave it alone, and `statusHistory` and
+ * `version` are derived by the repository rather than supplied. Its
+ * registrations and accreditations are updates too, on the same terms.
+ *
+ * @typedef {Omit<Organisation,
+ *     'accreditations' | 'id' | 'registrations' | 'status' | 'statusHistory' | 'version'
+ *   > & {
+ *   accreditations: AccreditationUpdate[];
+ *   registrations: RegistrationUpdate[];
+ *   status?: OrganisationStatus;
+ * }} OrganisationUpdate
  */

--- a/src/domain/organisations/registration.js
+++ b/src/domain/organisations/registration.js
@@ -84,4 +84,18 @@
  * }} ReportableRegistration
  */
 
+/**
+ * A registration as a validated update carries it. Status is optional, since
+ * it is derived from statusHistory on read; neither statusHistory nor the
+ * resolved accreditation come from the caller.
+ *
+ * @typedef {Omit<RegistrationBase, 'statusHistory' | 'accreditation'> & {
+ *  cbduNumber?: string;
+ *  registrationNumber?: string | null;
+ *  status?: RegistrationStatus;
+ *  validFrom?: string;
+ *  validTo?: string;
+ * }} RegistrationUpdate
+ */
+
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/domain/organisations/status.js
+++ b/src/domain/organisations/status.js
@@ -5,8 +5,9 @@ import {
   REGISTRATION_STATUS
 } from '#domain/organisations/model.js'
 
-/** @import { AccreditationStatus, RegistrationStatus } from '#domain/organisations/model.js' */
+/** @import { AccreditationStatus, OrganisationStatus, RegistrationStatus } from '#domain/organisations/model.js' */
 
+/** @type {Record<OrganisationStatus, OrganisationStatus[]>} */
 const VALID_ORG_TRANSITIONS = {
   [ORGANISATION_STATUS.CREATED]: [
     ORGANISATION_STATUS.APPROVED,
@@ -58,6 +59,14 @@ const VALID_ACC_TRANSITIONS = {
   [ACCREDITATION_STATUS.REJECTED]: [ACCREDITATION_STATUS.CREATED]
 }
 
+/**
+ * The table covers every `OrganisationStatus`, so a lookup keyed by one cannot
+ * come back undefined and the assertion needs no fallback.
+ *
+ * @param {OrganisationStatus} fromStatus
+ * @param {OrganisationStatus} toStatus
+ * @returns {void}
+ */
 export const assertOrgStatusTransitionValid = (fromStatus, toStatus) => {
   const allowedTransitions = VALID_ORG_TRANSITIONS[fromStatus]
   const isValid = allowedTransitions.includes(toStatus)

--- a/src/repositories/organisations/collate-users.js
+++ b/src/repositories/organisations/collate-users.js
@@ -1,11 +1,32 @@
 import { REGISTRATION_STATUS, USER_ROLES } from '#domain/organisations/model.js'
 import { getCurrentStatus } from './status.js'
 
-/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
-/** @import {CollatedUser, Organisation, RegOrAccStatus, UserRoles} from '#domain/organisations/model.js' */
-/** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {AccreditationUpdate} from '#domain/organisations/accreditation.js' */
+/** @import {CollatedUser, RegOrAccStatus, StatusHistoryItem, User, UserRoles} from '#domain/organisations/model.js' */
+/** @import {RegistrationUpdate} from '#domain/organisations/registration.js' */
 
 /** @typedef {Pick<CollatedUser, 'fullName'|'email'|'roles'>} SlimUser */
+
+/**
+ * @typedef {Omit<RegistrationUpdate, 'status'> & { statusHistory: StatusHistoryItem[] }} CollatableRegistration
+ */
+
+/**
+ * @typedef {Omit<AccreditationUpdate, 'status'> & { statusHistory: StatusHistoryItem[] }} CollatableAccreditation
+ */
+
+/**
+ * The organisation as the write path holds it: statusHistory rather than a
+ * materialised status, on the organisation and on every item.
+ *
+ * @typedef {{
+ *   accreditations: CollatableAccreditation[],
+ *   registrations: CollatableRegistration[],
+ *   statusHistory: StatusHistoryItem[],
+ *   submitterContactDetails?: User,
+ *   users?: CollatedUser[]
+ * }} UserCollationSource
+ */
 
 /**
  * get user roles for the provided status. Generic over registrations and
@@ -26,8 +47,8 @@ const getUserRolesForStatus = (status) => {
 }
 
 /**
- * @template {Accreditation|Registration} T
- * @param {Organisation} updated
+ * @template {CollatableAccreditation|CollatableRegistration} T
+ * @param {UserCollationSource} updated
  * @param {'accreditations'|'registrations'} collectionKey
  * @param {(item: T) => SlimUser[]} extractAdditionalUsers
  * @returns {SlimUser[]}
@@ -57,14 +78,14 @@ const collateItems = (updated, collectionKey, extractAdditionalUsers) => {
 }
 
 /**
- * @param {Organisation} updated
+ * @param {UserCollationSource} updated
  * @returns {SlimUser[]}
  */
 const collateRegistrationUsers = (updated) =>
   collateItems(
     updated,
     'registrations',
-    (/** @type {Registration} */ registration) => {
+    (/** @type {CollatableRegistration} */ registration) => {
       const roles = getUserRolesForStatus(getCurrentStatus(registration))
 
       const additional = registration.approvedPersons.map(
@@ -81,14 +102,14 @@ const collateRegistrationUsers = (updated) =>
   )
 
 /**
- * @param {Organisation} updated
+ * @param {UserCollationSource} updated
  * @returns {SlimUser[]}
  */
 const collateAccreditationUsers = (updated) =>
   collateItems(
     updated,
     'accreditations',
-    (/** @type {Accreditation} */ accreditation) =>
+    (/** @type {CollatableAccreditation} */ accreditation) =>
       accreditation.prnIssuance.signatories.map(({ email, fullName }) => ({
         fullName,
         email,
@@ -133,7 +154,7 @@ const deduplicateUsers = (users) => {
 }
 
 /**
- * @param {Organisation} updated
+ * @param {UserCollationSource} updated
  * @returns {CollatedUser[]}
  */
 export const collateUsers = (updated) => {

--- a/src/repositories/organisations/collate-users.test.js
+++ b/src/repositories/organisations/collate-users.test.js
@@ -7,9 +7,8 @@ import {
 } from '#domain/organisations/model.js'
 
 /**
- * @import {AccreditationStatus, Organisation, RegistrationStatus} from '#domain/organisations/model.js'
- * @import {Registration} from '#domain/organisations/registration.js'
- * @import {Accreditation} from '#domain/organisations/accreditation.js'
+ * @import {AccreditationStatus, RegistrationStatus} from '#domain/organisations/model.js'
+ * @import {CollatableAccreditation, CollatableRegistration, UserCollationSource} from './collate-users.js'
  *
  * @typedef {{ email: string, fullName: string }} TestPerson
  */
@@ -17,12 +16,12 @@ import {
 describe('collateUsers', () => {
   /**
    * @param {{
-   *   registrations?: Registration[]
-   *   accreditations?: Accreditation[]
+   *   registrations?: CollatableRegistration[]
+   *   accreditations?: CollatableAccreditation[]
    *   users?: TestPerson[]
    *   submitterContactDetails?: TestPerson
    * }} [options]
-   * @returns {Organisation}
+   * @returns {UserCollationSource}
    */
   const buildOrg = ({
     registrations = [],
@@ -33,7 +32,7 @@ describe('collateUsers', () => {
       email: 'org-submitter@example.com'
     }
   } = {}) =>
-    /** @type {Organisation} */ (
+    /** @type {UserCollationSource} */ (
       /** @type {unknown} */ ({
         statusHistory: [{ status: 'created', updatedAt: new Date() }],
         submitterContactDetails,
@@ -51,7 +50,7 @@ describe('collateUsers', () => {
    *   approvedPersons?: TestPerson[]
    *   applicationContact?: TestPerson
    * }} options
-   * @returns {Registration}
+   * @returns {CollatableRegistration}
    */
   const buildRegistration = ({
     id = 'reg-1',
@@ -60,7 +59,7 @@ describe('collateUsers', () => {
     approvedPersons = [],
     applicationContact
   }) =>
-    /** @type {Registration} */ (
+    /** @type {CollatableRegistration} */ (
       /** @type {unknown} */ ({
         id,
         statusHistory: [{ status, updatedAt: new Date() }],
@@ -82,7 +81,7 @@ describe('collateUsers', () => {
    *   submitterEmail?: string
    *   signatories?: TestPerson[]
    * }} options
-   * @returns {Accreditation}
+   * @returns {CollatableAccreditation}
    */
   const buildAccreditation = ({
     id = 'acc-1',
@@ -90,7 +89,7 @@ describe('collateUsers', () => {
     submitterEmail = 'acc-submitter@example.com',
     signatories = []
   }) =>
-    /** @type {Accreditation} */ (
+    /** @type {CollatableAccreditation} */ (
       /** @type {unknown} */ ({
         id,
         statusHistory: [{ status, updatedAt: new Date() }],
@@ -269,7 +268,9 @@ describe('collateUsers', () => {
 
   it('omits the org-level submitter when it is absent', () => {
     const org = buildOrg()
-    delete (/** @type {Partial<Organisation>} */ (org).submitterContactDetails)
+    delete (
+      /** @type {Partial<UserCollationSource>} */ (org).submitterContactDetails
+    )
 
     const emails = collateUsers(org).map((u) => u.email)
 
@@ -278,7 +279,7 @@ describe('collateUsers', () => {
 
   it('handles an org with no users field', () => {
     const org = buildOrg()
-    delete (/** @type {Partial<Organisation>} */ (org).users)
+    delete (/** @type {Partial<UserCollationSource>} */ (org).users)
 
     expect(() => collateUsers(org)).not.toThrow()
     expect(collateUsers(org)).toEqual([

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -22,9 +22,9 @@ import { collateUsers } from './collate-users.js'
 import { getCurrentStatus } from './status.js'
 
 /** @import { WithId } from 'mongodb' */
-/** @import { Organisation, OrganisationStatus } from '#domain/organisations/model.js' */
+/** @import { Organisation, OrganisationStatus, OrganisationUpdate } from '#domain/organisations/model.js' */
 /** @import { StatusTransitionAsserter } from '#domain/organisations/status.js' */
-/** @import { FindPageForOverseasSitesAdminListParams } from './port.js' */
+/** @import { FindPageForOverseasSitesAdminListParams, OrganisationReplacement } from './port.js' */
 
 export const createStatusHistoryEntry = (status) => ({
   status,
@@ -55,9 +55,13 @@ export const statusHistoryWithChanges = (updatedItem, existingItem) => {
 }
 
 /**
+ * Status is dropped from each item and its statusHistory refreshed instead —
+ * the current status is derived from that history on read.
+ *
  * @template {string} S
+ * @template {{ id: string, status?: S }} T
  * @param {Array<{ id: string, status: S }>} existingItems
- * @param {Array<{ id: string, status?: S }>} itemUpdates
+ * @param {T[]} itemUpdates
  * @param {StatusTransitionAsserter<S>} assertStatusTransitionValid
  * @param {Set<string>} [systemAppliedItemIds] - items whose status change was
  *   applied by the system (the registration-cancellation cascade), exempt from
@@ -123,6 +127,10 @@ export const mapDocumentWithCurrentStatuses = (org) => {
   return { id: _id.toString(), ...rest }
 }
 
+/**
+ * @param {OrganisationUpdate} validated
+ * @param {Organisation} existing
+ */
 function prepareRegAccForReplace(validated, existing) {
   const { accreditations: accreditationsAfterUpdate, cascadeCancelledIds } =
     applyRegistrationStatusToLinkedAccreditations(
@@ -154,6 +162,11 @@ function prepareRegAccForReplace(validated, existing) {
   return { registrations, accreditations }
 }
 
+/**
+ * @param {Organisation} existing
+ * @param {OrganisationReplacement} updates - the caller's proposed replacement,
+ *   unvalidated until validateOrganisationUpdate has been through it.
+ */
 export const prepareForReplace = (existing, updates) => {
   const validated = validateOrganisationUpdate(updates, existing)
   const { registrations, accreditations } = prepareRegAccForReplace(

--- a/src/repositories/organisations/schema/helpers.js
+++ b/src/repositories/organisations/schema/helpers.js
@@ -12,7 +12,8 @@ import {
 import Boom from '@hapi/boom'
 import { isoDateString } from '#common/validation/iso-date-schema.js'
 
-/** @import {Registration} from '#domain/organisations/registration.js' */
+/** @import {RegistrationUpdate} from '#domain/organisations/registration.js' */
+/** @import {AccreditationUpdate} from '#domain/organisations/accreditation.js' */
 /** @import {RegistrationOrAccreditation} from '#domain/organisations/model.js' */
 
 export const PREVIOUS_SCHEMA_VERSION = 2
@@ -150,8 +151,8 @@ function formatDuplicateError(duplicates, itemType) {
 }
 
 /**
- * @param {Registration[]} registrations
- * @returns {[string, Registration[]][]}
+ * @param {RegistrationUpdate[]} registrations
+ * @returns {[string, RegistrationUpdate[]][]}
  */
 function findAccreditationIdsLinkedToMultipleRegistrations(registrations) {
   const linkedRegistrations = registrations.filter(
@@ -164,13 +165,13 @@ function findAccreditationIdsLinkedToMultipleRegistrations(registrations) {
   )
 
   return (
-    /** @type {[string, Registration[]][]} */
+    /** @type {[string, RegistrationUpdate[]][]} */
     (Object.entries(grouped)).filter(([, regs]) => regs.length > 1)
   )
 }
 
 /**
- * @param {Registration[]} registrations
+ * @param {RegistrationUpdate[]} registrations
  */
 export function validateAccreditationLinkUniqueness(registrations) {
   const duplicates =
@@ -192,8 +193,8 @@ export function validateAccreditationLinkUniqueness(registrations) {
 }
 
 /**
- * @param {Registration[]} registrations
- * @param {import('#domain/organisations/accreditation.js').Accreditation[]} accreditations
+ * @param {RegistrationUpdate[]} registrations
+ * @param {AccreditationUpdate[]} accreditations
  */
 export function validateAccreditationLinkExists(registrations, accreditations) {
   const accreditationIds = new Set(accreditations.map((acc) => acc.id))
@@ -217,8 +218,8 @@ export function validateAccreditationLinkExists(registrations, accreditations) {
 }
 
 /**
- * @param {Registration[]} registrations
- * @param {import('#domain/organisations/accreditation.js').Accreditation[]} accreditations
+ * @param {RegistrationUpdate[]} registrations
+ * @param {AccreditationUpdate[]} accreditations
  */
 export function validateAccreditationLinkMatches(
   registrations,

--- a/src/repositories/organisations/schema/status-transition.js
+++ b/src/repositories/organisations/schema/status-transition.js
@@ -7,17 +7,17 @@ import {
   REGISTRATION_STATUS
 } from '#domain/organisations/model.js'
 
-/** @import {Organisation} from '#domain/organisations/model.js' */
+/** @import {Organisation, OrganisationUpdate} from '#domain/organisations/model.js' */
 /** @import {StatusTransitionAsserter} from '#domain/organisations/status.js' */
-/** @import {Registration} from '#domain/organisations/registration.js' */
-/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
+/** @import {RegistrationUpdate} from '#domain/organisations/registration.js' */
+/** @import {AccreditationUpdate} from '#domain/organisations/accreditation.js' */
 
 /**
- * @param {Organisation} existing
+ * @param {OrganisationUpdate} updated
  * @returns {void}
  */
-const requireApprovedRegistration = (existing) => {
-  const hasApproved = existing.registrations.some(
+const requireApprovedRegistration = (updated) => {
+  const hasApproved = updated.registrations.some(
     (reg) => reg.status === REGISTRATION_STATUS.APPROVED
   )
 
@@ -30,7 +30,7 @@ const requireApprovedRegistration = (existing) => {
 }
 
 /**
- * @param {Organisation} updated
+ * @param {OrganisationUpdate} updated
  * @returns {void}
  */
 const requireLinkedDefraOrg = (updated) => {
@@ -48,7 +48,7 @@ const requireLinkedDefraOrg = (updated) => {
 /**
  * Validates organisation status transitions and ensures required conditions are met
  * @param {Organisation} existing
- * @param {Organisation} updated
+ * @param {OrganisationUpdate} updated
  * @returns {void}
  */
 export const assertOrgStatusTransition = (existing, updated) => {
@@ -87,6 +87,10 @@ export const assertAndHandleItemStateTransition = (
   assertStatusTransitionValid(existing.status, updated.status)
 }
 
+/**
+ * @param {RegistrationUpdate} registration
+ * @returns {boolean}
+ */
 const isRegistrationCancelled = (registration) =>
   registration.status === REGISTRATION_STATUS.CANCELLED
 
@@ -98,9 +102,9 @@ const isRegistrationCancelled = (registration) =>
  * system-driven changes, exempt from the accreditation transition table —
  * which deliberately has no direct approved -> cancelled arc for user-driven
  * updates (ADR 0042).
- * @param {Registration[]} registrations
- * @param {Accreditation[]} accreditations
- * @returns {{ accreditations: Accreditation[], cascadeCancelledIds: Set<string> }}
+ * @param {RegistrationUpdate[]} registrations
+ * @param {AccreditationUpdate[]} accreditations
+ * @returns {{ accreditations: AccreditationUpdate[], cascadeCancelledIds: Set<string> }}
  */
 export const applyRegistrationStatusToLinkedAccreditations = (
   registrations,
@@ -119,12 +123,15 @@ export const applyRegistrationStatusToLinkedAccreditations = (
   const cascadeCancelledIds = new Set()
 
   const updatedAccreditations = accreditations.map((acc) => {
+    // Liveness is judged on the incoming payload status, so an update that
+    // proposes no status for an accreditation leaves it out of the cascade.
     if (
       linkedToCancelledRegistration.has(acc.id) &&
+      acc.status !== undefined &&
       ACTIVE_ACCREDITATION_STATUSES.has(acc.status)
     ) {
       cascadeCancelledIds.add(acc.id)
-      return /** @type {Accreditation} */ ({
+      return /** @type {AccreditationUpdate} */ ({
         ...acc,
         status: ACCREDITATION_STATUS.CANCELLED
       })

--- a/src/repositories/organisations/schema/status-transition.test.js
+++ b/src/repositories/organisations/schema/status-transition.test.js
@@ -5,21 +5,21 @@ import {
 } from '#domain/organisations/model.js'
 import { partialMock } from '#test/type-helpers.js'
 
-/** @import {Registration} from '#domain/organisations/registration.js' */
-/** @import {Accreditation} from '#domain/organisations/accreditation.js' */
+/** @import {RegistrationUpdate} from '#domain/organisations/registration.js' */
+/** @import {AccreditationUpdate} from '#domain/organisations/accreditation.js' */
 
 describe('applyRegistrationStatusToLinkedAccreditations', () => {
   it.each([ACCREDITATION_STATUS.APPROVED, ACCREDITATION_STATUS.SUSPENDED])(
     'cancels a linked %s accreditation and reports it as cascade-cancelled',
     (status) => {
-      /** @type {Registration[]} */
+      /** @type {RegistrationUpdate[]} */
       const registrations = [
         partialMock({
           status: REGISTRATION_STATUS.CANCELLED,
           accreditationId: 'acc-1'
         })
       ]
-      /** @type {Accreditation[]} */
+      /** @type {AccreditationUpdate[]} */
       const accreditations = [partialMock({ id: 'acc-1', status })]
 
       const result = applyRegistrationStatusToLinkedAccreditations(
@@ -37,14 +37,14 @@ describe('applyRegistrationStatusToLinkedAccreditations', () => {
   it.each([ACCREDITATION_STATUS.CREATED, ACCREDITATION_STATUS.REJECTED])(
     'leaves a linked %s accreditation untouched — it was never live',
     (status) => {
-      /** @type {Registration[]} */
+      /** @type {RegistrationUpdate[]} */
       const registrations = [
         partialMock({
           status: REGISTRATION_STATUS.CANCELLED,
           accreditationId: 'acc-1'
         })
       ]
-      /** @type {Accreditation[]} */
+      /** @type {AccreditationUpdate[]} */
       const accreditations = [partialMock({ id: 'acc-1', status })]
 
       const result = applyRegistrationStatusToLinkedAccreditations(
@@ -58,14 +58,14 @@ describe('applyRegistrationStatusToLinkedAccreditations', () => {
   )
 
   it('leaves accreditations untouched when the linked registration is not cancelled', () => {
-    /** @type {Registration[]} */
+    /** @type {RegistrationUpdate[]} */
     const registrations = [
       partialMock({
         status: REGISTRATION_STATUS.APPROVED,
         accreditationId: 'acc-1'
       })
     ]
-    /** @type {Accreditation[]} */
+    /** @type {AccreditationUpdate[]} */
     const accreditations = [
       partialMock({ id: 'acc-1', status: ACCREDITATION_STATUS.APPROVED })
     ]
@@ -80,11 +80,11 @@ describe('applyRegistrationStatusToLinkedAccreditations', () => {
   })
 
   it('leaves accreditations untouched when the cancelled registration has no linked accreditation', () => {
-    /** @type {Registration[]} */
+    /** @type {RegistrationUpdate[]} */
     const registrations = [
       partialMock({ status: REGISTRATION_STATUS.CANCELLED })
     ]
-    /** @type {Accreditation[]} */
+    /** @type {AccreditationUpdate[]} */
     const accreditations = [
       partialMock({ id: 'acc-1', status: ACCREDITATION_STATUS.APPROVED })
     ]
@@ -95,6 +95,26 @@ describe('applyRegistrationStatusToLinkedAccreditations', () => {
     )
 
     expect(result.accreditations[0].status).toBe(ACCREDITATION_STATUS.APPROVED)
+    expect(result.cascadeCancelledIds).toStrictEqual(new Set())
+  })
+
+  it('skips a linked accreditation whose update proposes no status, since liveness is judged on the payload', () => {
+    /** @type {RegistrationUpdate[]} */
+    const registrations = [
+      partialMock({
+        status: REGISTRATION_STATUS.CANCELLED,
+        accreditationId: 'acc-1'
+      })
+    ]
+    /** @type {AccreditationUpdate[]} */
+    const accreditations = [partialMock({ id: 'acc-1', status: undefined })]
+
+    const result = applyRegistrationStatusToLinkedAccreditations(
+      registrations,
+      accreditations
+    )
+
+    expect(result.accreditations[0].status).toBeUndefined()
     expect(result.cascadeCancelledIds).toStrictEqual(new Set())
   })
 })

--- a/src/repositories/organisations/schema/validation.js
+++ b/src/repositories/organisations/schema/validation.js
@@ -49,7 +49,11 @@ export const validateOrganisationInsert = (data) => {
   )
 }
 
-/** @param {object} data @param {import('#domain/organisations/model.js').Organisation | null} [existing] */
+/**
+ * @param {object} data
+ * @param {import('#domain/organisations/model.js').Organisation | null} [existing]
+ * @returns {import('#domain/organisations/model.js').OrganisationUpdate}
+ */
 export const validateOrganisationUpdate = (data, existing = null) => {
   return validateWithSchema(
     organisationReplaceSchema,


### PR DESCRIPTION
Ticket: [PAE-1790](https://eaflood.atlassian.net/browse/PAE-1790)
The organisation write path is annotated as if it handles stored `Organisation` values. It doesn't. `validateOrganisationUpdate` returns what `organisationReplaceSchema` validates: `id` is forbidden, `status` is optional, and `statusHistory` and `version` are the repository's to derive. Its registrations and accreditations are the same — each item's status is optional and neither carries a status history. This names those shapes and threads them through the code that actually receives them. Behaviour is unchanged.

## What the types now say

- `OrganisationUpdate`, `RegistrationUpdate` and `AccreditationUpdate` describe what the update schemas validate. `validateOrganisationUpdate` declares its return type, and `prepareForReplace`, the accreditation-link validators, the registration-cancellation cascade and `assertOrgStatusTransition` take the update shapes rather than the stored ones.
- `collateUsers` runs after each item's status has moved into its status history, so it never receives an `Organisation` either. `UserCollationSource` names what it does receive, and `updateStatusHistoryForItems` is generic so each item keeps its own shape through the refresh.
- `VALID_ORG_TRANSITIONS` is typed `Record<OrganisationStatus, OrganisationStatus[]>`, so the table has to cover every organisation status and cannot be indexed by one it lacks. The parameter annotations on `assertOrgStatusTransitionValid` say the same thing, but `noImplicitAny` is off in the blocking type-check config, so only the table's completeness is actually enforced there.

## The cascade's optional status

`applyRegistrationStatusToLinkedAccreditations` judges liveness on the status carried by the update payload, which an update may omit. Under the honest type that becomes an explicit `acc.status !== undefined` check rather than a `Set` lookup on `undefined`, with a test naming the case. The outcome is identical either way: an accreditation whose update proposes no status sits outside the cascade today, and still does. That is existing behaviour rather than something this branch introduces, and it is tracked separately.

Refs PAE-1790.


[PAE-1790]: https://eaflood.atlassian.net/browse/PAE-1790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ