### PR TITLE
PAE-1790: Classify a summary-log submission once

### DIFF
--- a/src/application/waste-records/sync-from-summary-log.js
+++ b/src/application/waste-records/sync-from-summary-log.js
@@ -280,6 +280,7 @@ export const syncFromSummaryLog = (dependencies) => {
         )
       : null
 
+    /** @type {import('#waste-balances/repository/ledger-schema.js').WasteBalanceLedgerId} */
     const ledgerId = {
       organisationId: summaryLog.organisationId,
       registrationId: summaryLog.registrationId,

--- a/src/application/waste-records/sync-from-summary-log.js
+++ b/src/application/waste-records/sync-from-summary-log.js
@@ -1,6 +1,6 @@
 import { transformFromSummaryLog } from './transform-from-summary-log.js'
 import { resolveOverseasSites } from './resolve-overseas-sites.js'
-import { writeSummaryLogRowStates } from '#waste-records/application/write-summary-log-row-states.js'
+import { commitSummaryLogSubmission } from '#waste-records/application/commit-summary-log-submission.js'
 import { summaryLogRowStatesForRegistration } from '#waste-records/application/read-summary-log-row-states.js'
 import { classifyRecordChanges } from '#application/summary-logs/classify-record-changes.js'
 import { RECORD_CHANGE } from '#application/summary-logs/record-change.js'
@@ -18,8 +18,6 @@ import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipel
 
 /**
  * @import { TypedLogger } from '#common/helpers/logging/logger.js'
- * @import { ParsedSummaryLog } from '#domain/summary-logs/extractor/port.js'
- * @import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
  */
 
 /**
@@ -155,40 +153,6 @@ const resolveAccreditation = async (
 }
 
 /**
- * @param {object} params
- * @param {ParsedSummaryLog} params.parsedData
- * @param {import('#domain/organisations/accreditation.js').Accreditation} params.accreditation
- * @param {ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>} params.wasteBalanceService
- * @param {Array<{ record: import('#domain/waste-records/model.js').WasteRecord }>} params.wasteRecords
- * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} params.user
- * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} params.overseasSites
- * @param {string} params.summaryLogId
- */
-const updateWasteBalances = async ({
-  parsedData,
-  accreditation,
-  wasteBalanceService,
-  wasteRecords,
-  user,
-  overseasSites,
-  summaryLogId
-}) => {
-  // We only calculate waste balance for exporters and reprocessor inputs currently
-  const processingType = parsedData?.meta?.PROCESSING_TYPE?.value
-  const shouldCalculateWasteBalance =
-    processingType === PROCESSING_TYPES.EXPORTER ||
-    processingType === PROCESSING_TYPES.REPROCESSOR_INPUT ||
-    processingType === PROCESSING_TYPES.REPROCESSOR_OUTPUT
-
-  if (shouldCalculateWasteBalance) {
-    await wasteBalanceService.submitSummaryLog(
-      wasteRecords.map((r) => r.record),
-      { user, accreditation, overseasSites, summaryLogId }
-    )
-  }
-}
-
-/**
  * Counts how the submission's rows changed against the registration's latest
  * committed submission — the same comparison the check-page classification
  * runs — for observability metrics. Added rows count as created, adjusted rows
@@ -237,79 +201,6 @@ const countRecordChanges = async ({
     created: changes.filter((change) => change === RECORD_CHANGE.ADDED).length,
     updated: changes.filter((change) => change === RECORD_CHANGE.ADJUSTED)
       .length
-  }
-}
-
-/**
- * Commits the per-row state for every submission (keyed by accreditation
- * existence) and, for an accredited balance-bearing submission, its waste
- * balance.
- *
- * Every submission records a summary-log-submitted event marking that the
- * summary log was submitted. For an accredited submission that event also
- * carries the waste-balance delta (written via updateWasteBalances). A
- * registered-only / no-accreditation submission has no balance, so its event is
- * zero-delta — the submission is still recorded, it just moves no tonnage.
- *
- * @param {object} params
- * @param {{ file: { id: string }, organisationId: string, registrationId: string }} params.summaryLog
- * @param {string | undefined} params.accreditationId
- * @param {import('#domain/organisations/accreditation.js').Accreditation | null} params.accreditation
- * @param {ValidatedWasteRecord[]} params.wasteRecords
- * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} params.overseasSites
- * @param {ParsedSummaryLog} params.parsedData
- * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} params.user
- * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} params.summaryLogRowStateRepository
- * @param {ReturnType<typeof createWasteBalanceService>} params.wasteBalanceService
- */
-const commitStateAndBalance = async ({
-  summaryLog,
-  accreditationId,
-  accreditation,
-  wasteRecords,
-  overseasSites,
-  parsedData,
-  user,
-  summaryLogRowStateRepository,
-  wasteBalanceService
-}) => {
-  await writeSummaryLogRowStates({
-    summaryLogRowStateRepository,
-    wasteRecords: wasteRecords.map((wasteRecord) => wasteRecord.record),
-    accreditation,
-    ledgerId: {
-      organisationId: summaryLog.organisationId,
-      registrationId: summaryLog.registrationId,
-      accreditationId: accreditationId ?? null
-    },
-    overseasSites,
-    summaryLogId: summaryLog.file.id
-  })
-
-  if (accreditation) {
-    await updateWasteBalances({
-      parsedData,
-      accreditation,
-      wasteBalanceService,
-      wasteRecords,
-      user,
-      overseasSites,
-      summaryLogId: summaryLog.file.id
-    })
-  } else {
-    await wasteBalanceService.commitSummaryLogSubmittedEvent(
-      {
-        registrationId: summaryLog.registrationId,
-        accreditationId: null,
-        organisationId: summaryLog.organisationId
-      },
-      { summaryLogId: summaryLog.file.id, creditTotal: 0 },
-      {
-        id: user.id,
-        ...(user.name && { name: user.name }),
-        email: user.email
-      }
-    )
   }
 }
 
@@ -389,32 +280,33 @@ export const syncFromSummaryLog = (dependencies) => {
         )
       : null
 
+    const ledgerId = {
+      organisationId: summaryLog.organisationId,
+      registrationId: summaryLog.registrationId,
+      accreditationId: accreditationId ?? null
+    }
+
     // 5. Classify created/updated against the committed head, before committing
     const metrics = await countRecordChanges({
       wasteRecords,
       accreditation,
       overseasSites,
-      ledgerId: {
-        organisationId: summaryLog.organisationId,
-        registrationId: summaryLog.registrationId,
-        accreditationId: accreditationId ?? null
-      },
+      ledgerId,
       ledgerRepository,
       summaryLogRowStateRepository
     })
 
-    // 6. Commit per-row state for every submission and the balance for
-    // accredited balance-bearing ones.
-    await commitStateAndBalance({
-      summaryLog,
-      accreditationId,
-      accreditation,
-      wasteRecords,
-      overseasSites,
-      parsedData,
-      user,
+    // 6. Commit the submission: its per-row state and its ledger event
+    await commitSummaryLogSubmission({
       summaryLogRowStateRepository,
-      wasteBalanceService
+      wasteBalanceService,
+      wasteRecords: wasteRecords.map((wasteRecord) => wasteRecord.record),
+      accreditation,
+      ledgerId,
+      processingType,
+      overseasSites,
+      summaryLogId: summaryLog.file.id,
+      user
     })
 
     return metrics

--- a/src/application/waste-records/sync-from-summary-log.test.js
+++ b/src/application/waste-records/sync-from-summary-log.test.js
@@ -7,6 +7,8 @@ import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledge
 import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
 import { getTargetAmount } from '#waste-balances/application/target-amount.js'
 import { LEDGER_EVENT_KIND } from '#waste-balances/repository/ledger-schema.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
+import { CLASSIFICATION_REASON } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 
 const TEST_DATE_2025_01_15 = '2025-01-15'
 const FIELD_GROSS_WEIGHT = 'GROSS_WEIGHT'
@@ -121,6 +123,75 @@ const balanceBearingInput = (rows) =>
       RECEIVED_LOADS_FOR_REPROCESSING: {
         location: { sheet: 'Sheet1', row: 1, column: 'A' },
         headers: BALANCE_BEARING_HEADERS,
+        rows
+      }
+    }
+  })
+
+const EXPORTED_LOAD_HEADERS = [
+  'ROW_ID',
+  'DATE_RECEIVED_FOR_EXPORT',
+  'EWC_CODE',
+  'DESCRIPTION_WASTE',
+  'WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE',
+  FIELD_GROSS_WEIGHT,
+  'TARE_WEIGHT',
+  'PALLET_WEIGHT',
+  'NET_WEIGHT',
+  'BAILING_WIRE_PROTOCOL',
+  'HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION',
+  'WEIGHT_OF_NON_TARGET_MATERIALS',
+  'RECYCLABLE_PROPORTION_PERCENTAGE',
+  'TONNAGE_RECEIVED_FOR_EXPORT',
+  'TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED',
+  'DATE_OF_EXPORT',
+  'BASEL_EXPORT_CODE',
+  'CUSTOMS_CODES',
+  'CONTAINER_NUMBER',
+  'DATE_RECEIVED_BY_OSR',
+  'OSR_ID',
+  'DID_WASTE_PASS_THROUGH_AN_INTERIM_SITE'
+]
+
+/**
+ * An exported load carrying every field the exporter balance classifier needs,
+ * so only its overseas-site reference decides whether it is included.
+ */
+const exportedLoadRow = (rowNumber, rowId, tonnage, { osrId }) => ({
+  rowNumber,
+  values: [
+    rowId,
+    ACCREDITED_DATE,
+    '15 01 02',
+    'Plastic packaging',
+    'No',
+    10,
+    1,
+    0,
+    9,
+    'No',
+    'Sampling',
+    0,
+    100,
+    tonnage,
+    tonnage,
+    ACCREDITED_DATE,
+    'B3011',
+    '3915',
+    'CONT-1',
+    ACCREDITED_DATE,
+    osrId,
+    'No'
+  ]
+})
+
+const exportedLoadsInput = (rows) =>
+  /** @type {any} */ ({
+    meta: { PROCESSING_TYPE: { value: 'EXPORTER' } },
+    data: {
+      RECEIVED_LOADS_FOR_EXPORT: {
+        location: { sheet: 'Sheet1', row: 1, column: 'A' },
+        headers: EXPORTED_LOAD_HEADERS,
         rows
       }
     }
@@ -335,7 +406,7 @@ describe('syncFromSummaryLog', () => {
     ])
   })
 
