### PR TITLE
PAE-1783: Size over-exported (T>S) rows in unexported-tonnage diagnostic

### DIFF
--- a/src/common/enums/event.js
+++ b/src/common/enums/event.js
@@ -48,6 +48,7 @@ export const LOGGING_EVENT_ACTIONS = {
   UNEXPORTED_TONNAGE_BY_MATERIAL: 'unexported_tonnage_by_material',
   UNEXPORTED_TONNAGE_BY_STATUS: 'unexported_tonnage_by_status',
   UNEXPORTED_TONNAGE_LARGEST_DELTAS: 'unexported_tonnage_largest_deltas',
+  UNEXPORTED_TONNAGE_OVER_EXPORT: 'unexported_tonnage_over_export',
   UNEXPORTED_TONNAGE_SUMMARY: 'unexported_tonnage_summary'
 }
 

--- a/src/reports/monitoring/unexported-tonnage.js
+++ b/src/reports/monitoring/unexported-tonnage.js
@@ -126,6 +126,26 @@ import { wasteRecordStatesForHead } from '#waste-records/application/read-summar
  */
 
 /**
+ * The over-export tally for one scanned summary log: how many of its loads
+ * exported more than they received (column T over column S — impossible on site,
+ * which validation nonetheless lets through), the tonnage that over-export comes
+ * to, and whether it drags the whole log's column S minus column T negative.
+ *
+ * Collected for every recomputed report, not only the ones the fix would move, so
+ * the sizing counts the real population rather than the mismatches alone. Carries
+ * the registration's material so the negative tonnage can be split by stream.
+ *
+ * @typedef {{
+ *   organisationId: string,
+ *   registrationId: string,
+ *   material: string,
+ *   rowsNegative: number,
+ *   negativeMagnitude: number,
+ *   netNegative: boolean
+ * }} OverExportRecord
+ */
+
+/**
  * What a finding says about its report: the stored figure disagrees with the
  * corrected rule, the source rows are not there to recompute from, they were
  * resolved but could not be read as tonnages, or reading them failed outright.
@@ -219,11 +239,22 @@ export const findReviewableReportRows = (periodicReports) =>
  * open with the business, so the sizing run takes the conservative reading and
  * counts the rows so the decision has a number behind it.
  *
+ * `overExported` carries the over-exported tonnage itself (column T minus column
+ * S) rather than a flag, so the sizing can total the impossible amount and not
+ * only count the rows. It is zero for every row that did not over-export.
+ *
+ * `net` is the signed column S minus column T with a blank received read as
+ * zero, kept so a whole summary log's net can be tested for going negative. It
+ * differs from `notExported`, which is clamped: a row exporting more than it
+ * received, or carrying no received tonnage against an export, pulls `net`
+ * negative while `notExported` stays at zero.
+ *
  * @param {Record<string, any>} data
  * @returns {{
  *   notExported: import('#common/helpers/rounded-tonnage.js').RoundedTonnage,
- *   overExported: boolean,
- *   missingReceived: boolean
+ *   overExported: import('#common/helpers/rounded-tonnage.js').RoundedTonnage,
+ *   missingReceived: boolean,
+ *   net: import('#common/helpers/rounded-tonnage.js').RoundedTonnage
  * }}
  */
 const classifyLoad = (data) => {
@@ -231,18 +262,26 @@ const classifyLoad = (data) => {
   if (isNil(data[TONNAGE_RECEIVED_FIELD])) {
     return {
       notExported: ZERO_TONNAGE,
-      overExported: false,
-      missingReceived: true
+      overExported: ZERO_TONNAGE,
+      missingReceived: true,
+      net: subtractTonnage(ZERO_TONNAGE, exported)
     }
   }
 
   const received = toRoundedTonnage(data[TONNAGE_RECEIVED_FIELD])
+  const net = subtractTonnage(received, exported)
   return greaterThan(exported, received)
-    ? { notExported: ZERO_TONNAGE, overExported: true, missingReceived: false }
+    ? {
+        notExported: ZERO_TONNAGE,
+        overExported: subtractTonnage(exported, received),
+        missingReceived: false,
+        net
+      }
     : {
-        notExported: subtractTonnage(received, exported),
-        overExported: false,
-        missingReceived: false
+        notExported: net,
+        overExported: ZERO_TONNAGE,
+        missingReceived: false,
+        net
       }
 }
 
@@ -268,12 +307,18 @@ const liveContribution = (data, startDate, endDate) =>
 
 /**
  * @typedef {{
- *   total: number,
  *   rowsInPeriod: number,
  *   rowsUnexported: number,
  *   rowsOverExported: number,
  *   rowsMissingReceived: number,
  *   rowsMiscounted: number
+ * }} RecomputationRowCounts
+ *
+ * @typedef {{
+ *   total: number,
+ *   rowCounts: RecomputationRowCounts,
+ *   negativeMagnitude: number,
+ *   netNegative: boolean
  * }} Recomputation
  */
 
@@ -283,7 +328,11 @@ const liveContribution = (data, startDate, endDate) =>
  * carrying an export date.
  *
  * Reports the rows behind the figure alongside it, so a finding says how much
- * data a backfill would move and not only how much tonnage.
+ * data a backfill would move and not only how much tonnage. Alongside those it
+ * carries the over-export sizing: `negativeMagnitude` totals the tonnage of the
+ * rows that exported more than they received, and `netNegative` says whether the
+ * whole log's column S minus column T came out below zero — the figure that
+ * would surface a negative rather than one masked by other loads on the log.
  *
  * @param {WasteRecordState[]} wasteRecordStates
  * @param {string} startDate
@@ -301,22 +350,30 @@ const recomputeUnexported = (wasteRecordStates, startDate, endDate) => {
     live: liveContribution(data, startDate, endDate)
   }))
 
