### PR TITLE
PAE-000: drop dead setup-mongo options in row-states integration test

### DIFF
--- a/src/server/summary-log-row-states-registration.integration.test.js
+++ b/src/server/summary-log-row-states-registration.integration.test.js
@@ -15,13 +15,7 @@ vi.mock(
 )
 
 const startMongo = async () => {
-  await setupMongo(
-    /** @type {*} */ ({
-      binary: { version: 'latest' },
-      serverOptions: {},
-      autoStart: false
-    })
-  )
+  await setupMongo()
   process.env.MONGO_URI = globalThis.__MONGO_URI__
 }
 


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
`summary-log-row-states-registration.integration.test.js` passed `setupMongo({ binary: { version: 'latest' }, serverOptions: {}, autoStart: false })`.

- only `type` and `serverOptions` exist on vitest-mongodb's `Options`, so `binary` and `autoStart` were silently discarded — the `/** @type {*} */` cast is what hid it
- moving `binary` into `serverOptions` would make it take effect and then fail, since `latest` is not a resolvable version
- replaced with bare `setupMongo()`, which is what has effectively been running

same change already made in `run-unexported-tonnage-report.integration.test.js` under PAE-1783.