-  it('updates waste balances when accreditationId is present', async () => {
+  it('credits the accredited ledger with the submission total', async () => {
     const fileId = 'file-wb'
     const extractor = extractorFor(
       fileId,
@@ -346,51 +417,61 @@ describe('syncFromSummaryLog', () => {
 
     await makeSync({ extractor })(summaryLogFor(fileId, 'acc-1'), TEST_USER)
 
-    expect(wasteBalanceService.submitSummaryLog).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          rowId: 'row-123',
-          type: WASTE_RECORD_TYPE.EXPORTED
-        })
-      ]),
-      {
-        user: TEST_USER,
-        accreditation: {
-          id: 'acc-default',
-          validFrom: '2023-01-01',
-          validTo: '2023-12-31'
-        },
-        overseasSites: {},
-        summaryLogId: fileId
-      }
-    )
+    expect(wasteBalanceService.submitSummaryLog).toHaveBeenCalledWith({
+      ledgerId: {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1'
+      },
+      creditTotal: 0,
+      summaryLogId: fileId,
+      user: TEST_USER
+    })
   })
 
-  it('resolves overseas sites for exporter waste balance validation', async () => {
+  it("classifies exporter rows against the registration's resolved overseas sites", async () => {
     const fileId = 'file-ors'
     const extractor = extractorFor(
       fileId,
-      exporterInput([
-        receivedRow(2, 'row-123', TEST_DATE_2025_01_15, TEST_WEIGHT_100_5)
+      exportedLoadsInput([
+        exportedLoadRow(2, 'row-2001', 12.5, { osrId: '001' }),
+        exportedLoadRow(3, 'row-2002', 40, { osrId: '002' })
       ])
     )
 
-    const validFrom = new Date('2024-01-01')
     overseasSitesRepository = {
-      findByIds: vi.fn().mockResolvedValue([{ id: 'site-aaa', validFrom }])
+      findByIds: vi
+        .fn()
+        .mockResolvedValue([
+          { id: 'site-aaa', validFrom: new Date('2024-01-01') }
+        ])
     }
     organisationsRepository.findRegistrationById = vi.fn().mockResolvedValue({
       overseasSites: { '001': { overseasSiteId: 'site-aaa' } }
     })
+    organisationsRepository.findAccreditationById.mockResolvedValue({
+      id: 'acc-1',
+      validFrom: '2026-01-01',
+      validTo: '2026-12-31',
+      statusHistory: []
+    })
 
     await makeSync({ extractor })(summaryLogFor(fileId, 'acc-1'), TEST_USER)
 
-    expect(wasteBalanceService.submitSummaryLog).toHaveBeenCalledWith(
-      expect.any(Array),
-      expect.objectContaining({
-        overseasSites: { '001': { validFrom } }
-      })
-    )
+    const rowStates =
+      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+        { ...LEDGER_ID, accreditationId: 'acc-1' },
+        fileId
+      )
+    const byRowId = new Map(rowStates.map((state) => [state.rowId, state]))
+    expect(byRowId.get('row-2001').classification).toEqual({
+      outcome: WASTE_BALANCE_OUTCOME.INCLUDED,
+      reasons: [],
+      transactionAmount: 12.5
+    })
+    expect(byRowId.get('row-2002').classification.reasons).toEqual([
+      { code: CLASSIFICATION_REASON.ORS_NOT_FOUND }
+    ])
   })
 
   it('commits a zero-delta event for registered-only submissions', async () => {

--- a/src/application/waste-records/sync-from-summary-log.test.js
+++ b/src/application/waste-records/sync-from-summary-log.test.js
@@ -5,6 +5,8 @@ import { createInMemorySummaryLogExtractor } from '#application/summary-logs/ext
 import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
 import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
+import { getTargetAmount } from '#waste-balances/application/target-amount.js'
+import { LEDGER_EVENT_KIND } from '#waste-balances/repository/ledger-schema.js'
 
 const TEST_DATE_2025_01_15 = '2025-01-15'
 const FIELD_GROSS_WEIGHT = 'GROSS_WEIGHT'
@@ -68,6 +70,61 @@ const receivedRow = (rowNumber, rowId, date, weight) => ({
   rowNumber,
   values: [rowId, date, weight]
 })
+
+const BALANCE_BEARING_HEADERS = [
+  'ROW_ID',
+  'DATE_RECEIVED_FOR_REPROCESSING',
+  'EWC_CODE',
+  'DESCRIPTION_WASTE',
+  'WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE',
+  FIELD_GROSS_WEIGHT,
+  'TARE_WEIGHT',
+  'PALLET_WEIGHT',
+  'NET_WEIGHT',
+  'BAILING_WIRE_PROTOCOL',
+  'HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION',
+  'WEIGHT_OF_NON_TARGET_MATERIALS',
+  'RECYCLABLE_PROPORTION_PERCENTAGE',
+  'TONNAGE_RECEIVED_FOR_RECYCLING'
+]
+
+const ACCREDITED_DATE = '2026-02-01'
+
+/**
+ * A row carrying every field the reprocessor-input balance classifier needs, so
+ * it classifies INCLUDED and contributes its tonnage.
+ */
+const balanceBearingRow = (rowNumber, rowId, tonnage, prnIssued = 'No') => ({
+  rowNumber,
+  values: [
+    rowId,
+    ACCREDITED_DATE,
+    '15 01 02',
+    'Plastic packaging',
+    prnIssued,
+    10,
+    1,
+    0,
+    9,
+    'No',
+    'Sampling',
+    0,
+    100,
+    tonnage
+  ]
+})
+
+const balanceBearingInput = (rows) =>
+  /** @type {any} */ ({
+    meta: { PROCESSING_TYPE: { value: 'REPROCESSOR_INPUT' } },
+    data: {
+      RECEIVED_LOADS_FOR_REPROCESSING: {
+        location: { sheet: 'Sheet1', row: 1, column: 'A' },
+        headers: BALANCE_BEARING_HEADERS,
+        rows
+      }
+    }
+  })
 
 describe('syncFromSummaryLog', () => {
   let wasteBalanceService
@@ -449,6 +506,136 @@ describe('syncFromSummaryLog', () => {
       )
 
       expect(result).toEqual({ created: 0, updated: 0 })
+    })
+  })
+
+  describe('the committed submission, against a real ledger', () => {
+    const ACCREDITATION = {
+      id: 'acc-1',
+      validFrom: '2026-01-01',
+      validTo: '2026-12-31',
+      statusHistory: []
+    }
+    const ACCREDITED_LEDGER_ID = {
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      accreditationId: 'acc-1'
+    }
+
+    const realBalanceSync = (extractor) =>
+      makeSync({
+        extractor,
+        wasteBalanceService: createWasteBalanceService(ledgerRepository)
+      })
+
+    const submittedEvents = async (ledgerId) =>
+      (await ledgerRepository.findAllInLedger(ledgerId)).filter(
+        (event) => event.kind === LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED
+      )
+
+    beforeEach(() => {
+      organisationsRepository.findAccreditationById.mockResolvedValue(
+        ACCREDITATION
+      )
+    })
+
+    it('credits the ledger with the total carried by the row states it committed', async () => {
+      const fileId = 'file-credit'
+      const extractor = createInMemorySummaryLogExtractor({
+        [fileId]: balanceBearingInput([
+          balanceBearingRow(2, 'row-1001', 1.005),
+          balanceBearingRow(3, 'row-1002', 2.5),
+          balanceBearingRow(4, 'row-1003', 4, 'Yes')
+        ])
+      })
+
+      await realBalanceSync(extractor)(
+        summaryLogFor(fileId, 'acc-1'),
+        TEST_USER
+      )
+
+      const rowStates =
+        await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+          ACCREDITED_LEDGER_ID,
+          fileId
+        )
+      const creditFromStates = rowStates.reduce(
+        (total, state) => total + getTargetAmount(state.classification),
+        0
+      )
+
+      const [event] = await submittedEvents(ACCREDITED_LEDGER_ID)
+      expect(event.payload).toEqual({ summaryLogId: fileId, creditTotal: 3.51 })
+      expect(creditFromStates).toBeCloseTo(3.51, 10)
+    })
+
+    it('commits no event when an accredited balance-bearing submission has no rows', async () => {
+      const fileId = 'file-accredited-empty'
+      const extractor = createInMemorySummaryLogExtractor({
+        [fileId]: balanceBearingInput([])
+      })
+
+      await realBalanceSync(extractor)(
+        summaryLogFor(fileId, 'acc-1'),
+        TEST_USER
+      )
+
+      expect(
+        await ledgerRepository.findAllInLedger(ACCREDITED_LEDGER_ID)
+      ).toEqual([])
+    })
+
+    it('commits no event for an accredited registered-only submission', async () => {
+      const fileId = 'file-accredited-reg-only'
+      const extractor = extractorFor(fileId, {
+        meta: { PROCESSING_TYPE: { value: 'REPROCESSOR_REGISTERED_ONLY' } },
+        data: {}
+      })
+
+      await realBalanceSync(extractor)(
+        summaryLogFor(fileId, 'acc-1'),
+        TEST_USER
+      )
+
+      expect(
+        await ledgerRepository.findAllInLedger(ACCREDITED_LEDGER_ID)
+      ).toEqual([])
+    })
+
+    it('commits a zero-credit event with no accreditation, even with no rows', async () => {
+      const fileId = 'file-unaccredited-empty'
+      const extractor = extractorFor(fileId, {
+        meta: { PROCESSING_TYPE: { value: 'REPROCESSOR_INPUT' } },
+        data: {}
+      })
+      organisationsRepository.findRegistrationById.mockResolvedValue({
+        overseasSites: {}
+      })
+
+      await realBalanceSync(extractor)(summaryLogFor(fileId), TEST_USER)
+
+      const [event] = await submittedEvents(LEDGER_ID)
+      expect(event.payload).toEqual({ summaryLogId: fileId, creditTotal: 0 })
+    })
+
+    it('commits the row states whether or not the submission bears a balance', async () => {
+      const fileId = 'file-states-always'
+      const extractor = createInMemorySummaryLogExtractor({
+        [fileId]: balanceBearingInput([balanceBearingRow(2, 'row-1001', 3.25)])
+      })
+
+      await realBalanceSync(extractor)(
+        summaryLogFor(fileId, 'acc-1'),
+        TEST_USER
+      )
+
+      const rowStates =
+        await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+          ACCREDITED_LEDGER_ID,
+          fileId
+        )
+      expect(rowStates.map((state) => state.rowId)).toEqual(['row-1001'])
+      expect(rowStates[0].classification.transactionAmount).toBe(3.25)
     })
   })
 })

