### PR TITLE
PAE-000: settle summary-log-row-states repository naming

### DIFF
--- a/src/application/summary-logs/submit.integration.test.js
+++ b/src/application/summary-logs/submit.integration.test.js
@@ -21,7 +21,7 @@ import {
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
 import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
 import { summaryLogRowStatesForRegistration } from '#waste-records/application/read-summary-log-row-states.js'
@@ -129,7 +129,7 @@ const setupSubmit = async ({ reportsRepository, createdAt }) => {
     summaryLogsRepository,
     organisationsRepository,
     summaryLogRowStatesRepository:
-      createInMemorySummaryLogRowStateRepository()(),
+      createInMemorySummaryLogRowStatesRepository()(),
     ledgerRepository,
     wasteBalanceService: createWasteBalanceService(ledgerRepository),
     summaryLogExtractor,
@@ -206,7 +206,7 @@ describe('submitSummaryLog staleness guard (period closure)', () => {
       registrationId,
       accreditationId: 'acc-123',
       ledgerRepository: deps.ledgerRepository,
-      summaryLogRowStateRepository: deps.summaryLogRowStatesRepository
+      summaryLogRowStatesRepository: deps.summaryLogRowStatesRepository
     })
     expect(rowStates.map((state) => state.rowId).sort()).toEqual([
       '1001',

--- a/src/application/summary-logs/submit.js
+++ b/src/application/summary-logs/submit.js
@@ -23,7 +23,7 @@ import { summaryLogMetrics } from '#application/summary-logs/metrics.js'
  * @import { SummaryLogsRepository } from '#repositories/summary-logs/port.js'
  * @import { WasteBalanceLedgerRepository } from '#waste-balances/repository/ledger-port.js'
  * @import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
- * @import { SummaryLogRowStateRepository } from '#waste-records/repository/port.js'
+ * @import { SummaryLogRowStatesRepository } from '#waste-records/repository/port.js'
  */
 
 /**
@@ -31,7 +31,7 @@ import { summaryLogMetrics } from '#application/summary-logs/metrics.js'
  * @property {TypedLogger} logger
  * @property {SummaryLogsRepository} summaryLogsRepository
  * @property {OrganisationsRepository} organisationsRepository
- * @property {SummaryLogRowStateRepository} summaryLogRowStatesRepository
+ * @property {SummaryLogRowStatesRepository} summaryLogRowStatesRepository
  * @property {WasteBalanceLedgerRepository} ledgerRepository
  * @property {ReturnType<typeof createWasteBalanceService>} wasteBalanceService
  * @property {ReportsService} reportsService
@@ -127,7 +127,7 @@ const syncAndFinalise = async (summaryLogId, version, summaryLog, deps) => {
     wasteBalanceService,
     organisationsRepository,
     overseasSitesRepository,
-    summaryLogRowStateRepository: summaryLogRowStatesRepository,
+    summaryLogRowStatesRepository,
     ledgerRepository,
     logger
   })

--- a/src/application/summary-logs/transform-and-validate-data.js
+++ b/src/application/summary-logs/transform-and-validate-data.js
@@ -6,7 +6,7 @@ import { ledgerIdFor } from './ledger-id.js'
 /** @import {ValidatedSummaryLog, ValidatedWasteRecord} from '#application/waste-records/transform-from-summary-log.js' */
 /** @import {ValidationIssuesCollector} from '#common/validation/validation-issues.js' */
 /** @import {Registration} from '#domain/organisations/registration.js' */
-/** @import {SummaryLogRowStateRepository} from '#waste-records/repository/port.js' */
+/** @import {SummaryLogRowStatesRepository} from '#waste-records/repository/port.js' */
 /** @import {WasteBalanceLedgerRepository} from '#waste-balances/repository/ledger-port.js' */
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 
@@ -19,7 +19,7 @@ import { ledgerIdFor } from './ledger-id.js'
  *   summaryLog: SubmittedSummaryLog,
  *   validatedData: ValidatedSummaryLog,
  *   registration: Registration | undefined,
- *   summaryLogRowStateRepository: SummaryLogRowStateRepository,
+ *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
  *   ledgerRepository: WasteBalanceLedgerRepository
  * }} params
  * @returns {Promise<{
@@ -31,13 +31,13 @@ export const transformAndValidateData = async ({
   summaryLog,
   validatedData,
   registration,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   ledgerRepository
 }) => {
   const previousSubmission = await latestSubmittedSummaryLogRowStates({
     ...ledgerIdFor(summaryLog, registration),
     ledgerRepository,
-    summaryLogRowStateRepository
+    summaryLogRowStatesRepository
   })
 
   /** @type {ValidatedWasteRecord[]} */

--- a/src/application/summary-logs/validate.integration.test.js
+++ b/src/application/summary-logs/validate.integration.test.js
@@ -16,7 +16,7 @@ import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data
 import { waitForVersion } from '#repositories/summary-logs/contract/test-helpers.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 
 /** @import {DataSection, MetadataEntry, SummaryLogExtractor} from '#domain/summary-logs/extractor/port.js' */
 /** @import {WasteProcessingTypeValue} from '#domain/organisations/model.js' */
@@ -121,14 +121,14 @@ describe('SummaryLogsValidator integration', () => {
       summaryLogExtractor || createExtractor(summaryLog.file.id, metadata, data)
 
     const ledgerRepository = createInMemoryLedgerRepository()()
-    const summaryLogRowStateRepository =
-      createInMemorySummaryLogRowStateRepository()()
+    const summaryLogRowStatesRepository =
+      createInMemorySummaryLogRowStatesRepository()()
 
     const validateSummaryLog = createSummaryLogsValidator({
       logger,
       summaryLogsRepository,
       organisationsRepository,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ledgerRepository,
       reportsService: /** @type {any} */ ({
         findPeriodicReports: async () => []

--- a/src/application/summary-logs/validate.js
+++ b/src/application/summary-logs/validate.js
@@ -49,7 +49,7 @@ export { MAX_ACTUAL_LENGTH } from './cap-issues-for-storage.js'
 /** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
 /** @import {OverseasSitesRepository} from '#overseas-sites/repository/port.js' */
 /** @import {SummaryLogsRepository} from '#repositories/summary-logs/port.js' */
-/** @import {SummaryLogRowStateRepository} from '#waste-records/repository/port.js' */
+/** @import {SummaryLogRowStatesRepository} from '#waste-records/repository/port.js' */
 /** @import {WasteBalanceLedgerRepository} from '#waste-balances/repository/ledger-port.js' */
 /** @import {SubmittedSummaryLog} from './validate-issue-logging.js' */
 /** @import {SummaryLogExtractor} from './extractor.js' */
@@ -232,7 +232,7 @@ const markIgnoredByDateRange = (
  *   logger: TypedLogger,
  *   summaryLogExtractor: SummaryLogExtractor,
  *   organisationsRepository: OrganisationsRepository,
- *   summaryLogRowStateRepository: SummaryLogRowStateRepository,
+ *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
  *   ledgerRepository: WasteBalanceLedgerRepository,
  *   validateDataSyntax: (parsed: ParsedSummaryLog) => { issues: ValidationIssuesCollector, validatedData: ValidatedSummaryLog }
  * }} params
@@ -244,7 +244,7 @@ const performValidationChecks = async ({
   logger,
   summaryLogExtractor,
   organisationsRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   ledgerRepository,
   validateDataSyntax
 }) => {
@@ -305,7 +305,7 @@ const performValidationChecks = async ({
       summaryLog,
       validatedData,
       registration,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ledgerRepository
     })
 
@@ -496,7 +496,7 @@ const persistValidationResult = async ({
  *
  * @param {{
  *   ledgerRepository: WasteBalanceLedgerRepository,
- *   summaryLogRowStateRepository: SummaryLogRowStateRepository,
+ *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
  *   summaryLog: SubmittedSummaryLog,
  *   registration: Registration | undefined
  * }} params
@@ -504,14 +504,14 @@ const persistValidationResult = async ({
  */
 const loadSubmittedRowStatesByKey = async ({
   ledgerRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   summaryLog,
   registration
 }) => {
   const submittedRowStates = await summaryLogRowStatesForRegistration({
     ...ledgerIdFor(summaryLog, registration),
     ledgerRepository,
-    summaryLogRowStateRepository
+    summaryLogRowStatesRepository
   })
 
   return new Map(
@@ -536,7 +536,7 @@ const classifyAndPersistResult = async ({
   meta,
   summaryLog,
   summaryLogsRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   ledgerRepository,
   version,
   reportsService,
@@ -559,7 +559,7 @@ const classifyAndPersistResult = async ({
 
   const submittedRowStatesByKey = await loadSubmittedRowStatesByKey({
     ledgerRepository,
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     summaryLog,
     registration
   })
@@ -595,7 +595,7 @@ const classifyAndPersistResult = async ({
  *   logger: TypedLogger,
  *   summaryLogsRepository: SummaryLogsRepository,
  *   organisationsRepository: OrganisationsRepository,
- *   summaryLogRowStateRepository: SummaryLogRowStateRepository,
+ *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
  *   ledgerRepository: WasteBalanceLedgerRepository,
  *   reportsService: ReportsService,
  *   overseasSitesRepository: OverseasSitesRepository,
@@ -607,7 +607,7 @@ export const createSummaryLogsValidator = ({
   logger,
   summaryLogsRepository,
   organisationsRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   ledgerRepository,
   reportsService,
   overseasSitesRepository,
@@ -641,7 +641,7 @@ export const createSummaryLogsValidator = ({
         logger,
         summaryLogExtractor,
         organisationsRepository,
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         ledgerRepository,
         validateDataSyntax
       })
@@ -676,7 +676,7 @@ export const createSummaryLogsValidator = ({
       meta,
       summaryLog,
       summaryLogsRepository,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ledgerRepository,
       version,
       reportsService,

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -29,7 +29,7 @@ import { buildSummaryLogRowStateEntry } from '#waste-records/repository/test-dat
  * @param {WasteBalanceLedgerId} params.ledgerId
  * @param {string} params.summaryLogId
  * @param {number} params.number - the submission's ledger position
- * @param {Array<{ rowId: string, wasteRecordType?: string }>} params.rows
+ * @param {{ rowId: string, wasteRecordType?: string }[]} params.rows
  * @param {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} params.summaryLogRowStatesRepository
  * @param {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} params.ledgerRepository
  */
@@ -135,7 +135,7 @@ const rowToArray = (rowObject) =>
 
 /**
  * @param {{
- *   rows?: Array<unknown[] | Record<string, unknown>>,
+ *   rows?: (unknown[] | Record<string, unknown>)[],
  *   headers?: string[]
  * }} [options]
  */

--- a/src/application/summary-logs/validate.test.js
+++ b/src/application/summary-logs/validate.test.js
@@ -15,7 +15,7 @@ import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repositor
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
 import { LEDGER_EVENT_KIND } from '#waste-balances/repository/ledger-schema.js'
 import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { buildSummaryLogRowStateEntry } from '#waste-records/repository/test-data.js'
 
 /** @import {TypedLogger} from '#common/helpers/logging/logger.js' */
@@ -30,7 +30,7 @@ import { buildSummaryLogRowStateEntry } from '#waste-records/repository/test-dat
  * @param {string} params.summaryLogId
  * @param {number} params.number - the submission's ledger position
  * @param {Array<{ rowId: string, wasteRecordType?: string }>} params.rows
- * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} params.summaryLogRowStateRepository
+ * @param {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} params.summaryLogRowStatesRepository
  * @param {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} params.ledgerRepository
  */
 const seedSubmittedSummaryLog = async ({
@@ -38,10 +38,10 @@ const seedSubmittedSummaryLog = async ({
   summaryLogId,
   number,
   rows,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   ledgerRepository
 }) => {
-  await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+  await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
     ledgerId,
     rows.map((row) => buildSummaryLogRowStateEntry(row)),
     summaryLogId
@@ -193,7 +193,7 @@ describe('SummaryLogsValidator', () => {
   let summaryLogExtractor
   let summaryLogsRepository
   let organisationsRepository
-  let summaryLogRowStateRepository
+  let summaryLogRowStatesRepository
   let ledgerRepository
   let validateSummaryLog
   let summaryLogId
@@ -201,8 +201,8 @@ describe('SummaryLogsValidator', () => {
 
   beforeEach(async () => {
     ledgerRepository = createInMemoryLedgerRepository()()
-    summaryLogRowStateRepository =
-      createInMemorySummaryLogRowStateRepository()()
+    summaryLogRowStatesRepository =
+      createInMemorySummaryLogRowStatesRepository()()
 
     summaryLogExtractor = {
       extract: vi.fn().mockResolvedValue({
@@ -262,7 +262,7 @@ describe('SummaryLogsValidator', () => {
       logger,
       summaryLogsRepository: /** @type {any} */ (summaryLogsRepository),
       organisationsRepository: /** @type {any} */ (organisationsRepository),
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ledgerRepository,
       reportsService: /** @type {any} */ ({
         findPeriodicReports: vi.fn().mockResolvedValue([])
@@ -690,7 +690,7 @@ describe('SummaryLogsValidator', () => {
       logger,
       summaryLogsRepository: brokenRepository,
       organisationsRepository: /** @type {any} */ (organisationsRepository),
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ledgerRepository,
       reportsService: /** @type {any} */ ({
         findPeriodicReports: vi.fn().mockResolvedValue([])
@@ -736,7 +736,7 @@ describe('SummaryLogsValidator', () => {
       logger,
       summaryLogsRepository: /** @type {any} */ (summaryLogsRepository),
       organisationsRepository: /** @type {any} */ (organisationsRepository),
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ledgerRepository,
       reportsService: /** @type {any} */ ({
         findPeriodicReports: vi.fn().mockRejectedValue(fetchError)
@@ -2101,7 +2101,7 @@ describe('SummaryLogsValidator', () => {
         summaryLogId: 'previous-summary-log',
         number: 1,
         rows: [{ rowId: '99999' }],
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         ledgerRepository
       })
 
@@ -2144,7 +2144,7 @@ describe('SummaryLogsValidator', () => {
         summaryLogId: 'previous-log',
         number: 1,
         rows: [{ rowId: 'A' }],
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         ledgerRepository
       })
 
@@ -2168,7 +2168,7 @@ describe('SummaryLogsValidator', () => {
         summaryLogId: 'previous-log',
         number: 1,
         rows: [{ rowId: 'A' }],
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         ledgerRepository
       })
 
@@ -2190,7 +2190,7 @@ describe('SummaryLogsValidator', () => {
         summaryLogId: 'log-1',
         number: 1,
         rows: [{ rowId: 'A' }],
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         ledgerRepository
       })
       await seedSubmittedSummaryLog({
@@ -2198,7 +2198,7 @@ describe('SummaryLogsValidator', () => {
         summaryLogId: 'log-2',
         number: 2,
         rows: [{ rowId: 'A' }],
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         ledgerRepository
       })
 

--- a/src/application/waste-records/sync-from-summary-log.js
+++ b/src/application/waste-records/sync-from-summary-log.js
@@ -201,7 +201,7 @@ const updateWasteBalances = async ({
  * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} params.overseasSites
  * @param {import('#waste-balances/repository/ledger-schema.js').WasteBalanceLedgerId} params.ledgerId
  * @param {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} params.ledgerRepository
- * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} params.summaryLogRowStateRepository
+ * @param {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} params.summaryLogRowStatesRepository
  * @returns {Promise<{ created: number, updated: number }>}
  */
 const countRecordChanges = async ({
@@ -210,12 +210,12 @@ const countRecordChanges = async ({
   overseasSites,
   ledgerId,
   ledgerRepository,
-  summaryLogRowStateRepository
+  summaryLogRowStatesRepository
 }) => {
   const previousRowStates = await summaryLogRowStatesForRegistration({
     ...ledgerId,
     ledgerRepository,
-    summaryLogRowStateRepository
+    summaryLogRowStatesRepository
   })
 
   const submittedRowStatesByKey = new Map(
@@ -259,7 +259,7 @@ const countRecordChanges = async ({
  * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} params.overseasSites
  * @param {ParsedSummaryLog} params.parsedData
  * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} params.user
- * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} params.summaryLogRowStateRepository
+ * @param {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} params.summaryLogRowStatesRepository
  * @param {ReturnType<typeof createWasteBalanceService>} params.wasteBalanceService
  */
 const commitStateAndBalance = async ({
@@ -270,11 +270,11 @@ const commitStateAndBalance = async ({
   overseasSites,
   parsedData,
   user,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   wasteBalanceService
 }) => {
   await writeSummaryLogRowStates({
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     wasteRecords: wasteRecords.map((wasteRecord) => wasteRecord.record),
     accreditation,
     ledgerId: {
@@ -323,7 +323,7 @@ const commitStateAndBalance = async ({
  * @param {ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>} dependencies.wasteBalanceService - The waste balance application service
  * @param {Object} dependencies.organisationsRepository - The organisations repository
  * @param {import('#overseas-sites/repository/port.js').OverseasSitesRepository} dependencies.overseasSitesRepository - The overseas sites repository
- * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} dependencies.summaryLogRowStateRepository - The summary-log row states repository
+ * @param {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} dependencies.summaryLogRowStatesRepository - The summary-log row states repository
  * @param {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} dependencies.ledgerRepository - The ledger repository, read to classify created/updated against the committed head
  * @param {TypedLogger} dependencies.logger - Logger forwarded to extractor for trace correlation
  * @returns {Function} A function that accepts a summary log and returns a Promise
@@ -334,7 +334,7 @@ export const syncFromSummaryLog = (dependencies) => {
     wasteBalanceService,
     organisationsRepository,
     overseasSitesRepository,
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     ledgerRepository,
     logger
   } = dependencies
@@ -400,7 +400,7 @@ export const syncFromSummaryLog = (dependencies) => {
         accreditationId: accreditationId ?? null
       },
       ledgerRepository,
-      summaryLogRowStateRepository
+      summaryLogRowStatesRepository
     })
 
     // 6. Commit per-row state for every submission and the balance for
@@ -413,7 +413,7 @@ export const syncFromSummaryLog = (dependencies) => {
       overseasSites,
       parsedData,
       user,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       wasteBalanceService
     })
 

--- a/src/application/waste-records/sync-from-summary-log.js
+++ b/src/application/waste-records/sync-from-summary-log.js
@@ -54,8 +54,8 @@ const isTemplateRow = (rowIdValue) => {
  * coerce-waste-record.js), so the persisted record preserves the
  * user's original input.
  *
- * @param {Array<string|null>} headers - Array of header names
- * @param {Array<{rowNumber: number, values: Array<*>}>} rows - Array of row objects with row number and values
+ * @param {(string | null)[]} headers - Array of header names
+ * @param {{rowNumber: number, values: *[]}[]} rows - Array of row objects with row number and values
  * @param {string} rowIdField - The header name used to identify the row ID
  * @returns {TransformableRow[]} Array of rows with data objects built
  */
@@ -159,7 +159,7 @@ const resolveAccreditation = async (
  * @param {ParsedSummaryLog} params.parsedData
  * @param {import('#domain/organisations/accreditation.js').Accreditation} params.accreditation
  * @param {ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>} params.wasteBalanceService
- * @param {Array<{ record: import('#domain/waste-records/model.js').WasteRecord }>} params.wasteRecords
+ * @param {{ record: import('#domain/waste-records/model.js').WasteRecord }[]} params.wasteRecords
  * @param {import('#domain/summary-logs/worker/port.js').SubmitUser} params.user
  * @param {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} params.overseasSites
  * @param {string} params.summaryLogId

--- a/src/application/waste-records/sync-from-summary-log.test.js
+++ b/src/application/waste-records/sync-from-summary-log.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { syncFromSummaryLog } from './sync-from-summary-log.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createInMemorySummaryLogExtractor } from '#application/summary-logs/extractor-inmemory.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
 import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
 
@@ -73,13 +73,13 @@ describe('syncFromSummaryLog', () => {
   let wasteBalanceService
   let organisationsRepository
   let overseasSitesRepository
-  let summaryLogRowStateRepository
+  let summaryLogRowStatesRepository
   let ledgerRepository
 
   beforeEach(() => {
     ledgerRepository = createInMemoryLedgerRepository()()
-    summaryLogRowStateRepository =
-      createInMemorySummaryLogRowStateRepository()()
+    summaryLogRowStatesRepository =
+      createInMemorySummaryLogRowStatesRepository()()
     wasteBalanceService = {
       submitSummaryLog: vi.fn(),
       commitSummaryLogSubmittedEvent: vi.fn()
@@ -102,7 +102,7 @@ describe('syncFromSummaryLog', () => {
       wasteBalanceService,
       organisationsRepository,
       overseasSitesRepository,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ledgerRepository,
       ...overrides
     })
@@ -119,7 +119,7 @@ describe('syncFromSummaryLog', () => {
     await makeSync({ extractor })(summaryLogFor(fileId), TEST_USER)
 
     const rowStates =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         LEDGER_ID,
         fileId
       )
@@ -150,7 +150,7 @@ describe('syncFromSummaryLog', () => {
     await makeSync({ extractor })(summaryLogFor(fileId), TEST_USER)
 
     const rowStates =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         LEDGER_ID,
         fileId
       )
@@ -190,7 +190,7 @@ describe('syncFromSummaryLog', () => {
     await makeSync({ extractor })(summaryLogFor(fileId), TEST_USER)
 
     const rowStates =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         LEDGER_ID,
         fileId
       )
@@ -268,7 +268,7 @@ describe('syncFromSummaryLog', () => {
     await makeSync({ extractor })(summaryLogFor(fileId), TEST_USER)
 
     const rowStates =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         LEDGER_ID,
         fileId
       )

--- a/src/common/hapi-types.js
+++ b/src/common/hapi-types.js
@@ -4,7 +4,9 @@
  * @typedef {import('../feature-flags/feature-flags.port.js').FeatureFlags} FeatureFlags
  * @import {Db} from 'mongodb'
  * @import {LockManager} from 'mongo-locks'
+ * @import {PublicRegisterRepository} from '#domain/public-register/repository/port.js'
  * @import {UploadsRepository} from '#domain/uploads/repository/port.js'
+ * @import {NonProdDataReset} from '#non-prod-data-reset/mongodb.js'
  * @import {OrsImportsRepository} from '#overseas-sites/imports/repository/port.js'
  * @import {OverseasSitesRepository} from '#overseas-sites/repository/port.js'
  * @import {PrnEvents} from '#packaging-recycling-notes/application/prn-events.plugin.js'
@@ -16,8 +18,6 @@
  * @import {SystemLogsRepository} from '#repositories/system-logs/port.js'
  * @import {WasteBalanceLedgerRepository} from '#waste-balances/repository/ledger-port.js'
  * @import {SummaryLogRowStatesRepository} from '#waste-records/repository/port.js'
- * @typedef {ReturnType<typeof import('#adapters/repositories/public-register/public-register.js').createPublicRegisterRepository>} PublicRegisterRepository
- * @typedef {ReturnType<typeof import('#non-prod-data-reset/mongodb.js').createNonProdDataReset>} NonProdDataReset
  * @typedef {ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>} WasteBalanceService
  */
 

--- a/src/common/hapi-types.js
+++ b/src/common/hapi-types.js
@@ -4,11 +4,20 @@
  * @typedef {import('../feature-flags/feature-flags.port.js').FeatureFlags} FeatureFlags
  * @import {Db} from 'mongodb'
  * @import {LockManager} from 'mongo-locks'
- * @import {OrganisationsRepository} from '#repositories/organisations/port.js'
+ * @import {UploadsRepository} from '#domain/uploads/repository/port.js'
+ * @import {OrsImportsRepository} from '#overseas-sites/imports/repository/port.js'
+ * @import {OverseasSitesRepository} from '#overseas-sites/repository/port.js'
+ * @import {PrnEvents} from '#packaging-recycling-notes/application/prn-events.plugin.js'
+ * @import {PackagingRecyclingNotesRepository} from '#packaging-recycling-notes/repository/port.js'
  * @import {ReportsRepository} from '#reports/repository/port.js'
- * @import {SummaryLogRowStatesRepository} from '#waste-records/repository/port.js'
+ * @import {FormSubmissionsRepository} from '#repositories/form-submissions/port.js'
+ * @import {OrganisationsRepository} from '#repositories/organisations/port.js'
+ * @import {SummaryLogsRepository} from '#repositories/summary-logs/port.js'
  * @import {SystemLogsRepository} from '#repositories/system-logs/port.js'
  * @import {WasteBalanceLedgerRepository} from '#waste-balances/repository/ledger-port.js'
+ * @import {SummaryLogRowStatesRepository} from '#waste-records/repository/port.js'
+ * @typedef {ReturnType<typeof import('#adapters/repositories/public-register/public-register.js').createPublicRegisterRepository>} PublicRegisterRepository
+ * @typedef {ReturnType<typeof import('#non-prod-data-reset/mongodb.js').createNonProdDataReset>} NonProdDataReset
  * @typedef {ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>} WasteBalanceService
  */
 
@@ -117,15 +126,26 @@
  */
 
 /**
- * Dependencies `registerDependency` decorates onto `server.app`. Naming one
- * types its reads, so a property name no plugin registers fails the type check;
- * the index signature keeps the rest readable.
+ * Every dependency `registerDependency` decorates onto `server.app`. The shape
+ * is closed, so reading a property no plugin registers fails the type check.
+ * Adding a `registerDependency` call means adding its name here too.
  *
  * @typedef {{
+ *   formSubmissionsRepository: FormSubmissionsRepository,
+ *   ledgerRepository: WasteBalanceLedgerRepository,
+ *   nonProdDataReset: NonProdDataReset,
  *   organisationsRepository: OrganisationsRepository,
+ *   orsImportsRepository: OrsImportsRepository,
+ *   overseasSitesRepository: OverseasSitesRepository,
+ *   packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository,
+ *   prnEvents: PrnEvents,
+ *   publicRegisterRepository: PublicRegisterRepository,
  *   reportsRepository: ReportsRepository,
  *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
- *   [key: string]: unknown
+ *   summaryLogsRepository: SummaryLogsRepository,
+ *   systemLogsRepository: SystemLogsRepository,
+ *   uploadsRepository: UploadsRepository,
+ *   wasteBalanceService: WasteBalanceService
  * }} ServerApp
  */
 

--- a/src/common/hapi-types.js
+++ b/src/common/hapi-types.js
@@ -6,7 +6,7 @@
  * @import {LockManager} from 'mongo-locks'
  * @import {OrganisationsRepository} from '#repositories/organisations/port.js'
  * @import {ReportsRepository} from '#reports/repository/port.js'
- * @import {SummaryLogRowStateRepository} from '#waste-records/repository/port.js'
+ * @import {SummaryLogRowStatesRepository} from '#waste-records/repository/port.js'
  * @import {SystemLogsRepository} from '#repositories/system-logs/port.js'
  * @import {WasteBalanceLedgerRepository} from '#waste-balances/repository/ledger-port.js'
  * @typedef {ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>} WasteBalanceService
@@ -124,7 +124,7 @@
  * @typedef {{
  *   organisationsRepository: OrganisationsRepository,
  *   reportsRepository: ReportsRepository,
- *   summaryLogRowStatesRepository: SummaryLogRowStateRepository,
+ *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
  *   [key: string]: unknown
  * }} ServerApp
  */

--- a/src/non-prod-data-reset/mongodb.test.js
+++ b/src/non-prod-data-reset/mongodb.test.js
@@ -21,7 +21,7 @@ import { buildSystemLog } from '#repositories/system-logs/contract/test-data.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/mongodb.js'
 import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
 import { buildSummaryLogRowStateEntry } from '#waste-records/repository/test-data.js'
-import { createMongoSummaryLogRowStateRepository } from '#waste-records/repository/mongodb.js'
+import { createMongoSummaryLogRowStatesRepository } from '#waste-records/repository/mongodb.js'
 
 import { config } from '#root/config.js'
 import { createNonProdDataReset } from './mongodb.js'
@@ -111,7 +111,7 @@ const it = /** @type {import('vitest').TestAPI<ResetTestFixtures>} */ (
       const overseasSitesFactory = await createOverseasSitesRepository(database)
       const systemLogsFactory = await createSystemLogsRepository(database)
       const summaryLogRowStatesFactory =
-        await createMongoSummaryLogRowStateRepository(database)
+        await createMongoSummaryLogRowStatesRepository(database)
 
       await use({
         organisations: organisationsFactory(),

--- a/src/packaging-recycling-notes/application/prn-events.plugin.js
+++ b/src/packaging-recycling-notes/application/prn-events.plugin.js
@@ -12,6 +12,10 @@ import { registerDependency } from '#plugins/register-dependency.js'
  */
 
 /**
+ * @typedef {{ onCancelled: OnPrnCancelledHandler }} PrnEvents
+ */
+
+/**
  * Generic PRN lifecycle event plugin: exposes `request.prnEvents` so any
  * route can notify interested domains of a PRN transition without knowing
  * who's listening. Each event fans out to every registered handler, so a

--- a/src/plugins/register-dependency.js
+++ b/src/plugins/register-dependency.js
@@ -1,3 +1,5 @@
+/** @import { ServerApp, TypedLogger } from '#common/hapi-types.js' */
+
 /**
  * Registers a named dependency on both server.app and request objects.
  *
@@ -8,9 +10,10 @@
  * - request[name]: Created lazily per-request using request.logger.
  *   Use this in HTTP route handlers to get correlation IDs in logs.
  *
+ * @template {keyof ServerApp} K
  * @param {import('@hapi/hapi').Server} server - Hapi server instance
- * @param {string} name - Property name to register (e.g. 'organisationsRepository')
- * @param {(request: {logger: import('#common/hapi-types.js').TypedLogger}) => unknown} getInstance - Factory function that returns the dependency instance
+ * @param {K} name - Property name to register (e.g. 'organisationsRepository')
+ * @param {(request: {logger: TypedLogger}) => ServerApp[K]} getInstance - Factory function that returns the dependency instance
  */
 export const registerDependency = (server, name, getInstance) => {
   // Register on server.app for background jobs (using server.logger)

--- a/src/plugins/register-dependency.test.js
+++ b/src/plugins/register-dependency.test.js
@@ -2,7 +2,6 @@ import Hapi from '@hapi/hapi'
 import { describe, it, expect, vi } from 'vitest'
 import { registerDependency } from './register-dependency.js'
 
-/** @import { ServerApp } from '#common/hapi-types.js' */
 /** @import { Request } from '@hapi/hapi' */
 
 describe('registerDependency', () => {
@@ -13,7 +12,7 @@ describe('registerDependency', () => {
 
     registerDependency(server, 'testDependency', getInstance)
 
-    const app = /** @type {ServerApp} */ (server.app)
+    const app = /** @type {{ testDependency: unknown }} */ (server.app)
     expect(app.testDependency).toBe(dependency)
     expect(getInstance).toHaveBeenCalledWith({ logger: server.logger })
   })

--- a/src/plugins/register-dependency.test.js
+++ b/src/plugins/register-dependency.test.js
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { registerDependency } from './register-dependency.js'
 
 /** @import { Request } from '@hapi/hapi' */
+/** @import { ServerApp } from '#common/hapi-types.js' */
 
 describe('registerDependency', () => {
   it('registers the dependency on server.app built with server.logger', () => {
@@ -10,10 +11,10 @@ describe('registerDependency', () => {
     const dependency = { findById: vi.fn() }
     const getInstance = vi.fn().mockReturnValue(dependency)
 
-    registerDependency(server, 'testDependency', getInstance)
+    registerDependency(server, 'reportsRepository', getInstance)
 
-    const app = /** @type {{ testDependency: unknown }} */ (server.app)
-    expect(app.testDependency).toBe(dependency)
+    const app = /** @type {ServerApp} */ (server.app)
+    expect(app.reportsRepository).toBe(dependency)
     expect(getInstance).toHaveBeenCalledWith({ logger: server.logger })
   })
 
@@ -22,7 +23,7 @@ describe('registerDependency', () => {
     const dependency = { findById: vi.fn() }
     const getInstance = vi.fn().mockReturnValue(dependency)
 
-    registerDependency(server, 'testDependency', getInstance)
+    registerDependency(server, 'reportsRepository', getInstance)
 
     /** @type {unknown[]} */
     const accesses = []
@@ -33,11 +34,11 @@ describe('registerDependency', () => {
       path: '/',
       handler: (request, h) => {
         handledRequest = request
-        const typed = /** @type {Request & { testDependency: unknown }} */ (
+        const typed = /** @type {Request & { reportsRepository: unknown }} */ (
           request
         )
         // Access twice so both the compute-and-cache and cached-read paths run.
-        accesses.push(typed.testDependency, typed.testDependency)
+        accesses.push(typed.reportsRepository, typed.reportsRepository)
         return h.response('ok')
       }
     })

--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -137,7 +137,7 @@ function buildReportData(aggregated, registration) {
  * @param {object} params
  * @param {import('#reports/repository/port.js').ReportsRepository} params.reportsRepository
  * @param {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} params.ledgerRepository
- * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} params.summaryLogRowStateRepository
+ * @param {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} params.summaryLogRowStatesRepository
  * @param {PackagingRecyclingNotesRepository} params.packagingRecyclingNotesRepository
  * @param {import('#overseas-sites/repository/port.js').OverseasSitesRepository} params.overseasSitesRepository
  * @param {string} params.organisationId
@@ -152,7 +152,7 @@ function buildReportData(aggregated, registration) {
 export async function fetchOrGenerateReportForPeriod({
   reportsRepository,
   ledgerRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   packagingRecyclingNotesRepository,
   overseasSitesRepository,
   organisationId,
@@ -198,7 +198,7 @@ export async function fetchOrGenerateReportForPeriod({
 
   const aggregatedReportDetail = await getAggregatedReportDetail({
     ledgerRepository,
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     packagingRecyclingNotesRepository,
     overseasSitesRepository,
     operatorCategory,
@@ -234,7 +234,7 @@ function toSource(latestSubmission) {
  * summary log into a report and appends issued PRN tonnage.
  * @param {object} params
  * @param {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} params.ledgerRepository
- * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} params.summaryLogRowStateRepository
+ * @param {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} params.summaryLogRowStatesRepository
  * @param {PackagingRecyclingNotesRepository} params.packagingRecyclingNotesRepository
  * @param {import('#overseas-sites/repository/port.js').OverseasSitesRepository} params.overseasSitesRepository
  * @param {string} params.operatorCategory
@@ -248,7 +248,7 @@ function toSource(latestSubmission) {
  */
 async function getAggregatedReportDetail({
   ledgerRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   packagingRecyclingNotesRepository,
   overseasSitesRepository,
   operatorCategory,
@@ -271,7 +271,7 @@ async function getAggregatedReportDetail({
   )
 
   const wasteRecordStates = await wasteRecordStatesForHead(
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     ledgerId,
     latestSubmission === null ? null : latestSubmission.summaryLogId
   )
@@ -310,7 +310,7 @@ async function getAggregatedReportDetail({
  * @param {object} params
  * @param {import('#reports/repository/port.js').ReportsRepository} params.reportsRepository
  * @param {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} params.ledgerRepository
- * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} params.summaryLogRowStateRepository
+ * @param {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} params.summaryLogRowStatesRepository
  * @param {PackagingRecyclingNotesRepository} params.packagingRecyclingNotesRepository
  * @param {import('#overseas-sites/repository/port.js').OverseasSitesRepository} params.overseasSitesRepository
  * @param {string} params.organisationId
@@ -326,7 +326,7 @@ async function getAggregatedReportDetail({
 export async function createReportForPeriod({
   reportsRepository,
   ledgerRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   packagingRecyclingNotesRepository,
   overseasSitesRepository,
   organisationId,
@@ -372,7 +372,7 @@ export async function createReportForPeriod({
 
   const aggregatedReportData = await getAggregatedReportDetail({
     ledgerRepository,
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     packagingRecyclingNotesRepository,
     overseasSitesRepository,
     operatorCategory,

--- a/src/reports/application/report-service.test.js
+++ b/src/reports/application/report-service.test.js
@@ -5,7 +5,7 @@ import {
 } from '#reports/domain/report-status.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
 import { buildSummaryLogRowStateEntry } from '#waste-records/repository/test-data.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
@@ -94,11 +94,11 @@ const seedState = async ({ organisationId, registration }, entries) => {
     registrationId: registration.id,
     accreditationId
   }
-  const summaryLogRowStateRepository =
-    createInMemorySummaryLogRowStateRepository()()
+  const summaryLogRowStatesRepository =
+    createInMemorySummaryLogRowStatesRepository()()
   const ledgerEvents = []
   if (entries.length > 0) {
-    await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+    await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       ledgerId,
       entries,
       SUMMARY_LOG_ID
@@ -116,7 +116,7 @@ const seedState = async ({ organisationId, registration }, entries) => {
   }
   return {
     ledgerRepository: createInMemoryLedgerRepository(ledgerEvents)(),
-    summaryLogRowStateRepository
+    summaryLogRowStatesRepository
   }
 }
 
@@ -148,13 +148,13 @@ describe('report-service', () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const packagingRecyclingNotesRepository = createPrnRepo()
       const params = defaultParams()
-      const { ledgerRepository, summaryLogRowStateRepository } =
+      const { ledgerRepository, summaryLogRowStatesRepository } =
         await seedState(params, [])
 
       const report = await fetchOrGenerateReportForPeriod({
         reportsRepository,
         ledgerRepository,
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         packagingRecyclingNotesRepository,
         ...params
       })
@@ -177,14 +177,14 @@ describe('report-service', () => {
         accreditationId
       }
 
-      const summaryLogRowStateRepository =
-        createInMemorySummaryLogRowStateRepository()()
-      await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+      const summaryLogRowStatesRepository =
+        createInMemorySummaryLogRowStatesRepository()()
+      await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
         ledgerId,
         [buildReceivedEntry({ SUPPLIER_NAME: 'First Supplier' })],
         'sl-1'
       )
-      await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+      await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
         ledgerId,
         [buildReceivedEntry({ SUPPLIER_NAME: 'Second Supplier' })],
         'sl-2'
@@ -225,7 +225,7 @@ describe('report-service', () => {
           await fetchOrGenerateReportForPeriod({
             reportsRepository,
             ledgerRepository,
-            summaryLogRowStateRepository,
+            summaryLogRowStatesRepository,
             packagingRecyclingNotesRepository,
             ...params
           })
@@ -246,7 +246,7 @@ describe('report-service', () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const packagingRecyclingNotesRepository = createPrnRepo()
       const params = defaultParams()
-      const { ledgerRepository, summaryLogRowStateRepository } =
+      const { ledgerRepository, summaryLogRowStatesRepository } =
         await seedState(params, [])
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
 
@@ -285,7 +285,7 @@ describe('report-service', () => {
       const report = await fetchOrGenerateReportForPeriod({
         reportsRepository,
         ledgerRepository,
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         packagingRecyclingNotesRepository,
         ...params
       })
@@ -300,7 +300,7 @@ describe('report-service', () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const packagingRecyclingNotesRepository = createPrnRepo()
       const params = defaultParams()
-      const { ledgerRepository, summaryLogRowStateRepository } =
+      const { ledgerRepository, summaryLogRowStatesRepository } =
         await seedState(params, [])
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
 
@@ -352,7 +352,7 @@ describe('report-service', () => {
       const report = await fetchOrGenerateReportForPeriod({
         reportsRepository,
         ledgerRepository,
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         packagingRecyclingNotesRepository,
         ...params,
         submissionNumber: 1
@@ -365,7 +365,7 @@ describe('report-service', () => {
 
     it('returns computed report with aggregated waste data', async () => {
       const params = defaultParams()
-      const { ledgerRepository, summaryLogRowStateRepository } =
+      const { ledgerRepository, summaryLogRowStatesRepository } =
         await seedState(params, [buildReceivedEntry()])
       const reportsRepository = createInMemoryReportsRepository()()
       const packagingRecyclingNotesRepository = createPrnRepo()
@@ -373,7 +373,7 @@ describe('report-service', () => {
       const report = await fetchOrGenerateReportForPeriod({
         reportsRepository,
         ledgerRepository,
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         packagingRecyclingNotesRepository,
         ...params
       })
@@ -442,7 +442,7 @@ describe('report-service', () => {
     it('creates a report and returns the full object', async () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const params = defaultParams()
-      const { ledgerRepository, summaryLogRowStateRepository } =
+      const { ledgerRepository, summaryLogRowStatesRepository } =
         await seedState(params, [buildReceivedEntry()])
       const packagingRecyclingNotesRepository = createPrnRepo()
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
@@ -450,7 +450,7 @@ describe('report-service', () => {
       const report = await createReportForPeriod({
         reportsRepository,
         ledgerRepository,
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         packagingRecyclingNotesRepository,
         ...params,
         changedBy
@@ -466,7 +466,7 @@ describe('report-service', () => {
     it('throws conflict when report already exists for period', async () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const params = defaultParams()
-      const { ledgerRepository, summaryLogRowStateRepository } =
+      const { ledgerRepository, summaryLogRowStatesRepository } =
         await seedState(params, [buildReceivedEntry()])
       const packagingRecyclingNotesRepository = createPrnRepo()
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
@@ -474,7 +474,7 @@ describe('report-service', () => {
       await createReportForPeriod({
         reportsRepository,
         ledgerRepository,
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         packagingRecyclingNotesRepository,
         ...params,
         changedBy
@@ -484,7 +484,7 @@ describe('report-service', () => {
         createReportForPeriod({
           reportsRepository,
           ledgerRepository,
-          summaryLogRowStateRepository,
+          summaryLogRowStatesRepository,
           packagingRecyclingNotesRepository,
           ...params,
           changedBy
@@ -497,7 +497,7 @@ describe('report-service', () => {
       const packagingRecyclingNotesRepository = createPrnRepo()
       const params = defaultParams()
       params.year = 2099
-      const { ledgerRepository, summaryLogRowStateRepository } =
+      const { ledgerRepository, summaryLogRowStatesRepository } =
         await seedState(params, [])
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
 
@@ -505,7 +505,7 @@ describe('report-service', () => {
         createReportForPeriod({
           reportsRepository,
           ledgerRepository,
-          summaryLogRowStateRepository,
+          summaryLogRowStatesRepository,
           packagingRecyclingNotesRepository,
           ...params,
           changedBy
@@ -520,7 +520,7 @@ describe('report-service', () => {
         material: 'glass',
         glassRecyclingProcess: ['glass_re_melt']
       })
-      const { ledgerRepository, summaryLogRowStateRepository } =
+      const { ledgerRepository, summaryLogRowStatesRepository } =
         await seedState(params, [buildReceivedEntry()])
       const packagingRecyclingNotesRepository = createPrnRepo()
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
@@ -528,7 +528,7 @@ describe('report-service', () => {
       const report = await createReportForPeriod({
         reportsRepository,
         ledgerRepository,
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         packagingRecyclingNotesRepository,
         ...params,
         changedBy
@@ -540,7 +540,7 @@ describe('report-service', () => {
     it('formats site address into single-line string', async () => {
       const reportsRepository = createInMemoryReportsRepository()()
       const params = defaultParams()
-      const { ledgerRepository, summaryLogRowStateRepository } =
+      const { ledgerRepository, summaryLogRowStatesRepository } =
         await seedState(params, [buildReceivedEntry()])
       const packagingRecyclingNotesRepository = createPrnRepo()
       const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
@@ -548,7 +548,7 @@ describe('report-service', () => {
       const report = await createReportForPeriod({
         reportsRepository,
         ledgerRepository,
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         packagingRecyclingNotesRepository,
         ...params,
         changedBy
@@ -593,14 +593,14 @@ describe('report-service', () => {
         const reportsRepository = createInMemoryReportsRepository()()
         const params = defaultParams()
         params.registration = buildRegistration({ accreditationId: undefined })
-        const { ledgerRepository, summaryLogRowStateRepository } =
+        const { ledgerRepository, summaryLogRowStatesRepository } =
           await seedState(params, [buildReceivedEntry()])
         const prnRepo = createPrnRepo()
 
         const report = await createReportForPeriod({
           reportsRepository,
           ledgerRepository,
-          summaryLogRowStateRepository,
+          summaryLogRowStatesRepository,
           packagingRecyclingNotesRepository: prnRepo,
           ...params,
           changedBy
@@ -612,14 +612,14 @@ describe('report-service', () => {
       it('persists prn with issuedTonnage 0 when accredited and no PRNs exist', async () => {
         const reportsRepository = createInMemoryReportsRepository()()
         const params = defaultParams()
-        const { ledgerRepository, summaryLogRowStateRepository } =
+        const { ledgerRepository, summaryLogRowStatesRepository } =
           await seedState(params, [buildReceivedEntry()])
         const prnRepo = createPrnRepo()
 
         const report = await createReportForPeriod({
           reportsRepository,
           ledgerRepository,
-          summaryLogRowStateRepository,
+          summaryLogRowStatesRepository,
           packagingRecyclingNotesRepository: prnRepo,
           ...params,
           changedBy
@@ -631,7 +631,7 @@ describe('report-service', () => {
       it('persists prn with summed issuedTonnage from PRNs in period', async () => {
         const reportsRepository = createInMemoryReportsRepository()()
         const params = defaultParams()
-        const { ledgerRepository, summaryLogRowStateRepository } =
+        const { ledgerRepository, summaryLogRowStatesRepository } =
           await seedState(params, [buildReceivedEntry()])
         const prnRepo = createPrnRepo()
 
@@ -641,7 +641,7 @@ describe('report-service', () => {
         const report = await createReportForPeriod({
           reportsRepository,
           ledgerRepository,
-          summaryLogRowStateRepository,
+          summaryLogRowStatesRepository,
           packagingRecyclingNotesRepository: prnRepo,
           ...params,
           changedBy

--- a/src/reports/monitoring/pre-cpa-resubmission-backfill.js
+++ b/src/reports/monitoring/pre-cpa-resubmission-backfill.js
@@ -17,7 +17,7 @@ import { auditMarkReportsRequiringResubmission } from '#reports/application/audi
  * @typedef {import('#reports/repository/port.js').ReportsRepository} ReportsRepository
  * @typedef {import('#reports/repository/port.js').MarkSubmittedReportRequiringResubmissionResult} MarkSubmittedReportRequiringResubmissionResult
  * @typedef {import('#waste-records/repository/port.js').SummaryLogRowState} SummaryLogRowState
- * @typedef {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} SummaryLogRowStateRepository
+ * @typedef {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} SummaryLogRowStatesRepository
  * @typedef {import('#waste-records/repository/port.js').WasteBalanceLedgerId} WasteBalanceLedgerId
  * @typedef {import('#repositories/summary-logs/port.js').SummaryLogsRepository} SummaryLogsRepository
  * @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository
@@ -327,18 +327,18 @@ const cadenceForRow = (row) =>
  * registered-only/accredited transition still pairs with its predecessor (within
  * the ledgers read -- see residual 1).
  *
- * @param {SummaryLogRowStateRepository} summaryLogRowStateRepository
+ * @param {SummaryLogRowStatesRepository} summaryLogRowStatesRepository
  * @param {WasteBalanceLedgerId[]} ledgers
  * @param {{ id: string, fileId: string, submittedAt: string }[]} logs
  * @returns {Promise<{ id: string, fileId: string, submittedAt: string, rows: SummaryLogRowState[] }[]>}
  */
-const loadSnapshots = async (summaryLogRowStateRepository, ledgers, logs) => {
+const loadSnapshots = async (summaryLogRowStatesRepository, ledgers, logs) => {
   const snapshots = []
   for (const log of logs) {
     const rows = []
     for (const ledger of ledgers) {
       rows.push(
-        ...(await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+        ...(await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
           ledger,
           log.fileId
         ))
@@ -538,7 +538,7 @@ const diffFindings = ({
  *   registrationId: string,
  *   reports: SubmittedReport[],
  *   summaryLogsRepository: SummaryLogsRepository,
- *   summaryLogRowStateRepository: SummaryLogRowStateRepository,
+ *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
  *   organisationsRepository: OrganisationsRepository
  * }} params
  * @returns {Promise<{ findings: PreCpaResubmissionFinding[], ignored: PreCpaResubmissionFinding[] }>}
@@ -548,7 +548,7 @@ const findForRegistration = async ({
   registrationId,
   reports,
   summaryLogsRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   organisationsRepository
 }) => {
   const ledgers = await resolveLedgers(
@@ -570,7 +570,7 @@ const findForRegistration = async ({
     return { findings: [], ignored: [] }
   }
   const snapshots = await loadSnapshots(
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     ledgers,
     logs
   )
@@ -616,7 +616,7 @@ const dedupeByReportId = (findings) => {
  * @param {{
  *   reportsRepository: ReportsRepository,
  *   summaryLogsRepository: SummaryLogsRepository,
- *   summaryLogRowStateRepository: SummaryLogRowStateRepository,
+ *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
  *   organisationsRepository: OrganisationsRepository
  * }} deps
  * @returns {Promise<{ scanned: number, findings: PreCpaResubmissionFinding[], ignoredInClosedPeriods: PreCpaResubmissionFinding[], reportsMissingSubmittedAt: ReportIdentity[] }>}
@@ -624,7 +624,7 @@ const dedupeByReportId = (findings) => {
 export const findPreCpaResubmissionReports = async ({
   reportsRepository,
   summaryLogsRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   organisationsRepository
 }) => {
   const periodicReports = await reportsRepository.findAllPeriodicReports()
@@ -640,7 +640,7 @@ export const findPreCpaResubmissionReports = async ({
       registrationId,
       reports,
       summaryLogsRepository,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       organisationsRepository
     })
     findings.push(...result.findings)
@@ -759,7 +759,7 @@ const unexpectedlyFlaggedReportIds = (expectedReportIds, flaggedReports) =>
  * @param {{
  *   reportsRepository: ReportsRepository,
  *   summaryLogsRepository: SummaryLogsRepository,
- *   summaryLogRowStateRepository: SummaryLogRowStateRepository,
+ *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
  *   organisationsRepository: OrganisationsRepository,
  *   systemLogsRepository: SystemLogsRepository
  * }} deps
@@ -775,7 +775,7 @@ const unexpectedlyFlaggedReportIds = (expectedReportIds, flaggedReports) =>
 export const backfillPreCpaResubmissionReports = async ({
   reportsRepository,
   summaryLogsRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   organisationsRepository,
   systemLogsRepository
 }) => {
@@ -783,7 +783,7 @@ export const backfillPreCpaResubmissionReports = async ({
     await findPreCpaResubmissionReports({
       reportsRepository,
       summaryLogsRepository,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       organisationsRepository
     })
 

--- a/src/reports/monitoring/pre-cpa-resubmission-backfill.js
+++ b/src/reports/monitoring/pre-cpa-resubmission-backfill.js
@@ -769,7 +769,7 @@ const unexpectedlyFlaggedReportIds = (expectedReportIds, flaggedReports) =>
  *   reportsMissingSubmittedAt: ReportIdentity[],
  *   flagged: MarkSubmittedReportRequiringResubmissionResult[],
  *   unexpectedlyFlaggedReportIds: string[],
- *   failed: Array<{ organisationId: string, registrationId: string, summaryLogId: string, error: Error }>
+ *   failed: { organisationId: string, registrationId: string, summaryLogId: string, error: Error }[]
  * }>}
  */
 export const backfillPreCpaResubmissionReports = async ({

--- a/src/reports/monitoring/pre-cpa-resubmission-backfill.test.js
+++ b/src/reports/monitoring/pre-cpa-resubmission-backfill.test.js
@@ -7,7 +7,7 @@ import { createInMemoryOrganisationsRepository } from '#repositories/organisatio
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { summaryLogFactory } from '#repositories/summary-logs/contract/test-data.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import {
   findPreCpaResubmissionReports,
   backfillPreCpaResubmissionReports,
@@ -167,8 +167,8 @@ const buildRepos = async (registrations) => {
   return {
     reportsRepository: createInMemoryReportsRepository(reportDocs)(),
     summaryLogsRepository,
-    summaryLogRowStateRepository:
-      createInMemorySummaryLogRowStateRepository(rowStateDocs)(),
+    summaryLogRowStatesRepository:
+      createInMemorySummaryLogRowStatesRepository(rowStateDocs)(),
     organisationsRepository:
       createInMemoryOrganisationsRepository(organisations)()
   }

--- a/src/reports/monitoring/unexported-tonnage.js
+++ b/src/reports/monitoring/unexported-tonnage.js
@@ -27,7 +27,7 @@ import { wasteRecordStatesForHead } from '#waste-records/application/read-summar
  * @import { OrganisationsRepository } from '#repositories/organisations/port.js'
  * @import { PeriodicReport, ReportsRepository } from '#reports/repository/port.js'
  * @import { WasteRecordState } from '#waste-records/application/read-summary-log-row-states.js'
- * @import { SummaryLogRowStateRepository } from '#waste-records/repository/port.js'
+ * @import { SummaryLogRowStatesRepository } from '#waste-records/repository/port.js'
  */
 
 /**
@@ -639,13 +639,13 @@ const NO_ROWS = 'no rows found under the registration ledgers'
  * @param {{
  *   reportsRepository: ReportsRepository,
  *   organisationsRepository: OrganisationsRepository,
- *   summaryLogRowStateRepository: SummaryLogRowStateRepository
+ *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository
  * }} deps
  * @param {ReviewableReportRow} row
  * @returns {Promise<SourceRowStates>}
  */
 const loadSourceRowStates = async (
-  { reportsRepository, organisationsRepository, summaryLogRowStateRepository },
+  { reportsRepository, organisationsRepository, summaryLogRowStatesRepository },
   row
 ) => {
   const report = await reportsRepository.findReportById(row.reportId)
@@ -664,7 +664,7 @@ const loadSourceRowStates = async (
   for (const ledger of ledgers) {
     states.push(
       ...(await wasteRecordStatesForHead(
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         ledger,
         summaryLogId
       ))
@@ -688,7 +688,7 @@ const loadSourceRowStates = async (
  * @param {{
  *   reportsRepository: ReportsRepository,
  *   organisationsRepository: OrganisationsRepository,
- *   summaryLogRowStateRepository: SummaryLogRowStateRepository
+ *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository
  * }} deps
  * @returns {Promise<{ scanned: number, findings: UnexportedTonnageFinding[] }>}
  */

--- a/src/reports/monitoring/unexported-tonnage.test.js
+++ b/src/reports/monitoring/unexported-tonnage.test.js
@@ -770,7 +770,7 @@ describe('unexported-tonnage', () => {
       organisationsRepository: {
         findRegistrationById: vi.fn().mockResolvedValue(registration)
       },
-      summaryLogRowStateRepository: {
+      summaryLogRowStatesRepository: {
         findRowStatesForSummaryLog: vi
           .fn()
           .mockImplementation(async ({ accreditationId }) =>
@@ -806,7 +806,7 @@ describe('unexported-tonnage', () => {
       await scan(deps)
 
       expect(
-        deps.summaryLogRowStateRepository.findRowStatesForSummaryLog
+        deps.summaryLogRowStatesRepository.findRowStatesForSummaryLog
       ).toHaveBeenCalledWith(
         {
           organisationId: 'org-1',
@@ -823,7 +823,7 @@ describe('unexported-tonnage', () => {
       await scan(deps)
 
       expect(
-        deps.summaryLogRowStateRepository.findRowStatesForSummaryLog
+        deps.summaryLogRowStatesRepository.findRowStatesForSummaryLog
       ).toHaveBeenCalledWith(
         {
           organisationId: 'org-1',
@@ -840,7 +840,7 @@ describe('unexported-tonnage', () => {
       const { findings } = await scan(deps)
 
       expect(
-        deps.summaryLogRowStateRepository.findRowStatesForSummaryLog
+        deps.summaryLogRowStatesRepository.findRowStatesForSummaryLog
       ).toHaveBeenCalledExactlyOnceWith(
         {
           organisationId: 'org-1',

--- a/src/reports/routes/get-detail.js
+++ b/src/reports/routes/get-detail.js
@@ -12,7 +12,7 @@ import { SCOPES } from '#common/helpers/auth/constants.js'
  * @import { OrganisationsRepository } from '#repositories/organisations/port.js'
  * @import { ReportsRepository } from '#reports/repository/port.js'
  * @import { WasteBalanceLedgerRepository } from '#waste-balances/repository/ledger-port.js'
- * @import { SummaryLogRowStateRepository } from '#waste-records/repository/port.js'
+ * @import { SummaryLogRowStatesRepository } from '#waste-records/repository/port.js'
  * @import { PackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/port.js'
  * @import { OverseasSitesRepository } from '#overseas-sites/repository/port.js'
  * @import { PeriodWithSubmissionPathParams } from './shared.js'
@@ -73,7 +73,7 @@ export const reportsGetDetail = {
    *   params: PeriodWithSubmissionPathParams,
    *   organisationsRepository: OrganisationsRepository,
    *   ledgerRepository: WasteBalanceLedgerRepository,
-   *   summaryLogRowStatesRepository: SummaryLogRowStateRepository,
+   *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
    *   packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository,
    *   reportsRepository: ReportsRepository,
    *   overseasSitesRepository: OverseasSitesRepository
@@ -107,7 +107,7 @@ export const reportsGetDetail = {
     const report = await fetchOrGenerateReportForPeriod({
       reportsRepository,
       ledgerRepository,
-      summaryLogRowStateRepository: summaryLogRowStatesRepository,
+      summaryLogRowStatesRepository,
       packagingRecyclingNotesRepository,
       overseasSitesRepository,
       organisationId,

--- a/src/reports/routes/get-detail.test.js
+++ b/src/reports/routes/get-detail.test.js
@@ -6,7 +6,7 @@ import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
 import { buildSummaryLogRowStateEntry } from '#waste-records/repository/test-data.js'
 import {
@@ -44,7 +44,7 @@ const seedRepositories = async (org, registration, wasteRecordOverrides) => {
     accreditationId
   }
   const summaryLogRowStatesRepository =
-    createInMemorySummaryLogRowStateRepository()()
+    createInMemorySummaryLogRowStatesRepository()()
   const ledgerEvents = []
   if (wasteRecordOverrides.length > 0) {
     const entries = wasteRecordOverrides.map((override, index) =>

--- a/src/reports/routes/post.js
+++ b/src/reports/routes/post.js
@@ -23,7 +23,7 @@ import { reportResponseFailAction } from './response-fail-action.js'
  * @import { OrganisationsRepository } from '#repositories/organisations/port.js'
  * @import { ReportsRepository } from '#reports/repository/port.js'
  * @import { WasteBalanceLedgerRepository } from '#waste-balances/repository/ledger-port.js'
- * @import { SummaryLogRowStateRepository } from '#waste-records/repository/port.js'
+ * @import { SummaryLogRowStatesRepository } from '#waste-records/repository/port.js'
  * @import { PackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/port.js'
  * @import { OverseasSitesRepository } from '#overseas-sites/repository/port.js'
  * @import { PeriodWithSubmissionPathParams } from './shared.js'
@@ -71,7 +71,7 @@ export const reportsPost = {
    *   params: PeriodWithSubmissionPathParams,
    *   organisationsRepository: OrganisationsRepository,
    *   ledgerRepository: WasteBalanceLedgerRepository,
-   *   summaryLogRowStatesRepository: SummaryLogRowStateRepository,
+   *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
    *   packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository,
    *   reportsRepository: ReportsRepository,
    *   overseasSitesRepository: OverseasSitesRepository
@@ -109,7 +109,7 @@ export const reportsPost = {
       const createdReport = await createReportForPeriod({
         reportsRepository,
         ledgerRepository,
-        summaryLogRowStateRepository: summaryLogRowStatesRepository,
+        summaryLogRowStatesRepository,
         packagingRecyclingNotesRepository,
         overseasSitesRepository,
         organisationId,

--- a/src/reports/routes/post.test.js
+++ b/src/reports/routes/post.test.js
@@ -7,7 +7,7 @@ import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
 import { buildSummaryLogRowStateEntry } from '#waste-records/repository/test-data.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
@@ -57,7 +57,7 @@ describe(`POST ${reportsPostPath}`, () => {
       accreditationId
     }
     const summaryLogRowStatesRepository =
-      createInMemorySummaryLogRowStateRepository()()
+      createInMemorySummaryLogRowStatesRepository()()
     await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       ledgerId,
       [

--- a/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration-test-helpers.js
@@ -13,7 +13,7 @@ import { createInMemoryOrganisationsRepository } from '#repositories/organisatio
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
 import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
@@ -486,13 +486,13 @@ export const createTestInfrastructure = async (
   const summaryLogExtractor = createInMemorySummaryLogExtractor(extractorData)
   const overseasSitesRepository = createInMemoryOverseasSitesRepository([])()
   const ledgerRepository = createInMemoryLedgerRepository()()
-  const summaryLogRowStateRepository =
-    createInMemorySummaryLogRowStateRepository()()
+  const summaryLogRowStatesRepository =
+    createInMemorySummaryLogRowStatesRepository()()
 
   const validateSummaryLog = createSummaryLogsValidator({
     summaryLogsRepository,
     organisationsRepository,
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     ledgerRepository,
     reportsService: /** @type {any} */ ({
       findPeriodicReports: async () => []
@@ -551,8 +551,8 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
   const featureFlags = createInMemoryFeatureFlags(featureFlagOverrides)
 
   const ledgerRepository = createInMemoryLedgerRepository()()
-  const summaryLogRowStateRepository =
-    createInMemorySummaryLogRowStateRepository()()
+  const summaryLogRowStatesRepository =
+    createInMemorySummaryLogRowStatesRepository()()
 
   const systemLogsForBalanceAudit = {
     insert: vi.fn().mockResolvedValue(undefined),
@@ -609,7 +609,7 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
   const validateSummaryLog = createSummaryLogsValidator({
     summaryLogsRepository,
     organisationsRepository,
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     ledgerRepository,
     reportsService: createReportsService(reportsRepository),
     overseasSitesRepository,
@@ -622,7 +622,7 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
     wasteBalanceService,
     organisationsRepository,
     overseasSitesRepository,
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     ledgerRepository,
     logger: mockLogger
   })
@@ -664,7 +664,7 @@ export const setupWasteBalanceIntegrationEnvironment = async ({
     accreditationId,
     fileDataMap,
     ledgerRepository,
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     systemLogsForBalanceAudit,
     reportsRepository
   }

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.repeated-uploads.test.js
@@ -14,7 +14,7 @@ import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemor
 import { buildReadOrganisation } from '#repositories/organisations/contract/test-data.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
 import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
 import { createMockLogger } from '#test/mock-logger.js'
@@ -60,7 +60,7 @@ describe('Repeated uploads of identical data', () => {
     const secondFileId = 'file-second-upload'
 
     let server
-    let summaryLogRowStateRepository
+    let summaryLogRowStatesRepository
     let ledgerRepository
     let accreditationId
     let secondUploadResponse
@@ -248,14 +248,14 @@ describe('Repeated uploads of identical data', () => {
       // Validate reads and submit writes the same latest-submitted row states,
       // so both paths must share one ledger and one row-state repository.
       ledgerRepository = createInMemoryLedgerRepository()()
-      summaryLogRowStateRepository =
-        createInMemorySummaryLogRowStateRepository()()
+      summaryLogRowStatesRepository =
+        createInMemorySummaryLogRowStatesRepository()()
       const featureFlags = createInMemoryFeatureFlags()
 
       const validateSummaryLog = createSummaryLogsValidator({
         summaryLogsRepository,
         organisationsRepository,
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         ledgerRepository,
         summaryLogExtractor,
         logger: mockLogger,
@@ -270,7 +270,7 @@ describe('Repeated uploads of identical data', () => {
       const syncWasteRecords = syncFromSummaryLog({
         extractor: summaryLogExtractor,
         wasteBalanceService: createWasteBalanceService(ledgerRepository),
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         ledgerRepository,
         organisationsRepository,
         overseasSitesRepository: createMockOverseasSitesRepository({
@@ -412,7 +412,7 @@ describe('Repeated uploads of identical data', () => {
         const committedBefore = await summaryLogRowStatesForRegistration({
           ...ledgerId,
           ledgerRepository,
-          summaryLogRowStateRepository
+          summaryLogRowStatesRepository
         })
 
         await server.inject({
@@ -436,7 +436,7 @@ describe('Repeated uploads of identical data', () => {
         const committedAfter = await summaryLogRowStatesForRegistration({
           ...ledgerId,
           ledgerRepository,
-          summaryLogRowStateRepository
+          summaryLogRowStatesRepository
         })
 
         const rowIdsBefore = committedBefore.map((state) => state.rowId).sort()

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.submission-and-placeholders.test.js
@@ -21,7 +21,7 @@ import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js
 import { createReportsService } from '#reports/application/report-service.js'
 import { createInMemorySummaryLogsRepository } from '#repositories/summary-logs/inmemory.js'
 import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
 import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
 import { createMockLogger } from '#test/mock-logger.js'
@@ -71,7 +71,7 @@ describe('Submission and placeholder tests', () => {
     const secondSummaryLogId = 'summary-submit-test-2'
     const secondFileId = 'file-submit-456'
     const secondFilename = 'waste-data-2.xlsx'
-    let summaryLogRowStateRepository
+    let summaryLogRowStatesRepository
     let ledgerRepository
     let accreditationId
     let submitResponse
@@ -360,14 +360,14 @@ describe('Submission and placeholder tests', () => {
       // Validate reads and submit writes the same latest-submitted row states,
       // so both paths must share one ledger and one row-state repository.
       ledgerRepository = createInMemoryLedgerRepository()()
-      summaryLogRowStateRepository =
-        createInMemorySummaryLogRowStateRepository()()
+      summaryLogRowStatesRepository =
+        createInMemorySummaryLogRowStatesRepository()()
       const featureFlags = createInMemoryFeatureFlags()
 
       const validateSummaryLog = createSummaryLogsValidator({
         summaryLogsRepository,
         organisationsRepository,
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         ledgerRepository,
         summaryLogExtractor: validationExtractor,
         logger: mockLogger,
@@ -380,7 +380,7 @@ describe('Submission and placeholder tests', () => {
       const syncWasteRecords = syncFromSummaryLog({
         extractor: transformationExtractor,
         wasteBalanceService: createWasteBalanceService(ledgerRepository),
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         ledgerRepository,
         organisationsRepository,
         overseasSitesRepository: createMockOverseasSitesRepository({
@@ -485,7 +485,7 @@ describe('Submission and placeholder tests', () => {
         registrationId,
         accreditationId,
         ledgerRepository,
-        summaryLogRowStateRepository
+        summaryLogRowStatesRepository
       })
 
       expect(rowStates.map((state) => state.rowId).sort()).toEqual([
@@ -804,8 +804,8 @@ describe('Submission and placeholder tests', () => {
       const validateSummaryLog = createSummaryLogsValidator({
         summaryLogsRepository: testSummaryLogsRepository,
         organisationsRepository,
-        summaryLogRowStateRepository:
-          createInMemorySummaryLogRowStateRepository()(),
+        summaryLogRowStatesRepository:
+          createInMemorySummaryLogRowStatesRepository()(),
         ledgerRepository: createInMemoryLedgerRepository()(),
         summaryLogExtractor,
         logger: mockLogger,

--- a/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
+++ b/src/routes/v1/organisations/registrations/summary-logs/integration.validation-advanced.test.js
@@ -12,7 +12,7 @@ import { createTestServer } from '#test/create-test-server.js'
 import { createInMemorySummaryLogExtractor } from '#application/summary-logs/extractor-inmemory.js'
 import { createSummaryLogsValidator } from '#application/summary-logs/validate.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 
@@ -385,8 +385,8 @@ describe('Advanced validation scenarios', () => {
       const validateSummaryLog = createSummaryLogsValidator({
         summaryLogsRepository: testSummaryLogsRepository,
         organisationsRepository,
-        summaryLogRowStateRepository:
-          createInMemorySummaryLogRowStateRepository()(),
+        summaryLogRowStatesRepository:
+          createInMemorySummaryLogRowStatesRepository()(),
         ledgerRepository: createInMemoryLedgerRepository()(),
         overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
         summaryLogExtractor,
@@ -571,8 +571,8 @@ describe('Advanced validation scenarios', () => {
       const validateSummaryLog = createSummaryLogsValidator({
         summaryLogsRepository: testSummaryLogsRepository,
         organisationsRepository,
-        summaryLogRowStateRepository:
-          createInMemorySummaryLogRowStateRepository()(),
+        summaryLogRowStatesRepository:
+          createInMemorySummaryLogRowStatesRepository()(),
         ledgerRepository: createInMemoryLedgerRepository()(),
         overseasSitesRepository: createInMemoryOverseasSitesRepository([])(),
         summaryLogExtractor,

--- a/src/server/queue-consumer/queue-consumer.plugin.js
+++ b/src/server/queue-consumer/queue-consumer.plugin.js
@@ -22,7 +22,7 @@ import { orsImportCommandHandlers } from './ors-import-commands.js'
  *   uploadsRepository: import('#domain/uploads/repository/port.js').UploadsRepository,
  *   summaryLogsRepository: import('#repositories/summary-logs/port.js').SummaryLogsRepository,
  *   organisationsRepository: import('#repositories/organisations/port.js').OrganisationsRepository,
- *   summaryLogRowStatesRepository: import('#waste-records/repository/port.js').SummaryLogRowStateRepository,
+ *   summaryLogRowStatesRepository: import('#waste-records/repository/port.js').SummaryLogRowStatesRepository,
  *   ledgerRepository: import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository,
  *   wasteBalanceService: ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>,
  *   reportsRepository: import('#reports/repository/port.js').ReportsRepository,

--- a/src/server/queue-consumer/queue-consumer.plugin.js
+++ b/src/server/queue-consumer/queue-consumer.plugin.js
@@ -18,19 +18,6 @@ import { orsImportCommandHandlers } from './ors-import-commands.js'
  */
 
 /**
- * @typedef {{
- *   uploadsRepository: import('#domain/uploads/repository/port.js').UploadsRepository,
- *   summaryLogsRepository: import('#repositories/summary-logs/port.js').SummaryLogsRepository,
- *   organisationsRepository: import('#repositories/organisations/port.js').OrganisationsRepository,
- *   summaryLogRowStatesRepository: import('#waste-records/repository/port.js').SummaryLogRowStatesRepository,
- *   ledgerRepository: import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository,
- *   wasteBalanceService: ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>,
- *   reportsRepository: import('#reports/repository/port.js').ReportsRepository,
- *   systemLogsRepository: import('#repositories/system-logs/port.js').SystemLogsRepository
- * }} QueueConsumerRepositories
- */
-
-/**
  * Builds the base consumer dependencies from server app and config.
  * @param {import('#common/hapi-types.js').HapiServer} server
  * @param {CommandQueueConsumerPluginOptions} options
@@ -50,7 +37,7 @@ function buildConsumerDeps(server, { config }) {
     wasteBalanceService,
     reportsRepository,
     systemLogsRepository
-  } = /** @type {QueueConsumerRepositories} */ (server.app)
+  } = server.app
 
   const onSummaryLogUploaded = createOnSummaryLogUploaded({
     reportsRepository,

--- a/src/server/queue-consumer/summary-log-commands.js
+++ b/src/server/queue-consumer/summary-log-commands.js
@@ -16,7 +16,7 @@ import { submitSummaryLog } from '#application/summary-logs/submit.js'
 /** @typedef {import('#common/helpers/logging/logger.js').TypedLogger} TypedLogger */
 /** @typedef {import('#repositories/summary-logs/port.js').SummaryLogsRepository} SummaryLogsRepository */
 /** @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository */
-/** @typedef {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} SummaryLogRowStateRepository */
+/** @typedef {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} SummaryLogRowStatesRepository */
 /** @typedef {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} WasteBalanceLedgerRepository */
 /** @typedef {ReturnType<typeof import('#waste-balances/application/waste-balance-service.js').createWasteBalanceService>} WasteBalanceService */
 /** @typedef {import('#domain/summary-logs/extractor/port.js').SummaryLogExtractor} SummaryLogExtractor */
@@ -28,7 +28,7 @@ import { submitSummaryLog } from '#application/summary-logs/submit.js'
  * @property {TypedLogger} logger
  * @property {SummaryLogsRepository} summaryLogsRepository
  * @property {OrganisationsRepository} organisationsRepository
- * @property {SummaryLogRowStateRepository} summaryLogRowStatesRepository
+ * @property {SummaryLogRowStatesRepository} summaryLogRowStatesRepository
  * @property {WasteBalanceLedgerRepository} ledgerRepository
  * @property {WasteBalanceService} wasteBalanceService
  * @property {ReportsService} reportsService
@@ -95,7 +95,7 @@ export const summaryLogCommandHandlers = [
         logger,
         summaryLogsRepository,
         organisationsRepository,
-        summaryLogRowStateRepository: summaryLogRowStatesRepository,
+        summaryLogRowStatesRepository,
         ledgerRepository,
         reportsService,
         overseasSitesRepository,

--- a/src/server/run-forms-data-migration.js
+++ b/src/server/run-forms-data-migration.js
@@ -7,6 +7,11 @@ import { createS3Client } from '#common/helpers/s3/s3-client.js'
 import { createFormsFileUploadsRepository } from '#adapters/repositories/forms-submissions/forms-file-uploads.js'
 import { config } from '../config.js'
 
+/** @import { StartedServer } from '#common/hapi-types.js' */
+
+/**
+ * @param {StartedServer} server
+ */
 export const runFormsDataMigration = async (server) => {
   try {
     logger.info({

--- a/src/server/run-organisation-validation-sweep.js
+++ b/src/server/run-organisation-validation-sweep.js
@@ -2,6 +2,7 @@ import { logger } from '#common/helpers/logging/logger.js'
 import { createOrganisationsRepository } from '#repositories/organisations/mongodb.js'
 import { validateOrganisation } from '#domain/organisations/validation/validate-organisation.js'
 
+/** @import { StartedServer } from '#common/hapi-types.js' */
 /** @import { Organisation } from '#domain/organisations/model.js' */
 /** @import { ValidationIssue } from '#domain/organisations/validation/issue.js' */
 
@@ -23,7 +24,7 @@ const formatIssueLine = (org, issue) =>
   ].join(' ')
 
 /**
- * @param {Object} server - Hapi server instance
+ * @param {StartedServer} server - Hapi server instance
  */
 const runSweep = async (server) => {
   const repository = (await createOrganisationsRepository(server.db))()
@@ -66,7 +67,7 @@ const runSweep = async (server) => {
  * export paths: organisations are a bounded top-level set, unlike the
  * per-transaction waste-balance population the sibling diagnostics stream.
  *
- * @param {Object} server - Hapi server instance
+ * @param {StartedServer} server - Hapi server instance
  */
 export const runOrganisationValidationSweep = async (server) => {
   try {

--- a/src/server/run-pre-cpa-resubmission-backfill.js
+++ b/src/server/run-pre-cpa-resubmission-backfill.js
@@ -6,6 +6,8 @@ import {
   summarisePreCpaResubmissionFindings
 } from '#reports/monitoring/pre-cpa-resubmission-backfill.js'
 
+/** @import { StartedServer } from '#common/hapi-types.js' */
+
 const LOCK_NAME = 'pre-cpa-resubmission'
 
 /**
@@ -57,7 +59,7 @@ const logMissingSubmittedAt = (missing) => {
  * an already-closed period, then logs each affected report, a sizing summary,
  * and the invariant probe result. Read-only.
  *
- * @param {Object} server - Hapi server instance
+ * @param {StartedServer} server - Hapi server instance
  */
 const runReport = async (server) => {
   const {
@@ -142,7 +144,7 @@ const logFailedGroups = (failed) => {
  * also logs its own invariant probe and missing-submittedAt anomalies, and
  * any group whose write failed.
  *
- * @param {Object} server - Hapi server instance
+ * @param {StartedServer} server - Hapi server instance
  */
 const runBackfill = async (server) => {
   const {
@@ -196,7 +198,7 @@ const runBackfill = async (server) => {
  * With both flags off, this returns before touching the locker or any
  * repository.
  *
- * @param {Object} server - Hapi server instance
+ * @param {StartedServer} server - Hapi server instance
  */
 export const runPreCpaResubmissionBackfill = async (server) => {
   const reportEnabled = server.featureFlags.isPreCpaResubmissionReportEnabled()

--- a/src/server/run-pre-cpa-resubmission-backfill.js
+++ b/src/server/run-pre-cpa-resubmission-backfill.js
@@ -68,7 +68,7 @@ const runReport = async (server) => {
   } = await findPreCpaResubmissionReports({
     reportsRepository: server.app.reportsRepository,
     summaryLogsRepository: server.app.summaryLogsRepository,
-    summaryLogRowStateRepository: server.app.summaryLogRowStatesRepository,
+    summaryLogRowStatesRepository: server.app.summaryLogRowStatesRepository,
     organisationsRepository: server.app.organisationsRepository
   })
 
@@ -155,7 +155,7 @@ const runBackfill = async (server) => {
   } = await backfillPreCpaResubmissionReports({
     reportsRepository: server.app.reportsRepository,
     summaryLogsRepository: server.app.summaryLogsRepository,
-    summaryLogRowStateRepository: server.app.summaryLogRowStatesRepository,
+    summaryLogRowStatesRepository: server.app.summaryLogRowStatesRepository,
     organisationsRepository: server.app.organisationsRepository,
     systemLogsRepository: server.app.systemLogsRepository
   })

--- a/src/server/run-pre-cpa-resubmission-backfill.js
+++ b/src/server/run-pre-cpa-resubmission-backfill.js
@@ -119,7 +119,7 @@ const logUnexpectedlyFlagged = (reportIds) => {
  * threw, so the run's log makes clear which groups still need a retry rather
  * than only a generic top-level failure message. Expected empty.
  *
- * @param {Array<{ organisationId: string, registrationId: string, summaryLogId: string, error: Error }>} failed
+ * @param {{ organisationId: string, registrationId: string, summaryLogId: string, error: Error }[]} failed
  */
 const logFailedGroups = (failed) => {
   for (const group of failed) {

--- a/src/server/run-pre-cpa-resubmission-backfill.test.js
+++ b/src/server/run-pre-cpa-resubmission-backfill.test.js
@@ -6,6 +6,8 @@ import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-clas
 import { logger } from '#common/helpers/logging/logger.js'
 import { runPreCpaResubmissionBackfill } from './run-pre-cpa-resubmission-backfill.js'
 
+/** @import { StartedServer } from '#common/hapi-types.js' */
+
 vi.mock('#common/helpers/logging/logger.js', () => ({
   logger: {
     info: vi.fn(),
@@ -149,6 +151,10 @@ const missingSubmittedAtApp = () => ({
   }
 })
 
+/**
+ * @param {*} app
+ * @param {{ lock?: { free: () => Promise<void> } | null, reportEnabled?: boolean, backfillEnabled?: boolean }} [overrides]
+ */
 const buildServer = (
   app,
   {
@@ -156,14 +162,17 @@ const buildServer = (
     reportEnabled = true,
     backfillEnabled = false
   } = {}
-) => ({
-  app,
-  featureFlags: {
-    isPreCpaResubmissionReportEnabled: () => reportEnabled,
-    isPreCpaResubmissionBackfillEnabled: () => backfillEnabled
-  },
-  locker: { lock: vi.fn().mockResolvedValue(lock) }
-})
+) =>
+  /** @type {StartedServer} */ (
+    /** @type {unknown} */ ({
+      app,
+      featureFlags: {
+        isPreCpaResubmissionReportEnabled: () => reportEnabled,
+        isPreCpaResubmissionBackfillEnabled: () => backfillEnabled
+      },
+      locker: { lock: vi.fn().mockResolvedValue(lock) }
+    })
+  )
 
 describe('runPreCpaResubmissionBackfill', () => {
   beforeEach(() => {
@@ -202,14 +211,7 @@ describe('runPreCpaResubmissionBackfill', () => {
 
     it('skips the report and reads nothing when the lock is held by another instance', async () => {
       const app = emptyEstateApp()
-      const server = {
-        app,
-        featureFlags: {
-          isPreCpaResubmissionReportEnabled: () => true,
-          isPreCpaResubmissionBackfillEnabled: () => false
-        },
-        locker: { lock: vi.fn().mockResolvedValue(null) }
-      }
+      const server = buildServer(app, { lock: null })
 
       await runPreCpaResubmissionBackfill(server)
 
@@ -323,14 +325,16 @@ describe('runPreCpaResubmissionBackfill', () => {
 
     it('tolerates the locker itself throwing', async () => {
       const error = new Error('locker unavailable')
-      const server = {
-        app: emptyEstateApp(),
-        featureFlags: {
-          isPreCpaResubmissionReportEnabled: () => true,
-          isPreCpaResubmissionBackfillEnabled: () => false
-        },
-        locker: { lock: vi.fn().mockRejectedValue(error) }
-      }
+      const server = /** @type {StartedServer} */ (
+        /** @type {unknown} */ ({
+          app: emptyEstateApp(),
+          featureFlags: {
+            isPreCpaResubmissionReportEnabled: () => true,
+            isPreCpaResubmissionBackfillEnabled: () => false
+          },
+          locker: { lock: vi.fn().mockRejectedValue(error) }
+        })
+      )
 
       await runPreCpaResubmissionBackfill(server)
 

--- a/src/server/run-pre-cpa-resubmission-backfill.test.js
+++ b/src/server/run-pre-cpa-resubmission-backfill.test.js
@@ -153,12 +153,13 @@ const missingSubmittedAtApp = () => ({
 
 /**
  * @param {*} app
- * @param {{ lock?: { free: () => Promise<void> } | null, reportEnabled?: boolean, backfillEnabled?: boolean }} [overrides]
+ * @param {{ lock?: { free: () => Promise<void> } | null, lockError?: Error, reportEnabled?: boolean, backfillEnabled?: boolean }} [overrides]
  */
 const buildServer = (
   app,
   {
     lock = { free: vi.fn().mockResolvedValue(undefined) },
+    lockError,
     reportEnabled = true,
     backfillEnabled = false
   } = {}
@@ -170,7 +171,11 @@ const buildServer = (
         isPreCpaResubmissionReportEnabled: () => reportEnabled,
         isPreCpaResubmissionBackfillEnabled: () => backfillEnabled
       },
-      locker: { lock: vi.fn().mockResolvedValue(lock) }
+      locker: {
+        lock: lockError
+          ? vi.fn().mockRejectedValue(lockError)
+          : vi.fn().mockResolvedValue(lock)
+      }
     })
   )
 
@@ -325,16 +330,7 @@ describe('runPreCpaResubmissionBackfill', () => {
 
     it('tolerates the locker itself throwing', async () => {
       const error = new Error('locker unavailable')
-      const server = /** @type {StartedServer} */ (
-        /** @type {unknown} */ ({
-          app: emptyEstateApp(),
-          featureFlags: {
-            isPreCpaResubmissionReportEnabled: () => true,
-            isPreCpaResubmissionBackfillEnabled: () => false
-          },
-          locker: { lock: vi.fn().mockRejectedValue(error) }
-        })
-      )
+      const server = buildServer(emptyEstateApp(), { lockError: error })
 
       await runPreCpaResubmissionBackfill(server)
 

--- a/src/server/run-stale-issued-tonnage-report.js
+++ b/src/server/run-stale-issued-tonnage-report.js
@@ -4,6 +4,8 @@ import {
   formatStaleIssuedTonnageFinding
 } from '#reports/monitoring/stale-issued-tonnage.js'
 
+/** @import { StartedServer } from '#common/hapi-types.js' */
+
 const LOCK_NAME = 'stale-issued-tonnage-report'
 
 /**
@@ -12,7 +14,7 @@ const LOCK_NAME = 'stale-issued-tonnage-report'
  * PAE-1665 rule change (excluding PRNs cancelled after issuance) stales any
  * report computed before the fix. Read-only, safe under live traffic.
  *
- * @param {Object} server - Hapi server instance
+ * @param {StartedServer} server - Hapi server instance
  */
 const runReport = async (server) => {
   const { scanned, findings } = await findStaleIssuedTonnageReports({
@@ -44,7 +46,7 @@ const runReport = async (server) => {
  * Gated by the stale-issued-tonnage-report feature flag: with it off this
  * returns before touching the locker or any repository.
  *
- * @param {Object} server - Hapi server instance
+ * @param {StartedServer} server - Hapi server instance
  */
 export const runStaleIssuedTonnageReport = async (server) => {
   if (!server.featureFlags.isStaleIssuedTonnageReportEnabled()) {

--- a/src/server/run-stale-issued-tonnage-report.test.js
+++ b/src/server/run-stale-issued-tonnage-report.test.js
@@ -27,12 +27,13 @@ const emptyEstateApp = () => ({
 
 /**
  * @param {*} app
- * @param {{ lock?: { free: () => Promise<void> } | null, reportEnabled?: boolean }} [overrides]
+ * @param {{ lock?: { free: () => Promise<void> } | null, lockError?: Error, reportEnabled?: boolean }} [overrides]
  */
 const buildServer = (
   app,
   {
     lock = { free: vi.fn().mockResolvedValue(undefined) },
+    lockError,
     reportEnabled = true
   } = {}
 ) =>
@@ -42,7 +43,11 @@ const buildServer = (
       featureFlags: {
         isStaleIssuedTonnageReportEnabled: () => reportEnabled
       },
-      locker: { lock: vi.fn().mockResolvedValue(lock) }
+      locker: {
+        lock: lockError
+          ? vi.fn().mockRejectedValue(lockError)
+          : vi.fn().mockResolvedValue(lock)
+      }
     })
   )
 
@@ -234,13 +239,7 @@ describe('runStaleIssuedTonnageReport', () => {
 
   it('tolerates the locker itself throwing', async () => {
     const error = new Error('locker unavailable')
-    const server = /** @type {StartedServer} */ (
-      /** @type {unknown} */ ({
-        app: emptyEstateApp(),
-        featureFlags: { isStaleIssuedTonnageReportEnabled: () => true },
-        locker: { lock: vi.fn().mockRejectedValue(error) }
-      })
-    )
+    const server = buildServer(emptyEstateApp(), { lockError: error })
 
     await runStaleIssuedTonnageReport(server)
 

--- a/src/server/run-stale-issued-tonnage-report.test.js
+++ b/src/server/run-stale-issued-tonnage-report.test.js
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { logger } from '#common/helpers/logging/logger.js'
 import { runStaleIssuedTonnageReport } from './run-stale-issued-tonnage-report.js'
 
+/** @import { StartedServer } from '#common/hapi-types.js' */
+
 vi.mock('#common/helpers/logging/logger.js', () => ({
   logger: {
     info: vi.fn(),
@@ -23,19 +25,26 @@ const emptyEstateApp = () => ({
   }
 })
 
+/**
+ * @param {*} app
+ * @param {{ lock?: { free: () => Promise<void> } | null, reportEnabled?: boolean }} [overrides]
+ */
 const buildServer = (
   app,
   {
     lock = { free: vi.fn().mockResolvedValue(undefined) },
     reportEnabled = true
   } = {}
-) => ({
-  app,
-  featureFlags: {
-    isStaleIssuedTonnageReportEnabled: () => reportEnabled
-  },
-  locker: { lock: vi.fn().mockResolvedValue(lock) }
-})
+) =>
+  /** @type {StartedServer} */ (
+    /** @type {unknown} */ ({
+      app,
+      featureFlags: {
+        isStaleIssuedTonnageReportEnabled: () => reportEnabled
+      },
+      locker: { lock: vi.fn().mockResolvedValue(lock) }
+    })
+  )
 
 describe('runStaleIssuedTonnageReport', () => {
   beforeEach(() => {
@@ -69,11 +78,7 @@ describe('runStaleIssuedTonnageReport', () => {
 
   it('skips the report and reads nothing when the lock is held by another instance', async () => {
     const app = emptyEstateApp()
-    const server = {
-      app,
-      featureFlags: { isStaleIssuedTonnageReportEnabled: () => true },
-      locker: { lock: vi.fn().mockResolvedValue(null) }
-    }
+    const server = buildServer(app, { lock: null })
 
     await runStaleIssuedTonnageReport(server)
 
@@ -229,11 +234,13 @@ describe('runStaleIssuedTonnageReport', () => {
 
   it('tolerates the locker itself throwing', async () => {
     const error = new Error('locker unavailable')
-    const server = {
-      app: emptyEstateApp(),
-      featureFlags: { isStaleIssuedTonnageReportEnabled: () => true },
-      locker: { lock: vi.fn().mockRejectedValue(error) }
-    }
+    const server = /** @type {StartedServer} */ (
+      /** @type {unknown} */ ({
+        app: emptyEstateApp(),
+        featureFlags: { isStaleIssuedTonnageReportEnabled: () => true },
+        locker: { lock: vi.fn().mockRejectedValue(error) }
+      })
+    )
 
     await runStaleIssuedTonnageReport(server)
 

--- a/src/server/run-unexported-tonnage-report.js
+++ b/src/server/run-unexported-tonnage-report.js
@@ -142,7 +142,7 @@ const logSummary = (scanned, findings) => {
 export const unexportedTonnageDependencies = (server) => ({
   reportsRepository: server.app.reportsRepository,
   organisationsRepository: server.app.organisationsRepository,
-  summaryLogRowStateRepository: server.app.summaryLogRowStatesRepository
+  summaryLogRowStatesRepository: server.app.summaryLogRowStatesRepository
 })
 
 /**

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -226,7 +226,7 @@ async function createServer(options = {}) {
     const startedServer = /** @type {StartedServer} */ (
       /** @type {unknown} */ (server)
     )
-    runFormsDataMigration(server)
+    runFormsDataMigration(startedServer)
     runOrganisationValidationSweep(startedServer)
     runStaleIssuedTonnageReport(startedServer)
     runPreCpaResubmissionBackfill(startedServer)

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -223,13 +223,14 @@ async function createServer(options = {}) {
   await server.register(plugins)
 
   server.ext('onPostStart', () => {
-    runFormsDataMigration(server)
-    runOrganisationValidationSweep(server)
-    runStaleIssuedTonnageReport(server)
-    runPreCpaResubmissionBackfill(server)
-    runUnexportedTonnageReport(
-      /** @type {StartedServer} */ (/** @type {unknown} */ (server))
+    const startedServer = /** @type {StartedServer} */ (
+      /** @type {unknown} */ (server)
     )
+    runFormsDataMigration(server)
+    runOrganisationValidationSweep(startedServer)
+    runStaleIssuedTonnageReport(startedServer)
+    runPreCpaResubmissionBackfill(startedServer)
+    runUnexportedTonnageReport(startedServer)
   })
 
   return server

--- a/src/test/create-test-server.js
+++ b/src/test/create-test-server.js
@@ -40,7 +40,7 @@ import { createInMemorySummaryLogRowStatesRepositoryPlugin } from '#waste-record
 
 /** @import { Lifecycle, Plugin } from '@hapi/hapi' */
 /** @import { Db } from 'mongodb' */
-/** @import { FeatureFlags } from '#common/hapi-types.js' */
+/** @import { FeatureFlags, ServerApp } from '#common/hapi-types.js' */
 /** @import { LogMethod } from '#common/helpers/logging/logger.js' */
 /** @import { Mock } from 'vitest' */
 
@@ -69,7 +69,7 @@ import { createInMemorySummaryLogRowStatesRepositoryPlugin } from '#waste-record
  * Creates a plugin that wraps a repository for request access.
  * Supports both factory functions (per-request instantiation) and direct instances.
  *
- * @param {string} name - Repository name
+ * @param {keyof ServerApp} name - Repository name
  * @param {Function|Object} repositoryOrFactory - Repository instance OR factory function
  * @returns {import('@hapi/hapi').Plugin<void>}
  */
@@ -106,6 +106,7 @@ const createDbPlugin = (db) => ({
   }
 })
 
+/** @type {{name: keyof ServerApp, createDefault: Function}[]} */
 const repositoryConfigs = [
   {
     name: 'organisationsRepository',
@@ -161,6 +162,7 @@ const repositoryConfigs = [
   }
 ]
 
+/** @type {{name: keyof ServerApp, createDefault: Function}[]} */
 const devEndpointsRepositoryConfigs = [
   {
     name: 'nonProdDataReset',
@@ -170,7 +172,7 @@ const devEndpointsRepositoryConfigs = [
 
 /**
  * Builds repository plugins from config, applying any overrides.
- * @param {Array<{name: string, createDefault: Function}>} configs - Repository configurations
+ * @param {{name: keyof ServerApp, createDefault: Function}[]} configs - Repository configurations
  * @param {Object} repoOverrides - Repository overrides keyed by name
  * @returns {import('@hapi/hapi').Plugin<void>[]}
  */

--- a/src/waste-balances/application/credited-tonnage-report.js
+++ b/src/waste-balances/application/credited-tonnage-report.js
@@ -9,7 +9,7 @@ import { monthKeyForDate } from '#common/helpers/dates/year-month.js'
 
 /**
  * @typedef {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} WasteBalanceLedgerRepository
- * @typedef {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} SummaryLogRowStateRepository
+ * @typedef {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} SummaryLogRowStatesRepository
  * @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository
  * @typedef {import('#overseas-sites/repository/port.js').OverseasSitesRepository} OverseasSitesRepository
  * @typedef {import('#domain/organisations/model.js').Organisation} Organisation
@@ -153,7 +153,7 @@ const compareRows = (a, b) =>
  *
  * @param {Object} params
  * @param {WasteBalanceLedgerRepository} params.ledgerRepository
- * @param {SummaryLogRowStateRepository} params.summaryLogRowStateRepository
+ * @param {SummaryLogRowStatesRepository} params.summaryLogRowStatesRepository
  * @param {OrganisationsRepository} params.organisationsRepository
  * @param {OverseasSitesRepository} params.overseasSitesRepository
  * @param {TypedLogger} params.logger
@@ -162,7 +162,7 @@ const compareRows = (a, b) =>
  */
 export const buildCreditedTonnageReport = async ({
   ledgerRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   organisationsRepository,
   overseasSitesRepository,
   logger,
@@ -215,7 +215,7 @@ export const buildCreditedTonnageReport = async ({
     const { organisation, registration, accreditation } = context
 
     const storedRowStates =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         ledgerId,
         summaryLogId
       )

--- a/src/waste-balances/application/credited-tonnage-report.test.js
+++ b/src/waste-balances/application/credited-tonnage-report.test.js
@@ -12,11 +12,10 @@ import {
 } from '#domain/organisations/model.js'
 
 /**
- * @typedef {import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository} LedgerRepository
- * @typedef {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} RowStateRepository
- * @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository
- * @typedef {import('#overseas-sites/repository/port.js').OverseasSitesRepository} OverseasSitesRepository
- * @typedef {import('#common/hapi-types.js').TypedLogger} TypedLogger
+ * @import {TypedLogger} from '#common/hapi-types.js'
+ * @import {OrganisationsRepository} from '#repositories/organisations/port.js'
+ * @import {WasteBalanceLedgerRepository} from '#waste-balances/repository/ledger-port.js'
+ * @import {SummaryLogRowStatesRepository} from '#waste-records/repository/port.js'
  */
 
 // The test environment configures 999999 as a test organisation
@@ -229,7 +228,7 @@ const run = ({
   const ledgerRepository = {
     findLatestSubmittedSummaryLogPerLedger: async () => entries
   }
-  const summaryLogRowStateRepository = {
+  const summaryLogRowStatesRepository = {
     findRowStatesForSummaryLog: async (
       /** @type {{ accreditationId: string }} */ ledgerId
     ) => rowStatesByAccreditationId[ledgerId.accreditationId] ?? []
@@ -241,12 +240,13 @@ const run = ({
   return {
     logger,
     report: buildCreditedTonnageReport({
-      ledgerRepository: /** @type {LedgerRepository} */ (
+      ledgerRepository: /** @type {WasteBalanceLedgerRepository} */ (
         /** @type {unknown} */ (ledgerRepository)
       ),
-      summaryLogRowStateRepository: /** @type {RowStateRepository} */ (
-        /** @type {unknown} */ (summaryLogRowStateRepository)
-      ),
+      summaryLogRowStatesRepository:
+        /** @type {SummaryLogRowStatesRepository} */ (
+          /** @type {unknown} */ (summaryLogRowStatesRepository)
+        ),
       organisationsRepository: /** @type {OrganisationsRepository} */ (
         /** @type {unknown} */ (organisationsRepository)
       ),

--- a/src/waste-balances/routes/credited-tonnage-get.js
+++ b/src/waste-balances/routes/credited-tonnage-get.js
@@ -23,7 +23,7 @@ export const creditedTonnageGet = {
   /**
    * @param {HapiRequest & {
    *   ledgerRepository: import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository,
-   *   summaryLogRowStatesRepository: import('#waste-records/repository/port.js').SummaryLogRowStateRepository,
+   *   summaryLogRowStatesRepository: import('#waste-records/repository/port.js').SummaryLogRowStatesRepository,
    *   organisationsRepository: import('#repositories/organisations/port.js').OrganisationsRepository,
    *   overseasSitesRepository: import('#overseas-sites/repository/port.js').OverseasSitesRepository
    * }} request
@@ -41,7 +41,7 @@ export const creditedTonnageGet = {
 
     const report = await buildCreditedTonnageReport({
       ledgerRepository,
-      summaryLogRowStateRepository: summaryLogRowStatesRepository,
+      summaryLogRowStatesRepository,
       organisationsRepository,
       overseasSitesRepository,
       logger,

--- a/src/waste-balances/routes/credited-tonnage-get.test.js
+++ b/src/waste-balances/routes/credited-tonnage-get.test.js
@@ -6,7 +6,7 @@ import { partialMock } from '#test/type-helpers.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
 import { buildSummaryLogRowStateEntry } from '#waste-records/repository/test-data.js'
 import {
@@ -100,7 +100,7 @@ describe(`GET ${creditedTonnageGetPath}`, () => {
     }
 
     const summaryLogRowStatesRepository =
-      createInMemorySummaryLogRowStateRepository()()
+      createInMemorySummaryLogRowStatesRepository()()
     await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       ledgerId,
       [

--- a/src/waste-records-export/application/stream-csv-export.js
+++ b/src/waste-records-export/application/stream-csv-export.js
@@ -22,7 +22,7 @@ const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 /** @import {SummaryLogRowState} from '#waste-records/repository/schema.js' */
 /** @import {OverseasSite} from '#overseas-sites/repository/port.js' */
 /** @import {OrganisationsRepository} from '#repositories/organisations/port.js' */
-/** @import {SummaryLogRowStateRepository} from '#waste-records/repository/port.js' */
+/** @import {SummaryLogRowStatesRepository} from '#waste-records/repository/port.js' */
 /** @import {WasteBalanceLedgerRepository, LatestSubmittedSummaryLogPerLedger} from '#waste-balances/repository/ledger-port.js' */
 /** @import {SummaryLogsRepository} from '#repositories/summary-logs/port.js' */
 /** @import {OverseasSitesRepository} from '#overseas-sites/repository/port.js' */
@@ -30,7 +30,7 @@ const TEST_ORGANISATIONS = new Set(TEST_ORGANISATION_IDS)
 /**
  * @typedef {Object} StreamCsvExportDeps
  * @property {Pick<OrganisationsRepository, 'findAll' | 'findById'>} organisationsRepository
- * @property {Pick<SummaryLogRowStateRepository, 'findRowStatesForSummaryLog' | 'findDistinctDataKeys'>} summaryLogRowStatesRepository
+ * @property {Pick<SummaryLogRowStatesRepository, 'findRowStatesForSummaryLog' | 'findDistinctDataKeys'>} summaryLogRowStatesRepository
  * @property {Pick<WasteBalanceLedgerRepository, 'findLatestSubmittedSummaryLogPerLedger'>} ledgerRepository
  * @property {Pick<SummaryLogsRepository, 'findAllByOrgReg'>} summaryLogsRepository
  * @property {Pick<OverseasSitesRepository, 'findAll'>} overseasSitesRepository
@@ -109,7 +109,7 @@ const sortEntriesByAccreditationId = (a, b) =>
  * @param {LatestSubmittedSummaryLogPerLedger[]} input.entries - The registration's per-partition latest submissions.
  * @param {Map<string, OverseasSite>} input.sitesById
  * @param {string[]} input.dataFieldColumns
- * @param {Pick<SummaryLogRowStateRepository, 'findRowStatesForSummaryLog'>} input.summaryLogRowStatesRepository
+ * @param {Pick<SummaryLogRowStatesRepository, 'findRowStatesForSummaryLog'>} input.summaryLogRowStatesRepository
  * @param {Pick<SummaryLogsRepository, 'findAllByOrgReg'>} input.summaryLogsRepository
  * @returns {AsyncGenerator<string>}
  */

--- a/src/waste-records-export/application/stream-csv-export.test.js
+++ b/src/waste-records-export/application/stream-csv-export.test.js
@@ -17,7 +17,7 @@ import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledge
 import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
 
 /** @import { LedgerEvent } from '#waste-balances/repository/ledger-schema.js' */
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 
 const collect = async (gen) => {
   const out = []
@@ -169,7 +169,7 @@ const buildDeps = async ({
   )()
 
   const summaryLogRowStatesRepository =
-    createInMemorySummaryLogRowStateRepository()()
+    createInMemorySummaryLogRowStatesRepository()()
   for (const seed of seeds) {
     await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       {

--- a/src/waste-records-export/routes/export.js
+++ b/src/waste-records-export/routes/export.js
@@ -6,7 +6,7 @@ import { streamCsvExportToReadable } from '../application/stream-csv-export.js'
 
 /** @import { HapiRequest } from '#common/hapi-types.js' */
 /** @import { OrganisationsRepository } from '#repositories/organisations/port.js' */
-/** @import { SummaryLogRowStateRepository } from '#waste-records/repository/port.js' */
+/** @import { SummaryLogRowStatesRepository } from '#waste-records/repository/port.js' */
 /** @import { WasteBalanceLedgerRepository } from '#waste-balances/repository/ledger-port.js' */
 /** @import { SummaryLogsRepository } from '#repositories/summary-logs/port.js' */
 /** @import { OverseasSitesRepository } from '#overseas-sites/repository/port.js' */
@@ -55,7 +55,7 @@ export const wasteRecordsExportRoute = {
   /**
    * @param {HapiRequest & {
    *   organisationsRepository: OrganisationsRepository,
-   *   summaryLogRowStatesRepository: SummaryLogRowStateRepository,
+   *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository,
    *   ledgerRepository: WasteBalanceLedgerRepository,
    *   summaryLogsRepository: SummaryLogsRepository,
    *   overseasSitesRepository: OverseasSitesRepository,

--- a/src/waste-records-export/routes/export.test.js
+++ b/src/waste-records-export/routes/export.test.js
@@ -7,7 +7,7 @@ import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledge
 import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
 
 /** @import { LedgerEvent } from '#waste-balances/repository/ledger-schema.js' */
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { createTestServer } from '#test/create-test-server.js'
 import { asServiceMaintainer, asOperator } from '#test/inject-auth.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
@@ -88,7 +88,7 @@ const createServerWithRepos = async ({
   )()
 
   const summaryLogRowStatesRepository =
-    createInMemorySummaryLogRowStateRepository()()
+    createInMemorySummaryLogRowStatesRepository()()
   for (const seed of seeds) {
     await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       {

--- a/src/waste-records/application/live-classified-row-states.js
+++ b/src/waste-records/application/live-classified-row-states.js
@@ -21,7 +21,7 @@ import { toWasteRecordState } from './read-summary-log-row-states.js'
  *
  * @param {import('#waste-balances/repository/ledger-schema.js').WasteBalanceLedgerId & {
  *   ledgerRepository: import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository,
- *   summaryLogRowStateRepository: import('#waste-records/repository/port.js').SummaryLogRowStateRepository,
+ *   summaryLogRowStatesRepository: import('#waste-records/repository/port.js').SummaryLogRowStatesRepository,
  *   organisationsRepository: import('#repositories/organisations/port.js').OrganisationsRepository,
  *   overseasSitesRepository: import('#overseas-sites/repository/port.js').OverseasSitesRepository
  * }} context
@@ -29,7 +29,7 @@ import { toWasteRecordState } from './read-summary-log-row-states.js'
  */
 export const liveClassifiedRowStatesForRegistration = async ({
   ledgerRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   organisationsRepository,
   overseasSitesRepository,
   organisationId,
@@ -44,7 +44,7 @@ export const liveClassifiedRowStatesForRegistration = async ({
   }
 
   const rowStates =
-    await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+    await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
       ledgerId,
       head
     )

--- a/src/waste-records/application/live-classified-row-states.test.js
+++ b/src/waste-records/application/live-classified-row-states.test.js
@@ -9,7 +9,7 @@ import {
   REPROCESSING_TYPE,
   WASTE_PROCESSING_TYPE
 } from '#domain/organisations/model.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
 import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
 import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
@@ -167,10 +167,10 @@ const readLiveStates = async ({
   submitted = true,
   overseasSites = /** @type {import('#overseas-sites/repository/port.js').OverseasSite[]} */ ([])
 }) => {
-  const summaryLogRowStateRepository =
-    createInMemorySummaryLogRowStateRepository()()
+  const summaryLogRowStatesRepository =
+    createInMemorySummaryLogRowStatesRepository()()
   if (submitted) {
-    await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+    await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       ledgerId,
       entries,
       SUMMARY_LOG_ID
@@ -191,7 +191,7 @@ const readLiveStates = async ({
           ]
         : []
     )(),
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     organisationsRepository: createInMemoryOrganisationsRepository([
       organisation
     ])(),

--- a/src/waste-records/application/read-summary-log-row-states.js
+++ b/src/waste-records/application/read-summary-log-row-states.js
@@ -51,13 +51,13 @@ export const toWasteRecordState = ({
  * stay consistent with it), this is the whole read;
  * `summaryLogRowStatesForRegistration` composes it with the head resolution.
  *
- * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} summaryLogRowStateRepository
+ * @param {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} summaryLogRowStatesRepository
  * @param {import('#waste-balances/repository/ledger-schema.js').WasteBalanceLedgerId} ledgerId
  * @param {string | null} head
  * @returns {Promise<WasteRecordState[]>}
  */
 export const wasteRecordStatesForHead = async (
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   ledgerId,
   head
 ) => {
@@ -65,7 +65,7 @@ export const wasteRecordStatesForHead = async (
     return []
   }
   const summaryLogRowStates =
-    await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+    await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
       ledgerId,
       head
     )
@@ -84,7 +84,7 @@ export const wasteRecordStatesForHead = async (
 /**
  * @typedef {import('#waste-balances/repository/ledger-schema.js').WasteBalanceLedgerId & {
  *   ledgerRepository: import('#waste-balances/repository/ledger-port.js').WasteBalanceLedgerRepository,
- *   summaryLogRowStateRepository: import('#waste-records/repository/port.js').SummaryLogRowStateRepository
+ *   summaryLogRowStatesRepository: import('#waste-records/repository/port.js').SummaryLogRowStatesRepository
  * }} RegistrationRowStateContext
  */
 
@@ -99,7 +99,7 @@ export const wasteRecordStatesForHead = async (
  */
 export const latestSubmittedSummaryLogRowStates = async ({
   ledgerRepository,
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   organisationId,
   registrationId,
   accreditationId
@@ -113,7 +113,7 @@ export const latestSubmittedSummaryLogRowStates = async ({
   }
 
   const wasteRecordStates = await wasteRecordStatesForHead(
-    summaryLogRowStateRepository,
+    summaryLogRowStatesRepository,
     ledgerId,
     summaryLog.summaryLogId
   )

--- a/src/waste-records/application/read-summary-log-row-states.test.js
+++ b/src/waste-records/application/read-summary-log-row-states.test.js
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest'
 import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
 import {
   buildSummaryLogRowStateEntry,
@@ -45,8 +45,8 @@ describe('summaryLogRowStatesForRegistration', () => {
   it('returns an empty array when the stream has no submission', async () => {
     const states = await summaryLogRowStatesForRegistration({
       ledgerRepository: createInMemoryLedgerRepository()(),
-      summaryLogRowStateRepository:
-        createInMemorySummaryLogRowStateRepository()(),
+      summaryLogRowStatesRepository:
+        createInMemorySummaryLogRowStatesRepository()(),
       ...registration
     })
 
@@ -54,9 +54,9 @@ describe('summaryLogRowStatesForRegistration', () => {
   })
 
   it('returns the full committed snapshot at the head submission', async () => {
-    const summaryLogRowStateRepository =
-      createInMemorySummaryLogRowStateRepository()()
-    await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+    const summaryLogRowStatesRepository =
+      createInMemorySummaryLogRowStatesRepository()()
+    await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       DEFAULT_LEDGER_ID,
       [
         buildSummaryLogRowStateEntry({ rowId: 'row-1', data: { tonnage: 10 } }),
@@ -64,7 +64,7 @@ describe('summaryLogRowStatesForRegistration', () => {
       ],
       'log-1'
     )
-    await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+    await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       DEFAULT_LEDGER_ID,
       [
         buildSummaryLogRowStateEntry({ rowId: 'row-1', data: { tonnage: 99 } }),
@@ -80,7 +80,7 @@ describe('summaryLogRowStatesForRegistration', () => {
 
     const states = await summaryLogRowStatesForRegistration({
       ledgerRepository,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ...registration
     })
 
@@ -94,14 +94,14 @@ describe('summaryLogRowStatesForRegistration', () => {
   })
 
   it('reads the row states of its own ledger when another ledger shares the summary log id', async () => {
-    const summaryLogRowStateRepository =
-      createInMemorySummaryLogRowStateRepository()()
-    await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+    const summaryLogRowStatesRepository =
+      createInMemorySummaryLogRowStatesRepository()()
+    await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       DEFAULT_LEDGER_ID,
       [buildSummaryLogRowStateEntry({ rowId: 'row-1', data: { tonnage: 10 } })],
       'log-1'
     )
-    await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+    await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       { ...DEFAULT_LEDGER_ID, organisationId: 'org-2' },
       [buildSummaryLogRowStateEntry({ rowId: 'row-1', data: { tonnage: 20 } })],
       'log-1'
@@ -112,7 +112,7 @@ describe('summaryLogRowStatesForRegistration', () => {
 
     const states = await summaryLogRowStatesForRegistration({
       ledgerRepository,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ...registration
     })
 
@@ -122,9 +122,9 @@ describe('summaryLogRowStatesForRegistration', () => {
   })
 
   it('projects to domain content, keeping the template the row reported under and dropping storage id, membership and ledger identity', async () => {
-    const summaryLogRowStateRepository =
-      createInMemorySummaryLogRowStateRepository()()
-    await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+    const summaryLogRowStatesRepository =
+      createInMemorySummaryLogRowStatesRepository()()
+    await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       DEFAULT_LEDGER_ID,
       [buildSummaryLogRowStateEntry({ rowId: 'row-1', data: { tonnage: 10 } })],
       'log-1'
@@ -135,7 +135,7 @@ describe('summaryLogRowStatesForRegistration', () => {
 
     const [state] = await summaryLogRowStatesForRegistration({
       ledgerRepository,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ...registration
     })
 
@@ -157,8 +157,8 @@ describe('latestSubmittedSummaryLogRowStates', () => {
   it('returns null when the stream has no submission', async () => {
     const previousSubmission = await latestSubmittedSummaryLogRowStates({
       ledgerRepository: createInMemoryLedgerRepository()(),
-      summaryLogRowStateRepository:
-        createInMemorySummaryLogRowStateRepository()(),
+      summaryLogRowStatesRepository:
+        createInMemorySummaryLogRowStatesRepository()(),
       ...registration
     })
 
@@ -166,14 +166,14 @@ describe('latestSubmittedSummaryLogRowStates', () => {
   })
 
   it('names the latest submitted summary log with when it was submitted and its row states', async () => {
-    const summaryLogRowStateRepository =
-      createInMemorySummaryLogRowStateRepository()()
-    await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+    const summaryLogRowStatesRepository =
+      createInMemorySummaryLogRowStatesRepository()()
+    await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       DEFAULT_LEDGER_ID,
       [buildSummaryLogRowStateEntry({ rowId: 'row-1', data: { tonnage: 10 } })],
       'log-1'
     )
-    await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+    await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
       DEFAULT_LEDGER_ID,
       [
         buildSummaryLogRowStateEntry({ rowId: 'row-1', data: { tonnage: 99 } }),
@@ -190,7 +190,7 @@ describe('latestSubmittedSummaryLogRowStates', () => {
 
     const previousSubmission = await latestSubmittedSummaryLogRowStates({
       ledgerRepository,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ...registration
     })
 

--- a/src/waste-records/application/registered-only-submitted-event-read-through.test.js
+++ b/src/waste-records/application/registered-only-submitted-event-read-through.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
 import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
 import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
@@ -23,8 +23,8 @@ const registeredOnlyLedgerId = {
 }
 const createdBy = { id: 'system', name: 'backfill' }
 
-const seedMembership = async (summaryLogRowStateRepository, summaryLogId) =>
-  summaryLogRowStateRepository.upsertSummaryLogRowStates(
+const seedMembership = async (summaryLogRowStatesRepository, summaryLogId) =>
+  summaryLogRowStatesRepository.upsertSummaryLogRowStates(
     registeredOnlyLedgerId,
     [buildSummaryLogRowStateEntry({ rowId: 'row-1', data: { tonnage: 10 } })],
     summaryLogId
@@ -39,13 +39,13 @@ const emitRegOnlyEvent = (ledgerRepository, summaryLogId) =>
 
 describe('registered-only summary-log submitted event — read-through', () => {
   it('returns nothing for the registered-only ledger before an event exists (the gap)', async () => {
-    const summaryLogRowStateRepository =
-      createInMemorySummaryLogRowStateRepository()()
-    await seedMembership(summaryLogRowStateRepository, 'log-1')
+    const summaryLogRowStatesRepository =
+      createInMemorySummaryLogRowStatesRepository()()
+    await seedMembership(summaryLogRowStatesRepository, 'log-1')
 
     const states = await summaryLogRowStatesForRegistration({
       ledgerRepository: createInMemoryLedgerRepository()(),
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ...registeredOnlyLedgerId
     })
 
@@ -53,16 +53,16 @@ describe('registered-only summary-log submitted event — read-through', () => {
   })
 
   it('returns the membership once the reg-only event is emitted (gap closed)', async () => {
-    const summaryLogRowStateRepository =
-      createInMemorySummaryLogRowStateRepository()()
-    await seedMembership(summaryLogRowStateRepository, 'log-1')
+    const summaryLogRowStatesRepository =
+      createInMemorySummaryLogRowStatesRepository()()
+    await seedMembership(summaryLogRowStatesRepository, 'log-1')
     const ledgerRepository = createInMemoryLedgerRepository()()
 
     await emitRegOnlyEvent(ledgerRepository, 'log-1')
 
     const states = await summaryLogRowStatesForRegistration({
       ledgerRepository,
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       ...registeredOnlyLedgerId
     })
 

--- a/src/waste-records/application/write-summary-log-row-states.js
+++ b/src/waste-records/application/write-summary-log-row-states.js
@@ -17,7 +17,7 @@ import { projectSummaryLogRowState } from './project-summary-log-row-state.js'
  * states whichever path it arrives through.
  *
  * @param {Object} params
- * @param {import('#waste-records/repository/port.js').SummaryLogRowStateRepository} params.summaryLogRowStateRepository
+ * @param {import('#waste-records/repository/port.js').SummaryLogRowStatesRepository} params.summaryLogRowStatesRepository
  * @param {import('#domain/waste-records/model.js').WasteRecord[]} params.wasteRecords
  * @param {{ id: string, validFrom?: string, validTo?: string } | null} params.accreditation
  * @param {import('#waste-records/repository/schema.js').WasteBalanceLedgerId} params.ledgerId
@@ -26,7 +26,7 @@ import { projectSummaryLogRowState } from './project-summary-log-row-state.js'
  * @returns {Promise<void>}
  */
 export const writeSummaryLogRowStates = async ({
-  summaryLogRowStateRepository,
+  summaryLogRowStatesRepository,
   wasteRecords,
   accreditation,
   ledgerId,
@@ -37,7 +37,7 @@ export const writeSummaryLogRowStates = async ({
     projectSummaryLogRowState(record, accreditation, overseasSites)
   )
 
-  await summaryLogRowStateRepository.upsertSummaryLogRowStates(
+  await summaryLogRowStatesRepository.upsertSummaryLogRowStates(
     ledgerId,
     classifiedRows,
     summaryLogId

--- a/src/waste-records/application/write-summary-log-row-states.test.js
+++ b/src/waste-records/application/write-summary-log-row-states.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 
 import { writeSummaryLogRowStates } from './write-summary-log-row-states.js'
-import { createInMemorySummaryLogRowStateRepository } from '#waste-records/repository/inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
 /** @typedef {import('#domain/waste-records/model.js').WasteRecord} WasteRecord */
@@ -81,16 +81,16 @@ const accreditedLedgerId = {
 }
 
 describe('writeSummaryLogRowStates', () => {
-  let summaryLogRowStateRepository
+  let summaryLogRowStatesRepository
 
   beforeEach(() => {
-    summaryLogRowStateRepository =
-      createInMemorySummaryLogRowStateRepository()()
+    summaryLogRowStatesRepository =
+      createInMemorySummaryLogRowStatesRepository()()
   })
 
   it('writes a row state per record under the registered-only ledger', async () => {
     await writeSummaryLogRowStates({
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       wasteRecords: [
         buildRegisteredOnlyRecord({ rowId: '1', tonnage: 10 }),
         buildRegisteredOnlyRecord({ rowId: '2', tonnage: 20 })
@@ -102,7 +102,7 @@ describe('writeSummaryLogRowStates', () => {
     })
 
     const committed =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         registeredOnlyLedgerId,
         'log-A'
       )
@@ -123,7 +123,7 @@ describe('writeSummaryLogRowStates', () => {
 
   it('stores tonnages coerced to two decimal places', async () => {
     await writeSummaryLogRowStates({
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       wasteRecords: [buildReceivedRecord({ rowId: '1', tonnage: 1.005 })],
       accreditation: null,
       ledgerId: registeredOnlyLedgerId,
@@ -132,7 +132,7 @@ describe('writeSummaryLogRowStates', () => {
     })
 
     const [committed] =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         registeredOnlyLedgerId,
         'log-A'
       )
@@ -141,7 +141,7 @@ describe('writeSummaryLogRowStates', () => {
 
   it('stores weight quantities coerced to two decimal places', async () => {
     await writeSummaryLogRowStates({
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       wasteRecords: [buildRegisteredOnlyRecord({ rowId: '1', tonnage: 7.536 })],
       accreditation: null,
       ledgerId: registeredOnlyLedgerId,
@@ -150,7 +150,7 @@ describe('writeSummaryLogRowStates', () => {
     })
 
     const [committed] =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         registeredOnlyLedgerId,
         'log-A'
       )
@@ -159,7 +159,7 @@ describe('writeSummaryLogRowStates', () => {
 
   it('stores tonnages so round-each-then-sum no longer drifts from sum-then-round', async () => {
     await writeSummaryLogRowStates({
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       wasteRecords: [
         buildReceivedRecord({ rowId: '1', tonnage: 1.005 }),
         buildReceivedRecord({ rowId: '2', tonnage: 1.005 }),
@@ -172,7 +172,7 @@ describe('writeSummaryLogRowStates', () => {
     })
 
     const committed =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         registeredOnlyLedgerId,
         'log-A'
       )
@@ -188,7 +188,7 @@ describe('writeSummaryLogRowStates', () => {
 
   it('carries the supplied accreditation id onto the ledger', async () => {
     await writeSummaryLogRowStates({
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       wasteRecords: [buildRegisteredOnlyRecord({ rowId: '1', tonnage: 10 })],
       accreditation: {
         id: 'acc-1',
@@ -201,7 +201,7 @@ describe('writeSummaryLogRowStates', () => {
     })
 
     const [committed] =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         accreditedLedgerId,
         'log-A'
       )
@@ -210,7 +210,7 @@ describe('writeSummaryLogRowStates', () => {
 
   it('stamps the missing field on a row excluded for incomplete data', async () => {
     await writeSummaryLogRowStates({
-      summaryLogRowStateRepository,
+      summaryLogRowStatesRepository,
       wasteRecords: [buildIncompleteReprocessorInputRecord({ rowId: '1' })],
       accreditation: {
         id: 'acc-1',
@@ -223,7 +223,7 @@ describe('writeSummaryLogRowStates', () => {
     })
 
     const [committed] =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         accreditedLedgerId,
         'log-A'
       )
@@ -240,7 +240,7 @@ describe('writeSummaryLogRowStates', () => {
   it('is idempotent — re-running the same submission adds no duplicate', async () => {
     const submit = () =>
       writeSummaryLogRowStates({
-        summaryLogRowStateRepository,
+        summaryLogRowStatesRepository,
         wasteRecords: [buildRegisteredOnlyRecord({ rowId: '1', tonnage: 10 })],
         accreditation: null,
         ledgerId: registeredOnlyLedgerId,
@@ -252,7 +252,7 @@ describe('writeSummaryLogRowStates', () => {
     await submit()
 
     const committed =
-      await summaryLogRowStateRepository.findRowStatesForSummaryLog(
+      await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
         registeredOnlyLedgerId,
         'log-A'
       )

--- a/src/waste-records/repository/contract/findDistinctDataKeys.contract.js
+++ b/src/waste-records/repository/contract/findDistinctDataKeys.contract.js
@@ -9,8 +9,8 @@ export const testFindDistinctDataKeysBehaviour = (it) => {
   describe('findDistinctDataKeys', () => {
     let repository
 
-    beforeEach((/** @type {*} */ { summaryLogRowStateRepository }) => {
-      repository = summaryLogRowStateRepository()
+    beforeEach((/** @type {*} */ { summaryLogRowStatesRepository }) => {
+      repository = summaryLogRowStatesRepository()
     })
 
     it('returns an empty array when no row states exist', async () => {

--- a/src/waste-records/repository/contract/findRowHistory.contract.js
+++ b/src/waste-records/repository/contract/findRowHistory.contract.js
@@ -11,8 +11,8 @@ export const testFindRowHistoryBehaviour = (it) => {
   describe('findRowHistory', () => {
     let repository
 
-    beforeEach((/** @type {*} */ { summaryLogRowStateRepository }) => {
-      repository = summaryLogRowStateRepository()
+    beforeEach((/** @type {*} */ { summaryLogRowStatesRepository }) => {
+      repository = summaryLogRowStatesRepository()
     })
 
     it('returns an empty list for a row that has never committed', async () => {

--- a/src/waste-records/repository/contract/findRowStatesForSummaryLog.contract.js
+++ b/src/waste-records/repository/contract/findRowStatesForSummaryLog.contract.js
@@ -14,8 +14,8 @@ export const testFindRowStatesForSummaryLogBehaviour = (it) => {
   describe('findRowStatesForSummaryLog', () => {
     let repository
 
-    beforeEach((/** @type {*} */ { summaryLogRowStateRepository }) => {
-      repository = summaryLogRowStateRepository()
+    beforeEach((/** @type {*} */ { summaryLogRowStatesRepository }) => {
+      repository = summaryLogRowStatesRepository()
     })
 
     it('returns an empty list for a summary log with no row states', async () => {

--- a/src/waste-records/repository/contract/upsertSummaryLogRowStates.contract.js
+++ b/src/waste-records/repository/contract/upsertSummaryLogRowStates.contract.js
@@ -18,8 +18,8 @@ export const testUpsertSummaryLogRowStatesBehaviour = (it) => {
   describe('upsertSummaryLogRowStates', () => {
     let repository
 
-    beforeEach((/** @type {*} */ { summaryLogRowStateRepository }) => {
-      repository = summaryLogRowStateRepository()
+    beforeEach((/** @type {*} */ { summaryLogRowStatesRepository }) => {
+      repository = summaryLogRowStatesRepository()
     })
 
     it('inserts a new state document for a previously unseen row', async () => {

--- a/src/waste-records/repository/inmemory.js
+++ b/src/waste-records/repository/inmemory.js
@@ -91,9 +91,9 @@ const upsertOne = (storage, ledgerId, entry, summaryLogId) => {
 
 /**
  * @param {SummaryLogRowState[]} [initialSummaryLogRowStates]
- * @returns {import('./port.js').SummaryLogRowStateRepositoryFactory}
+ * @returns {import('./port.js').SummaryLogRowStatesRepositoryFactory}
  */
-export const createInMemorySummaryLogRowStateRepository = (
+export const createInMemorySummaryLogRowStatesRepository = (
   initialSummaryLogRowStates = []
 ) => {
   const storage = initialSummaryLogRowStates

--- a/src/waste-records/repository/inmemory.plugin.js
+++ b/src/waste-records/repository/inmemory.plugin.js
@@ -1,8 +1,8 @@
-import { createInMemorySummaryLogRowStateRepository } from './inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from './inmemory.js'
 import { registerDependency } from '#plugins/register-dependency.js'
 
 export function createInMemorySummaryLogRowStatesRepositoryPlugin() {
-  const repository = createInMemorySummaryLogRowStateRepository()()
+  const repository = createInMemorySummaryLogRowStatesRepository()()
 
   return {
     name: 'summaryLogRowStatesRepository',

--- a/src/waste-records/repository/inmemory.test.js
+++ b/src/waste-records/repository/inmemory.test.js
@@ -1,26 +1,26 @@
 import { describe, it as base, expect } from 'vitest'
 
-import { createInMemorySummaryLogRowStateRepository } from './inmemory.js'
-import { testSummaryLogRowStateRepositoryContract } from './port.contract.js'
+import { createInMemorySummaryLogRowStatesRepository } from './inmemory.js'
+import { testSummaryLogRowStatesRepositoryContract } from './port.contract.js'
 import { DEFAULT_LEDGER_ID } from './test-data.js'
 
 const it = base.extend({
   // eslint-disable-next-line no-empty-pattern
-  summaryLogRowStateRepository: async ({}, use) => {
-    await use(createInMemorySummaryLogRowStateRepository())
+  summaryLogRowStatesRepository: async ({}, use) => {
+    await use(createInMemorySummaryLogRowStatesRepository())
   }
 })
 
 describe('summary-log row states repository - in-memory implementation', () => {
   it('exposes the row-state port surface', () => {
-    const repository = createInMemorySummaryLogRowStateRepository()()
+    const repository = createInMemorySummaryLogRowStatesRepository()()
     expect(repository.upsertSummaryLogRowStates).toBeTypeOf('function')
     expect(repository.findRowStatesForSummaryLog).toBeTypeOf('function')
     expect(repository.findRowHistory).toBeTypeOf('function')
   })
 
   it('seeds storage from the provided initial state documents', async () => {
-    const repository = createInMemorySummaryLogRowStateRepository([
+    const repository = createInMemorySummaryLogRowStatesRepository([
       {
         id: 'seed-1',
         organisationId: 'org-1',
@@ -47,5 +47,5 @@ describe('summary-log row states repository - in-memory implementation', () => {
     expect(committed[0].id).toBe('seed-1')
   })
 
-  testSummaryLogRowStateRepositoryContract(it)
+  testSummaryLogRowStatesRepositoryContract(it)
 })

--- a/src/waste-records/repository/mongodb.js
+++ b/src/waste-records/repository/mongodb.js
@@ -299,9 +299,9 @@ const performFindDistinctDataKeys = (collection) => async () => {
  * Creates a MongoDB-backed summary-log row state repository.
  *
  * @param {Db} db
- * @returns {Promise<import('./port.js').SummaryLogRowStateRepositoryFactory>}
+ * @returns {Promise<import('./port.js').SummaryLogRowStatesRepositoryFactory>}
  */
-export const createMongoSummaryLogRowStateRepository = async (db) => {
+export const createMongoSummaryLogRowStatesRepository = async (db) => {
   const collection = await ensureSummaryLogRowStatesCollection(db)
 
   return () => ({

--- a/src/waste-records/repository/mongodb.plugin.js
+++ b/src/waste-records/repository/mongodb.plugin.js
@@ -1,4 +1,4 @@
-import { createMongoSummaryLogRowStateRepository } from './mongodb.js'
+import { createMongoSummaryLogRowStatesRepository } from './mongodb.js'
 import { registerDependency } from '#plugins/register-dependency.js'
 
 export const mongoSummaryLogRowStatesRepositoryPlugin = {
@@ -7,7 +7,7 @@ export const mongoSummaryLogRowStatesRepositoryPlugin = {
   dependencies: ['mongodb'],
 
   register: async (server) => {
-    const factory = await createMongoSummaryLogRowStateRepository(server.db)
+    const factory = await createMongoSummaryLogRowStatesRepository(server.db)
     const repository = factory()
 
     registerDependency(

--- a/src/waste-records/repository/mongodb.test.js
+++ b/src/waste-records/repository/mongodb.test.js
@@ -5,11 +5,11 @@ import { MongoClient } from 'mongodb'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
 import {
-  createMongoSummaryLogRowStateRepository,
+  createMongoSummaryLogRowStatesRepository,
   ensureSummaryLogRowStatesCollection,
   SUMMARY_LOG_ROW_STATES_COLLECTION_NAME
 } from './mongodb.js'
-import { testSummaryLogRowStateRepositoryContract } from './port.contract.js'
+import { testSummaryLogRowStatesRepositoryContract } from './port.contract.js'
 import { buildSummaryLogRowStateEntry, DEFAULT_LEDGER_ID } from './test-data.js'
 
 const DATABASE_NAME = 'epr-backend'
@@ -37,7 +37,7 @@ const it = mongoIt.extend({
     await use(database.collection(SUMMARY_LOG_ROW_STATES_COLLECTION_NAME))
   },
 
-  summaryLogRowStateRepository: async (
+  summaryLogRowStatesRepository: async (
     /** @type {*} */ { mongoClient },
     use
   ) => {
@@ -45,7 +45,7 @@ const it = mongoIt.extend({
     await database
       .collection(SUMMARY_LOG_ROW_STATES_COLLECTION_NAME)
       .deleteMany({})
-    const factory = await createMongoSummaryLogRowStateRepository(database)
+    const factory = await createMongoSummaryLogRowStatesRepository(database)
     await use(factory)
   }
 })
@@ -117,7 +117,7 @@ describe('summary-log row states repository - mongodb implementation', () => {
   }) => {
     const database = mongoClient.db(DATABASE_NAME)
     const repository = (
-      await createMongoSummaryLogRowStateRepository(database)
+      await createMongoSummaryLogRowStatesRepository(database)
     )()
     expect(repository.upsertSummaryLogRowStates).toBeTypeOf('function')
     expect(repository.findRowStatesForSummaryLog).toBeTypeOf('function')
@@ -125,16 +125,16 @@ describe('summary-log row states repository - mongodb implementation', () => {
   })
 
   describe('row-state repository contract', () => {
-    testSummaryLogRowStateRepositoryContract(it)
+    testSummaryLogRowStatesRepositoryContract(it)
   })
 
   describe('concurrent same-ledger writes', () => {
     const CONCURRENT_WRITERS = 20
 
     it('collapses concurrent identical submissions into a single document with all memberships accreted', async (/** @type {*} */ {
-      summaryLogRowStateRepository
+      summaryLogRowStatesRepository
     }) => {
-      const repository = summaryLogRowStateRepository()
+      const repository = summaryLogRowStatesRepository()
       const entry = buildSummaryLogRowStateEntry()
       const summaryLogIds = Array.from(
         { length: CONCURRENT_WRITERS },
@@ -164,9 +164,9 @@ describe('summary-log row states repository - mongodb implementation', () => {
     })
 
     it('keeps a concurrently-redelivered submission to a single summary-log-row-state row', async (/** @type {*} */ {
-      summaryLogRowStateRepository
+      summaryLogRowStatesRepository
     }) => {
-      const repository = summaryLogRowStateRepository()
+      const repository = summaryLogRowStatesRepository()
       const entry = buildSummaryLogRowStateEntry()
 
       await Promise.all(
@@ -205,7 +205,9 @@ describe('summary-log row states repository - mongodb implementation', () => {
       }
       const stubDb = { collection: () => stubCollection }
       const repository = (
-        await createMongoSummaryLogRowStateRepository(/** @type {*} */ (stubDb))
+        await createMongoSummaryLogRowStatesRepository(
+          /** @type {*} */ (stubDb)
+        )
       )()
 
       await expect(
@@ -240,7 +242,7 @@ describe('write round-trip count', () => {
       SUMMARY_LOG_ROW_STATES_COLLECTION_NAME
     )
     const repository = (
-      await createMongoSummaryLogRowStateRepository(database)
+      await createMongoSummaryLogRowStatesRepository(database)
     )()
 
     const roundTripsFor = async (rowCount, summaryLogId) => {

--- a/src/waste-records/repository/port.contract.js
+++ b/src/waste-records/repository/port.contract.js
@@ -3,7 +3,7 @@ import { testFindRowStatesForSummaryLogBehaviour } from './contract/findRowState
 import { testFindRowHistoryBehaviour } from './contract/findRowHistory.contract.js'
 import { testFindDistinctDataKeysBehaviour } from './contract/findDistinctDataKeys.contract.js'
 
-export const testSummaryLogRowStateRepositoryContract = (it) => {
+export const testSummaryLogRowStatesRepositoryContract = (it) => {
   testUpsertSummaryLogRowStatesBehaviour(it)
   testFindRowStatesForSummaryLogBehaviour(it)
   testFindRowHistoryBehaviour(it)

--- a/src/waste-records/repository/port.js
+++ b/src/waste-records/repository/port.js
@@ -31,7 +31,7 @@
  */
 
 /**
- * @typedef {Object} SummaryLogRowStateRepository
+ * @typedef {Object} SummaryLogRowStatesRepository
  * @property {(ledgerId: WasteBalanceLedgerId, summaryLogRowStates: SummaryLogRowStateEntry[], summaryLogId: string) => Promise<SummaryLogRowState[]>} upsertSummaryLogRowStates
  *   For each row, find the existing state document for that row identity whose
  *   coerced `data` and `classification` equal the incoming entry. If one
@@ -53,7 +53,7 @@
  */
 
 /**
- * @typedef {() => SummaryLogRowStateRepository} SummaryLogRowStateRepositoryFactory
+ * @typedef {() => SummaryLogRowStatesRepository} SummaryLogRowStatesRepositoryFactory
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)

settles the row-state repository on one spelling and closes the `ServerApp` shape so the class of typo behind PAE-1783 fails the type check.

- rename `summaryLogRowStateRepository` -> `summaryLogRowStatesRepository` (and the `SummaryLogRowStatesRepository` port type) throughout — the plural matches the registration name and the nine other collection repositories
- collapse the boundary renames the split forced at each consumer
- name all 15 `registerDependency` dependencies in `ServerApp` and drop the `[key: string]: unknown` escape hatch
- retype the three `src/server/run-*.js` background jobs from `@param {Object} server` to `StartedServer` — bare `Object` made `server.app.<anything>` `any`, so the closed shape gave no protection at the exact sites that failed
- hoist the repeated `StartedServer` cast in `server.js` onto one local

verified the guard bites: reintroducing the original typo produces
`TS2551: Property 'summaryLogRowStateRepository' does not exist on type 'ServerApp'. Did you mean 'summaryLogRowStatesRepository'?`