### PR TITLE
PAE-1779: Remove the dead waste-record versions property

### DIFF
--- a/src/application/summary-logs/validations/data-business.test.js
+++ b/src/application/summary-logs/validations/data-business.test.js
@@ -30,8 +30,7 @@ describe('validateDataBusiness', () => {
             ROW_ID: rowId,
             DATE_RECEIVED_FOR_REPROCESSING: '2024-01-15',
             GROSS_WEIGHT: 100
-          },
-          versions: []
+          }
         },
         issues: []
       })

--- a/src/application/waste-records/transform-from-summary-log.js
+++ b/src/application/waste-records/transform-from-summary-log.js
@@ -95,13 +95,16 @@ const transformTable = (
       wasteRecord.accreditationId = accreditationId
     }
 
-    return {
+    /** @type {ValidatedWasteRecord} */
+    const validatedWasteRecord = {
       record: wasteRecord,
       issues,
       outcome,
       tableName,
       wasteRecordType: tableWasteRecordType
     }
+
+    return validatedWasteRecord
   })
 }
 

--- a/src/application/waste-records/transform-from-summary-log.test.js
+++ b/src/application/waste-records/transform-from-summary-log.test.js
@@ -67,37 +67,6 @@ describe('transformFromSummaryLog', () => {
     expectValidWasteRecord(result[1], 'row-456', '2025-01-16', SECOND_WEIGHT)
   })
 