--- a/src/application/waste-records/sync-from-summary-log.test.js
+++ b/src/application/waste-records/sync-from-summary-log.test.js
@@ -214,11 +214,15 @@ describe('syncFromSummaryLog', () => {
     }
     organisationsRepository = {
       findRegistrationById: vi.fn().mockResolvedValue({ overseasSites: {} }),
-      findAccreditationById: vi.fn().mockResolvedValue({
-        id: 'acc-default',
-        validFrom: '2023-01-01',
-        validTo: '2023-12-31'
-      })
+      // Both organisations repositories find the accreditation by matching its
+      // own id, so the one returned always carries the id that was asked for.
+      findAccreditationById: vi
+        .fn()
+        .mockImplementation(async (_organisationId, accreditationId) => ({
+          id: accreditationId,
+          validFrom: '2023-01-01',
+          validTo: '2023-12-31'
+        }))
     }
     overseasSitesRepository = {
       findByIds: vi.fn().mockResolvedValue([])

--- a/src/application/waste-records/transform-from-summary-log.test.js
+++ b/src/application/waste-records/transform-from-summary-log.test.js
@@ -30,6 +30,59 @@ const RECEIVED_LOADS_HEADERS = [
 ]
 
 describe('transformFromSummaryLog', () => {
+  it('stamps every record with the whole ancestor chain it is given, unaltered', () => {
+    /** @type {any} */ const parsedData = {
+      meta: { PROCESSING_TYPE: { value: 'REPROCESSOR_INPUT' } },
+      data: {
+        RECEIVED_LOADS_FOR_REPROCESSING: {
+          location: { sheet: 'Sheet1', row: 1, column: 'A' },
+          headers: RECEIVED_LOADS_HEADERS,
+          rows: [
+            createRow(
+              RECEIVED_LOADS_HEADERS,
+              [FIRST_ROW_ID, FIRST_DATE, FIRST_WEIGHT],
+              FIRST_ROW_ID
+            ),
+            createRow(
+              RECEIVED_LOADS_HEADERS,
+              ['row-456', '2025-01-16', SECOND_WEIGHT],
+              'row-456'
+            )
+          ]
+        }
+      }
+    }
+
+    // The submit path keys the row states and the ledger event off the summary
+    // log's own organisation, registration and accreditation, and classifies
+    // the records against that same key. That is only sound while the records
+    // carry exactly what they were given here.
+    const result = transformFromSummaryLog(parsedData, {
+      organisationId: 'org-ancestor',
+      registrationId: 'reg-ancestor',
+      accreditationId: 'acc-ancestor'
+    })
+
+    expect(
+      result.map(({ record }) => ({
+        organisationId: record.organisationId,
+        registrationId: record.registrationId,
+        accreditationId: record.accreditationId
+      }))
+    ).toEqual([
+      {
+        organisationId: 'org-ancestor',
+        registrationId: 'reg-ancestor',
+        accreditationId: 'acc-ancestor'
+      },
+      {
+        organisationId: 'org-ancestor',
+        registrationId: 'reg-ancestor',
+        accreditationId: 'acc-ancestor'
+      }
+    ])
+  })
+
   it('transforms parsed RECEIVED_LOADS data into waste records', () => {
     /** @type {any} */ const parsedData = {
       meta: {

--- a/src/waste-balances/application/update-via-ledger.js
+++ b/src/waste-balances/application/update-via-ledger.js
@@ -1,64 +1,36 @@
-/** @import {OverseasSitesContext} from '#domain/summary-logs/table-schemas/validation-pipeline.js' */
-
-import { add, toNumber } from '#common/helpers/decimal-utils.js'
-
 import { recordWasteBalanceUpdateAudit } from './audit.js'
-import { classifyWasteRecord, getTargetAmount } from './target-amount.js'
 
 /**
  * Apply a summary-log submission to the event-sourced ledger.
  *
- * Computes the aggregate `creditTotal` (sum of all row-level target amounts)
- * and commits it through the injected `commitSummaryLogSubmittedEvent`, which
- * folds the ledger, decides the submission event, and appends it. A competing
- * write that
+ * Commits the submission's aggregate `creditTotal` — summed by the caller from
+ * the row states the submission committed — through the injected
+ * `commitSummaryLogSubmittedEvent`, which folds the ledger, decides the
+ * submission event, and appends it. A competing write that
  * advanced the head since the fold surfaces as a slot conflict and propagates to
  * the caller (ADR-0036): the caller is the summary-log worker job, so the
  * conflict fails the job and the queue redelivers, recomputing against fresh
  * state.
  *
  * @param {Object} params
- * @param {Array<import('#domain/waste-records/model.js').WasteRecord>} params.wasteRecords
- * @param {import('#domain/organisations/accreditation.js').Accreditation} params.accreditation
+ * @param {import('../repository/ledger-schema.js').AccreditedLedgerId} params.ledgerId
+ * @param {number} params.creditTotal
  * @param {import('./waste-balance-service.js').CommitSummaryLogSubmittedEvent} params.commitSummaryLogSubmittedEvent
  * @param {Object} [params.dependencies]
  * @param {import('#repositories/system-logs/port.js').SystemLogsRepository} [params.dependencies.systemLogsRepository]
  * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} params.user
- * @param {OverseasSitesContext} params.overseasSites
  * @param {string} params.summaryLogId
  */
 export const performUpdateViaLedger = async ({
-  wasteRecords,
-  accreditation,
+  ledgerId,
+  creditTotal,
   commitSummaryLogSubmittedEvent,
   dependencies = {},
   user,
-  overseasSites,
   summaryLogId
 }) => {
-  if (wasteRecords.length === 0) {
-    return
-  }
-
-  const registrationId = wasteRecords[0].registrationId
-  const organisationId = wasteRecords[0].organisationId
-
-  const classifiedRows = wasteRecords.map((record) =>
-    classifyWasteRecord(
-      record,
-      record.data?.processingType,
-      accreditation,
-      overseasSites
-    )
-  )
-
-  let creditTotal = 0
-  for (const { classification } of classifiedRows) {
-    creditTotal = toNumber(add(creditTotal, getTargetAmount(classification)))
-  }
-
   const [event] = await commitSummaryLogSubmittedEvent(
-    { registrationId, accreditationId: accreditation.id, organisationId },
+    ledgerId,
     { summaryLogId, creditTotal },
     {
       id: user.id,
@@ -69,7 +41,7 @@ export const performUpdateViaLedger = async ({
 
   await recordWasteBalanceUpdateAudit({
     systemLogsRepository: dependencies.systemLogsRepository,
-    accreditationId: accreditation.id,
+    accreditationId: ledgerId.accreditationId,
     amount: event.closingBalance.amount,
     availableAmount: event.closingBalance.availableAmount,
     events: [event],

--- a/src/waste-balances/application/update-via-ledger.test.js
+++ b/src/waste-balances/application/update-via-ledger.test.js
@@ -31,6 +31,7 @@ vi.mock('#common/helpers/logging/logger.js', () => ({
 
 const accreditationId = 'acc-1'
 
+/** @type {import('../repository/ledger-schema.js').AccreditedLedgerId} */
 const ledgerId = {
   organisationId: 'org-1',
   registrationId: 'reg-1',

--- a/src/waste-balances/application/update-via-ledger.test.js
+++ b/src/waste-balances/application/update-via-ledger.test.js
@@ -7,13 +7,6 @@ import { performUpdateViaLedger } from './update-via-ledger.js'
 import { createWasteBalanceService } from './waste-balance-service.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
 import { logger } from '#common/helpers/logging/logger.js'
-import { partialMock } from '#test/type-helpers.js'
-import {
-  WASTE_RECORD_TYPE,
-  VERSION_STATUS
-} from '#domain/waste-records/model.js'
-import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
-import { CLASSIFICATION_REASON } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 
 vi.mock('@defra/cdp-auditing', () => ({
   audit: vi.fn()
@@ -36,29 +29,6 @@ vi.mock('#common/helpers/logging/logger.js', () => ({
   }
 }))
 
-// Excludes on a PRN having been issued rather than on absent data, so an
-// excluded row still carries a real tonnage — the amount the ledger must
-// withhold, and the shape every genuine exclusion reason takes.
-const prnAwareSchema = /** @type {*} */ ({
-  classifyForWasteBalance: (data) =>
-    data.prnIssued
-      ? {
-          outcome: ROW_OUTCOME.EXCLUDED,
-          reasons: [{ code: CLASSIFICATION_REASON.PRN_ISSUED }]
-        }
-      : {
-          outcome: ROW_OUTCOME.INCLUDED,
-          reasons: [],
-          transactionAmount: data.tonnage
-        }
-})
-
-vi.mock('#domain/summary-logs/table-schemas/index.js', () => ({
-  findSchemaForProcessingType: vi.fn()
-}))
-
-/** @typedef {import('#domain/organisations/accreditation.js').Accreditation} Accreditation */
-
 const accreditationId = 'acc-1'
 
 const ledgerId = {
@@ -67,14 +37,6 @@ const ledgerId = {
   accreditationId
 }
 
-/** @type {Accreditation} */
-const accreditation = partialMock({
-  id: accreditationId,
-  validFrom: '2023-01-01',
-  validTo: '2030-12-31'
-})
-
-const overseasSites = /** @type {*} */ (new Map())
 const user = {
   id: 'user-1',
   name: 'Test User',
@@ -83,63 +45,34 @@ const user = {
   role: 'standard_user'
 }
 
-const buildExporterRecord = ({
-  rowId,
-  tonnage,
-  prnIssued = false,
-  versionId = `version-${rowId}`,
-  summaryLogId = 'log-1'
-}) => ({
-  organisationId: 'org-1',
-  registrationId: 'reg-1',
-  accreditationId,
-  rowId: String(rowId),
-  type: WASTE_RECORD_TYPE.EXPORTED,
-  versions: [
-    {
-      id: versionId,
-      createdAt: '2025-01-20T10:00:00.000Z',
-      status: VERSION_STATUS.CREATED,
-      summaryLog: { id: summaryLogId, uri: 's3://bucket/log' },
-      data: {}
-    }
-  ],
-  data: { processingType: 'EXPORTER', tonnage, prnIssued }
-})
-
 describe('performUpdateViaLedger', () => {
   let ledgerRepository
   let systemLogsRepository
   let commitSummaryLogSubmittedEvent
 
-  beforeEach(async () => {
+  beforeEach(() => {
     ledgerRepository = createInMemoryLedgerRepository()()
     systemLogsRepository = createSystemLogsRepository()(logger)
     commitSummaryLogSubmittedEvent = createWasteBalanceService(
       ledgerRepository,
       systemLogsRepository
     ).commitSummaryLogSubmittedEvent
-    const { findSchemaForProcessingType } =
-      await import('#domain/summary-logs/table-schemas/index.js')
-    vi.mocked(findSchemaForProcessingType).mockReturnValue(prnAwareSchema)
   })
 
-  describe('first submission', () => {
-    it('appends a single summary-log-submitted event with aggregate creditTotal', async () => {
-      const records = [
-        buildExporterRecord({ rowId: '1', tonnage: 100 }),
-        buildExporterRecord({ rowId: '2', tonnage: 50 })
-      ]
+  const submit = (summaryLogId, creditTotal, overrides = {}) =>
+    performUpdateViaLedger({
+      ledgerId,
+      creditTotal,
+      commitSummaryLogSubmittedEvent,
+      dependencies: { systemLogsRepository },
+      user,
+      summaryLogId,
+      ...overrides
+    })
 
-      await performUpdateViaLedger({
-        wasteRecords: records,
-        accreditation,
-        commitSummaryLogSubmittedEvent,
-        dependencies: { systemLogsRepository },
-        user,
-        overseasSites,
-        summaryLogId: 'log-A'
-      })
+  describe('first submission', () => {
+    it('appends a single summary-log-submitted event carrying the credit total', async () => {
+      await submit('log-A', 150)
 
       const latest = await ledgerRepository.findLatestInLedger(ledgerId)
       expect(latest.number).toBe(1)
@@ -157,32 +90,8 @@ describe('performUpdateViaLedger', () => {
 
   describe('subsequent submission', () => {
     it('computes delta from previous creditTotal', async () => {
-      await performUpdateViaLedger({
-        wasteRecords: [
-          buildExporterRecord({ rowId: '1', tonnage: 100 }),
-          buildExporterRecord({ rowId: '2', tonnage: 50 })
-        ],
-        accreditation,
-        commitSummaryLogSubmittedEvent,
-        dependencies: { systemLogsRepository },
-        user,
-        overseasSites,
-        summaryLogId: 'log-A'
-      })
-
-      await performUpdateViaLedger({
-        wasteRecords: [
-          buildExporterRecord({ rowId: '1', tonnage: 100, versionId: 'v-1b' }),
-          buildExporterRecord({ rowId: '2', tonnage: 80, versionId: 'v-2b' }),
-          buildExporterRecord({ rowId: '3', tonnage: 20 })
-        ],
-        accreditation,
-        commitSummaryLogSubmittedEvent,
-        dependencies: { systemLogsRepository },
-        user,
-        overseasSites,
-        summaryLogId: 'log-B'
-      })
+      await submit('log-A', 150)
+      await submit('log-B', 200)
 
       const latest = await ledgerRepository.findLatestInLedger(ledgerId)
       expect(latest.number).toBe(2)
@@ -197,89 +106,9 @@ describe('performUpdateViaLedger', () => {
     })
   })
 
-  describe('excluded records', () => {
-    it('skips records the schema excludes', async () => {
-      const records = [
-        buildExporterRecord({ rowId: '1', tonnage: 100 }),
-        buildExporterRecord({ rowId: '2', tonnage: 50, prnIssued: true })
-      ]
-
-      await performUpdateViaLedger({
-        wasteRecords: records,
-        accreditation,
-        commitSummaryLogSubmittedEvent,
-        dependencies: { systemLogsRepository },
-        user,
-        overseasSites,
-        summaryLogId: 'log-A'
-      })
-
-      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
-      expect(latest.payload.creditTotal).toBe(100)
-    })
-  })
-
-  describe('credit total invariant', () => {
-    it('sums exactly the INCLUDED transaction amounts, dropping excluded rows', async () => {
-      const includedTonnages = [120, 30, 45]
-      const records = [
-        buildExporterRecord({ rowId: '1', tonnage: includedTonnages[0] }),
-        buildExporterRecord({ rowId: '2', tonnage: includedTonnages[1] }),
-        buildExporterRecord({ rowId: '3', tonnage: 999, prnIssued: true }),
-        buildExporterRecord({ rowId: '4', tonnage: includedTonnages[2] })
-      ]
-
-      await performUpdateViaLedger({
-        wasteRecords: records,
-        accreditation,
-        commitSummaryLogSubmittedEvent,
-        dependencies: { systemLogsRepository },
-        user,
-        overseasSites,
-        summaryLogId: 'log-A'
-      })
-
-      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
-      expect(latest.payload.creditTotal).toBe(
-        includedTonnages.reduce((sum, tonnage) => sum + tonnage, 0)
-      )
-    })
-  })
-
-  describe('empty input', () => {
-    it('does not touch the ledger when no waste records are provided', async () => {
-      const appendSpy = vi.spyOn(ledgerRepository, 'appendEvents')
-
-      await performUpdateViaLedger({
-        wasteRecords: [],
-        accreditation,
-        commitSummaryLogSubmittedEvent,
-        dependencies: { systemLogsRepository },
-        user,
-        overseasSites,
-        summaryLogId: 'log-A'
-      })
-
-      expect(appendSpy).not.toHaveBeenCalled()
-      const { systemLogs } = await systemLogsRepository.find({ limit: 10 })
-      expect(systemLogs).toHaveLength(0)
-    })
-  })
-
   describe('audit emission', () => {
     it('inserts one system-log entry covering the submission', async () => {
-      await performUpdateViaLedger({
-        wasteRecords: [
-          buildExporterRecord({ rowId: '1', tonnage: 100 }),
-          buildExporterRecord({ rowId: '2', tonnage: 50 })
-        ],
-        accreditation,
-        commitSummaryLogSubmittedEvent,
-        dependencies: { systemLogsRepository },
-        user,
-        overseasSites,
-        summaryLogId: 'log-A'
-      })
+      await submit('log-A', 150)
 
       const latest = await ledgerRepository.findLatestInLedger(ledgerId)
 
@@ -310,12 +139,11 @@ describe('performUpdateViaLedger', () => {
         ).commitSummaryLogSubmittedEvent
 
       await performUpdateViaLedger({
-        wasteRecords: [buildExporterRecord({ rowId: '1', tonnage: 100 })],
-        accreditation,
+        ledgerId,
+        creditTotal: 100,
         commitSummaryLogSubmittedEvent: auditlessSubmit,
         dependencies: {},
         user,
-        overseasSites,
         summaryLogId: 'log-A'
       })
 
@@ -328,45 +156,9 @@ describe('performUpdateViaLedger', () => {
     })
   })
 
-  describe('classifier outcome', () => {
-    it('treats records with non-INCLUDED outcome as zero contribution', async () => {
-      const { findSchemaForProcessingType } =
-        await import('#domain/summary-logs/table-schemas/index.js')
-      vi.mocked(findSchemaForProcessingType).mockReturnValue(
-        /** @type {*} */ ({
-          classifyForWasteBalance: () => ({
-            outcome: ROW_OUTCOME.IGNORED,
-            reasons: [{ code: 'OUTSIDE_ACCREDITATION_PERIOD' }]
-          })
-        })
-      )
-
-      await performUpdateViaLedger({
-        wasteRecords: [buildExporterRecord({ rowId: '1', tonnage: 100 })],
-        accreditation,
-        commitSummaryLogSubmittedEvent,
-        dependencies: { systemLogsRepository },
-        user,
-        overseasSites,
-        summaryLogId: 'log-A'
-      })
-
-      const latest = await ledgerRepository.findLatestInLedger(ledgerId)
-      expect(latest.payload.creditTotal).toBe(0)
-    })
-  })
-
   describe('actor attribution', () => {
     it('stamps createdBy with the submitter id, name and email', async () => {
-      await performUpdateViaLedger({
-        wasteRecords: [buildExporterRecord({ rowId: '1', tonnage: 50 })],
-        accreditation,
-        commitSummaryLogSubmittedEvent,
-        dependencies: { systemLogsRepository },
-        user,
-        overseasSites,
-        summaryLogId: 'log-A'
-      })
+      await submit('log-A', 50)
 
       const latest = await ledgerRepository.findLatestInLedger(ledgerId)
       expect(latest.createdBy).toEqual({
@@ -377,19 +169,13 @@ describe('performUpdateViaLedger', () => {
     })
 
     it('omits name when the submitter has none, keeping the email distinct', async () => {
-      await performUpdateViaLedger({
-        wasteRecords: [buildExporterRecord({ rowId: '1', tonnage: 50 })],
-        accreditation,
-        commitSummaryLogSubmittedEvent,
-        dependencies: { systemLogsRepository },
+      await submit('log-A', 50, {
         user: {
           id: 'user-2',
           email: 'noname@example.test',
           scope: [],
           role: null
-        },
-        overseasSites,
-        summaryLogId: 'log-A'
+        }
       })
 
       const latest = await ledgerRepository.findLatestInLedger(ledgerId)
@@ -402,17 +188,6 @@ describe('performUpdateViaLedger', () => {
 
   describe('optimistic concurrency', () => {
     it('lets one of two concurrent submissions win and surfaces the loser as a slot conflict', async () => {
-      const submit = (summaryLogId, tonnage) =>
-        performUpdateViaLedger({
-          wasteRecords: [buildExporterRecord({ rowId: '1', tonnage })],
-          accreditation,
-          commitSummaryLogSubmittedEvent,
-          dependencies: { systemLogsRepository },
-          user,
-          overseasSites,
-          summaryLogId
-        })
-
       const results = await Promise.allSettled([
         submit('log-A', 150),
         submit('log-B', 200)

--- a/src/waste-balances/application/waste-balance-service.js
+++ b/src/waste-balances/application/waste-balance-service.js
@@ -203,36 +203,29 @@ export const createWasteBalanceService = (
     commitSummaryLogSubmittedEvent,
 
     /**
-     * Credit the ledger from a summary log's waste records: mark each row's
-     * balance inclusion, then fold, decide, and append the aggregate
-     * submission. The sole write entry the summary-log worker calls.
+     * Credit an accredited ledger with a summary log's total: fold, decide, and
+     * append the aggregate submission, then audit the balance it moved. The
+     * total arrives already summed from the row states the submission
+     * committed. The sole balance-bearing write entry the summary-log worker
+     * calls.
      *
-     * @param {import('#domain/waste-records/model.js').WasteRecord[]} wasteRecords
      * @param {Object} options
+     * @param {import('../repository/ledger-schema.js').WasteBalanceLedgerId} options.ledgerId
+     * @param {number} options.creditTotal
      * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} options.user
-     * @param {import('#domain/organisations/accreditation.js').Accreditation} options.accreditation
-     * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} options.overseasSites
      * @param {string} options.summaryLogId
      * @returns {Promise<void>}
      */
-    submitSummaryLog: async (
-      wasteRecords,
-      { user, accreditation, overseasSites, summaryLogId }
-    ) => {
-      if (wasteRecords.length === 0) {
-        return
-      }
-
+    submitSummaryLog: async ({ ledgerId, creditTotal, user, summaryLogId }) => {
       await performUpdateViaLedger({
-        wasteRecords,
-        accreditation: {
-          ...accreditation,
-          id: validateAccreditationId(accreditation.id)
+        ledgerId: {
+          ...ledgerId,
+          accreditationId: validateAccreditationId(ledgerId.accreditationId)
         },
+        creditTotal,
         commitSummaryLogSubmittedEvent,
         dependencies: { systemLogsRepository },
         user,
-        overseasSites,
         summaryLogId
       })
     },

--- a/src/waste-balances/application/waste-balance-service.js
+++ b/src/waste-balances/application/waste-balance-service.js
@@ -210,7 +210,7 @@ export const createWasteBalanceService = (
      * calls.
      *
      * @param {Object} options
-     * @param {import('../repository/ledger-schema.js').WasteBalanceLedgerId} options.ledgerId
+     * @param {import('../repository/ledger-schema.js').AccreditedLedgerId} options.ledgerId
      * @param {number} options.creditTotal
      * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} options.user
      * @param {string} options.summaryLogId

--- a/src/waste-balances/application/waste-balance-service.test.js
+++ b/src/waste-balances/application/waste-balance-service.test.js
@@ -12,7 +12,9 @@ import {
   PRN_COMMAND_REJECTION
 } from '../domain/commands.js'
 import { createWasteBalanceService } from './waste-balance-service.js'
+import { invalidArg } from '#test/type-helpers.js'
 
+/** @type {import('../repository/ledger-schema.js').AccreditedLedgerId} */
 const ledgerId = {
   organisationId: 'org-1',
   registrationId: 'reg-1',
@@ -24,6 +26,9 @@ const createdBy = {
   name: 'Test User',
   email: 'user@example.test'
 }
+
+/** @type {import('#domain/summary-logs/worker/port.js').SubmitUser} */
+const submitter = { ...createdBy, scope: ['some-scope'], role: 'standard_user' }
 
 describe('createWasteBalanceService', () => {
   let ledgerRepository
@@ -380,7 +385,7 @@ describe('createWasteBalanceService', () => {
       await service.submitSummaryLog({
         ledgerId,
         creditTotal: 150,
-        user: createdBy,
+        user: submitter,
         summaryLogId: 'log-A'
       })
 
@@ -393,11 +398,13 @@ describe('createWasteBalanceService', () => {
     })
 
     it('refuses a ledger with no accreditation behind it', async () => {
+      // The signature takes an accredited ledger, so only an unchecked caller
+      // can get here — which is what the runtime guard is for.
       await expect(
         service.submitSummaryLog({
-          ledgerId: { ...ledgerId, accreditationId: null },
+          ledgerId: invalidArg({ ...ledgerId, accreditationId: null }),
           creditTotal: 150,
-          user: createdBy,
+          user: submitter,
           summaryLogId: 'log-A'
         })
       ).rejects.toThrow('accreditationId must be a string')

--- a/src/waste-balances/application/waste-balance-service.test.js
+++ b/src/waste-balances/application/waste-balance-service.test.js
@@ -376,20 +376,31 @@ describe('createWasteBalanceService', () => {
   })
 
   describe('submitSummaryLog', () => {
-    it('does not touch the ledger when there are no waste records to credit', async () => {
-      await service.submitSummaryLog([], {
+    it('credits the ledger with the total the submission carries', async () => {
+      await service.submitSummaryLog({
+        ledgerId,
+        creditTotal: 150,
         user: createdBy,
-        accreditation: { id: 'acc-1' },
-        overseasSites: /** @type {*} */ (new Map()),
         summaryLogId: 'log-A'
       })
 
-      const all = await ledgerRepository.findAllInLedger({
-        organisationId: 'org-1',
-        registrationId: 'reg-1',
-        accreditationId: 'acc-1'
+      const all = await ledgerRepository.findAllInLedger(ledgerId)
+      expect(all).toHaveLength(1)
+      expect(all[0].payload).toEqual({
+        summaryLogId: 'log-A',
+        creditTotal: 150
       })
-      expect(all).toHaveLength(0)
+    })
+
+    it('refuses a ledger with no accreditation behind it', async () => {
+      await expect(
+        service.submitSummaryLog({
+          ledgerId: { ...ledgerId, accreditationId: null },
+          creditTotal: 150,
+          user: createdBy,
+          summaryLogId: 'log-A'
+        })
+      ).rejects.toThrow('accreditationId must be a string')
     })
   })
 

--- a/src/waste-balances/repository/ledger-schema.js
+++ b/src/waste-balances/repository/ledger-schema.js
@@ -89,6 +89,14 @@ export const BACKFILL_ACTOR = Object.freeze({ id: 'system', name: 'backfill' })
  */
 
 /**
+ * A ledger id that names an accreditation rather than a registration alone.
+ * Only an accredited ledger carries a waste balance, so the paths that move
+ * tonnage take this and cannot be handed a registered-only ledger by mistake.
+ *
+ * @typedef {Omit<WasteBalanceLedgerId, 'accreditationId'> & { accreditationId: string }} AccreditedLedgerId
+ */
+
+/**
  * A position within a waste balance ledger: the ledger id plus a sequence
  * number. The head a decision reads at, the slot it commits to (`number + 1`),
  * and the coordinate a slot-conflict or sequence error reports on a clash.

--- a/src/waste-records/application/commit-summary-log-submission.js
+++ b/src/waste-records/application/commit-summary-log-submission.js
@@ -83,7 +83,13 @@ export const commitSummaryLogSubmission = async ({
     summaryLogId
   })
 
-  if (!accreditation) {
+  // The accreditation is what makes a ledger able to hold a balance, so the
+  // accredited identity is derived from it rather than tested for separately.
+  const accreditedLedgerId = accreditation
+    ? { ...ledgerId, accreditationId: accreditation.id }
+    : null
+
+  if (!accreditedLedgerId) {
     await wasteBalanceService.commitSummaryLogSubmittedEvent(
       ledgerId,
       { summaryLogId, creditTotal: 0 },
@@ -104,7 +110,7 @@ export const commitSummaryLogSubmission = async ({
   }
 
   await wasteBalanceService.submitSummaryLog({
-    ledgerId,
+    ledgerId: accreditedLedgerId,
     creditTotal: creditTotalOf(rowStates),
     summaryLogId,
     user

--- a/src/waste-records/application/commit-summary-log-submission.js
+++ b/src/waste-records/application/commit-summary-log-submission.js
@@ -1,0 +1,112 @@
+import { add, toNumber } from '#common/helpers/decimal-utils.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { getTargetAmount } from '#waste-balances/application/target-amount.js'
+
+import { writeSummaryLogRowStates } from './write-summary-log-row-states.js'
+
+/**
+ * @import { OverseasSitesContext } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+ * @import { SummaryLogRowStateEntry } from '#waste-records/repository/schema.js'
+ * @import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
+ */
+
+/**
+ * Processing types whose templates carry loads the waste balance reads. The
+ * registered-only variants report activity without an accreditation behind it,
+ * so they move no tonnage.
+ *
+ * @type {Set<import('#domain/summary-logs/meta-fields.js').ProcessingType>}
+ */
+const BALANCE_BEARING_PROCESSING_TYPES = new Set([
+  PROCESSING_TYPES.EXPORTER,
+  PROCESSING_TYPES.REPROCESSOR_INPUT,
+  PROCESSING_TYPES.REPROCESSOR_OUTPUT
+])
+
+/**
+ * The tonnage a set of committed row states credits to the balance: the sum of
+ * every included row's contribution, added at full decimal precision.
+ *
+ * @param {SummaryLogRowStateEntry[]} rowStates
+ * @returns {number}
+ */
+const creditTotalOf = (rowStates) =>
+  rowStates.reduce(
+    (total, { classification }) =>
+      toNumber(add(total, getTargetAmount(classification))),
+    0
+  )
+
+/**
+ * Commits a summary-log submission: the per-row state that is the submission's
+ * committed contents, and the ledger event recording that it was submitted.
+ *
+ * The rows are classified once, when their states are built. The credit the
+ * ledger event carries is then summed from those same states, so the balance
+ * and the committed contents can never disagree about which rows counted.
+ *
+ * Which submissions carry a balance is decided here rather than by the caller:
+ * a submission with no accreditation records a zero-delta event under the
+ * registered-only ledger, an accredited submission on a balance-bearing
+ * template credits its total, and an accredited submission that is either
+ * registered-only or has no rows at all appends nothing.
+ *
+ * @param {Object} params
+ * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} params.summaryLogRowStateRepository
+ * @param {ReturnType<typeof createWasteBalanceService>} params.wasteBalanceService
+ * @param {import('#domain/waste-records/model.js').WasteRecord[]} params.wasteRecords
+ * @param {import('#domain/organisations/accreditation.js').Accreditation | null} params.accreditation
+ * @param {import('#waste-records/repository/schema.js').WasteBalanceLedgerId} params.ledgerId
+ * @param {import('#domain/summary-logs/meta-fields.js').ProcessingType} params.processingType
+ * @param {OverseasSitesContext} params.overseasSites
+ * @param {string} params.summaryLogId
+ * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} params.user
+ * @returns {Promise<void>}
+ */
+export const commitSummaryLogSubmission = async ({
+  summaryLogRowStateRepository,
+  wasteBalanceService,
+  wasteRecords,
+  accreditation,
+  ledgerId,
+  processingType,
+  overseasSites,
+  summaryLogId,
+  user
+}) => {
+  const rowStates = await writeSummaryLogRowStates({
+    summaryLogRowStateRepository,
+    wasteRecords,
+    accreditation,
+    ledgerId,
+    overseasSites,
+    summaryLogId
+  })
+
+  if (!accreditation) {
+    await wasteBalanceService.commitSummaryLogSubmittedEvent(
+      ledgerId,
+      { summaryLogId, creditTotal: 0 },
+      {
+        id: user.id,
+        ...(user.name && { name: user.name }),
+        email: user.email
+      }
+    )
+    return
+  }
+
+  if (
+    !BALANCE_BEARING_PROCESSING_TYPES.has(processingType) ||
+    rowStates.length === 0
+  ) {
+    return
+  }
+
+  await wasteBalanceService.submitSummaryLog({
+    ledgerId,
+    creditTotal: creditTotalOf(rowStates),
+    summaryLogId,
+    user
+  })
+}

--- a/src/waste-records/application/commit-summary-log-submission.test.js
+++ b/src/waste-records/application/commit-summary-log-submission.test.js
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { commitSummaryLogSubmission } from './commit-summary-log-submission.js'
+import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
+import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { partialMock } from '#test/type-helpers.js'
+
+const ORGANISATION_ID = 'org-1'
+const REGISTRATION_ID = 'reg-1'
+const ACCREDITATION_ID = 'acc-1'
+const SUMMARY_LOG_ID = 'log-A'
+
+const accreditedLedgerId = {
+  organisationId: ORGANISATION_ID,
+  registrationId: REGISTRATION_ID,
+  accreditationId: ACCREDITATION_ID
+}
+
+const registeredOnlyLedgerId = {
+  organisationId: ORGANISATION_ID,
+  registrationId: REGISTRATION_ID,
+  accreditationId: null
+}
+
+/** @type {import('#domain/organisations/accreditation.js').Accreditation} */
+const accreditation = partialMock({
+  id: ACCREDITATION_ID,
+  validFrom: '2026-01-01',
+  validTo: '2026-12-31',
+  statusHistory: []
+})
+
+const user = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'user@example.test',
+  scope: ['some-scope'],
+  role: 'standard_user'
+}
+
+const overseasSites = /** @type {any} */ (new Map())
+
+/**
+ * A reprocessor-input row carrying every field the balance classifier needs, so
+ * it is included and contributes `tonnage`. A PRN issued on the waste excludes
+ * it while leaving the tonnage on the row.
+ */
+const includableRecord = ({ rowId, tonnage, prnIssued = 'No' }) => ({
+  organisationId: ORGANISATION_ID,
+  registrationId: REGISTRATION_ID,
+  accreditationId: ACCREDITATION_ID,
+  rowId: String(rowId),
+  type: WASTE_RECORD_TYPE.RECEIVED,
+  versions: [],
+  data: {
+    processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+    ROW_ID: String(rowId),
+    DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01',
+    EWC_CODE: '15 01 02',
+    DESCRIPTION_WASTE: 'Plastic packaging',
+    WERE_PRN_OR_PERN_ISSUED_ON_THIS_WASTE: prnIssued,
+    GROSS_WEIGHT: 10,
+    TARE_WEIGHT: 1,
+    PALLET_WEIGHT: 0,
+    NET_WEIGHT: 9,
+    BAILING_WIRE_PROTOCOL: 'No',
+    HOW_DID_YOU_CALCULATE_RECYCLABLE_PROPORTION: 'Sampling',
+    WEIGHT_OF_NON_TARGET_MATERIALS: 0,
+    RECYCLABLE_PROPORTION_PERCENTAGE: 100,
+    TONNAGE_RECEIVED_FOR_RECYCLING: tonnage
+  }
+})
+
+describe('commitSummaryLogSubmission', () => {
+  let summaryLogRowStateRepository
+  let ledgerRepository
+  let wasteBalanceService
+
+  beforeEach(() => {
+    summaryLogRowStateRepository =
+      createInMemorySummaryLogRowStateRepository()()
+    ledgerRepository = createInMemoryLedgerRepository()()
+    wasteBalanceService = createWasteBalanceService(ledgerRepository)
+  })
+
+  const commit = (overrides = {}) =>
+    commitSummaryLogSubmission({
+      summaryLogRowStateRepository,
+      wasteBalanceService,
+      wasteRecords: [],
+      accreditation,
+      ledgerId: accreditedLedgerId,
+      processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+      overseasSites,
+      summaryLogId: SUMMARY_LOG_ID,
+      user,
+      ...overrides
+    })
+
+  /** @param {import('#waste-records/repository/schema.js').WasteBalanceLedgerId} ledgerId */
+  const committedStates = (ledgerId = accreditedLedgerId) =>
+    summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      ledgerId,
+      SUMMARY_LOG_ID
+    )
+
+  it('credits the ledger with the total the committed states carry', async () => {
+    await commit({
+      wasteRecords: [
+        includableRecord({ rowId: 1, tonnage: 1.005 }),
+        includableRecord({ rowId: 2, tonnage: 2.5 }),
+        includableRecord({ rowId: 3, tonnage: 4, prnIssued: 'Yes' })
+      ]
+    })
+
+    const states = await committedStates()
+    const includedTotal = states
+      .filter(
+        (state) =>
+          state.classification.outcome === WASTE_BALANCE_OUTCOME.INCLUDED
+      )
+      .reduce(
+        (total, state) => total + state.classification.transactionAmount,
+        0
+      )
+
+    const [event] = await ledgerRepository.findAllInLedger(accreditedLedgerId)
+    expect(event.payload).toEqual({
+      summaryLogId: SUMMARY_LOG_ID,
+      creditTotal: 3.51
+    })
+    expect(includedTotal).toBeCloseTo(3.51, 10)
+  })
+
+  it('commits the row states before crediting the ledger', async () => {
+    await commit({
+      wasteRecords: [includableRecord({ rowId: 1, tonnage: 12 })]
+    })
+
+    const states = await committedStates()
+    expect(states.map((state) => state.rowId)).toEqual(['1'])
+    expect(states[0].classification.outcome).toBe(
+      WASTE_BALANCE_OUTCOME.INCLUDED
+    )
+  })
+
+  it('records a zero-delta event under the registered-only ledger with no accreditation', async () => {
+    await commit({
+      accreditation: null,
+      ledgerId: registeredOnlyLedgerId,
+      wasteRecords: [includableRecord({ rowId: 1, tonnage: 12 })]
+    })
+
+    const [event] = await ledgerRepository.findAllInLedger(
+      registeredOnlyLedgerId
+    )
+    expect(event.payload).toEqual({
+      summaryLogId: SUMMARY_LOG_ID,
+      creditTotal: 0
+    })
+    expect(event.createdBy).toEqual({
+      id: user.id,
+      name: user.name,
+      email: user.email
+    })
+    expect(await committedStates(registeredOnlyLedgerId)).toHaveLength(1)
+  })
+
+  it('omits the submitter name from the zero-delta event when they have none', async () => {
+    await commit({
+      accreditation: null,
+      ledgerId: registeredOnlyLedgerId,
+      user: { id: 'user-2', email: 'noname@example.test', scope: [] }
+    })
+
+    const [event] = await ledgerRepository.findAllInLedger(
+      registeredOnlyLedgerId
+    )
+    expect(event.createdBy).toEqual({
+      id: 'user-2',
+      email: 'noname@example.test'
+    })
+  })
+
+  it('appends no event for an accredited registered-only template', async () => {
+    await commit({
+      processingType: PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY,
+      wasteRecords: [includableRecord({ rowId: 1, tonnage: 12 })]
+    })
+
+    expect(await ledgerRepository.findAllInLedger(accreditedLedgerId)).toEqual(
+      []
+    )
+    expect(await committedStates()).toHaveLength(1)
+  })
+
+  it('appends no event for an accredited submission with no rows', async () => {
+    await commit({ wasteRecords: [] })
+
+    expect(await ledgerRepository.findAllInLedger(accreditedLedgerId)).toEqual(
+      []
+    )
+  })
+
+  it('credits an exporter submission too — every balance-bearing template appends', async () => {
+    await commit({
+      processingType: PROCESSING_TYPES.EXPORTER,
+      wasteRecords: [includableRecord({ rowId: 1, tonnage: 7 })]
+    })
+
+    const [event] = await ledgerRepository.findAllInLedger(accreditedLedgerId)
+    expect(event.payload.creditTotal).toBe(7)
+  })
+})

--- a/src/waste-records/application/commit-summary-log-submission.test.js
+++ b/src/waste-records/application/commit-summary-log-submission.test.js
@@ -14,12 +14,14 @@ const REGISTRATION_ID = 'reg-1'
 const ACCREDITATION_ID = 'acc-1'
 const SUMMARY_LOG_ID = 'log-A'
 
+/** @type {import('#waste-balances/repository/ledger-schema.js').AccreditedLedgerId} */
 const accreditedLedgerId = {
   organisationId: ORGANISATION_ID,
   registrationId: REGISTRATION_ID,
   accreditationId: ACCREDITATION_ID
 }
 
+/** @type {import('#waste-records/repository/schema.js').WasteBalanceLedgerId} */
 const registeredOnlyLedgerId = {
   organisationId: ORGANISATION_ID,
   registrationId: REGISTRATION_ID,

--- a/src/waste-records/application/commit-summary-log-submission.test.js
+++ b/src/waste-records/application/commit-summary-log-submission.test.js
@@ -7,6 +7,7 @@ import { createWasteBalanceService } from '#waste-balances/application/waste-bal
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 import { partialMock } from '#test/type-helpers.js'
 
 const ORGANISATION_ID = 'org-1'
@@ -44,12 +45,18 @@ const user = {
   role: 'standard_user'
 }
 
-const overseasSites = /** @type {any} */ (new Map())
+// These submissions are reprocessor-input, which the orchestrator resolves to
+// the disabled sentinel rather than a sites lookup.
+/** @type {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} */
+const overseasSites = ORS_VALIDATION_DISABLED
 
 /**
  * A reprocessor-input row carrying every field the balance classifier needs, so
  * it is included and contributes `tonnage`. A PRN issued on the waste excludes
  * it while leaving the tonnage on the row.
+ *
+ * @param {{ rowId: number, tonnage: number, prnIssued?: string }} row
+ * @returns {import('#domain/waste-records/model.js').WasteRecord}
  */
 const includableRecord = ({ rowId, tonnage, prnIssued = 'No' }) => ({
   organisationId: ORGANISATION_ID,

--- a/src/waste-records/application/write-summary-log-row-states.js
+++ b/src/waste-records/application/write-summary-log-row-states.js
@@ -23,7 +23,10 @@ import { projectSummaryLogRowState } from './project-summary-log-row-state.js'
  * @param {import('#waste-records/repository/schema.js').WasteBalanceLedgerId} params.ledgerId
  * @param {OverseasSitesContext} params.overseasSites
  * @param {string} params.summaryLogId
- * @returns {Promise<void>}
+ * @returns {Promise<import('#waste-records/repository/schema.js').SummaryLogRowStateEntry[]>}
+ *   The states committed, so a caller deriving a submission total from the
+ *   committed contents reads them here rather than classifying the records
+ *   a second time.
  */
 export const writeSummaryLogRowStates = async ({
   summaryLogRowStateRepository,
@@ -42,4 +45,6 @@ export const writeSummaryLogRowStates = async ({
     classifiedRows,
     summaryLogId
   )
+
+  return classifiedRows
 }


### PR DESCRIPTION
Ticket: [PAE-1790](https://eaflood.atlassian.net/browse/PAE-1790)
A summary-log submission commits two things: the per-row state that is its committed contents, and the ledger event recording that it was submitted. This puts both in one operation, `commitSummaryLogSubmission`, and classifies the rows once for both.

**Which submissions carry a balance now reads as one rule.** The three conditions were previously emergent from an `if (accreditation)` in the orchestrator, a processing-type check in one helper and a zero-rows early return in another. They now sit together: an unaccredited submission records a zero-delta event, an accredited submission on a balance-bearing template credits its total, and an accredited submission that is either registered-only or has no rows appends nothing. All three behave exactly as before — the third covers two cases that look like latent bugs, and both are deliberately left alone, tracked separately.

**The rows are classified once instead of twice.** The row-state write and the balance event were each running the same classification over the same records, the second one summing a credit and discarding the rows. The credit is now summed from the states the submission just committed, so the balance and the committed contents cannot disagree about which rows counted.

**Waste balances is out of the classification business on the submit path.** `submitSummaryLog` takes a ledger id, a credit total, the user and the summary-log id; `performUpdateViaLedger` appends and audits.

**One ledger id per submission instead of three.** The change count, the row-state write and the event append were each building their own organisation/registration/accreditation triple. They now share one, built where the accreditation is resolved and annotated `WasteBalanceLedgerId`, so dropping a link from the chain is a type error.

**`AccreditedLedgerId` names a ledger that can hold a balance,** composed from `WasteBalanceLedgerId` with a non-null accreditation. The paths that move tonnage take it, so a registered-only ledger reaching them is a type error rather than a runtime validation throw.

Characterisation tests run the real waste-balance service over the real in-memory ledger and row-state repositories, pinning the states persisted, the credit summed and the event emitted for each of the append conditions. A test fixture that returned a fixed accreditation id regardless of the id requested — something neither repository implementation can do — now echoes its argument.

PAE-1790


[PAE-1790]: https://eaflood.atlassian.net/browse/PAE-1790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