+  const sumTonnage = (pick) =>
+    loads.reduce((sum, load) => addTonnage(sum, pick(load)), ZERO_TONNAGE)
+
   return {
-    total: toNumber(
-      loads.reduce(
-        (sum, { notExported }) => addTonnage(sum, notExported),
-        ZERO_TONNAGE
-      )
-    ),
-    rowsInPeriod: loads.length,
-    rowsUnexported: loads.filter(({ notExported }) => !isZero(notExported))
-      .length,
-    rowsOverExported: loads.filter(({ overExported }) => overExported).length,
-    rowsMissingReceived: loads.filter(({ missingReceived }) => missingReceived)
-      .length,
-    rowsMiscounted: loads.filter(
-      ({ notExported, live }) => !equals(live, notExported)
-    ).length
+    total: toNumber(sumTonnage(({ notExported }) => notExported)),
+    rowCounts: {
+      rowsInPeriod: loads.length,
+      rowsUnexported: loads.filter(({ notExported }) => !isZero(notExported))
+        .length,
+      rowsOverExported: loads.filter(
+        ({ overExported }) => !isZero(overExported)
+      ).length,
+      rowsMissingReceived: loads.filter(
+        ({ missingReceived }) => missingReceived
+      ).length,
+      rowsMiscounted: loads.filter(
+        ({ notExported, live }) => !equals(live, notExported)
+      ).length
+    },
+    negativeMagnitude: toNumber(sumTonnage(({ overExported }) => overExported)),
+    netNegative: greaterThan(
+      ZERO_TONNAGE,
+      sumTonnage(({ net }) => net)
+    )
   }
 }
 
