### PR TITLE
PAE-000: reduce local dev watcher cpu

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "benchmark:file": "node benchmarks/parse-file.js",
     "test": "TZ=UTC vitest run --coverage",
     "test:watch": "TZ=UTC vitest --coverage",
-    "server:watch": "nodemon --inspect=0.0.0.0 --ext js,json --legacy-watch ./src",
+    "server:watch": "nodemon --inspect=0.0.0.0 --ext js,json --legacy-watch --polling-interval 1000 ./src",
     "server:debug": "nodemon --inspect-brk=0.0.0.0 --ext js,json --legacy-watch ./src",
     "start": "NODE_ENV=production node --use-strict .",
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module",


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
cuts idle cpu from local dev file watchers, which were using ~99% of the cpu these containers burn while the stack sits idle.

- nodemon `--legacy-watch` ran at its default 100ms polling interval; set to 1000ms
- webpack polled its whole module graph including `node_modules` (~43k files) every second; now ignores `node_modules`

measured on the local compose stack, matched 240s idle windows:

| container | before | after |
|---|---|---|
| epr-frontend | 8.92% | 1.64% |
| epr-admin-frontend | 10.72% | 2.31% |
| epr-backend | 8.57% | 2.68% |

polling interval was swept before picking 1000ms - 100ms 8.35%, 250ms 3.80%, 500ms 2.28%, 1000ms 1.29%, 2000ms 0.71%, 5000ms 0.65%. flattens after 1000ms, so that is the knee.

polling is still required - `src/` is bind-mounted from macos and inotify does not propagate across that mount.

trade-offs: up to 1s before a change is picked up rather than ~100ms; webpack no longer notices dependency changes from `npm install` without a container restart.