-  it('transforms rows into records without version history', () => {
-    /** @type {any} */ const parsedData = {
-      meta: {
-        PROCESSING_TYPE: {
-          value: 'REPROCESSOR_INPUT'
-        }
-      },
-      data: {
-        RECEIVED_LOADS_FOR_REPROCESSING: {
-          location: { sheet: 'Sheet1', row: 1, column: 'A' },
-          headers: RECEIVED_LOADS_HEADERS,
-          rows: [
-            createRow(
-              RECEIVED_LOADS_HEADERS,
-              [FIRST_ROW_ID, FIRST_DATE, FIRST_WEIGHT],
-              FIRST_ROW_ID
-            )
-          ]
-        }
-      }
-    }
-
-    const result = transformFromSummaryLog(parsedData, {
-      organisationId: 'org-1',
-      registrationId: 'reg-1'
-    })
-
-    expect(result[0].record).not.toHaveProperty('versions')
-    expect(result[0]).not.toHaveProperty('change')
-  })
-
   it('returns empty array when no RECEIVED_LOADS data present', () => {
     /** @type {any} */ const parsedData = {
       meta: {

--- a/src/domain/waste-records/model.js
+++ b/src/domain/waste-records/model.js
@@ -9,31 +9,6 @@ export const WASTE_RECORD_TYPE = Object.freeze({
  * @typedef {typeof WASTE_RECORD_TYPE[keyof typeof WASTE_RECORD_TYPE]} WasteRecordType
  */
 
-export const VERSION_STATUS = Object.freeze({
-  CREATED: 'created',
-  UPDATED: 'updated',
-  PENDING: 'pending'
-})
-
-/**
- * @typedef {typeof VERSION_STATUS[keyof typeof VERSION_STATUS]} VersionStatus
- */
-
-/**
- * @typedef {Object} SummaryLogReference
- * @property {string} id - Summary log ID
- * @property {string} uri - S3 object URI
- */
-
-/**
- * @typedef {Object} WasteRecordVersion
- * @property {string} id - Version ID
- * @property {string} createdAt - ISO8601 timestamp
- * @property {VersionStatus} status
- * @property {SummaryLogReference} summaryLog - Reference to summary log that created this version
- * @property {Object} data - For 'created' status: all fields required for reporting. For 'updated'/'pending': only changed fields
- */
-
 /**
  * A waste record is keyed by `(organisationId, registrationId, type, rowId)` —
  * `accreditationId` is not part of that key and is never persisted. It is set
@@ -50,5 +25,4 @@ export const VERSION_STATUS = Object.freeze({
  * @property {string} rowId - The waste record row identifier
  * @property {WasteRecordType} type
  * @property {Object} data - Reporting fields only
- * @property {WasteRecordVersion[]} [versions] - Legacy version history, present only on records read from the legacy waste-records collection; absent on freshly transformed records
  */

--- a/src/waste-balances/application/update-via-ledger.test.js
+++ b/src/waste-balances/application/update-via-ledger.test.js
@@ -8,10 +8,7 @@ import { createWasteBalanceService } from './waste-balance-service.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
 import { logger } from '#common/helpers/logging/logger.js'
 import { partialMock } from '#test/type-helpers.js'
-import {
-  WASTE_RECORD_TYPE,
-  VERSION_STATUS
-} from '#domain/waste-records/model.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { CLASSIFICATION_REASON } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 
@@ -83,27 +80,12 @@ const user = {
   role: 'standard_user'
 }
 
-const buildExporterRecord = ({
-  rowId,
-  tonnage,
-  prnIssued = false,
-  versionId = `version-${rowId}`,
-  summaryLogId = 'log-1'
-}) => ({
+const buildExporterRecord = ({ rowId, tonnage, prnIssued = false }) => ({
   organisationId: 'org-1',
   registrationId: 'reg-1',
   accreditationId,
   rowId: String(rowId),
   type: WASTE_RECORD_TYPE.EXPORTED,
-  versions: [
-    {
-      id: versionId,
-      createdAt: '2025-01-20T10:00:00.000Z',
-      status: VERSION_STATUS.CREATED,
-      summaryLog: { id: summaryLogId, uri: 's3://bucket/log' },
-      data: {}
-    }
-  ],
   data: { processingType: 'EXPORTER', tonnage, prnIssued }
 })
 
@@ -172,8 +154,8 @@ describe('performUpdateViaLedger', () => {
 
       await performUpdateViaLedger({
         wasteRecords: [
-          buildExporterRecord({ rowId: '1', tonnage: 100, versionId: 'v-1b' }),
-          buildExporterRecord({ rowId: '2', tonnage: 80, versionId: 'v-2b' }),
+          buildExporterRecord({ rowId: '1', tonnage: 100 }),
+          buildExporterRecord({ rowId: '2', tonnage: 80 }),
           buildExporterRecord({ rowId: '3', tonnage: 20 })
         ],
         accreditation,

--- a/src/waste-balances/application/update-via-ledger.test.js
+++ b/src/waste-balances/application/update-via-ledger.test.js
@@ -55,6 +55,7 @@ vi.mock('#domain/summary-logs/table-schemas/index.js', () => ({
 }))
 
 /** @typedef {import('#domain/organisations/accreditation.js').Accreditation} Accreditation */
+/** @typedef {import('#domain/waste-records/model.js').WasteRecord} WasteRecord */
 
 const accreditationId = 'acc-1'
 
@@ -80,6 +81,10 @@ const user = {
   role: 'standard_user'
 }
 
+/**
+ * @param {{ rowId: string, tonnage: number, prnIssued?: boolean }} args
+ * @returns {WasteRecord}
+ */
 const buildExporterRecord = ({ rowId, tonnage, prnIssued = false }) => ({
   organisationId: 'org-1',
   registrationId: 'reg-1',

--- a/src/waste-balances/application/update-via-ledger.test.js
+++ b/src/waste-balances/application/update-via-ledger.test.js
@@ -89,7 +89,7 @@ const buildExporterRecord = ({ rowId, tonnage, prnIssued = false }) => ({
   organisationId: 'org-1',
   registrationId: 'reg-1',
   accreditationId,
-  rowId: String(rowId),
+  rowId,
   type: WASTE_RECORD_TYPE.EXPORTED,
   data: { processingType: 'EXPORTER', tonnage, prnIssued }
 })

--- a/src/waste-records/application/project-summary-log-row-state.js
+++ b/src/waste-records/application/project-summary-log-row-state.js
@@ -7,13 +7,11 @@ import { coerceStoredTonnages } from './stored-tonnage-coercion.js'
 
 /**
  * Project a waste record into its committed row state: classify it for the
- * waste balance, coerce the stored tonnages to two decimal places, and hold the
- * rowId as a string. These are properties of the row-state value itself, so they
+ * waste balance and coerce the stored tonnages to two decimal places. These are
+ * properties of the row-state value itself, so they
  * live here in the projection rather than at each write site — every path that
- * persists a row state goes through this seam and inherits the shape. The
- * rowId is a row reference, not a number; a string holding matches the insert
- * schema and the forward-write transformer regardless of how the source record
- * stored it. `processingType` names the template the row reports under
+ * persists a row state goes through this seam and inherits the shape.
+ * `processingType` names the template the row reports under
  * rather than describing the load, so it is hoisted to a top-level field
  * alongside the record rather than kept inside the raw `data`; the redundant
  * `ROW_ID` copy is dropped in favour of the top-level
@@ -40,7 +38,6 @@ export const projectSummaryLogRowState = (
   const { ROW_ID: _ROW_ID, processingType, ...data } = classified.data
   return {
     ...classified,
-    rowId: String(classified.rowId),
     processingType,
     data: coerceStoredTonnages(data)
   }

--- a/src/waste-records/application/project-summary-log-row-state.test.js
+++ b/src/waste-records/application/project-summary-log-row-state.test.js
@@ -106,25 +106,6 @@ describe('projectSummaryLogRowState', () => {
     )
   })
 
-  it('coerces a numeric rowId to a string', () => {
-    /** @type {WasteRecord} */
-    const record = {
-      organisationId: 'org-1',
-      registrationId: 'reg-1',
-      rowId: '1000',
-      type: WASTE_RECORD_TYPE.RECEIVED,
-      data: { processingType: 'REPROCESSOR_REGISTERED_ONLY' }
-    }
-
-    const projected = projectSummaryLogRowState(
-      /** @type {any} */ (record),
-      null,
-      overseasSites
-    )
-
-    expect(projected.rowId).toBe('1000')
-  })
-
   it('coerces a copy, leaving the source record data at full precision', () => {
     /** @type {WasteRecord} */
     const record = {

--- a/src/waste-records/application/project-summary-log-row-state.test.js
+++ b/src/waste-records/application/project-summary-log-row-state.test.js
@@ -2,12 +2,15 @@ import { describe, it, expect } from 'vitest'
 
 import { projectSummaryLogRowState } from './project-summary-log-row-state.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+/** @typedef {import('#domain/waste-records/model.js').WasteRecord} WasteRecord */
 import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 
 const overseasSites = /** @type {any} */ (new Map())
 
 describe('projectSummaryLogRowState', () => {
   it('classifies the record and coerces its stored tonnages to two decimal places', () => {
+    /** @type {WasteRecord} */
     const record = {
       organisationId: 'org-1',
       registrationId: 'reg-1',
@@ -41,6 +44,7 @@ describe('projectSummaryLogRowState', () => {
   })
 
   it('hoists processingType to a top-level field, leaving it out of the stored data', () => {
+    /** @type {WasteRecord} */
     const record = {
       organisationId: 'org-1',
       registrationId: 'reg-1',
@@ -59,6 +63,7 @@ describe('projectSummaryLogRowState', () => {
   })
 
   it('drops the redundant ROW_ID key from the stored data', () => {
+    /** @type {WasteRecord} */
     const record = {
       organisationId: 'org-1',
       registrationId: 'reg-1',
@@ -78,6 +83,7 @@ describe('projectSummaryLogRowState', () => {
   })
 
   it('stores a row state that reconciles by construction — NET equals GROSS minus TARE minus PALLET at 2dp', () => {
+    /** @type {WasteRecord} */
     const record = {
       organisationId: 'org-1',
       registrationId: 'reg-1',
@@ -101,10 +107,11 @@ describe('projectSummaryLogRowState', () => {
   })
 
   it('coerces a numeric rowId to a string', () => {
+    /** @type {WasteRecord} */
     const record = {
       organisationId: 'org-1',
       registrationId: 'reg-1',
-      rowId: 1000,
+      rowId: '1000',
       type: WASTE_RECORD_TYPE.RECEIVED,
       data: { processingType: 'REPROCESSOR_REGISTERED_ONLY' }
     }
@@ -119,6 +126,7 @@ describe('projectSummaryLogRowState', () => {
   })
 
   it('coerces a copy, leaving the source record data at full precision', () => {
+    /** @type {WasteRecord} */
     const record = {
       organisationId: 'org-1',
       registrationId: 'reg-1',

--- a/src/waste-records/application/project-summary-log-row-state.test.js
+++ b/src/waste-records/application/project-summary-log-row-state.test.js
@@ -13,7 +13,6 @@ describe('projectSummaryLogRowState', () => {
       registrationId: 'reg-1',
       rowId: '1',
       type: WASTE_RECORD_TYPE.RECEIVED,
-      versions: [],
       data: {
         processingType: 'REPROCESSOR_REGISTERED_ONLY',
         TONNAGE_RECEIVED_FOR_RECYCLING: 1.005,
@@ -47,7 +46,6 @@ describe('projectSummaryLogRowState', () => {
       registrationId: 'reg-1',
       rowId: '1',
       type: WASTE_RECORD_TYPE.RECEIVED,
-      versions: [],
       data: {
         processingType: 'REPROCESSOR_REGISTERED_ONLY',
         supplierName: 'Acme'
@@ -66,7 +64,6 @@ describe('projectSummaryLogRowState', () => {
       registrationId: 'reg-1',
       rowId: '1011',
       type: WASTE_RECORD_TYPE.RECEIVED,
-      versions: [],
       data: {
         processingType: 'REPROCESSOR_REGISTERED_ONLY',
         ROW_ID: 1011,
@@ -86,7 +83,6 @@ describe('projectSummaryLogRowState', () => {
       registrationId: 'reg-1',
       rowId: '3',
       type: WASTE_RECORD_TYPE.RECEIVED,
-      versions: [],
       data: {
         processingType: 'REPROCESSOR_REGISTERED_ONLY',
         GROSS_WEIGHT: 10.004,
@@ -110,7 +106,6 @@ describe('projectSummaryLogRowState', () => {
       registrationId: 'reg-1',
       rowId: 1000,
       type: WASTE_RECORD_TYPE.RECEIVED,
-      versions: [],
       data: { processingType: 'REPROCESSOR_REGISTERED_ONLY' }
     }
 
@@ -129,7 +124,6 @@ describe('projectSummaryLogRowState', () => {
       registrationId: 'reg-1',
       rowId: '2',
       type: WASTE_RECORD_TYPE.RECEIVED,
-      versions: [],
       data: { processingType: 'REPROCESSOR_REGISTERED_ONLY', NET_WEIGHT: 7.536 }
     }
 

--- a/src/waste-records/application/reclassify-waste-record-states.test.js
+++ b/src/waste-records/application/reclassify-waste-record-states.test.js
@@ -158,7 +158,6 @@ const fullPrecisionReceivedRecord = (tonnage) => ({
   registrationId: 'reg-1',
   rowId: '1001',
   type: WASTE_RECORD_TYPE.RECEIVED,
-  versions: [],
   data: {
     processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
     DATE_RECEIVED_FOR_REPROCESSING: '2026-02-01',

--- a/src/waste-records/application/reclassify-waste-record-states.test.js
+++ b/src/waste-records/application/reclassify-waste-record-states.test.js
@@ -7,6 +7,8 @@ import {
 import { projectSummaryLogRowState } from './project-summary-log-row-state.js'
 import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+/** @typedef {import('#domain/waste-records/model.js').WasteRecord} WasteRecord */
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { ORS_VALIDATION_DISABLED } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 import { roundToTwoDecimalPlaces } from '#common/helpers/decimal-utils.js'
@@ -153,6 +155,7 @@ describe('reclassifyWasteRecordStates', () => {
   })
 })
 
+/** @returns {WasteRecord} */
 const fullPrecisionReceivedRecord = (tonnage) => ({
   organisationId: 'org-1',
   registrationId: 'reg-1',

--- a/src/waste-records/application/write-summary-log-row-states.test.js
+++ b/src/waste-records/application/write-summary-log-row-states.test.js
@@ -11,7 +11,6 @@ const buildRegisteredOnlyRecord = ({ rowId, tonnage }) => ({
   registrationId: 'reg-1',
   rowId: String(rowId),
   type: WASTE_RECORD_TYPE.RECEIVED,
-  versions: [],
   data: {
     processingType: 'REPROCESSOR_REGISTERED_ONLY',
     NET_WEIGHT: tonnage
@@ -23,7 +22,6 @@ const buildReceivedRecord = ({ rowId, tonnage }) => ({
   registrationId: 'reg-1',
   rowId: String(rowId),
   type: WASTE_RECORD_TYPE.RECEIVED,
-  versions: [],
   data: {
     processingType: 'REPROCESSOR_REGISTERED_ONLY',
     TONNAGE_RECEIVED_FOR_RECYCLING: tonnage
@@ -35,7 +33,6 @@ const buildIncompleteReprocessorInputRecord = ({ rowId }) => ({
   registrationId: 'reg-1',
   rowId: String(rowId),
   type: WASTE_RECORD_TYPE.RECEIVED,
-  versions: [],
   data: {
     processingType: 'REPROCESSOR_INPUT',
     ROW_ID: String(rowId),

--- a/src/waste-records/application/write-summary-log-row-states.test.js
+++ b/src/waste-records/application/write-summary-log-row-states.test.js
@@ -3,13 +3,19 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { writeSummaryLogRowStates } from './write-summary-log-row-states.js'
 import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+
+/** @typedef {import('#domain/waste-records/model.js').WasteRecord} WasteRecord */
 import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
 import { CLASSIFICATION_REASON } from '#domain/summary-logs/table-schemas/shared/classification-reason.js'
 
+/**
+ * @param {{ rowId: string, tonnage: number }} args
+ * @returns {WasteRecord}
+ */
 const buildRegisteredOnlyRecord = ({ rowId, tonnage }) => ({
   organisationId: 'org-1',
   registrationId: 'reg-1',
-  rowId: String(rowId),
+  rowId,
   type: WASTE_RECORD_TYPE.RECEIVED,
   data: {
     processingType: 'REPROCESSOR_REGISTERED_ONLY',
@@ -17,10 +23,14 @@ const buildRegisteredOnlyRecord = ({ rowId, tonnage }) => ({
   }
 })
 
+/**
+ * @param {{ rowId: string, tonnage: number }} args
+ * @returns {WasteRecord}
+ */
 const buildReceivedRecord = ({ rowId, tonnage }) => ({
   organisationId: 'org-1',
   registrationId: 'reg-1',
-  rowId: String(rowId),
+  rowId,
   type: WASTE_RECORD_TYPE.RECEIVED,
   data: {
     processingType: 'REPROCESSOR_REGISTERED_ONLY',
@@ -28,10 +38,14 @@ const buildReceivedRecord = ({ rowId, tonnage }) => ({
   }
 })
 
+/**
+ * @param {{ rowId: string }} args
+ * @returns {WasteRecord}
+ */
 const buildIncompleteReprocessorInputRecord = ({ rowId }) => ({
   organisationId: 'org-1',
   registrationId: 'reg-1',
-  rowId: String(rowId),
+  rowId,
   type: WASTE_RECORD_TYPE.RECEIVED,
   data: {
     processingType: 'REPROCESSOR_INPUT',
@@ -78,8 +92,8 @@ describe('writeSummaryLogRowStates', () => {
     await writeSummaryLogRowStates({
       summaryLogRowStateRepository,
       wasteRecords: [
-        buildRegisteredOnlyRecord({ rowId: 1, tonnage: 10 }),
-        buildRegisteredOnlyRecord({ rowId: 2, tonnage: 20 })
+        buildRegisteredOnlyRecord({ rowId: '1', tonnage: 10 }),
+        buildRegisteredOnlyRecord({ rowId: '2', tonnage: 20 })
       ],
       accreditation: null,
       ledgerId: registeredOnlyLedgerId,
@@ -110,7 +124,7 @@ describe('writeSummaryLogRowStates', () => {
   it('stores tonnages coerced to two decimal places', async () => {
     await writeSummaryLogRowStates({
       summaryLogRowStateRepository,
-      wasteRecords: [buildReceivedRecord({ rowId: 1, tonnage: 1.005 })],
+      wasteRecords: [buildReceivedRecord({ rowId: '1', tonnage: 1.005 })],
       accreditation: null,
       ledgerId: registeredOnlyLedgerId,
       overseasSites,
@@ -128,7 +142,7 @@ describe('writeSummaryLogRowStates', () => {
   it('stores weight quantities coerced to two decimal places', async () => {
     await writeSummaryLogRowStates({
       summaryLogRowStateRepository,
-      wasteRecords: [buildRegisteredOnlyRecord({ rowId: 1, tonnage: 7.536 })],
+      wasteRecords: [buildRegisteredOnlyRecord({ rowId: '1', tonnage: 7.536 })],
       accreditation: null,
       ledgerId: registeredOnlyLedgerId,
       overseasSites,
@@ -147,9 +161,9 @@ describe('writeSummaryLogRowStates', () => {
     await writeSummaryLogRowStates({
       summaryLogRowStateRepository,
       wasteRecords: [
-        buildReceivedRecord({ rowId: 1, tonnage: 1.005 }),
-        buildReceivedRecord({ rowId: 2, tonnage: 1.005 }),
-        buildReceivedRecord({ rowId: 3, tonnage: 1.005 })
+        buildReceivedRecord({ rowId: '1', tonnage: 1.005 }),
+        buildReceivedRecord({ rowId: '2', tonnage: 1.005 }),
+        buildReceivedRecord({ rowId: '3', tonnage: 1.005 })
       ],
       accreditation: null,
       ledgerId: registeredOnlyLedgerId,
@@ -175,7 +189,7 @@ describe('writeSummaryLogRowStates', () => {
   it('carries the supplied accreditation id onto the ledger', async () => {
     await writeSummaryLogRowStates({
       summaryLogRowStateRepository,
-      wasteRecords: [buildRegisteredOnlyRecord({ rowId: 1, tonnage: 10 })],
+      wasteRecords: [buildRegisteredOnlyRecord({ rowId: '1', tonnage: 10 })],
       accreditation: {
         id: 'acc-1',
         validFrom: '2023-01-01',
@@ -197,7 +211,7 @@ describe('writeSummaryLogRowStates', () => {
   it('stamps the missing field on a row excluded for incomplete data', async () => {
     await writeSummaryLogRowStates({
       summaryLogRowStateRepository,
-      wasteRecords: [buildIncompleteReprocessorInputRecord({ rowId: 1 })],
+      wasteRecords: [buildIncompleteReprocessorInputRecord({ rowId: '1' })],
       accreditation: {
         id: 'acc-1',
         validFrom: '2023-01-01',
@@ -227,7 +241,7 @@ describe('writeSummaryLogRowStates', () => {
     const submit = () =>
       writeSummaryLogRowStates({
         summaryLogRowStateRepository,
-        wasteRecords: [buildRegisteredOnlyRecord({ rowId: 1, tonnage: 10 })],
+        wasteRecords: [buildRegisteredOnlyRecord({ rowId: '1', tonnage: 10 })],
         accreditation: null,
         ledgerId: registeredOnlyLedgerId,
         overseasSites,


### PR DESCRIPTION
Ticket: [PAE-1779](https://eaflood.atlassian.net/browse/PAE-1779)
A waste record could carry a `versions` array — version history stamped on documents read back from the legacy `waste-records` collection. That collection has been dropped in every environment and the repository that read it went earlier, so nothing in the system can produce the field. This removes it, along with the typedefs that existed only to describe it.

## What goes

The property was documented as "present only on records read from the legacy waste-records collection; absent on freshly transformed records" — a description of a state that can no longer occur. `WasteRecordVersion` typed the array, and `VersionStatus`, `VERSION_STATUS` and `SummaryLogReference` typed the fields of `WasteRecordVersion`. None had another reader, so `src/domain/waste-records/model.js` is left holding just `WASTE_RECORD_TYPE`, `WasteRecordType` and `WasteRecord`.

## Establishing the property was actually dead

This repo runs `noImplicitAny: false`, so a clean type-check after a deletion proves nothing — the edge may never have been checked in the first place. Retyping the property as `{string}` before removing it produced 32 errors under `lint:types:tests` and none under `lint:types`, which places every reference in test fixtures and none in production code.

## Making the removal stick

Six test files carried the field as an inert fixture. One test asserted the property was absent from freshly transformed records, so removing the property removes what that test was for.

Deleting a test that guards an invariant is only safe if something else still guards it, and here four fixtures turned out not to. Excess-property checking only reaches fresh object literals, and these built records through a helper or a `const` and passed them onward as variables, so an extra field matched `WasteRecord` structurally and no check fired. Annotating them makes each literal checked where it is written — verified by putting `versions` back and watching all ten fixtures fail.

The deleted test also asserted the transform adds no `change` field, which is a live invariant: `change` belongs to the separate record-changes map that period status builds, not to the transform's output. That wrapper was the inferred return of a `map` callback and equally unchecked, so it is annotated too, moving the guard onto the blocking production type-check.

Typing `rowId` as the string the domain requires surfaced fixtures passing numbers and coercing them. Those callers now pass strings and the coercions go. One test was then left asserting a string against itself under a name that described coercing a number, so it goes too. The projection's string holding of `rowId` is already asserted by the test that drops the redundant numeric `ROW_ID` from the stored data.

<details>
<summary>File-by-file</summary>

| File | Change |
|---|---|
| `src/domain/waste-records/model.js` | Remove `versions`, `WasteRecordVersion`, `VersionStatus`, `VERSION_STATUS`, `SummaryLogReference` |
| `src/application/waste-records/transform-from-summary-log.js` | Annotate the validated-record wrapper so its literal is checked |
| `src/application/waste-records/transform-from-summary-log.test.js` | Remove the test asserting the property's absence |
| `src/waste-balances/application/update-via-ledger.test.js` | Drop the populated `versions` array and the `versionId`/`summaryLogId` parameters that fed it; type the fixture builder |
| `src/waste-records/application/write-summary-log-row-states.test.js` | Remove three inert `versions: []` fixtures; type three builders; string row IDs |
| `src/waste-records/application/project-summary-log-row-state.test.js` | Remove six inert `versions: []` fixtures; type five record literals; remove the row-ID coercion test left asserting a string against itself |
| `src/waste-records/application/reclassify-waste-record-states.test.js` | Remove one inert `versions: []` fixture; type the builder |
| `src/application/summary-logs/validations/data-business.test.js` | Remove one inert `versions: []` fixture |

</details>


[PAE-1779]: https://eaflood.atlassian.net/browse/PAE-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
