### PR TITLE
PAE-250: Fix brace-expansion, protobufjs and fast-uri vulnerabilities

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,4 @@ save-exact=true
 engine-strict=true
 allow-git=none
 ignore-scripts=true
-min-release-age=3
+min-release-age=7

--- a/package-lock.json
+++ b/package-lock.json
@@ -4825,15 +4825,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6557,9 +6557,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -8983,9 +8983,9 @@
       "license": "MIT"
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10623,9 +10623,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -10724,9 +10724,9 @@
       "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -109,12 +109,9 @@
   "overrides": {
     "@apidevtools/json-schema-ref-parser": "15.3.6",
     "@apidevtools/swagger-parser": "12.1.0",
-    "@grpc/grpc-js": "1.14.4",
-    "fast-xml-parser": "5.7.3",
-    "form-data": "4.0.6",
+    "fast-uri": "3.1.5",
     "glob": "11.1.0",
     "joi": "18.2.1",
-    "tmp": "0.2.7",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Clears every outstanding npm advisory in this repo, removes four `overrides` entries that had stopped doing anything, and raises the `.npmrc` package cooldown to the CDP standard. `npm audit` reports zero vulnerabilities afterwards. One Snyk finding remains and is explained at the end.

## Vulnerability fixes

| Package | From → to | How |
|---|---|---|
| `brace-expansion` | 5.0.7 → 5.0.9, 2.1.2 → 2.1.4, 1.1.16 → 1.1.18 | re-resolved; no pin needed |
| `protobufjs` | 7.6.4 → 7.6.5 | re-resolved; no pin needed |
| `fast-uri` | 3.1.4 → 3.1.5 | new `overrides` entry |

`fast-uri` reaches us through `hapi-swagger` → `swagger-parser` → `@apidevtools/swagger-parser` → `ajv`, none of which have moved their ranges yet, so an override is the only way to the patched version without disturbing that chain. Verified applied with `npm ls fast-uri`, which reports it as `overridden` at 3.1.5.

## Removed four dead overrides

`@grpc/grpc-js`, `form-data` and `tmp` were each pinned to a patched version that normal resolution now reaches on its own — the pins were holding versions npm would pick anyway. `fast-xml-parser` was pinned but is not in the dependency tree at all, and isn't on `main` either, so it was pinning nothing.

Each was tested on its own, restoring the others in between, against both `npm audit` and `snyk test`. Anything still load-bearing would have shown up.

## Overrides kept, and why

<details>
<summary>Five overrides survived the same test — details of what each is still holding back</summary>

- **`@apidevtools/json-schema-ref-parser` 15.3.6** — without it, Snyk flags `SNYK-JS-APIDEVTOOLSJSONSCHEMAREFPARSER-17937352` at both 11.9.3 and 14.0.1.
- **`glob` 11.1.0** — without it the tree falls back to glob 7.x, which drags in `inflight` and its known memory leak.
- **`uuid` 14.0.0** — without it, `npm audit` flags uuid alongside exceljs, and Snyk flags `SNYK-JS-UUID-16133035` at 8.3.2.
- **`joi` 18.2.1** — this one isn't a security pin at all. Removing it makes the tree unresolvable: `hapi-swagger@17.3.2` declares a peer dependency on `joi@17.x` and `npm install` fails with `ERESOLVE`. It is what makes the dependency graph install.
- **`@apidevtools/swagger-parser` 12.1.0** — neither scanner flags anything when this is removed on its own, so by the mechanical test it looks stale. It is kept deliberately, because it is one half of a coupled pair. Dropping it alone lets `@apidevtools/swagger-parser` fall to 10.0.3, which asks for `@apidevtools/json-schema-ref-parser@^9.0.6` while the override above still forces 15.3.6 — a nine-major jump that also crosses a CJS to ESM boundary (15.3.6 is `"type": "module"`, 9.1.2 is CommonJS). Dropping both instead brings the ref-parser advisory straight back at 9.1.2 and 11.9.3. Happy to take the mechanical result and remove it if reviewers would rather.

</details>

## `.npmrc`

`min-release-age` raised from 3 to 7, matching the CDP node template. This is the supply-chain cooldown: npm refuses to resolve a package published inside the window, giving a week for a package takeover or typosquat to surface before it can reach us.

The setting gates *resolution* only, not installation, so `npm ci` from the committed lockfile is unaffected and CI behaves exactly as before. This branch is a useful demonstration: `fast-uri@3.1.5` was published three days ago and so sits inside the new seven-day window, yet installs without complaint from the pinned lockfile. Confirmed with a clean `npm ci`.

## One finding left open

`unzipper` carries `SNYK-JS-UNZIPPER-18365659`, a medium-severity Zip Slip, at 0.12.5 as a direct dependency and at 0.10.14 via exceljs. 0.12.5 is the newest version published and Snyk reports no fixed version, so there is nothing to upgrade to. No ignore has been added — leaving it visible seems better than suppressing a live finding that has no fix.

Held-back packages are untouched: `lint-staged` still resolves to 17.1.0, and `gitleaks` and `cssnano` do not appear in this repo's tree.


[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