### PR TITLE
PAE-1809: allow status-history date edits via the admin JSON editor

### DIFF
--- a/src/domain/organisations/status.js
+++ b/src/domain/organisations/status.js
@@ -75,17 +75,39 @@ export const assertOrgStatusTransitionValid = (fromStatus, toStatus) => {
  */
 
 /**
+ * Widened to plain strings: callers that walk a whole status history hold
+ * entries typed only as strings.
+ * @typedef {(fromStatus: string, toStatus: string) => boolean} StatusTransitionPredicate
+ */
+
+/**
+ * @param {Record<string, string[]>} validTransitions
+ * @returns {StatusTransitionPredicate}
+ */
+const makeIsStatusTransitionValid =
+  (validTransitions) => (fromStatus, toStatus) =>
+    (validTransitions[fromStatus] ?? []).includes(toStatus)
+
+// Exposed for callers that inspect a whole status history rather than a single
+// transition, and so must report every offending pair instead of throwing on
+// the first (the JSON editor's status-history guard, PAE-1809).
+export const isRegistrationStatusTransitionValid = makeIsStatusTransitionValid(
+  VALID_REG_TRANSITIONS
+)
+
+export const isAccreditationStatusTransitionValid = makeIsStatusTransitionValid(
+  VALID_ACC_TRANSITIONS
+)
+
+/**
  * @template {string} S
- * @param {Record<S, S[]>} validTransitions
+ * @param {StatusTransitionPredicate} isStatusTransitionValid
  * @param {'registration' | 'accreditation'} itemKind
  * @returns {StatusTransitionAsserter<S>}
  */
-const makeAssertStatusTransitionValid = (validTransitions, itemKind) => {
+const makeAssertStatusTransitionValid = (isStatusTransitionValid, itemKind) => {
   return (fromStatus, toStatus) => {
-    const allowedTransitions = validTransitions[fromStatus] ?? []
-    const isValid = allowedTransitions.includes(toStatus)
-
-    if (!isValid) {
+    if (!isStatusTransitionValid(fromStatus, toStatus)) {
       throw Boom.badData(
         `Cannot transition ${itemKind} status from ${fromStatus} to ${toStatus}`
       )
@@ -94,7 +116,13 @@ const makeAssertStatusTransitionValid = (validTransitions, itemKind) => {
 }
 
 export const assertRegistrationStatusTransitionValid =
-  makeAssertStatusTransitionValid(VALID_REG_TRANSITIONS, 'registration')
+  makeAssertStatusTransitionValid(
+    isRegistrationStatusTransitionValid,
+    'registration'
+  )
 
 export const assertAccreditationStatusTransitionValid =
-  makeAssertStatusTransitionValid(VALID_ACC_TRANSITIONS, 'accreditation')
+  makeAssertStatusTransitionValid(
+    isAccreditationStatusTransitionValid,
+    'accreditation'
+  )

--- a/src/repositories/organisations/contract/replace.contract.js
+++ b/src/repositories/organisations/contract/replace.contract.js
@@ -121,7 +121,10 @@ export const testReplaceBehaviour = (it) => {
 
         const { accreditationId: _, ...regWithoutLink } =
           organisationAfterInsert.registrations[0]
-        const updatePayload = prepareOrgUpdate(organisation, {
+        // Built from the stored organisation, as a real caller does: untouched
+        // items round-trip their stored statusHistory, which replace() now
+        // persists verbatim rather than discarding (PAE-1809).
+        const updatePayload = prepareOrgUpdate(organisationAfterInsert, {
           accreditations: [accreditationToUpdate],
           registrations: [regWithoutLink]
         })
@@ -533,6 +536,215 @@ export const testReplaceBehaviour = (it) => {
         await expect(
           repository.replace(organisation.id, 1, updatePayload)
         ).rejects.toThrow(/Invalid organisation data: status:.*must be one of/)
+      })
+
+      describe('supplied statusHistory', () => {
+        const CORRECTED_DATE = '2024-03-05T00:00:00.000Z'
+
+        it('persists a registration statusHistory supplied by the caller when the status is unchanged', async () => {
+          const organisation = buildOrganisation()
+          await repository.insert(organisation)
+
+          const registration = organisation.registrations[0]
+          const updatePayload = prepareOrgUpdate(organisation, {
+            registrations: [
+              {
+                ...registration,
+                statusHistory: [
+                  {
+                    status: REGISTRATION_STATUS.CREATED,
+                    updatedAt: CORRECTED_DATE
+                  }
+                ]
+              }
+            ]
+          })
+          await repository.replace(organisation.id, 1, updatePayload)
+
+          const result = await repository.findById(organisation.id, 2)
+          const updatedReg = result.registrations.find(
+            (r) => r.id === registration.id
+          )
+          expect(updatedReg.status).toBe(REGISTRATION_STATUS.CREATED)
+          expect(updatedReg.statusHistory).toHaveLength(1)
+          expect(
+            new Date(updatedReg.statusHistory[0].updatedAt).toISOString()
+          ).toBe(CORRECTED_DATE)
+        })
+
+        it('persists an accreditation statusHistory supplied by the caller when the status is unchanged', async () => {
+          const organisation = buildOrganisation()
+          await repository.insert(organisation)
+
+          const accreditationId = organisation.accreditations[0].id
+          await repository.replace(
+            organisation.id,
+            1,
+            prepareOrgUpdate(organisation, {
+              accreditations: [
+                {
+                  ...organisation.accreditations[0],
+                  status: ACCREDITATION_STATUS.REJECTED
+                }
+              ]
+            })
+          )
+
+          const afterRejection = await repository.findById(organisation.id, 2)
+          const rejectedAcc = afterRejection.accreditations.find(
+            (a) => a.id === accreditationId
+          )
+          const correctedHistory = [
+            rejectedAcc.statusHistory[0],
+            { ...rejectedAcc.statusHistory[1], updatedAt: CORRECTED_DATE }
+          ]
+
+          await repository.replace(
+            organisation.id,
+            2,
+            prepareOrgUpdate(afterRejection, {
+              accreditations: [
+                { ...rejectedAcc, statusHistory: correctedHistory }
+              ]
+            })
+          )
+
+          const result = await repository.findById(organisation.id, 3)
+          const updatedAcc = result.accreditations.find(
+            (a) => a.id === accreditationId
+          )
+          expect(updatedAcc.status).toBe(ACCREDITATION_STATUS.REJECTED)
+          expect(updatedAcc.statusHistory).toHaveLength(2)
+          expect(updatedAcc.statusHistory[0].status).toBe(
+            ACCREDITATION_STATUS.CREATED
+          )
+          expect(
+            new Date(updatedAcc.statusHistory[0].updatedAt).toISOString()
+          ).toBe(new Date(rejectedAcc.statusHistory[0].updatedAt).toISOString())
+          expect(
+            new Date(updatedAcc.statusHistory[1].updatedAt).toISOString()
+          ).toBe(CORRECTED_DATE)
+        })
+
+        it('appends to the stored history and ignores the supplied one when the status also changes', async () => {
+          const organisation = buildOrganisation()
+          await repository.insert(organisation)
+
+          const afterInsert = await repository.findById(organisation.id)
+          const registration = afterInsert.registrations[0]
+          const storedCreatedAt = registration.statusHistory[0].updatedAt
+          const updatePayload = prepareOrgUpdate(organisation, {
+            registrations: [
+              {
+                ...registration,
+                status: REGISTRATION_STATUS.REJECTED,
+                statusHistory: [
+                  {
+                    status: REGISTRATION_STATUS.CREATED,
+                    updatedAt: CORRECTED_DATE
+                  }
+                ]
+              }
+            ]
+          })
+          await repository.replace(organisation.id, 1, updatePayload)
+
+          const result = await repository.findById(organisation.id, 2)
+          const updatedReg = result.registrations.find(
+            (r) => r.id === registration.id
+          )
+          expect(updatedReg.statusHistory).toHaveLength(2)
+          expect(
+            new Date(updatedReg.statusHistory[0].updatedAt).toISOString()
+          ).toBe(new Date(storedCreatedAt).toISOString())
+          expect(updatedReg.statusHistory[1].status).toBe(
+            REGISTRATION_STATUS.REJECTED
+          )
+        })
+
+        it('ignores a statusHistory supplied for a brand new registration and seeds the created history', async () => {
+          const organisation = buildOrganisation()
+          await repository.insert(organisation)
+
+          const replaceStartedAt = new Date()
+          const newRegistration = buildRegistration({
+            statusHistory: [
+              { status: REGISTRATION_STATUS.CREATED, updatedAt: CORRECTED_DATE }
+            ]
+          })
+          const updatePayload = prepareOrgUpdate(organisation, {
+            registrations: [newRegistration]
+          })
+          await repository.replace(organisation.id, 1, updatePayload)
+
+          const result = await repository.findById(organisation.id, 2)
+          const addedReg = result.registrations.find(
+            (r) => r.id === newRegistration.id
+          )
+          expect(addedReg.statusHistory).toHaveLength(1)
+          expect(addedReg.statusHistory[0].status).toBe(
+            REGISTRATION_STATUS.CREATED
+          )
+          expect(
+            new Date(addedReg.statusHistory[0].updatedAt).getTime()
+          ).toBeGreaterThanOrEqual(replaceStartedAt.getTime())
+        })
+
+        it('rejects a supplied registration statusHistory holding a status registrations can never have', async () => {
+          const organisation = buildOrganisation()
+          await repository.insert(organisation)
+
+          const updatePayload = prepareOrgUpdate(organisation, {
+            registrations: [
+              {
+                ...organisation.registrations[0],
+                statusHistory: [
+                  {
+                    status: REGISTRATION_STATUS.CREATED,
+                    updatedAt: CORRECTED_DATE
+                  },
+                  {
+                    status: ACCREDITATION_STATUS.SUSPENDED,
+                    updatedAt: CORRECTED_DATE
+                  }
+                ]
+              }
+            ]
+          })
+
+          await expect(
+            repository.replace(organisation.id, 1, updatePayload)
+          ).rejects.toMatchObject({
+            isBoom: true,
+            output: { statusCode: 422 }
+          })
+        })
+
+        it('rejects a supplied statusHistory whose entries have an invalid shape', async () => {
+          const organisation = buildOrganisation()
+          await repository.insert(organisation)
+
+          const updatePayload = prepareOrgUpdate(organisation, {
+            registrations: [
+              {
+                ...organisation.registrations[0],
+                statusHistory: [
+                  {
+                    status: REGISTRATION_STATUS.CREATED,
+                    updatedAt: 'not-a-date'
+                  }
+                ]
+              }
+            ]
+          })
+
+          await expect(
+            repository.replace(organisation.id, 1, updatePayload)
+          ).rejects.toMatchObject({
+            isBoom: true,
+            output: { statusCode: 422 }
+          })
+        })
       })
     })
 

--- a/src/repositories/organisations/helpers.js
+++ b/src/repositories/organisations/helpers.js
@@ -26,6 +26,12 @@ import { getCurrentStatus } from './status.js'
 /** @import { StatusTransitionAsserter } from '#domain/organisations/status.js' */
 /** @import { FindPageForOverseasSitesAdminListParams } from './port.js' */
 
+/**
+ * A status history entry as it reaches the repository: stored entries carry a
+ * Date, caller-supplied ones an ISO string.
+ * @typedef {{status: string, updatedAt: Date | string}} StatusHistoryEntryInput
+ */
+
 export const createStatusHistoryEntry = (status) => ({
   status,
   updatedAt: new Date()
@@ -36,6 +42,20 @@ export const createInitialStatusHistory = () => {
   return validateStatusHistory(statusHistory)
 }
 
+/**
+ * Derives the statusHistory to persist for an item.
+ *
+ * A status change always appends to the stored history — a caller-supplied
+ * history is ignored in that case, so the recorded transition is the server's.
+ * Without a status change a supplied history is honoured (PAE-1809: admins
+ * correcting updatedAt dates); a new item is always seeded fresh. Only the
+ * registration and accreditation update schemas carry a statusHistory key, so
+ * the organisation-level call site never supplies one.
+ *
+ * @param {{ status?: string, statusHistory?: StatusHistoryEntryInput[] }} updatedItem
+ * @param {{ statusHistory: StatusHistoryEntryInput[] } | null | undefined} existingItem
+ * @returns {Array<{status: string, updatedAt: Date}>}
+ */
 export const statusHistoryWithChanges = (updatedItem, existingItem) => {
   let statusHistory = createInitialStatusHistory()
   if (existingItem) {
@@ -48,7 +68,7 @@ export const statusHistoryWithChanges = (updatedItem, existingItem) => {
         createStatusHistoryEntry(updatedItem.status)
       ]
     } else {
-      statusHistory = existingItem.statusHistory
+      statusHistory = updatedItem.statusHistory ?? existingItem.statusHistory
     }
   }
   return validateStatusHistory(statusHistory)
@@ -56,8 +76,8 @@ export const statusHistoryWithChanges = (updatedItem, existingItem) => {
 
 /**
  * @template {string} S
- * @param {Array<{ id: string, status: S }>} existingItems
- * @param {Array<{ id: string, status?: S }>} itemUpdates
+ * @param {Array<{ id: string, status: S, statusHistory: StatusHistoryEntryInput[] }>} existingItems
+ * @param {Array<{ id: string, status?: S, statusHistory?: StatusHistoryEntryInput[] }>} itemUpdates
  * @param {StatusTransitionAsserter<S>} assertStatusTransitionValid
  * @param {Set<string>} [systemAppliedItemIds] - items whose status change was
  *   applied by the system (the registration-cancellation cascade), exempt from

--- a/src/repositories/organisations/port.js
+++ b/src/repositories/organisations/port.js
@@ -52,6 +52,11 @@
 /**
  * Organisation replacement payload with identity fields removed.
  * Identity (id, version) is passed as separate parameters to replace().
+ *
+ * Organisation-level statusHistory is server-owned and is omitted here, but the
+ * Registration and Accreditation item types carry their own statusHistory and
+ * replace() honours it for an existing item whose status is unchanged
+ * (PAE-1809 — admins correcting updatedAt dates).
  * @typedef {Partial<Omit<Organisation, 'id'|'version'|'statusHistory'>>} OrganisationReplacement
  */
 

--- a/src/repositories/organisations/schema/accreditation.js
+++ b/src/repositories/organisations/schema/accreditation.js
@@ -8,6 +8,7 @@ import {
   WASTE_PROCESSING_TYPE
 } from '#domain/organisations/model.js'
 import {
+  accreditationStatusHistoryItemSchema,
   formFileUploadSchema,
   formSubmissionSchema,
   idSchema,
@@ -104,7 +105,12 @@ export const accreditationSchema = Joi.object({
   )
 })
 
-export const accreditationUpdateSchema = accreditationSchema.fork(
-  ['status'],
-  (schema) => schema.optional()
-)
+// See registrationUpdateSchema — statusHistory is accepted so admins can
+// correct the updatedAt dates of an existing accreditation (PAE-1809).
+export const accreditationUpdateSchema = accreditationSchema
+  .fork(['status'], (schema) => schema.optional())
+  .keys({
+    statusHistory: Joi.array()
+      .items(accreditationStatusHistoryItemSchema)
+      .optional()
+  })

--- a/src/repositories/organisations/schema/organisation-json-schema-overrides.js
+++ b/src/repositories/organisations/schema/organisation-json-schema-overrides.js
@@ -91,27 +91,45 @@ export const makeEditable = (schema) => {
   return editableSchema
 }
 
+/**
+ * A status history entry is editable only in its updatedAt date (PAE-1809);
+ * the status and updatedBy are frozen so the editor blocks them client-side.
+ *
+ * Entries deliberately bypass makeEditable: it makes every key it touches
+ * optional and nullable, which would drop updatedAt from the entry's required
+ * list — and an entry without a date is not an entry.
+ * @param {Joi.ObjectSchema} entrySchema
+ * @returns {Joi.ArraySchema}
+ */
+const editableStatusHistory = (entrySchema) =>
+  Joi.array()
+    .items(
+      entrySchema
+        .fork(['status'], (schema) => schema.meta({ readOnly: true }))
+        .fork(['updatedBy'], (schema) => schema.meta({ readOnly: true }))
+    )
+    .optional()
+
+// statusHistory is injected after makeEditable rather than merged into the
+// update schemas beforehand, which keeps the generated output the same whether
+// or not those schemas carry a statusHistory key of their own.
 export const organisationJSONSchemaOverrides = organisationReplaceSchema.keys({
   registrations: Joi.array()
     .items(
-      makeEditable(
-        registrationUpdateSchema.keys({
-          statusHistory: Joi.array()
-            .items(registrationStatusHistoryItemSchema)
-            .optional()
-        })
-      )
+      makeEditable(registrationUpdateSchema).keys({
+        statusHistory: editableStatusHistory(
+          registrationStatusHistoryItemSchema
+        )
+      })
     )
     .default([]),
   accreditations: Joi.array()
     .items(
-      makeEditable(
-        accreditationUpdateSchema.keys({
-          statusHistory: Joi.array()
-            .items(accreditationStatusHistoryItemSchema)
-            .optional()
-        })
-      )
+      makeEditable(accreditationUpdateSchema).keys({
+        statusHistory: editableStatusHistory(
+          accreditationStatusHistoryItemSchema
+        )
+      })
     )
     .default([])
 })

--- a/src/repositories/organisations/schema/organisation-json-schema-overrides.js
+++ b/src/repositories/organisations/schema/organisation-json-schema-overrides.js
@@ -92,21 +92,23 @@ export const makeEditable = (schema) => {
 }
 
 /**
- * A status history entry is editable only in its updatedAt date (PAE-1809);
- * the status and updatedBy are frozen so the editor blocks them client-side.
+ * A status history entry is editable in its status and updatedAt date
+ * (PAE-1809); updatedBy is frozen so the editor blocks it client-side. The
+ * route guard enforces the rest server-side: fixed entry count, created first,
+ * ascending dates, valid transitions.
  *
  * Entries deliberately bypass makeEditable: it makes every key it touches
- * optional and nullable, which would drop updatedAt from the entry's required
- * list — and an entry without a date is not an entry.
+ * optional and nullable, which would drop status and updatedAt from the
+ * entry's required list — and an entry without either is not an entry.
  * @param {Joi.ObjectSchema} entrySchema
  * @returns {Joi.ArraySchema}
  */
 const editableStatusHistory = (entrySchema) =>
   Joi.array()
     .items(
-      entrySchema
-        .fork(['status'], (schema) => schema.meta({ readOnly: true }))
-        .fork(['updatedBy'], (schema) => schema.meta({ readOnly: true }))
+      entrySchema.fork(['updatedBy'], (schema) =>
+        schema.meta({ readOnly: true })
+      )
     )
     .optional()
 

--- a/src/repositories/organisations/schema/organisation-json-schema-overrides.test.js
+++ b/src/repositories/organisations/schema/organisation-json-schema-overrides.test.js
@@ -204,13 +204,11 @@ describe('status history in the JSON editor schema (PAE-1809)', () => {
   )
 
   it.each(collections)(
-    'freezes status and updatedBy on every %s status history entry',
+    'freezes updatedBy but leaves status editable on every %s status history entry',
     (collection) => {
       const entry = entryOf(collection)
 
-      expect(entry.keys.status.metas).toEqual(
-        expect.arrayContaining([{ readOnly: true }])
-      )
+      expect(entry.keys.status.metas).toBeUndefined()
       expect(entry.keys.updatedBy.metas).toEqual(
         expect.arrayContaining([{ readOnly: true }])
       )

--- a/src/repositories/organisations/schema/organisation-json-schema-overrides.test.js
+++ b/src/repositories/organisations/schema/organisation-json-schema-overrides.test.js
@@ -186,3 +186,46 @@ describe('status keys in the JSON editor schema (PAE-1645)', () => {
     )
   })
 })
+
+describe('status history in the JSON editor schema (PAE-1809)', () => {
+  const collections = ['registrations', 'accreditations']
+
+  const statusHistoryOf = (collection) =>
+    organisationJSONSchemaOverrides.describe().keys[collection].items[0].keys
+      .statusHistory
+
+  const entryOf = (collection) => statusHistoryOf(collection).items[0]
+
+  it.each(collections)(
+    'leaves the %s status history editable',
+    (collection) => {
+      expect(statusHistoryOf(collection).metas).toBeUndefined()
+    }
+  )
+
+  it.each(collections)(
+    'freezes status and updatedBy on every %s status history entry',
+    (collection) => {
+      const entry = entryOf(collection)
+
+      expect(entry.keys.status.metas).toEqual(
+        expect.arrayContaining([{ readOnly: true }])
+      )
+      expect(entry.keys.updatedBy.metas).toEqual(
+        expect.arrayContaining([{ readOnly: true }])
+      )
+    }
+  )
+
+  it.each(collections)(
+    'keeps updatedAt an editable, required ISO date on every %s status history entry',
+    (collection) => {
+      const entry = entryOf(collection)
+
+      expect(entry.keys.updatedAt.metas).toBeUndefined()
+      expect(entry.keys.updatedAt.flags.presence).toBe('required')
+      expect(entry.keys.updatedAt.flags.format).toBe('iso')
+      expect(entry.keys.status.flags.presence).toBe('required')
+    }
+  )
+})

--- a/src/repositories/organisations/schema/registration.js
+++ b/src/repositories/organisations/schema/registration.js
@@ -13,6 +13,7 @@ import {
   formSubmissionSchema,
   idSchema,
   makeReprocessingTypeSchema,
+  registrationStatusHistoryItemSchema,
   userSchema
 } from './base.js'
 import { wasteManagementPermitSchema } from './waste-permits.js'
@@ -162,7 +163,15 @@ export const registrationSchema = Joi.object({
   })
 })
 
-export const registrationUpdateSchema = registrationSchema.fork(
-  ['status'],
-  (schema) => schema.optional()
-)
+// statusHistory is accepted so admins can correct the updatedAt dates of an
+// existing registration (PAE-1809). Anything the repository will not honour —
+// a history on a new registration, or one sent alongside a status change — is
+// discarded downstream by statusHistoryWithChanges, and the public route guards
+// it before it ever gets here.
+export const registrationUpdateSchema = registrationSchema
+  .fork(['status'], (schema) => schema.optional())
+  .keys({
+    statusHistory: Joi.array()
+      .items(registrationStatusHistoryItemSchema)
+      .optional()
+  })

--- a/src/routes/v1/dev/organisations/put-by-id.test.js
+++ b/src/routes/v1/dev/organisations/put-by-id.test.js
@@ -99,5 +99,74 @@ describe('PUT /v1/dev/organisations/{id}', () => {
         'approved'
       )
     })
+
+    it('seeds a registration statusHistory with custom dates when the status is unchanged (PAE-1809)', async () => {
+      const getResponse = await server.inject({
+        method: 'GET',
+        url: `/v1/organisations/${fixture.id}`,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+      const org = JSON.parse(getResponse.payload)
+      const registration = org.registrations[0]
+
+      const updateFragment = {
+        ...org,
+        registrations: [
+          {
+            ...registration,
+            statusHistory: [
+              { status: 'created', updatedAt: '2025-06-30T00:00:00.000Z' }
+            ]
+          }
+        ]
+      }
+
+      const response = await server.inject({
+        method: 'PUT',
+        url: `/v1/dev/organisations/${org.id}`,
+        payload: { version: Number(org.version), updateFragment }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const updatedRegistration = JSON.parse(response.payload).registrations[0]
+      expect(updatedRegistration.status).toBe('created')
+      expect(updatedRegistration.statusHistory).toEqual([
+        { status: 'created', updatedAt: '2025-06-30T00:00:00.000Z' }
+      ])
+    })
+
+    it('seeds an extra statusHistory entry — the structure change the public route refuses (PAE-1809)', async () => {
+      const getResponse = await server.inject({
+        method: 'GET',
+        url: `/v1/organisations/${fixture.id}`,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+      const org = JSON.parse(getResponse.payload)
+      const registration = org.registrations[0]
+
+      const updateFragment = {
+        ...org,
+        registrations: [
+          {
+            ...registration,
+            statusHistory: [
+              { status: 'created', updatedAt: '2025-06-30T00:00:00.000Z' },
+              { status: 'approved', updatedAt: '2025-07-01T00:00:00.000Z' }
+            ]
+          }
+        ]
+      }
+
+      const response = await server.inject({
+        method: 'PUT',
+        url: `/v1/dev/organisations/${org.id}`,
+        payload: { version: Number(org.version), updateFragment }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(response.payload).registrations[0].status).toBe(
+        'approved'
+      )
+    })
   })
 })

--- a/src/routes/v1/organisations/put-by-id.js
+++ b/src/routes/v1/organisations/put-by-id.js
@@ -2,7 +2,10 @@ import { SCOPES } from '#common/helpers/auth/constants.js'
 import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
 import { auditOrganisationUpdate } from '#root/auditing/organisations.js'
-import { ACCREDITATION_STATUS } from '#domain/organisations/model.js'
+import {
+  ACCREDITATION_STATUS,
+  REGISTRATION_STATUS
+} from '#domain/organisations/model.js'
 import {
   isAccreditationStatusTransitionValid,
   isRegistrationStatusTransitionValid
@@ -139,10 +142,12 @@ const toTimestamp = (updatedAt) => new Date(updatedAt).getTime()
 /**
  * @param {StatusHistoryEntry} incoming
  * @param {StatusHistoryEntry} stored
- * @returns {boolean} true when the entry's frozen fields are untouched
+ * @returns {boolean}
  */
-const hasSameFrozenFields = (incoming, stored) =>
-  incoming.status === stored.status && incoming.updatedBy === stored.updatedBy
+const isSameEntry = (incoming, stored) =>
+  incoming.status === stored.status &&
+  incoming.updatedBy === stored.updatedBy &&
+  toTimestamp(incoming.updatedAt) === toTimestamp(stored.updatedAt)
 
 /**
  * @param {StatusHistoryEntry[]} incoming
@@ -151,20 +156,15 @@ const hasSameFrozenFields = (incoming, stored) =>
  */
 const isUnchangedHistory = (incoming, stored) =>
   incoming.length === stored.length &&
-  incoming.every(
-    (entry, index) =>
-      hasSameFrozenFields(entry, stored[index]) &&
-      toTimestamp(entry.updatedAt) === toTimestamp(stored[index].updatedAt)
-  )
+  incoming.every((entry, index) => isSameEntry(entry, stored[index]))
 
 /**
  * @param {StatusHistoryEntry[]} incoming
- * @param {StatusHistoryEntry[]} stored
+ * @param {StatusHistoryEntry[]} stored - same length as incoming (checked first)
  * @returns {boolean}
  */
-const hasFrozenStructure = (incoming, stored) =>
-  incoming.length === stored.length &&
-  incoming.every((entry, index) => hasSameFrozenFields(entry, stored[index]))
+const hasSameUpdatedBy = (incoming, stored) =>
+  incoming.every((entry, index) => entry.updatedBy === stored[index].updatedBy)
 
 /**
  * @param {StatusHistoryEntry[]} history
@@ -228,8 +228,16 @@ const findStatusHistoryViolation = (
     return null
   }
 
-  if (!hasFrozenStructure(incoming, stored)) {
-    return `${label} ${id} status history can only change updatedAt dates — statuses and structure are fixed`
+  if (incoming.length !== stored.length) {
+    return `${label} ${id} status history entries cannot be added or removed`
+  }
+
+  if (!hasSameUpdatedBy(incoming, stored)) {
+    return `${label} ${id} status history updatedBy cannot be changed`
+  }
+
+  if (incoming[0].status !== REGISTRATION_STATUS.CREATED) {
+    return `${label} ${id} status history must start with created`
   }
 
   if (!isStrictlyAscending(incoming)) {
@@ -285,10 +293,14 @@ const collectStatusHistoryErrors = (
 }
 
 /**
- * A registration or accreditation status history may only have its updatedAt
- * dates corrected through this endpoint (PAE-1809): the statuses, the entries
- * and their order are fixed, corrected dates must stay strictly ascending, and
- * the resulting sequence must still be a walk of the domain transition table.
+ * A registration or accreditation status history may have its entry statuses
+ * and updatedAt dates corrected through this endpoint (PAE-1809). Entries
+ * cannot be added, removed or reattributed, the history must still start at
+ * created, corrected dates must stay strictly ascending, and the resulting
+ * sequence must be a walk of the domain transition table. Correcting the last
+ * entry changes the item's derived status directly — deliberately, per the
+ * ticket — without the dedicated transition endpoints' side effects (no
+ * cascade cancel, no grant fields, no approval-uniqueness check).
  *
  * @param {Organisation} initial - the stored organisation (findById throws 404 when the id is unknown)
  * @param {OrganisationReplacement} updates

--- a/src/routes/v1/organisations/put-by-id.js
+++ b/src/routes/v1/organisations/put-by-id.js
@@ -186,7 +186,10 @@ const findInvalidTransition = (history, isValidTransition) => {
   for (let index = 1; index < history.length; index++) {
     const from = history[index - 1].status
     const to = history[index].status
-    if (!isValidTransition(from, to)) {
+    // A repeated status is not a transition — the domain skips validation for
+    // same-status updates, and correcting an entry to match its neighbour
+    // (e.g. neutralising a wrongly recorded suspension) must be allowed.
+    if (from !== to && !isValidTransition(from, to)) {
       return { from, to }
     }
   }

--- a/src/routes/v1/organisations/put-by-id.js
+++ b/src/routes/v1/organisations/put-by-id.js
@@ -2,8 +2,18 @@ import { SCOPES } from '#common/helpers/auth/constants.js'
 import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
 import { auditOrganisationUpdate } from '#root/auditing/organisations.js'
+import { ACCREDITATION_STATUS } from '#domain/organisations/model.js'
+import {
+  isAccreditationStatusTransitionValid,
+  isRegistrationStatusTransitionValid
+} from '#domain/organisations/status.js'
 
 /** @import { Organisation } from '#domain/organisations/model.js' */
+/** @import { StatusTransitionPredicate } from '#domain/organisations/status.js' */
+
+/**
+ * @typedef {{status: string, updatedAt: Date | string, updatedBy?: string}} StatusHistoryEntry
+ */
 
 /** @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository */
 /** @typedef {import('#repositories/organisations/port.js').OrganisationReplacement} OrganisationReplacement */
@@ -119,11 +129,198 @@ const validateStatusesUnchanged = (initial, updates) => {
 }
 
 /**
- * Builds the PUT handler. The public route enforces the PAE-1645 status
- * immutability guard and audits the change; the non-prod dev seeding route
- * (`/v1/dev/organisations/{id}`) skips both — journey-test fixtures use it
- * to seed statuses and numbers directly, and it is unauthenticated so there
- * is no actor to audit.
+ * Incoming dates arrive as ISO strings from the editor round-trip while stored
+ * ones are Dates, so entries are only ever compared by timestamp.
+ * @param {Date | string} updatedAt
+ * @returns {number}
+ */
+const toTimestamp = (updatedAt) => new Date(updatedAt).getTime()
+
+/**
+ * @param {StatusHistoryEntry} incoming
+ * @param {StatusHistoryEntry} stored
+ * @returns {boolean} true when the entry's frozen fields are untouched
+ */
+const hasSameFrozenFields = (incoming, stored) =>
+  incoming.status === stored.status && incoming.updatedBy === stored.updatedBy
+
+/**
+ * @param {StatusHistoryEntry[]} incoming
+ * @param {StatusHistoryEntry[]} stored
+ * @returns {boolean}
+ */
+const isUnchangedHistory = (incoming, stored) =>
+  incoming.length === stored.length &&
+  incoming.every(
+    (entry, index) =>
+      hasSameFrozenFields(entry, stored[index]) &&
+      toTimestamp(entry.updatedAt) === toTimestamp(stored[index].updatedAt)
+  )
+
+/**
+ * @param {StatusHistoryEntry[]} incoming
+ * @param {StatusHistoryEntry[]} stored
+ * @returns {boolean}
+ */
+const hasFrozenStructure = (incoming, stored) =>
+  incoming.length === stored.length &&
+  incoming.every((entry, index) => hasSameFrozenFields(entry, stored[index]))
+
+/**
+ * @param {StatusHistoryEntry[]} history
+ * @returns {boolean}
+ */
+const isStrictlyAscending = (history) =>
+  history.every(
+    (entry, index) =>
+      index === 0 ||
+      toTimestamp(history[index - 1].updatedAt) < toTimestamp(entry.updatedAt)
+  )
+
+/**
+ * @param {StatusHistoryEntry[]} history
+ * @param {StatusTransitionPredicate} isValidTransition
+ * @returns {{from: string, to: string} | null} the first adjacent pair the transition table rejects
+ */
+const findInvalidTransition = (history, isValidTransition) => {
+  for (let index = 1; index < history.length; index++) {
+    const from = history[index - 1].status
+    const to = history[index].status
+    if (!isValidTransition(from, to)) {
+      return { from, to }
+    }
+  }
+  return null
+}
+
+/**
+ * Cancelling a registration force-cancels its linked accreditation, an edge the
+ * accreditation transition table deliberately omits for user-driven changes.
+ * Such a history is stored data an admin must still be able to redate.
+ * @param {string} fromStatus
+ * @param {string} toStatus
+ * @returns {boolean}
+ */
+const isValidAccreditationHistoryTransition = (fromStatus, toStatus) =>
+  isAccreditationStatusTransitionValid(fromStatus, toStatus) ||
+  (fromStatus === ACCREDITATION_STATUS.APPROVED &&
+    toStatus === ACCREDITATION_STATUS.CANCELLED)
+
+/**
+ * @param {string} label - 'Registration' or 'Accreditation', used in error messages
+ * @param {string | undefined} id
+ * @param {StatusHistoryEntry[]} incoming
+ * @param {StatusHistoryEntry[]} stored
+ * @param {StatusTransitionPredicate} isValidTransition
+ * @returns {string | null} the clause for the first rule the edit breaks, or null when it is allowed
+ */
+const findStatusHistoryViolation = (
+  label,
+  id,
+  incoming,
+  stored,
+  isValidTransition
+) => {
+  // An unchanged echo skips every check. The editor round-trips the whole
+  // document, so an organisation whose stored history already breaks the rules
+  // would otherwise 422 on every save, including edits to unrelated fields.
+  if (isUnchangedHistory(incoming, stored)) {
+    return null
+  }
+
+  if (!hasFrozenStructure(incoming, stored)) {
+    return `${label} ${id} status history can only change updatedAt dates — statuses and structure are fixed`
+  }
+
+  if (!isStrictlyAscending(incoming)) {
+    return `${label} ${id} status history dates must be in date order`
+  }
+
+  const invalidTransition = findInvalidTransition(incoming, isValidTransition)
+  if (invalidTransition) {
+    return `${label} ${id} status history contains an invalid transition from ${invalidTransition.from} to ${invalidTransition.to}`
+  }
+
+  return null
+}
+
+/**
+ * @param {string} label - 'Registration' or 'Accreditation', used in error messages
+ * @param {Array<{id: string, statusHistory: StatusHistoryEntry[]}>} existingItems - items from the stored document
+ * @param {Array<{id?: string, statusHistory?: StatusHistoryEntry[]}> | undefined} itemUpdates - items from the incoming update fragment
+ * @param {StatusTransitionPredicate} isValidTransition
+ * @returns {string[]} one error clause per offending item
+ */
+const collectStatusHistoryErrors = (
+  label,
+  existingItems,
+  itemUpdates,
+  isValidTransition
+) => {
+  /** @type {Map<string | undefined, {id: string, statusHistory: StatusHistoryEntry[]}>} */
+  const existingById = new Map(existingItems.map((item) => [item.id, item]))
+
+  const errors = []
+  for (const item of itemUpdates ?? []) {
+    if (!item.statusHistory) {
+      continue
+    }
+
+    const existing = existingById.get(item.id)
+    const violation = existing
+      ? findStatusHistoryViolation(
+          label,
+          item.id,
+          item.statusHistory,
+          existing.statusHistory,
+          isValidTransition
+        )
+      : `${label} ${item.id} status history cannot be set on new items`
+
+    if (violation) {
+      errors.push(violation)
+    }
+  }
+  return errors
+}
+
+/**
+ * A registration or accreditation status history may only have its updatedAt
+ * dates corrected through this endpoint (PAE-1809): the statuses, the entries
+ * and their order are fixed, corrected dates must stay strictly ascending, and
+ * the resulting sequence must still be a walk of the domain transition table.
+ *
+ * @param {Organisation} initial - the stored organisation (findById throws 404 when the id is unknown)
+ * @param {OrganisationReplacement} updates
+ * @throws {Boom.Boom} 422 with one clause per offending item, joined by '; '
+ */
+const validateStatusHistoryEdits = (initial, updates) => {
+  const errors = [
+    ...collectStatusHistoryErrors(
+      'Registration',
+      initial.registrations,
+      updates.registrations,
+      isRegistrationStatusTransitionValid
+    ),
+    ...collectStatusHistoryErrors(
+      'Accreditation',
+      initial.accreditations,
+      updates.accreditations,
+      isValidAccreditationHistoryTransition
+    )
+  ]
+
+  if (errors.length > 0) {
+    throw Boom.badData(errors.join('; '))
+  }
+}
+
+/**
+ * Builds the PUT handler. The public route enforces the status immutability
+ * and status-history guards and audits the change; the non-prod dev seeding
+ * route (`/v1/dev/organisations/{id}`) skips them all — journey-test fixtures
+ * use it to seed statuses, numbers and status histories directly, and it is
+ * unauthenticated so there is no actor to audit.
  * @param {{ devSeeding?: boolean }} [options]
  */
 export const makePutOrganisationHandler =
@@ -156,6 +353,7 @@ export const makePutOrganisationHandler =
     const initial = await organisationsRepository.findById(id)
     if (!devSeeding) {
       validateStatusesUnchanged(initial, updates)
+      validateStatusHistoryEdits(initial, updates)
     }
 
     await validateOverseasSiteReferences(

--- a/src/routes/v1/organisations/put-by-id.test.js
+++ b/src/routes/v1/organisations/put-by-id.test.js
@@ -1108,6 +1108,65 @@ describe('PUT /v1/organisations/{id} status history guard', () => {
     expect(systemLogs[0].context.organisationId).toBe(org.id)
   })
 
+  it('accepts a corrected status when the resulting sequence is valid', async () => {
+    const { server, org } = await seed({
+      accreditationHistory: SUSPENSION_HISTORY
+    })
+    const accreditation = org.accreditations[0]
+    const [created, approved, suspended] = accreditation.statusHistory
+
+    const response = await putOrganisation(
+      server,
+      org,
+      prepareOrgUpdate(org, {
+        accreditations: [
+          withHistory(accreditation, [
+            created,
+            approved,
+            { ...suspended, status: 'cancelled' }
+          ])
+        ]
+      })
+    )
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const reloaded = await getOrganisation(server, org.id)
+    expect(reloaded.accreditations[0].status).toBe('cancelled')
+    expect(
+      reloaded.accreditations[0].statusHistory.map((entry) => entry.status)
+    ).toEqual(['created', 'approved', 'cancelled'])
+  })
+
+  it('accepts a corrected registration status and derives the new current status', async () => {
+    const { server, org } = await seed({
+      registrationHistory: [
+        { status: 'created', updatedAt: CREATED_AT },
+        { status: 'approved', updatedAt: APPROVED_AT }
+      ]
+    })
+    const registration = org.registrations[0]
+    const [created, approved] = registration.statusHistory
+
+    const response = await putOrganisation(
+      server,
+      org,
+      prepareOrgUpdate(org, {
+        registrations: [
+          withHistory(registration, [
+            created,
+            { ...approved, status: 'rejected' }
+          ])
+        ]
+      })
+    )
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const reloaded = await getOrganisation(server, org.id)
+    expect(reloaded.registrations[0].status).toBe('rejected')
+  })
+
   it('accepts an unchanged echo of every status history', async () => {
     const { server, org } = await seed({
       accreditationHistory: SUSPENSION_HISTORY,
@@ -1216,8 +1275,8 @@ describe('PUT /v1/organisations/{id} status history guard', () => {
   })
 
   describe('rejected edits', () => {
-    const FROZEN_STRUCTURE_CLAUSE = (label, id) =>
-      `${label} ${id} status history can only change updatedAt dates — statuses and structure are fixed`
+    const ENTRIES_FIXED_CLAUSE = (label, id) =>
+      `${label} ${id} status history entries cannot be added or removed`
 
     it('returns 422 when an entry is added', async () => {
       const { server, org } = await seed({
@@ -1240,7 +1299,7 @@ describe('PUT /v1/organisations/{id} status history guard', () => {
 
       expectClause(
         response,
-        FROZEN_STRUCTURE_CLAUSE('Accreditation', accreditation.id)
+        ENTRIES_FIXED_CLAUSE('Accreditation', accreditation.id)
       )
     })
 
@@ -1262,11 +1321,11 @@ describe('PUT /v1/organisations/{id} status history guard', () => {
 
       expectClause(
         response,
-        FROZEN_STRUCTURE_CLAUSE('Accreditation', accreditation.id)
+        ENTRIES_FIXED_CLAUSE('Accreditation', accreditation.id)
       )
     })
 
-    it('returns 422 when a status value is changed', async () => {
+    it('returns 422 when a changed status breaks the transition sequence', async () => {
       const { server, org } = await seed({
         accreditationHistory: SUSPENSION_HISTORY
       })
@@ -1280,8 +1339,8 @@ describe('PUT /v1/organisations/{id} status history guard', () => {
           accreditations: [
             withHistory(accreditation, [
               created,
-              approved,
-              { ...suspended, status: 'cancelled' }
+              { ...approved, status: 'rejected' },
+              suspended
             ])
           ]
         })
@@ -1289,7 +1348,33 @@ describe('PUT /v1/organisations/{id} status history guard', () => {
 
       expectClause(
         response,
-        FROZEN_STRUCTURE_CLAUSE('Accreditation', accreditation.id)
+        `Accreditation ${accreditation.id} status history contains an invalid transition from rejected to suspended`
+      )
+    })
+
+    it('returns 422 when the first entry is no longer created', async () => {
+      const { server, org } = await seed({
+        accreditationHistory: SUSPENSION_HISTORY
+      })
+      const accreditation = org.accreditations[0]
+      const [created, ...rest] = accreditation.statusHistory
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, {
+          accreditations: [
+            withHistory(accreditation, [
+              { ...created, status: 'approved' },
+              ...rest
+            ])
+          ]
+        })
+      )
+
+      expectClause(
+        response,
+        `Accreditation ${accreditation.id} status history must start with created`
       )
     })
 
@@ -1312,7 +1397,7 @@ describe('PUT /v1/organisations/{id} status history guard', () => {
 
       expectClause(
         response,
-        FROZEN_STRUCTURE_CLAUSE('Accreditation', accreditation.id)
+        `Accreditation ${accreditation.id} status history dates must be in date order`
       )
     })
 
@@ -1338,7 +1423,7 @@ describe('PUT /v1/organisations/{id} status history guard', () => {
 
       expectClause(
         response,
-        FROZEN_STRUCTURE_CLAUSE('Accreditation', accreditation.id)
+        `Accreditation ${accreditation.id} status history updatedBy cannot be changed`
       )
     })
 
@@ -1436,7 +1521,7 @@ describe('PUT /v1/organisations/{id} status history guard', () => {
 
       expectClause(
         response,
-        `${FROZEN_STRUCTURE_CLAUSE('Registration', registration.id)}; ` +
+        `${ENTRIES_FIXED_CLAUSE('Registration', registration.id)}; ` +
           `Accreditation ${accreditation.id} status history dates must be in date order`
       )
     })

--- a/src/routes/v1/organisations/put-by-id.test.js
+++ b/src/routes/v1/organisations/put-by-id.test.js
@@ -1,6 +1,7 @@
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import {
+  buildAccreditation,
   buildOrganisation,
   buildRegistration,
   prepareOrgUpdate
@@ -14,6 +15,9 @@ import { testOnlyServiceMaintainerCanAccess } from '#vite/helpers/test-invalid-r
 import { testInvalidTokenScenarios } from '#vite/helpers/test-invalid-token-scenarios.js'
 import { StatusCodes } from 'http-status-codes'
 import { ObjectId } from 'mongodb'
+
+/** @import { Organisation } from '#domain/organisations/model.js' */
+/** @import { StatusHistoryEntry } from '#domain/organisations/accreditation.js' */
 
 const { validToken } = entraIdMockAuthTokens
 
@@ -857,9 +861,16 @@ describe('PUT /v1/organisations/{id} status change guard', () => {
     )
   })
 
+  // A new item may not carry a status history either — see the status history
+  // guard suite below — so these fixtures leave the seeding to the repository.
+  const buildNewRegistration = (overrides) => {
+    const { statusHistory: _, ...registration } = buildRegistration(overrides)
+    return registration
+  }
+
   it('accepts a new registration with status created', async () => {
     const org = await createOrganisation()
-    const newRegistration = buildRegistration({ status: 'created' })
+    const newRegistration = buildNewRegistration({ status: 'created' })
 
     const response = await putOrganisation(
       org,
@@ -873,7 +884,7 @@ describe('PUT /v1/organisations/{id} status change guard', () => {
 
   it('accepts a new registration without a status', async () => {
     const org = await createOrganisation()
-    const newRegistration = buildRegistration()
+    const newRegistration = buildNewRegistration()
 
     const response = await putOrganisation(
       org,
@@ -905,5 +916,529 @@ describe('PUT /v1/organisations/{id} status change guard', () => {
     )
 
     expect(response.statusCode).toBe(StatusCodes.OK)
+  })
+})
+
+describe('PUT /v1/organisations/{id} status history guard', () => {
+  setupAuthContext()
+
+  const CREATED_AT = '2026-01-01T00:00:00.000Z'
+  const APPROVED_AT = '2026-04-01T00:00:00.000Z'
+  const SUSPENDED_AT = '2026-05-05T00:00:00.000Z'
+  const CORRECTED_AT = '2026-05-01T00:00:00.000Z'
+
+  /** @type {StatusHistoryEntry[]} */
+  const CREATED_ONLY = [{ status: 'created', updatedAt: CREATED_AT }]
+  /** @type {StatusHistoryEntry[]} */
+  const SUSPENSION_HISTORY = [
+    { status: 'created', updatedAt: CREATED_AT },
+    { status: 'approved', updatedAt: APPROVED_AT },
+    { status: 'suspended', updatedAt: SUSPENDED_AT }
+  ]
+  /** @type {StatusHistoryEntry[]} */
+  const CANCELLATION_HISTORY = [
+    { status: 'created', updatedAt: CREATED_AT },
+    { status: 'approved', updatedAt: APPROVED_AT },
+    { status: 'cancelled', updatedAt: SUSPENDED_AT }
+  ]
+
+  const getOrganisation = async (server, id) => {
+    const response = await server.inject({
+      method: 'GET',
+      url: `/v1/organisations/${id}`,
+      headers: { Authorization: `Bearer ${validToken}` }
+    })
+    expect(response.statusCode).toBe(StatusCodes.OK)
+    return JSON.parse(response.payload)
+  }
+
+  const putOrganisation = (server, org, updateFragment) =>
+    server.inject({
+      method: 'PUT',
+      url: `/v1/organisations/${org.id}`,
+      headers: { Authorization: `Bearer ${validToken}` },
+      payload: { version: org.version, updateFragment }
+    })
+
+  const withHistory = (item, statusHistory) => ({ ...item, statusHistory })
+
+  const redated = (history, status, updatedAt) =>
+    history.map((entry) =>
+      entry.status === status ? { ...entry, updatedAt } : entry
+    )
+
+  const expectClause = (response, message) => {
+    expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+    expect(JSON.parse(response.payload).message).toBe(message)
+  }
+
+  /**
+   * Seeds the in-memory repository with an organisation holding the given
+   * stored status histories (insert() would overwrite them) and returns the
+   * organisation as the admin editor sees it.
+   */
+  const seed = async ({
+    registrationHistory = CREATED_ONLY,
+    accreditationHistory = CREATED_ONLY
+  } = {}) => {
+    const fixture = /** @type {Organisation} */ (
+      /** @type {unknown} */ (
+        buildOrganisation({
+          registrations: [
+            buildRegistration({
+              statusHistory: registrationHistory,
+              registrationNumber: 'REG12345',
+              validFrom: '2026-01-01',
+              validTo: '2027-01-01',
+              reprocessingType: 'input'
+            })
+          ],
+          accreditations: [
+            buildAccreditation({
+              statusHistory: accreditationHistory,
+              accreditationNumber: 'ACC12345',
+              validFrom: '2026-01-01',
+              validTo: '2027-01-01',
+              reprocessingType: 'input'
+            })
+          ]
+        })
+      )
+    )
+
+    const server = await createTestServer({
+      repositories: {
+        organisationsRepository: createInMemoryOrganisationsRepository([
+          fixture
+        ]),
+        systemLogsRepository: createSystemLogsRepository()
+      },
+      featureFlags: createInMemoryFeatureFlags()
+    })
+
+    return { server, org: await getOrganisation(server, fixture.id) }
+  }
+
+  it('accepts a corrected accreditation suspension date and leaves the derived status alone', async () => {
+    const { server, org } = await seed({
+      accreditationHistory: SUSPENSION_HISTORY
+    })
+    const accreditation = org.accreditations[0]
+
+    const response = await putOrganisation(
+      server,
+      org,
+      prepareOrgUpdate(org, {
+        accreditations: [
+          withHistory(
+            accreditation,
+            redated(accreditation.statusHistory, 'suspended', CORRECTED_AT)
+          )
+        ]
+      })
+    )
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const reloaded = await getOrganisation(server, org.id)
+    expect(reloaded.accreditations[0].status).toBe('suspended')
+    expect(
+      reloaded.accreditations[0].statusHistory.map((entry) => entry.updatedAt)
+    ).toEqual([CREATED_AT, APPROVED_AT, CORRECTED_AT])
+  })
+
+  it('accepts a corrected registration cancellation date', async () => {
+    const { server, org } = await seed({
+      registrationHistory: CANCELLATION_HISTORY
+    })
+    const registration = org.registrations[0]
+
+    const response = await putOrganisation(
+      server,
+      org,
+      prepareOrgUpdate(org, {
+        registrations: [
+          withHistory(
+            registration,
+            redated(registration.statusHistory, 'cancelled', CORRECTED_AT)
+          )
+        ]
+      })
+    )
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const reloaded = await getOrganisation(server, org.id)
+    expect(reloaded.registrations[0].status).toBe('cancelled')
+    expect(
+      reloaded.registrations[0].statusHistory.map((entry) => entry.updatedAt)
+    ).toEqual([CREATED_AT, APPROVED_AT, CORRECTED_AT])
+  })
+
+  it('records a system log for a date correction', async () => {
+    const { server, org } = await seed({
+      accreditationHistory: SUSPENSION_HISTORY
+    })
+    const accreditation = org.accreditations[0]
+
+    const response = await putOrganisation(
+      server,
+      org,
+      prepareOrgUpdate(org, {
+        accreditations: [
+          withHistory(
+            accreditation,
+            redated(accreditation.statusHistory, 'suspended', CORRECTED_AT)
+          )
+        ]
+      })
+    )
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const systemLogsResponse = await server.inject({
+      method: 'GET',
+      url: `/v1/system-logs/search?organisationId=${org.id}`,
+      headers: { Authorization: `Bearer ${validToken}` }
+    })
+
+    expect(systemLogsResponse.statusCode).toBe(StatusCodes.OK)
+    const { systemLogs } = JSON.parse(systemLogsResponse.payload)
+    expect(systemLogs).toHaveLength(1)
+    expect(systemLogs[0].event.action).toBe('update')
+    expect(systemLogs[0].context.organisationId).toBe(org.id)
+  })
+
+  it('accepts an unchanged echo of every status history', async () => {
+    const { server, org } = await seed({
+      accreditationHistory: SUSPENSION_HISTORY,
+      registrationHistory: CANCELLATION_HISTORY
+    })
+
+    const response = await putOrganisation(server, org, prepareOrgUpdate(org))
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+  })
+
+  it('accepts items whose fragment omits statusHistory entirely', async () => {
+    const { server, org } = await seed({
+      accreditationHistory: SUSPENSION_HISTORY
+    })
+    const { statusHistory: _, ...accreditationWithoutHistory } =
+      org.accreditations[0]
+
+    const response = await putOrganisation(
+      server,
+      org,
+      prepareOrgUpdate(org, { accreditations: [accreditationWithoutHistory] })
+    )
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+  })
+
+  describe('stored history that already breaks the rules', () => {
+    /** @type {StatusHistoryEntry[]} */
+    const OUT_OF_ORDER_HISTORY = [
+      { status: 'created', updatedAt: SUSPENDED_AT },
+      { status: 'approved', updatedAt: APPROVED_AT }
+    ]
+    /** @type {StatusHistoryEntry[]} */
+    const OFF_TABLE_HISTORY = [
+      { status: 'created', updatedAt: CREATED_AT },
+      { status: 'cancelled', updatedAt: APPROVED_AT }
+    ]
+
+    it('accepts an echo of out-of-order stored dates so the rest of the record stays editable', async () => {
+      const { server, org } = await seed({
+        registrationHistory: OUT_OF_ORDER_HISTORY
+      })
+
+      const response = await putOrganisation(server, org, prepareOrgUpdate(org))
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+
+    it('accepts an echo of an off-table stored transition', async () => {
+      const { server, org } = await seed({
+        registrationHistory: OFF_TABLE_HISTORY
+      })
+
+      const response = await putOrganisation(server, org, prepareOrgUpdate(org))
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+
+    it('returns 422 when a date on an off-table stored transition is edited', async () => {
+      const { server, org } = await seed({
+        registrationHistory: OFF_TABLE_HISTORY
+      })
+      const registration = org.registrations[0]
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, {
+          registrations: [
+            withHistory(
+              registration,
+              redated(registration.statusHistory, 'cancelled', CORRECTED_AT)
+            )
+          ]
+        })
+      )
+
+      expectClause(
+        response,
+        `Registration ${registration.id} status history contains an invalid transition from created to cancelled`
+      )
+    })
+
+    it('accepts a date edit on a cascade-cancelled accreditation history', async () => {
+      const { server, org } = await seed({
+        accreditationHistory: CANCELLATION_HISTORY
+      })
+      const accreditation = org.accreditations[0]
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, {
+          accreditations: [
+            withHistory(
+              accreditation,
+              redated(accreditation.statusHistory, 'cancelled', CORRECTED_AT)
+            )
+          ]
+        })
+      )
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+  })
+
+  describe('rejected edits', () => {
+    const FROZEN_STRUCTURE_CLAUSE = (label, id) =>
+      `${label} ${id} status history can only change updatedAt dates — statuses and structure are fixed`
+
+    it('returns 422 when an entry is added', async () => {
+      const { server, org } = await seed({
+        accreditationHistory: SUSPENSION_HISTORY
+      })
+      const accreditation = org.accreditations[0]
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, {
+          accreditations: [
+            withHistory(accreditation, [
+              ...accreditation.statusHistory,
+              { status: 'cancelled', updatedAt: '2026-06-01T00:00:00.000Z' }
+            ])
+          ]
+        })
+      )
+
+      expectClause(
+        response,
+        FROZEN_STRUCTURE_CLAUSE('Accreditation', accreditation.id)
+      )
+    })
+
+    it('returns 422 when an entry is removed', async () => {
+      const { server, org } = await seed({
+        accreditationHistory: SUSPENSION_HISTORY
+      })
+      const accreditation = org.accreditations[0]
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, {
+          accreditations: [
+            withHistory(accreditation, accreditation.statusHistory.slice(0, 2))
+          ]
+        })
+      )
+
+      expectClause(
+        response,
+        FROZEN_STRUCTURE_CLAUSE('Accreditation', accreditation.id)
+      )
+    })
+
+    it('returns 422 when a status value is changed', async () => {
+      const { server, org } = await seed({
+        accreditationHistory: SUSPENSION_HISTORY
+      })
+      const accreditation = org.accreditations[0]
+      const [created, approved, suspended] = accreditation.statusHistory
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, {
+          accreditations: [
+            withHistory(accreditation, [
+              created,
+              approved,
+              { ...suspended, status: 'cancelled' }
+            ])
+          ]
+        })
+      )
+
+      expectClause(
+        response,
+        FROZEN_STRUCTURE_CLAUSE('Accreditation', accreditation.id)
+      )
+    })
+
+    it('returns 422 when entries are reordered', async () => {
+      const { server, org } = await seed({
+        accreditationHistory: SUSPENSION_HISTORY
+      })
+      const accreditation = org.accreditations[0]
+      const [created, approved, suspended] = accreditation.statusHistory
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, {
+          accreditations: [
+            withHistory(accreditation, [created, suspended, approved])
+          ]
+        })
+      )
+
+      expectClause(
+        response,
+        FROZEN_STRUCTURE_CLAUSE('Accreditation', accreditation.id)
+      )
+    })
+
+    it('returns 422 when updatedBy is added to an entry', async () => {
+      const { server, org } = await seed({
+        accreditationHistory: SUSPENSION_HISTORY
+      })
+      const accreditation = org.accreditations[0]
+      const [created, ...rest] = accreditation.statusHistory
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, {
+          accreditations: [
+            withHistory(accreditation, [
+              { ...created, updatedBy: new ObjectId().toString() },
+              ...rest
+            ])
+          ]
+        })
+      )
+
+      expectClause(
+        response,
+        FROZEN_STRUCTURE_CLAUSE('Accreditation', accreditation.id)
+      )
+    })
+
+    it('returns 422 when the corrected dates are no longer ascending', async () => {
+      const { server, org } = await seed({
+        accreditationHistory: SUSPENSION_HISTORY
+      })
+      const accreditation = org.accreditations[0]
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, {
+          accreditations: [
+            withHistory(
+              accreditation,
+              redated(accreditation.statusHistory, 'suspended', CREATED_AT)
+            )
+          ]
+        })
+      )
+
+      expectClause(
+        response,
+        `Accreditation ${accreditation.id} status history dates must be in date order`
+      )
+    })
+
+    it('returns 422 when adjacent corrected dates are equal', async () => {
+      const { server, org } = await seed({
+        accreditationHistory: SUSPENSION_HISTORY
+      })
+      const accreditation = org.accreditations[0]
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, {
+          accreditations: [
+            withHistory(
+              accreditation,
+              redated(accreditation.statusHistory, 'suspended', APPROVED_AT)
+            )
+          ]
+        })
+      )
+
+      expectClause(
+        response,
+        `Accreditation ${accreditation.id} status history dates must be in date order`
+      )
+    })
+
+    it('returns 422 when a statusHistory is supplied for a new item', async () => {
+      const { server, org } = await seed()
+      const newRegistration = buildRegistration({
+        statusHistory: CREATED_ONLY
+      })
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, { registrations: [newRegistration] })
+      )
+
+      expectClause(
+        response,
+        `Registration ${newRegistration.id} status history cannot be set on new items`
+      )
+    })
+
+    it('lists a clause for every offending item separated by "; "', async () => {
+      const { server, org } = await seed({
+        registrationHistory: CANCELLATION_HISTORY,
+        accreditationHistory: SUSPENSION_HISTORY
+      })
+      const registration = org.registrations[0]
+      const accreditation = org.accreditations[0]
+
+      const response = await putOrganisation(
+        server,
+        org,
+        prepareOrgUpdate(org, {
+          registrations: [
+            withHistory(registration, registration.statusHistory.slice(0, 2))
+          ],
+          accreditations: [
+            withHistory(
+              accreditation,
+              redated(accreditation.statusHistory, 'suspended', CREATED_AT)
+            )
+          ]
+        })
+      )
+
+      expectClause(
+        response,
+        `${FROZEN_STRUCTURE_CLAUSE('Registration', registration.id)}; ` +
+          `Accreditation ${accreditation.id} status history dates must be in date order`
+      )
+    })
   })
 })

--- a/src/routes/v1/organisations/put-by-id.test.js
+++ b/src/routes/v1/organisations/put-by-id.test.js
@@ -1167,6 +1167,36 @@ describe('PUT /v1/organisations/{id} status history guard', () => {
     expect(reloaded.registrations[0].status).toBe('rejected')
   })
 
+  it('accepts adjacent entries with the same status — a repeat is not a transition', async () => {
+    const { server, org } = await seed({
+      accreditationHistory: SUSPENSION_HISTORY
+    })
+    const accreditation = org.accreditations[0]
+    const [created, approved, suspended] = accreditation.statusHistory
+
+    const response = await putOrganisation(
+      server,
+      org,
+      prepareOrgUpdate(org, {
+        accreditations: [
+          withHistory(accreditation, [
+            created,
+            approved,
+            { ...suspended, status: 'approved' }
+          ])
+        ]
+      })
+    )
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const reloaded = await getOrganisation(server, org.id)
+    expect(reloaded.accreditations[0].status).toBe('approved')
+    expect(
+      reloaded.accreditations[0].statusHistory.map((entry) => entry.status)
+    ).toEqual(['created', 'approved', 'approved'])
+  })
+
   it('accepts an unchanged echo of every status history', async () => {
     const { server, org } = await seed({
       accreditationHistory: SUSPENSION_HISTORY,


### PR DESCRIPTION
Ticket: [PAE-1809](https://eaflood.atlassian.net/browse/PAE-1809)
## Summary

- Allows admins to correct registration/accreditation `statusHistory` entries — both the **status** and the **updatedAt** date — through the JSON editor's save endpoint, `PUT /v1/organisations/{id}`. 
- Restrictive by design: entries cannot be added or removed, `updatedBy` is frozen, the history must still start at `created`, corrected dates must be strictly ascending, and the resulting sequence must be a valid walk of the domain transition table (plus the accreditation cascade-cancel edge `approved→cancelled`, which the table deliberately omits for user-driven changes). Violations return 422 with one `'; '`-joined clause per offending item.
- A value-equal echo of a stored history skips all checks — the editor round-trips the whole document, so organisations whose stored history already breaks the rules stay editable for unrelated fields.

[PAE-1809]: https://eaflood.atlassian.net/browse/PAE-1809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