@@ -343,16 +400,28 @@ const identityOf = (row) => ({
  * own. The reason rides onto the finding so the reader knows which of the
  * causes they are looking at.
  *
+ * Returns the recomputation alongside the finding whenever the rows could be
+ * read, whether or not they disagreed with the stored figure. The over-export
+ * sizing is counted over every recomputed report — a log whose stored figure
+ * happens to agree still carries rows that exported more than they received — so
+ * the caller needs the recomputation even when there is no finding to log.
+ *
  * @param {ReviewableReportRow} row
  * @param {SourceRowStates} sourceRowStates
- * @returns {UnexportedTonnageFinding | null}
+ * @returns {{
+ *   finding: UnexportedTonnageFinding | null,
+ *   recomputation: Recomputation | null
+ * }}
  */
 export const diagnoseReportRow = (row, sourceRowStates) => {
   if ('unresolved' in sourceRowStates) {
     return {
-      kind: FINDING_KIND.SOURCE_MISSING,
-      ...identityOf(row),
-      reason: sourceRowStates.unresolved
+      finding: {
+        kind: FINDING_KIND.SOURCE_MISSING,
+        ...identityOf(row),
+        reason: sourceRowStates.unresolved
+      },
+      recomputation: null
     }
   }
 
@@ -365,25 +434,31 @@ export const diagnoseReportRow = (row, sourceRowStates) => {
     )
   } catch (error) {
     return {
-      kind: FINDING_KIND.RECOMPUTE_FAILED,
-      ...identityOf(row),
-      reason: /** @type {Error} */ (error).message
+      finding: {
+        kind: FINDING_KIND.RECOMPUTE_FAILED,
+        ...identityOf(row),
+        reason: /** @type {Error} */ (error).message
+      },
+      recomputation: null
     }
   }
 
-  const { total, ...rowCounts } = recomputation
+  const { total, rowCounts } = recomputation
   if (equals(total, row.storedUnexported)) {
-    return null
+    return { finding: null, recomputation }
   }
 
   return {
-    kind: FINDING_KIND.MISMATCH,
-    ...identityOf(row),
-    material: sourceRowStates.material ?? UNKNOWN_MATERIAL,
-    stored: row.storedUnexported,
-    recomputed: total,
-    delta: toNumber(subtract(total, row.storedUnexported)),
-    ...rowCounts
+    finding: {
+      kind: FINDING_KIND.MISMATCH,
+      ...identityOf(row),
+      material: sourceRowStates.material ?? UNKNOWN_MATERIAL,
+      stored: row.storedUnexported,
+      recomputed: total,
+      delta: toNumber(subtract(total, row.storedUnexported)),
+      ...rowCounts
+    },
+    recomputation
   }
 }
 
@@ -645,6 +720,65 @@ export const summariseUnexportedTonnageFindings = (findings) => {
 }
 
 /**
+ * The estate-wide over-export sizing: how many loads exported more than they
+ * received, how many summary logs carry such a row, and — the number the whole
+ * enhancement turns on — how many of those logs hide it, netting non-negative
+ * because other loads on the log offset the impossible one.
+ *
+ * `summaryLogsMasking` is counted directly rather than subtracted from
+ * `summaryLogsNetNegative`: a summary log can net negative on a blank-received
+ * row alone, carrying no over-exporting row at all, so the two are not
+ * complements. Masking is precisely a log with an over-exporting row whose total
+ * still absorbs it.
+ *
+ * The negative tonnage is split by the registration's material, summed row by
+ * row so a masked row still lands in its stream's total — a log netting positive
+ * never hides the over-export from the material breakdown.
+ *
+ * @param {OverExportRecord[]} records
+ * @returns {{
+ *   rowsNegative: number,
+ *   summaryLogsWithNegativeRow: number,
+ *   summaryLogsNetNegative: number,
+ *   summaryLogsMasking: number,
+ *   affectedExporters: number,
+ *   magnitudeByMaterial: Record<string, number>
+ * }}
+ */
+export const summariseOverExport = (records) => {
+  const withNegativeRow = records.filter(({ rowsNegative }) => rowsNegative > 0)
+
+  const magnitudeByMaterial = Object.fromEntries(
+    [...Map.groupBy(withNegativeRow, ({ material }) => material).entries()].map(
+      ([material, group]) => [
+        material,
+        toNumber(
+          group.reduce(
+            (sum, { negativeMagnitude }) =>
+              addTonnage(sum, toRoundedTonnage(negativeMagnitude)),
+            ZERO_TONNAGE
+          )
+        )
+      ]
+    )
+  )
+
+  return {
+    rowsNegative: withNegativeRow.reduce((sum, r) => sum + r.rowsNegative, 0),
+    summaryLogsWithNegativeRow: withNegativeRow.length,
+    summaryLogsNetNegative: records.filter(({ netNegative }) => netNegative)
+      .length,
+    summaryLogsMasking: withNegativeRow.filter(
+      ({ netNegative }) => !netNegative
+    ).length,
+    affectedExporters: new Set(
+      withNegativeRow.map(({ registrationId }) => registrationId)
+    ).size,
+    magnitudeByMaterial
+  }
+}
+
+/**
  * The ledgers a registration's uploads may sit under: null (its registered-only
  * phase) and its current accreditation id. Reading both means a report built
  * before accreditation still resolves its rows. A row commits under exactly one
@@ -660,7 +794,8 @@ export const summariseUnexportedTonnageFindings = (findings) => {
  * not about the exporter's data, and the caller records it as such.
  *
  * Reads the registration's material off the same fetch, so a resolved report's
- * mismatch can be split by stream without a second lookup.
+ * mismatch can be split by stream and the over-export sizing can split the
+ * negative tonnage by material, both without a second lookup.
  *
  * @param {OrganisationsRepository} organisationsRepository
  * @param {string} organisationId
@@ -750,6 +885,26 @@ const loadSourceRowStates = async (
 }
 
 /**
+ * The over-export record for a recomputed report: the exporter it belongs to,
+ * its material, and the negative-tonnage counts lifted off the recomputation.
+ * `rowsNegative` is the recomputation's over-exported row count under the name
+ * the sizing reads it by.
+ *
+ * @param {ReviewableReportRow} row
+ * @param {string} material
+ * @param {Recomputation} recomputation
+ * @returns {OverExportRecord}
+ */
+const overExportRecordOf = (row, material, recomputation) => ({
+  organisationId: row.organisationId,
+  registrationId: row.registrationId,
+  material,
+  rowsNegative: recomputation.rowCounts.rowsOverExported,
+  negativeMagnitude: recomputation.negativeMagnitude,
+  netNegative: recomputation.netNegative
+})
+
+/**
  * Scans every reviewable accredited-exporter monthly report across the estate
  * and returns the ones whose stored unexported tonnage disagrees with the
  * corrected rule, alongside those that cannot be recomputed at all. Read-only.
@@ -760,26 +915,42 @@ const loadSourceRowStates = async (
  * single failure must not cost the run every figure it has already computed,
  * since the diagnostic gets one pass per deploy.
  *
+ * Alongside the findings it collects an over-export record for every report it
+ * could recompute — not only the mismatches — so the sizing counts the real
+ * population of rows that exported more than they received.
+ *
  * @param {{
  *   reportsRepository: ReportsRepository,
  *   organisationsRepository: OrganisationsRepository,
  *   summaryLogRowStatesRepository: SummaryLogRowStatesRepository
  * }} deps
- * @returns {Promise<{ scanned: number, findings: UnexportedTonnageFinding[] }>}
+ * @returns {Promise<{
+ *   scanned: number,
+ *   findings: UnexportedTonnageFinding[],
+ *   overExportRecords: OverExportRecord[]
+ * }>}
  */
 export const findUnexportedTonnageReports = async (deps) => {
   const periodicReports = await deps.reportsRepository.findAllPeriodicReports()
   const rows = findReviewableReportRows(periodicReports)
 
   const findings = []
+  const overExportRecords = []
   for (const row of rows) {
     try {
-      const finding = diagnoseReportRow(
-        row,
-        await loadSourceRowStates(deps, row)
-      )
+      const source = await loadSourceRowStates(deps, row)
+      const { finding, recomputation } = diagnoseReportRow(row, source)
       if (finding) {
         findings.push(finding)
+      }
+      if (recomputation) {
+        overExportRecords.push(
+          overExportRecordOf(
+            row,
+            /** @type {{ material: string }} */ (source).material,
+            recomputation
+          )
+        )
       }
     } catch (error) {
       findings.push({
@@ -790,5 +961,5 @@ export const findUnexportedTonnageReports = async (deps) => {
     }
   }
 
-  return { scanned: rows.length, findings }
+  return { scanned: rows.length, findings, overExportRecords }
 }

--- a/src/reports/monitoring/unexported-tonnage.test.js
+++ b/src/reports/monitoring/unexported-tonnage.test.js
@@ -6,6 +6,7 @@ import {
   findReviewableReportRows,
   formatUnexportedTonnageFinding,
   largestUnexportedTonnageDeltas,
+  summariseOverExport,
   summariseUnexportedTonnageByMaterial,
   summariseUnexportedTonnageByMonth,
   summariseUnexportedTonnageByStatus,
@@ -15,7 +16,7 @@ import {
 /**
  * @import { PeriodicReport } from '#reports/repository/port.js'
  * @import { WasteRecordState } from '#waste-records/application/read-summary-log-row-states.js'
- * @import { UnexportedTonnageFinding, ReviewableReportRow } from './unexported-tonnage.js'
+ * @import { OverExportRecord, UnexportedTonnageFinding, ReviewableReportRow } from './unexported-tonnage.js'
  */
 
 /**
@@ -212,7 +213,8 @@ describe('unexported-tonnage', () => {
   })
 
   describe('diagnoseReportRow', () => {
-    const diagnoseWithRows = (row, states) => diagnoseReportRow(row, { states })
+    const diagnoseWithRows = (row, states) =>
+      diagnoseReportRow(row, { states }).finding
 
     it('reports a mismatch when a received load has no exported tonnage', () => {
       const finding = diagnoseWithRows(buildRow(), [
@@ -393,7 +395,7 @@ describe('unexported-tonnage', () => {
     })
 
     it('marks a report whose source rows could not be resolved, saying why', () => {
-      const finding = diagnoseReportRow(buildRow(), {
+      const { finding } = diagnoseReportRow(buildRow(), {
         unresolved: 'no source summary log recorded on the report'
       })
 
@@ -405,7 +407,7 @@ describe('unexported-tonnage', () => {
     })
 
     it('distinguishes rows that were never recorded from rows that could not be found', () => {
-      const finding = diagnoseReportRow(buildRow(), {
+      const { finding } = diagnoseReportRow(buildRow(), {
         unresolved: 'no rows found under the registration ledgers'
       })
 
@@ -828,6 +830,83 @@ describe('unexported-tonnage', () => {
     })
   })
 
+  describe('summariseOverExport', () => {
+    /**
+     * @param {Partial<OverExportRecord>} [overrides]
+     * @returns {OverExportRecord}
+     */
+    const record = (overrides = {}) => ({
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      material: 'plastic',
+      rowsNegative: 0,
+      negativeMagnitude: 0,
+      netNegative: false,
+      ...overrides
+    })
+
+    it('counts a summary log that masks a negative row behind loads that net it out', () => {
+      const records = [
+        // one +50 / -30 summary log: carries a negative row but nets positive
+        record({ rowsNegative: 1, negativeMagnitude: 30, netNegative: false }),
+        // a summary log whose over-exports drag the whole log negative
+        record({
+          registrationId: 'reg-2',
+          material: 'paper',
+          rowsNegative: 2,
+          negativeMagnitude: 88,
+          netNegative: true
+        }),
+        // a clean summary log: no negative row, contributes nothing
+        record()
+      ]
+
+      expect(summariseOverExport(records)).toStrictEqual({
+        rowsNegative: 3,
+        summaryLogsWithNegativeRow: 2,
+        summaryLogsNetNegative: 1,
+        summaryLogsMasking: 1,
+        affectedExporters: 2,
+        magnitudeByMaterial: { plastic: 30, paper: 88 }
+      })
+    })
+
+    it('counts a log that nets negative on a blank received row alone, which carries no over-exporting row to mask', () => {
+      const records = [
+        record({ rowsNegative: 0, negativeMagnitude: 0, netNegative: true })
+      ]
+
+      expect(summariseOverExport(records)).toStrictEqual({
+        rowsNegative: 0,
+        summaryLogsWithNegativeRow: 0,
+        summaryLogsNetNegative: 1,
+        summaryLogsMasking: 0,
+        affectedExporters: 0,
+        magnitudeByMaterial: {}
+      })
+    })
+
+    it('sums an exporters over-export across its summary logs but counts the exporter once', () => {
+      const records = [
+        record({ rowsNegative: 1, negativeMagnitude: 12.5 }),
+        record({ rowsNegative: 2, negativeMagnitude: 7.5 })
+      ]
+
+      const { rowsNegative, affectedExporters, magnitudeByMaterial } =
+        summariseOverExport(records)
+
+      expect({
+        rowsNegative,
+        affectedExporters,
+        magnitudeByMaterial
+      }).toStrictEqual({
+        rowsNegative: 3,
+        affectedExporters: 1,
+        magnitudeByMaterial: { plastic: 20 }
+      })
+    })
+  })
+
   describe('findUnexportedTonnageReports', () => {
     const submittedFebReport = (tonnageReceivedNotExported) => ({
       organisationId: 'org-1',
@@ -855,8 +934,9 @@ describe('unexported-tonnage', () => {
         id: 'report-1',
         source: { summaryLogId: 'log-1' }
       }),
-      registration = /** @type {{ accreditationId: string } | null} */ ({
-        accreditationId: 'acc-1'
+      registration = /** @type {{ accreditationId: string, material: string } | null} */ ({
+        accreditationId: 'acc-1',
+        material: 'plastic'
       }),
       rowStates = [buildReceivedRow({ TONNAGE_RECEIVED_FOR_EXPORT: 12 })]
     } = {}) => ({
@@ -888,12 +968,27 @@ describe('unexported-tonnage', () => {
         )
       )
 
+    /**
+     * @param {Partial<OverExportRecord>} [overrides]
+     * @returns {OverExportRecord}
+     */
+    const overExportRecord = (overrides = {}) => ({
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      material: 'plastic',
+      rowsNegative: 0,
+      negativeMagnitude: 0,
+      netNegative: false,
+      ...overrides
+    })
+
     it('reports a mismatch against the rows the report was built from', async () => {
       const result = await scan(buildDeps())
 
       expect(result).toStrictEqual({
         scanned: 1,
-        findings: [mismatch({ recomputed: 12, delta: 12 })]
+        findings: [mismatch({ recomputed: 12, delta: 12 })],
+        overExportRecords: [overExportRecord()]
       })
     })
 
@@ -909,6 +1004,40 @@ describe('unexported-tonnage', () => {
 
       expect(findings).toStrictEqual([
         mismatch({ material: 'plastic', recomputed: 12, delta: 12 })
+      ])
+    })
+
+    it('records an over-exporting row against its material even when the stored figure already agrees', async () => {
+      const { findings, overExportRecords } = await scan(
+        buildDeps({
+          rowStates: [
+            buildReceivedRow({
+              TONNAGE_RECEIVED_FOR_EXPORT: 10,
+              TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 12
+            })
+          ]
+        })
+      )
+
+      expect({ findings, overExportRecords }).toStrictEqual({
+        findings: [],
+        overExportRecords: [
+          overExportRecord({
+            rowsNegative: 1,
+            negativeMagnitude: 2,
+            netNegative: true
+          })
+        ]
+      })
+    })
+
+    it('falls back to an unknown material when the registration cannot be read for one', async () => {
+      const { overExportRecords } = await scan(
+        buildDeps({ registration: null })
+      )
+
+      expect(overExportRecords).toStrictEqual([
+        overExportRecord({ material: '(material unknown)' })
       ])
     })
 
@@ -1049,7 +1178,11 @@ describe('unexported-tonnage', () => {
         buildDeps({ periodicReports: [submittedFebReport(12)] })
       )
 
-      expect(result).toStrictEqual({ scanned: 1, findings: [] })
+      expect(result).toStrictEqual({
+        scanned: 1,
+        findings: [],
+        overExportRecords: [overExportRecord()]
+      })
     })
   })
 })

--- a/src/reports/monitoring/unexported-tonnage.test.js
+++ b/src/reports/monitoring/unexported-tonnage.test.js
@@ -227,7 +227,7 @@ describe('unexported-tonnage', () => {
     })
 
     it('carries the resolved material onto a mismatch, so its figure can be split by stream', () => {
-      const finding = diagnoseReportRow(
+      const { finding } = diagnoseReportRow(
         buildRow(),
         /** @type {any} */ ({
           states: [buildReceivedRow({ TONNAGE_RECEIVED_FOR_EXPORT: 29.19 })],
@@ -987,7 +987,9 @@ describe('unexported-tonnage', () => {
 
       expect(result).toStrictEqual({
         scanned: 1,
-        findings: [mismatch({ recomputed: 12, delta: 12 })],
+        findings: [
+          mismatch({ material: 'plastic', recomputed: 12, delta: 12 })
+        ],
         overExportRecords: [overExportRecord()]
       })
     })
@@ -1166,6 +1168,7 @@ describe('unexported-tonnage', () => {
           mismatch({
             organisationId: 'org-2',
             registrationId: 'reg-2',
+            material: 'plastic',
             recomputed: 12,
             delta: 12
           })

--- a/src/server/run-unexported-tonnage-report.integration.test.js
+++ b/src/server/run-unexported-tonnage-report.integration.test.js
@@ -3,6 +3,11 @@ import { setup as setupMongo, teardown as teardownMongo } from 'vitest-mongodb'
 import { randomUUID } from 'node:crypto'
 
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+import { findUnexportedTonnageReports } from '#reports/monitoring/unexported-tonnage.js'
+import { createAndSubmitReport } from '#reports/repository/contract/test-data.js'
+import { buildOrganisation } from '#repositories/organisations/contract/test-data.js'
+import { buildSummaryLogRowStateEntry } from '#waste-records/repository/test-data.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { unexportedTonnageDependencies } from './run-unexported-tonnage-report.js'
 
 /**
@@ -54,5 +59,96 @@ describe('unexported tonnage diagnostic wiring', () => {
       .map(([name]) => name)
 
     expect(unresolved).toStrictEqual([])
+  })
+
+  it('sizes a masked over-export end-to-end, reading real persisted rows', async () => {
+    // An accredited plastic exporter: take the canonical fixture organisation
+    // and link its exporter registration to its exporter accreditation, so the
+    // over-exporting rows are read off a real accreditation ledger.
+    const organisation = buildOrganisation()
+    const registration = organisation.registrations.find(
+      (reg) => reg.wasteProcessingType === 'exporter'
+    )
+    const accreditation = organisation.accreditations.find(
+      (acc) => acc.wasteProcessingType === 'exporter'
+    )
+    if (!registration || !accreditation) {
+      throw new Error(
+        'fixture organisation must carry an exporter registration and accreditation'
+      )
+    }
+    registration.accreditationId = accreditation.id
+    await server.app.organisationsRepository.insert(organisation)
+
+    const organisationId = organisation.id
+    const registrationId = registration.id
+    const summaryLogId = 'sl-1'
+
+    // One summary log carrying a masked over-export: an impossible T>S row
+    // (exported 80 against 50 received, net -30) whose loss is absorbed by a
+    // plain 100t unexported load, so the log still nets positive (+70) and the
+    // over-export never surfaces in the log's own total.
+    await server.app.summaryLogRowStatesRepository.upsertSummaryLogRowStates(
+      { organisationId, registrationId, accreditationId: accreditation.id },
+      [
+        buildSummaryLogRowStateEntry({
+          rowId: 'row-over-export',
+          processingType: PROCESSING_TYPES.EXPORTER,
+          data: {
+            DATE_RECEIVED_FOR_EXPORT: '2024-01-15',
+            TONNAGE_RECEIVED_FOR_EXPORT: 50,
+            TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 80
+          }
+        }),
+        buildSummaryLogRowStateEntry({
+          rowId: 'row-unexported',
+          processingType: PROCESSING_TYPES.EXPORTER,
+          data: {
+            DATE_RECEIVED_FOR_EXPORT: '2024-01-20',
+            TONNAGE_RECEIVED_FOR_EXPORT: 100,
+            TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 0
+          }
+        })
+      ],
+      summaryLogId
+    )
+
+    // The stored figure agrees with the recompute (0 clamped + 100 = 100), so
+    // there is no mismatch finding — the over-export record is still collected,
+    // which is the behaviour under test.
+    const exportActivity = {
+      overseasSites: [],
+      unapprovedOverseasSites: [],
+      totalTonnageExported: 80,
+      tonnageRefusedAtDestination: 0,
+      tonnageStoppedDuringExport: 0,
+      totalTonnageRefusedOrStopped: 0,
+      tonnageRepatriated: 0,
+      tonnageReceivedNotExported: 100
+    }
+    await createAndSubmitReport(server.app.reportsRepository, {
+      organisationId,
+      registrationId,
+      wasteProcessingType: 'exporter',
+      material: 'plastic',
+      source: { summaryLogId, lastUploadedAt: '2026-04-01T00:00:00.000Z' },
+      exportActivity
+    })
+
+    const { scanned, findings, overExportRecords } =
+      await findUnexportedTonnageReports(unexportedTonnageDependencies(server))
+
+    expect(scanned).toBe(1)
+    expect(findings).toStrictEqual([])
+    expect(overExportRecords).toStrictEqual([
+      {
+        organisationId,
+        registrationId,
+        material: 'plastic',
+        rowsNegative: 1,
+        negativeMagnitude: 30,
+        netNegative: false
+      }
+    ])
   })
 })

--- a/src/server/run-unexported-tonnage-report.js
+++ b/src/server/run-unexported-tonnage-report.js
@@ -8,6 +8,7 @@ import {
   findUnexportedTonnageReports,
   formatUnexportedTonnageFinding,
   largestUnexportedTonnageDeltas,
+  summariseOverExport,
   summariseUnexportedTonnageByMaterial,
   summariseUnexportedTonnageByMonth,
   summariseUnexportedTonnageByStatus,
@@ -16,7 +17,7 @@ import {
 
 /**
  * @import { StartedServer } from '#common/hapi-types.js'
- * @import { MaterialBreakdown, UnexportedTonnageFinding } from '#reports/monitoring/unexported-tonnage.js'
+ * @import { MaterialBreakdown, OverExportRecord, UnexportedTonnageFinding } from '#reports/monitoring/unexported-tonnage.js'
  */
 
 const LOCK_NAME = 'unexported-tonnage-report'
@@ -121,6 +122,39 @@ const logBreakdowns = (findings) => {
 }
 
 /**
+ * Sizes the over-exports validation lets through: rows that exported more than
+ * they received, how many summary logs mask such a row behind loads that net it
+ * out, and the negative tonnage split by material. Logged whatever the count so
+ * a clean estate is stated rather than left silent.
+ *
+ * @param {OverExportRecord[]} overExportRecords
+ */
+const logOverExport = (overExportRecords) => {
+  const {
+    rowsNegative,
+    summaryLogsWithNegativeRow,
+    summaryLogsNetNegative,
+    summaryLogsMasking,
+    affectedExporters,
+    magnitudeByMaterial
+  } = summariseOverExport(overExportRecords)
+
+  const byMaterial =
+    Object.entries(magnitudeByMaterial)
+      .map(([material, tonnage]) => `${material} ${tonnage}`)
+      .join(', ') || 'none'
+
+  log(
+    LOGGING_EVENT_ACTIONS.UNEXPORTED_TONNAGE_OVER_EXPORT,
+    `Over-export sizing: ${rowsNegative} rows over-exported (T>S) in ` +
+      `${summaryLogsWithNegativeRow} summary logs, of which ` +
+      `${summaryLogsNetNegative} net negative and ${summaryLogsMasking} masked; ` +
+      `affected exporters ${affectedExporters}; ` +
+      `magnitude by material: ${byMaterial}`
+  )
+}
+
+/**
  * @param {number} scanned
  * @param {UnexportedTonnageFinding[]} findings
  */
@@ -180,9 +214,8 @@ export const unexportedTonnageDependencies = (server) => ({
  * @param {StartedServer} server
  */
 const runReport = async (server) => {
-  const { scanned, findings } = await findUnexportedTonnageReports(
-    unexportedTonnageDependencies(server)
-  )
+  const { scanned, findings, overExportRecords } =
+    await findUnexportedTonnageReports(unexportedTonnageDependencies(server))
 
   findings.forEach((finding) =>
     log(
@@ -192,6 +225,7 @@ const runReport = async (server) => {
     )
   )
   logBreakdowns(findings)
+  logOverExport(overExportRecords)
   logSummary(scanned, findings)
 }
 

--- a/src/server/run-unexported-tonnage-report.test.js
+++ b/src/server/run-unexported-tonnage-report.test.js
@@ -322,7 +322,7 @@ describe('runUnexportedTonnageReport', () => {
         'unexported_tonnage_by_month',
         'Unexported tonnage by month: Feb 2026 - 1 report(s), delta 29.19, ' +
           'understated 29.19, overstated 0; ' +
-          'by material: (material unknown) 1 report(s) delta 29.19'
+          'by material: plastic 1 report(s) delta 29.19'
       )
     )
     expect(logger.info).toHaveBeenCalledWith(
@@ -330,7 +330,7 @@ describe('runUnexportedTonnageReport', () => {
         'unexported_tonnage_by_month',
         'Unexported tonnage by month: Mar 2026 - 1 report(s), delta 4, ' +
           'understated 4, overstated 0; ' +
-          'by material: (material unknown) 1 report(s) delta 4'
+          'by material: plastic 1 report(s) delta 4'
       )
     )
   })

--- a/src/server/run-unexported-tonnage-report.test.js
+++ b/src/server/run-unexported-tonnage-report.test.js
@@ -93,7 +93,9 @@ const estateApp = (periodicReports, rowStates) => ({
     }))
   },
   organisationsRepository: {
-    findRegistrationById: vi.fn().mockResolvedValue({ accreditationId: null })
+    findRegistrationById: vi
+      .fn()
+      .mockResolvedValue({ accreditationId: null, material: 'plastic' })
   },
   summaryLogRowStatesRepository: {
     findRowStatesForSummaryLog: vi.fn().mockResolvedValue(rowStates)
@@ -370,6 +372,38 @@ describe('runUnexportedTonnageReport', () => {
         'Unexported tonnage by month: Feb 2026 - 2 report(s), delta 58.38, ' +
           'understated 58.38, overstated 0; ' +
           'by material: plastic 1 report(s) delta 29.19, steel 1 report(s) delta 29.19'
+      )
+    )
+  })
+
+  it('sizes the over-exports validation lets through, splitting the negative tonnage by material', async () => {
+    const server = buildServer(
+      estateApp([submittedFebReport()], [partlyExportedRow(10, 12)])
+    )
+
+    await runUnexportedTonnageReport(server)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      infoLine(
+        'unexported_tonnage_over_export',
+        'Over-export sizing: 1 rows over-exported (T>S) in 1 summary logs, ' +
+          'of which 1 net negative and 0 masked; affected exporters 1; ' +
+          'magnitude by material: plastic 2'
+      )
+    )
+  })
+
+  it('states a clean estate on the over-export line rather than leaving it silent', async () => {
+    const server = buildServer(emptyEstateApp())
+
+    await runUnexportedTonnageReport(server)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      infoLine(
+        'unexported_tonnage_over_export',
+        'Over-export sizing: 0 rows over-exported (T>S) in 0 summary logs, ' +
+          'of which 0 net negative and 0 masked; affected exporters 0; ' +
+          'magnitude by material: none'
       )
     )
   })


### PR DESCRIPTION
## What

Adds **over-export sizing** to the `unexported-tonnage` monitoring diagnostic. A summary-log load whose **column T (exported)** exceeds **column S (received)** is physically impossible — you cannot export more recyclable tonnage than you received — yet upload validation currently lets it through. [PAE-1783](https://eaflood.atlassian.net/browse/PAE-1783) question 3 asks how to handle these rows (clamp / fatal / non-fatal); that decision needs a number behind it. This change quantifies the estate-wide population so the call can be made on evidence rather than a guess.

No behaviour change to reports or validation — this is diagnostic instrumentation only.

## How

- **`classifyLoad`** now returns the over-exported tonnage itself (T − S) instead of a boolean, plus a signed `net` (S − T, blank received read as zero) that can go negative where `notExported` is clamped to zero.
- **`recomputeUnexported`** totals `negativeMagnitude` (sum of over-exported tonnage) and `netNegative` (whether the whole log's S − T fell below zero), and groups the row counts under `rowCounts`.
- **`diagnoseReportRow`** now returns `{ finding, recomputation }` so the caller gets the recomputation for **every** readable report, not just mismatches — the sizing must count the real population, including logs whose stored figure happens to agree.
- **`resolveLedgers`** carries the registration's `material` through so the negative tonnage can be split by stream without a second lookup.
- New **`summariseOverExport`** aggregates: rows over-exporting, summary logs carrying such a row, logs netting negative, **logs masking** (an over-export absorbed by other loads so the net stays non-negative — the number the enhancement turns on), affected exporters, and magnitude by material.
- **`logOverExport`** emits it under a new `UNEXPORTED_TONNAGE_OVER_EXPORT` event — logged whatever the count, so a clean estate is stated rather than left silent.

## What the log looks like

One line per run, emitted under `event.action: unexported_tonnage_over_export`. CDP indexes only an allowlisted set of ECS fields, so — as with the other lines in this diagnostic — every figure rolls up into the message rather than a property.

An estate with over-exports found:

```json
{
  "message": "Over-export sizing: 7 rows over-exported (T>S) in 5 summary logs, of which 2 net negative and 3 masked; affected exporters 4; magnitude by material: plastic 41.6, paper 88",
  "event": { "category": "server", "action": "unexported_tonnage_over_export" }
}
```

Read as: 7 impossible rows across 5 summary logs; 2 logs are dragged net-negative by them, and **3 mask** the over-export behind other loads so their total still nets non-negative (these are the ones a count of net-negative logs alone would miss); 4 distinct exporters affected; the over-exported tonnage splits to 41.6t plastic and 88t paper.

A clean estate still logs, so the run is never silent:

```json
{
  "message": "Over-export sizing: 0 rows over-exported (T>S) in 0 summary logs, of which 0 net negative and 0 masked; affected exporters 0; magnitude by material: none",
  "event": { "category": "server", "action": "unexported_tonnage_over_export" }
}
```

## Feature flag

No new flag. The whole diagnostic — this log included — is gated by the existing **`unexportedTonnageReport`** flag (env `FEATURE_FLAG_UNEXPORTED_TONNAGE_REPORT`, default `false`). `runUnexportedTonnageReport` returns early before touching the locker or any repository when it is off:

```js
if (!server.featureFlags.isUnexportedTonnageReportEnabled()) {
  return
}
```

So `logOverExport` only runs on the single locked pod per deploy that already runs the sizing diagnostic, and only where the flag is switched on.

## Testing

- Unit coverage for `summariseOverExport` (masking vs net-negative vs blank-received-only, per-exporter summing, material split).
- `diagnoseReportRow` tests updated for the new `{ finding, recomputation }` shape.

## Notes

Draft — raised to track the work-in-progress branch. Jira PAE-1783 is still **In Progress** pending the business decision on how over-export rows should ultimately be handled; this sizing feeds that decision.


[PAE-1783]: https://eaflood.atlassian.net/browse/PAE-1783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