### PR TITLE
feat(organisations): surface unlinked accreditations and assign one to a registration

### DIFF
--- a/src/routes/v1/organisations/accreditation-registration.js
+++ b/src/routes/v1/organisations/accreditation-registration.js
@@ -1,0 +1,160 @@
+import Boom from '@hapi/boom'
+import { SCOPES } from '#common/helpers/auth/constants.js'
+import { StatusCodes } from 'http-status-codes'
+import { auditOrganisationUpdate } from '#root/auditing/organisations.js'
+import {
+  REGISTRATION_STATUS,
+  WASTE_PROCESSING_TYPE
+} from '#domain/organisations/model.js'
+import { siteKey } from '#formsubmission/parsing-common/site.js'
+import { accreditationRegistrationPayloadSchema } from './accreditation-registration.schema.js'
+
+/** @typedef {import('#repositories/organisations/port.js').OrganisationsRepository} OrganisationsRepository */
+/** @typedef {import('#repositories/organisations/port.js').OrganisationReplacement} OrganisationReplacement */
+/** @typedef {import('#repositories/system-logs/port.js').SystemLogsRepository} SystemLogsRepository */
+/** @typedef {import('#domain/organisations/accreditation.js').Accreditation} Accreditation */
+/** @typedef {import('#domain/organisations/registration.js').Registration} Registration */
+
+// Deliberately not nested under a registration: an unlinked accreditation has
+// none, which is the whole reason it cannot be reached by any other admin
+// route.
+export const accreditationRegistrationPath =
+  '/v1/organisations/{organisationId}/accreditations/{accreditationId}/registration'
+
+/**
+ * The candidate rules. The material, processing type and site checks are not
+ * belt-and-braces: those fields make up the registration/accreditation identity
+ * key, so a mismatch would be rejected by validateAccreditationLinkMatches on
+ * the write with a far vaguer message. Each rule reports its own reason.
+ *
+ * @param {Registration} registration
+ * @param {Accreditation} accreditation
+ * @returns {void}
+ */
+const assertRegistrationIsACandidate = (registration, accreditation) => {
+  if (registration.status !== REGISTRATION_STATUS.APPROVED) {
+    throw Boom.badData(
+      `Cannot assign accreditation: registration ${registration.id} is ${registration.status}, not approved`
+    )
+  }
+
+  if (registration.material !== accreditation.material) {
+    throw Boom.badData(
+      `Cannot assign accreditation: registration material ${registration.material} does not match accreditation material ${accreditation.material}`
+    )
+  }
+
+  if (registration.wasteProcessingType !== accreditation.wasteProcessingType) {
+    throw Boom.badData(
+      `Cannot assign accreditation: registration processing type ${registration.wasteProcessingType} does not match accreditation processing type ${accreditation.wasteProcessingType}`
+    )
+  }
+
+  if (
+    registration.wasteProcessingType === WASTE_PROCESSING_TYPE.REPROCESSOR &&
+    siteKey(registration.site) !== siteKey(accreditation.site)
+  ) {
+    throw Boom.badData(
+      `Cannot assign accreditation: registration ${registration.id} is at a different site to the accreditation`
+    )
+  }
+
+  // Copied onto the accreditation below, so there has to be one to copy.
+  if (!registration.reprocessingType) {
+    throw Boom.badData(
+      `Cannot assign accreditation: registration ${registration.id} has no reprocessingType`
+    )
+  }
+
+  if (registration.accreditationId) {
+    throw Boom.badData(
+      `Cannot assign accreditation: registration ${registration.id} is already linked to accreditation ${registration.accreditationId}`
+    )
+  }
+}
+
+export const accreditationRegistrationAssign = {
+  method: 'POST',
+  path: accreditationRegistrationPath,
+  options: {
+    auth: {
+      scope: [SCOPES.adminWrite]
+    },
+    tags: ['api', 'admin'],
+    validate: {
+      payload: accreditationRegistrationPayloadSchema
+    }
+  },
+
+  /**
+   * @param {import('#common/hapi-types.js').HapiRequest<{ registrationId: string }> & {
+   *    organisationsRepository: OrganisationsRepository,
+   *    systemLogsRepository: SystemLogsRepository,
+   *    params: { organisationId: string, accreditationId: string }
+   * }} request
+   * @param {import('@hapi/hapi').ResponseToolkit} h
+   * @returns {Promise<import('@hapi/hapi').ResponseObject>}
+   */
+  handler: async (request, h) => {
+    const { organisationsRepository } = request
+    const { organisationId, accreditationId } = request.params
+    const { registrationId } = request.payload
+
+    const initial = await organisationsRepository.findById(organisationId)
+
+    const accreditation = initial.accreditations.find(
+      (acc) => acc.id === accreditationId
+    )
+    if (!accreditation) {
+      throw Boom.notFound(`Accreditation with id ${accreditationId} not found`)
+    }
+
+    const registration = initial.registrations.find(
+      (reg) => reg.id === registrationId
+    )
+    if (!registration) {
+      throw Boom.notFound(`Registration with id ${registrationId} not found`)
+    }
+
+    const currentHolder = initial.registrations.find(
+      (reg) => reg.accreditationId === accreditationId
+    )
+    if (currentHolder) {
+      throw Boom.badData(
+        `Cannot assign accreditation: accreditation ${accreditationId} is already linked to registration ${currentHolder.id}`
+      )
+    }
+
+    assertRegistrationIsACandidate(registration, accreditation)
+
+    const { id, version, ...orgFields } = initial
+
+    /** @type {OrganisationReplacement} */
+    const updates = {
+      ...orgFields,
+      registrations: initial.registrations.map((reg) =>
+        reg.id === registrationId
+          ? /** @type {typeof reg} */ ({ ...reg, accreditationId })
+          : reg
+      ),
+      // reprocessingType is part of the identity key, and an unlinked
+      // accreditation has none. Copying it across in the same replace is what
+      // makes the pair match — without it the write this very operation
+      // performs would be rejected.
+      accreditations: initial.accreditations.map((acc) =>
+        acc.id === accreditationId
+          ? /** @type {typeof acc} */ ({
+              ...acc,
+              reprocessingType: registration.reprocessingType
+            })
+          : acc
+      )
+    }
+
+    await organisationsRepository.replace(id, version, updates)
+    const updated = await organisationsRepository.findById(id, version + 1)
+    await auditOrganisationUpdate(request, id, initial, updated)
+
+    return h.response().code(StatusCodes.NO_CONTENT)
+  }
+}

--- a/src/routes/v1/organisations/accreditation-registration.schema.js
+++ b/src/routes/v1/organisations/accreditation-registration.schema.js
@@ -1,0 +1,7 @@
+import Joi from 'joi'
+
+// The accreditation is identified by the path; the body names only the
+// registration it is being assigned to.
+export const accreditationRegistrationPayloadSchema = Joi.object({
+  registrationId: Joi.string().trim().min(1).required()
+}).required()

--- a/src/routes/v1/organisations/accreditation-registration.test.js
+++ b/src/routes/v1/organisations/accreditation-registration.test.js
@@ -1,0 +1,456 @@
+import {
+  buildAccreditation,
+  buildOrganisation,
+  buildRegistration
+} from '#repositories/organisations/contract/test-data.js'
+import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
+import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
+import { createSystemLogsRepository } from '#repositories/system-logs/inmemory.js'
+import { createTestServer } from '#test/create-test-server.js'
+import { entraIdMockAuthTokens } from '#vite/helpers/create-entra-id-test-tokens.js'
+import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+import { testOnlyServiceMaintainerCanAccess } from '#vite/helpers/test-invalid-roles-scenarios.js'
+import { testInvalidTokenScenarios } from '#vite/helpers/test-invalid-token-scenarios.js'
+import { StatusCodes } from 'http-status-codes'
+import { ObjectId } from 'mongodb'
+import { accreditationRegistrationPath } from './accreditation-registration.js'
+
+const { validToken } = entraIdMockAuthTokens
+
+const mockCdpAuditing = vi.fn()
+
+vi.mock('@defra/cdp-auditing', () => ({
+  audit: (...args) => mockCdpAuditing(...args)
+}))
+
+const EXPORTER_ONLY_FIELDS = {
+  site: undefined,
+  orsFileUploads: [
+    {
+      defraFormUploadedFileId: 'file-ors',
+      defraFormUserDownloadLink: 'https://example.com/ors'
+    }
+  ]
+}
+
+/**
+ * An approved reprocessor registration with no accreditation of its own, and
+ * an orphaned accreditation that matches it on every identity field except
+ * reprocessingType — which an unlinked accreditation never has.
+ * @param {{
+ *   registrationOverrides?: object,
+ *   accreditationOverrides?: object,
+ *   extraRegistrations?: object[],
+ *   extraAccreditations?: object[]
+ * }} [options]
+ */
+const buildOrgWithOrphanAccreditation = ({
+  registrationOverrides = {},
+  accreditationOverrides = {},
+  extraRegistrations = [],
+  extraAccreditations = []
+} = {}) => {
+  const registration = buildRegistration({
+    reprocessingType: 'input',
+    registrationNumber: 'REG123456',
+    validFrom: '2024-01-01',
+    validTo: '2026-12-31',
+    statusHistory: [
+      { status: 'created', updatedAt: '2024-01-01' },
+      { status: 'approved', updatedAt: '2024-02-01' }
+    ],
+    ...registrationOverrides
+  })
+  const accreditation = buildAccreditation({
+    statusHistory: [{ status: 'created', updatedAt: '2024-01-01' }],
+    ...accreditationOverrides
+  })
+
+  return /** @type {import('#domain/organisations/model.js').Organisation} */ (
+    /** @type {unknown} */ (
+      buildOrganisation({
+        registrations: [registration, ...extraRegistrations],
+        accreditations: [accreditation, ...extraAccreditations]
+      })
+    )
+  )
+}
+
+const assignUrl = ({ organisationId, accreditationId }) =>
+  accreditationRegistrationPath
+    .replace('{organisationId}', organisationId)
+    .replace('{accreditationId}', accreditationId)
+
+describe(`POST ${accreditationRegistrationPath}`, () => {
+  setupAuthContext()
+  let server
+
+  const seedOrg = async (options = {}) => {
+    const fixture = buildOrgWithOrphanAccreditation(options)
+
+    server = await createTestServer({
+      repositories: {
+        organisationsRepository: createInMemoryOrganisationsRepository([
+          fixture
+        ]),
+        systemLogsRepository: createSystemLogsRepository()
+      },
+      featureFlags: createInMemoryFeatureFlags()
+    })
+
+    return {
+      organisationId: fixture.id,
+      registrationId: fixture.registrations[0].id,
+      accreditationId: fixture.accreditations[0].id
+    }
+  }
+
+  const assign = (ctx, overrides = {}) =>
+    server.inject({
+      method: 'POST',
+      url: assignUrl({ ...ctx, ...overrides }),
+      payload: {
+        registrationId: overrides.registrationId ?? ctx.registrationId
+      },
+      headers: { Authorization: `Bearer ${validToken}` }
+    })
+
+  const fetchOrganisation = async (ctx) => {
+    const response = await server.inject({
+      method: 'GET',
+      url: `/v1/organisations/${ctx.organisationId}`,
+      headers: { Authorization: `Bearer ${validToken}` }
+    })
+    expect(response.statusCode).toBe(StatusCodes.OK)
+    return JSON.parse(response.payload)
+  }
+
+  afterAll(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('assigning an unlinked accreditation', () => {
+    it('links the accreditation to the registration, leaving the other registrations and accreditations alone, and returns 204', async () => {
+      const otherRegistration = buildRegistration({
+        wasteProcessingType: 'exporter'
+      })
+      const otherAccreditation = buildAccreditation({
+        statusHistory: [{ status: 'created', updatedAt: '2024-01-01' }]
+      })
+      const ctx = await seedOrg({
+        extraRegistrations: [otherRegistration],
+        extraAccreditations: [otherAccreditation]
+      })
+
+      const response = await assign(ctx)
+
+      expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
+
+      const org = await fetchOrganisation(ctx)
+      const registration = org.registrations.find(
+        (reg) => reg.id === ctx.registrationId
+      )
+      expect(registration.accreditationId).toBe(ctx.accreditationId)
+
+      expect(
+        org.registrations.find((reg) => reg.id === otherRegistration.id)
+          .accreditationId
+      ).toBeUndefined()
+      expect(
+        org.accreditations.find((acc) => acc.id === otherAccreditation.id)
+          .reprocessingType
+      ).toBeNull()
+    })
+
+    it('copies the registration reprocessingType onto the accreditation', async () => {
+      const ctx = await seedOrg({
+        registrationOverrides: { reprocessingType: 'output' }
+      })
+
+      expect((await assign(ctx)).statusCode).toBe(StatusCodes.NO_CONTENT)
+
+      const org = await fetchOrganisation(ctx)
+      const accreditation = org.accreditations.find(
+        (acc) => acc.id === ctx.accreditationId
+      )
+      expect(accreditation.reprocessingType).toBe('output')
+    })
+
+    it('leaves the pair matched, so a later organisation write succeeds', async () => {
+      const ctx = await seedOrg()
+      expect((await assign(ctx)).statusCode).toBe(StatusCodes.NO_CONTENT)
+
+      // Any subsequent write revalidates the registration/accreditation
+      // identity keys. Without the reprocessingType copy this 422s.
+      const response = await server.inject({
+        method: 'POST',
+        url: `/v1/organisations/${ctx.organisationId}/registrations/${ctx.registrationId}/accreditations/${ctx.accreditationId}/status-history`,
+        payload: { fromStatus: 'created', toStatus: 'rejected' },
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+
+    it('captures a system log entry with actor and before/after link', async () => {
+      const ctx = await seedOrg()
+      const start = new Date()
+
+      expect((await assign(ctx)).statusCode).toBe(StatusCodes.NO_CONTENT)
+
+      const systemLogsResponse = await server.inject({
+        method: 'GET',
+        url: `/v1/system-logs/search?organisationId=${ctx.organisationId}`,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      expect(systemLogsResponse.statusCode).toBe(StatusCodes.OK)
+      const { systemLogs } = JSON.parse(systemLogsResponse.payload)
+      expect(systemLogs).toHaveLength(1)
+
+      const [entry] = systemLogs
+      expect(entry.createdBy).toMatchObject({
+        id: 'test-user-id',
+        email: 'me@example.com'
+      })
+      expect(new Date(entry.createdAt).getTime()).toBeGreaterThanOrEqual(
+        start.getTime()
+      )
+      expect(entry.event).toMatchObject({
+        category: 'entity',
+        subCategory: 'epr-organisations',
+        action: 'update'
+      })
+
+      const previous = entry.context.previous.registrations.find(
+        (reg) => reg.id === ctx.registrationId
+      )
+      const next = entry.context.next.registrations.find(
+        (reg) => reg.id === ctx.registrationId
+      )
+      expect(previous.accreditationId).toBeUndefined()
+      expect(next.accreditationId).toBe(ctx.accreditationId)
+
+      expect(mockCdpAuditing).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('rejected candidates', () => {
+    it('returns 422 when the registration is not approved', async () => {
+      const ctx = await seedOrg({
+        registrationOverrides: {
+          registrationNumber: null,
+          validFrom: null,
+          statusHistory: [{ status: 'created', updatedAt: '2024-01-01' }]
+        }
+      })
+
+      const response = await assign(ctx)
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      expect(JSON.parse(response.payload).message).toMatch(
+        /is created, not approved/
+      )
+    })
+
+    it('returns 422 when the materials differ', async () => {
+      const ctx = await seedOrg({
+        accreditationOverrides: {
+          material: 'plastic',
+          glassRecyclingProcess: null
+        }
+      })
+
+      const response = await assign(ctx)
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      expect(JSON.parse(response.payload).message).toMatch(
+        /registration material glass does not match accreditation material plastic/
+      )
+    })
+
+    it('returns 422 when the processing types differ', async () => {
+      const ctx = await seedOrg({
+        accreditationOverrides: {
+          wasteProcessingType: 'exporter',
+          ...EXPORTER_ONLY_FIELDS
+        }
+      })
+
+      const response = await assign(ctx)
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      expect(JSON.parse(response.payload).message).toMatch(
+        /registration processing type reprocessor does not match accreditation processing type exporter/
+      )
+    })
+
+    it('returns 422 when the reprocessor sites differ', async () => {
+      const ctx = await seedOrg({
+        accreditationOverrides: {
+          site: {
+            address: { line1: '9 Other processing site', postcode: 'ZZ1 1ZZ' }
+          }
+        }
+      })
+
+      const response = await assign(ctx)
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      expect(JSON.parse(response.payload).message).toMatch(
+        /is at a different site to the accreditation/
+      )
+    })
+
+    it('returns 422 when the registration has no reprocessingType', async () => {
+      const ctx = await seedOrg({
+        registrationOverrides: { reprocessingType: null }
+      })
+
+      const response = await assign(ctx)
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      expect(JSON.parse(response.payload).message).toMatch(
+        /has no reprocessingType/
+      )
+    })
+
+    it('returns 422 when the registration is already linked to another accreditation', async () => {
+      const otherAccreditationId = new ObjectId().toString()
+      const ctx = await seedOrg({
+        registrationOverrides: { accreditationId: otherAccreditationId },
+        extraAccreditations: [
+          buildAccreditation({
+            id: otherAccreditationId,
+            reprocessingType: 'input',
+            statusHistory: [{ status: 'created', updatedAt: '2024-01-01' }]
+          })
+        ]
+      })
+
+      const response = await assign(ctx)
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      expect(JSON.parse(response.payload).message).toMatch(
+        new RegExp(`is already linked to accreditation ${otherAccreditationId}`)
+      )
+    })
+
+    it('returns 422 when the accreditation is already linked to another registration', async () => {
+      const holder = buildRegistration({
+        statusHistory: [{ status: 'created', updatedAt: '2024-01-01' }]
+      })
+      const fixture = buildOrgWithOrphanAccreditation({
+        extraRegistrations: [holder]
+      })
+      fixture.registrations[1].accreditationId = fixture.accreditations[0].id
+
+      server = await createTestServer({
+        repositories: {
+          organisationsRepository: createInMemoryOrganisationsRepository([
+            fixture
+          ]),
+          systemLogsRepository: createSystemLogsRepository()
+        },
+        featureFlags: createInMemoryFeatureFlags()
+      })
+
+      const ctx = {
+        organisationId: fixture.id,
+        registrationId: fixture.registrations[0].id,
+        accreditationId: fixture.accreditations[0].id
+      }
+
+      const response = await assign(ctx)
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+      expect(JSON.parse(response.payload).message).toMatch(
+        new RegExp(
+          `is already linked to registration ${fixture.registrations[1].id}`
+        )
+      )
+    })
+  })
+
+  describe('payload validation', () => {
+    it.each([
+      ['the payload is missing', undefined],
+      ['the payload is empty', {}],
+      ['registrationId is blank', { registrationId: ' ' }],
+      [
+        'the payload has unexpected fields',
+        { registrationId: 'x', accreditationId: 'y' }
+      ]
+    ])('returns 422 when %s', async (_label, payload) => {
+      const ctx = await seedOrg()
+
+      const response = await server.inject({
+        method: 'POST',
+        url: assignUrl(ctx),
+        payload,
+        headers: { Authorization: `Bearer ${validToken}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+    })
+  })
+
+  describe('not found cases', () => {
+    it('returns 404 when the organisation does not exist', async () => {
+      const ctx = await seedOrg()
+
+      const response = await assign({
+        ...ctx,
+        organisationId: new ObjectId().toString()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    })
+
+    it('returns 404 when the accreditation does not exist on the organisation', async () => {
+      const ctx = await seedOrg()
+
+      const response = await assign({
+        ...ctx,
+        accreditationId: new ObjectId().toString()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    })
+
+    it('returns 404 when the registration does not exist on the organisation', async () => {
+      const ctx = await seedOrg()
+
+      const response = await assign(ctx, {
+        registrationId: new ObjectId().toString()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    })
+  })
+
+  testInvalidTokenScenarios({
+    server: () => server,
+    makeRequest: async () => {
+      const ctx = await seedOrg()
+      return {
+        method: 'POST',
+        url: assignUrl(ctx),
+        payload: { registrationId: ctx.registrationId }
+      }
+    }
+  })
+
+  testOnlyServiceMaintainerCanAccess({
+    server: () => server,
+    makeRequest: async () => {
+      const ctx = await seedOrg()
+      return {
+        method: 'POST',
+        url: assignUrl(ctx),
+        payload: { registrationId: ctx.registrationId }
+      }
+    },
+    successStatus: StatusCodes.NO_CONTENT
+  })
+})

--- a/src/routes/v1/organisations/index.js
+++ b/src/routes/v1/organisations/index.js
@@ -1,6 +1,7 @@
 export { organisationsGetAll } from './get.js'
 export { organisationsGetById } from './get-by-id.js'
 export { organisationsPutById } from './put-by-id.js'
+export { accreditationRegistrationAssign } from './accreditation-registration.js'
 export { accreditationStatusHistory } from './accreditation-status-history.js'
 export { registrationStatusHistory } from './registration-status-history.js'
 export { organisationsLink } from './link.js'

--- a/src/routes/v1/organisations/overview/get.js
+++ b/src/routes/v1/organisations/overview/get.js
@@ -46,13 +46,16 @@ export const organisationsOverviewGet = {
         organisation.accreditations.map((acc) => [acc.id, acc])
       )
 
+      const linkedAccreditationIds = new Set(
+        organisation.registrations
+          .map((reg) => reg.accreditationId)
+          .filter((accreditationId) => !!accreditationId)
+      )
+
       const registrations = organisation.registrations.map((reg) => {
         const linkedAccreditation = reg.accreditationId
           ? accreditationsById.get(reg.accreditationId)
           : undefined
-
-        const isExporter =
-          reg.wasteProcessingType === WASTE_PROCESSING_TYPE.EXPORTER
 
         return {
           id: reg.id,
@@ -60,7 +63,8 @@ export const organisationsOverviewGet = {
           status: reg.status,
           material: reg.material,
           processingType: getProcessingType(reg),
-          site: isExporter ? null : reg.site.address.line1,
+          reprocessingType: reg.reprocessingType ?? null,
+          site: getSite(reg),
           ...(linkedAccreditation && {
             accreditation: {
               id: linkedAccreditation.id,
@@ -71,10 +75,25 @@ export const organisationsOverviewGet = {
         }
       })
 
+      // An accreditation is unlinked when no registration on this organisation
+      // claims it. Nothing on the record itself says so, and nothing should:
+      // the link lives on the registration.
+      const unlinkedAccreditations = organisation.accreditations
+        .filter((acc) => !linkedAccreditationIds.has(acc.id))
+        .map((acc) => ({
+          id: acc.id,
+          accreditationNumber: acc.accreditationNumber,
+          status: acc.status,
+          material: acc.material,
+          processingType: getProcessingType(acc),
+          site: getSite(acc)
+        }))
+
       const response = {
         id: organisation.id,
         companyName: organisation.companyDetails.name,
-        registrations
+        registrations,
+        unlinkedAccreditations
       }
 
       if (organisation.linkedDefraOrganisation) {
@@ -114,14 +133,29 @@ export const organisationsOverviewGet = {
 }
 
 /**
- * @param {{ wasteProcessingType: string, reprocessingType?: string | null }} registration
+ * Shared by registrations and accreditations so the overview table labels both
+ * the same way.
+ * @param {{ wasteProcessingType: string, reprocessingType?: string | null }} item
  * @returns {string}
  */
-function getProcessingType(registration) {
-  if (registration.wasteProcessingType === WASTE_PROCESSING_TYPE.EXPORTER) {
+function getProcessingType(item) {
+  if (item.wasteProcessingType === WASTE_PROCESSING_TYPE.EXPORTER) {
     return WASTE_PROCESSING_TYPE.EXPORTER
   }
-  return registration.reprocessingType
-    ? `${WASTE_PROCESSING_TYPE.REPROCESSOR} - ${registration.reprocessingType}`
+  return item.reprocessingType
+    ? `${WASTE_PROCESSING_TYPE.REPROCESSOR} - ${item.reprocessingType}`
     : WASTE_PROCESSING_TYPE.REPROCESSOR
+}
+
+/**
+ * @param {{ wasteProcessingType: string, site?: { address: { line1?: string } } }} item
+ * @returns {string | null}
+ */
+function getSite(item) {
+  if (item.wasteProcessingType === WASTE_PROCESSING_TYPE.EXPORTER) {
+    return null
+  }
+  // A reprocessor always has a site with a line1: the persistence schema
+  // requires one of both registrations and accreditations.
+  return /** @type {{ address: { line1: string } }} */ (item.site).address.line1
 }

--- a/src/routes/v1/organisations/overview/get.test.js
+++ b/src/routes/v1/organisations/overview/get.test.js
@@ -49,7 +49,7 @@ describe(`GET ${organisationsOverviewGetPath}`, () => {
     expect(Array.isArray(result.registrations)).toBe(true)
   })
 
-  it('returns only id, companyName, and registrations fields at the top level', async () => {
+  it('returns only id, companyName, registrations and unlinkedAccreditations fields at the top level', async () => {
     const org = buildOrganisation()
     await organisationsRepository.insert(org)
 
@@ -64,7 +64,8 @@ describe(`GET ${organisationsOverviewGetPath}`, () => {
     expect(Object.keys(result).sort()).toEqual([
       'companyName',
       'id',
-      'registrations'
+      'registrations',
+      'unlinkedAccreditations'
     ])
   })
 
@@ -105,6 +106,7 @@ describe(`GET ${organisationsOverviewGetPath}`, () => {
       'material',
       'processingType',
       'registrationNumber',
+      'reprocessingType',
       'site',
       'status'
     ])
@@ -130,6 +132,7 @@ describe(`GET ${organisationsOverviewGetPath}`, () => {
       'material',
       'processingType',
       'registrationNumber',
+      'reprocessingType',
       'site',
       'status',
       'accreditation'
@@ -227,6 +230,44 @@ describe(`GET ${organisationsOverviewGetPath}`, () => {
     expect(result.registrations[0].site).toBeNull()
   })
 
+  it.each(['input', 'output'])(
+    'returns reprocessingType %s alongside the processingType display string',
+    async (reprocessingType) => {
+      const registration = buildRegistration({
+        wasteProcessingType: 'reprocessor',
+        reprocessingType
+      })
+      const org = buildOrganisation({ registrations: [registration] })
+      await organisationsRepository.insert(org)
+
+      const response = await server.inject({
+        method: 'GET',
+        url: makePath(org.id),
+        ...asServiceMaintainer()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const result = JSON.parse(response.payload)
+      expect(result.registrations[0].reprocessingType).toBe(reprocessingType)
+    }
+  )
+
+  it('returns null reprocessingType for a registration that has none', async () => {
+    const registration = buildRegistration({ wasteProcessingType: 'exporter' })
+    const org = buildOrganisation({ registrations: [registration] })
+    await organisationsRepository.insert(org)
+
+    const response = await server.inject({
+      method: 'GET',
+      url: makePath(org.id),
+      ...asServiceMaintainer()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+    const result = JSON.parse(response.payload)
+    expect(result.registrations[0].reprocessingType).toBeNull()
+  })
+
   it('includes linked accreditation with id, accreditationNumber, and status', async () => {
     const accreditation = buildAccreditation({ accreditationNumber: 'ACC0001' })
     const registration = buildRegistration({
@@ -276,6 +317,134 @@ describe(`GET ${organisationsOverviewGetPath}`, () => {
     expect(response.statusCode).toBe(StatusCodes.OK)
     const result = JSON.parse(response.payload)
     expect(result.registrations[0]).not.toHaveProperty('accreditation')
+  })
+
+  describe('unlinked accreditations', () => {
+    it('returns an accreditation that no registration claims, with the expected fields', async () => {
+      const unlinked = buildAccreditation({ reprocessingType: 'input' })
+      const org = buildOrganisation({
+        registrations: [buildRegistration()],
+        accreditations: [unlinked]
+      })
+      await organisationsRepository.insert(org)
+
+      const response = await server.inject({
+        method: 'GET',
+        url: makePath(org.id),
+        ...asServiceMaintainer()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const result = JSON.parse(response.payload)
+      expect(result.unlinkedAccreditations).toHaveLength(1)
+      const [accreditation] = result.unlinkedAccreditations
+      expect(Object.keys(accreditation).sort()).toEqual([
+        'accreditationNumber',
+        'id',
+        'material',
+        'processingType',
+        'site',
+        'status'
+      ])
+      expect(accreditation.id).toBe(unlinked.id)
+      expect(accreditation.material).toBe(unlinked.material)
+      expect(accreditation.status).toBe('created')
+      expect(accreditation.processingType).toBe('reprocessor - input')
+      expect(accreditation.site).toBe(unlinked.site?.address.line1)
+    })
+
+    it('returns a null accreditationNumber for an accreditation that is not yet approved', async () => {
+      const org = buildOrganisation({
+        registrations: [buildRegistration()],
+        accreditations: [buildAccreditation()]
+      })
+      await organisationsRepository.insert(org)
+
+      const response = await server.inject({
+        method: 'GET',
+        url: makePath(org.id),
+        ...asServiceMaintainer()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const result = JSON.parse(response.payload)
+      expect(result.unlinkedAccreditations[0].accreditationNumber).toBeNull()
+    })
+
+    it('returns a null site for an unlinked exporter accreditation', async () => {
+      const unlinked = buildAccreditation({
+        wasteProcessingType: 'exporter',
+        material: 'plastic',
+        glassRecyclingProcess: null,
+        site: undefined,
+        orsFileUploads: [
+          {
+            defraFormUploadedFileId: 'file-ors',
+            defraFormUserDownloadLink: 'https://example.com/ors'
+          }
+        ]
+      })
+      const org = buildOrganisation({
+        registrations: [buildRegistration()],
+        accreditations: [unlinked]
+      })
+      await organisationsRepository.insert(org)
+
+      const response = await server.inject({
+        method: 'GET',
+        url: makePath(org.id),
+        ...asServiceMaintainer()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const result = JSON.parse(response.payload)
+      expect(result.unlinkedAccreditations[0].site).toBeNull()
+      expect(result.unlinkedAccreditations[0].processingType).toBe('exporter')
+    })
+
+    it('leaves a linked accreditation out, so it appears only under its registration', async () => {
+      const accreditation = buildAccreditation({
+        accreditationNumber: 'ACC0001'
+      })
+      const registration = buildRegistration({
+        accreditationId: accreditation.id
+      })
+      const org = buildOrganisation({
+        registrations: [registration],
+        accreditations: [accreditation]
+      })
+      await organisationsRepository.insert(org)
+
+      const response = await server.inject({
+        method: 'GET',
+        url: makePath(org.id),
+        ...asServiceMaintainer()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const result = JSON.parse(response.payload)
+      expect(result.unlinkedAccreditations).toEqual([])
+      expect(result.registrations[0].accreditation.id).toBe(accreditation.id)
+    })
+
+    it('returns an empty collection, not a missing key, when the organisation has no accreditations', async () => {
+      const org = buildOrganisation({
+        registrations: [buildRegistration()],
+        accreditations: []
+      })
+      await organisationsRepository.insert(org)
+
+      const response = await server.inject({
+        method: 'GET',
+        url: makePath(org.id),
+        ...asServiceMaintainer()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      const result = JSON.parse(response.payload)
+      expect(result).toHaveProperty('unlinkedAccreditations')
+      expect(result.unlinkedAccreditations).toEqual([])
+    })
   })
 
   it('omits linkedDefraOrganisation when the organisation is not linked', async () => {

--- a/src/routes/v1/organisations/overview/response.schema.js
+++ b/src/routes/v1/organisations/overview/response.schema.js
@@ -12,8 +12,20 @@ const registrationSchema = Joi.object({
   status: Joi.string().required(),
   material: Joi.string().required(),
   processingType: Joi.string().required(),
+  reprocessingType: Joi.string().allow(null).required(),
   site: Joi.string().allow(null).required(),
   accreditation: accreditationSchema.optional()
+})
+
+// An accreditation no registration on this organisation links to. It carries
+// the same display fields as a registration row so the two render together.
+const unlinkedAccreditationSchema = Joi.object({
+  id: Joi.string().required(),
+  accreditationNumber: Joi.string().allow(null).required(),
+  status: Joi.string().required(),
+  material: Joi.string().required(),
+  processingType: Joi.string().required(),
+  site: Joi.string().allow(null).required()
 })
 
 const linkedDefraOrganisationSchema = Joi.object({
@@ -29,5 +41,8 @@ export const organisationsOverviewResponseSchema = Joi.object({
   id: Joi.string().required(),
   companyName: Joi.string().required(),
   registrations: Joi.array().items(registrationSchema).required(),
+  unlinkedAccreditations: Joi.array()
+    .items(unlinkedAccreditationSchema)
+    .required(),
   linkedDefraOrganisation: linkedDefraOrganisationSchema.optional()
 })


### PR DESCRIPTION
Ticket: [PAE-1816](https://eaflood.atlassian.net/browse/PAE-1816)
## Summary

An accreditation that no registration links to is invisible and unroutable today. The organisation overview endpoint returns only registrations, with each accreditation nested inside its registration, so an orphan is absent from the response entirely; and every admin accreditation route is nested under a registration id, with the status-history handler hard-requiring the link. Nobody can tell such an accreditation exists and nothing can be done about it.

This surfaces them on the overview and adds an endpoint that assigns one to a registration.

Assigning sets `registration.accreditationId`, which immediately subjects the pair to `validateAccreditationLinkMatches` on every write. The identity key includes `reprocessingType` only when truthy, and `isAccreditationForRegistration` requires equal key length as well as equal values. An approved registration always has a `reprocessingType`; an orphaned accreditation never does. So the assignment copies it across in the same `replace()` — without that copy the write the assignment itself performs is rejected with a 3-vs-4 component mismatch. The candidate rules (same material, processing type and site) exist for the same reason: those key fields have to agree already or the link cannot be saved.

Jira: PAE-1816

## Changes

- `GET /v1/organisations/{organisationId}/overview` returns a new `unlinkedAccreditations` collection alongside `registrations`, carrying `{id, accreditationNumber, status, material, processingType, site}`. "Unlinked" is derived from the registrations' `accreditationId`s — there is no stored flag. `processingType` comes from the same helper the registrations use, so the shared overview table labels both consistently, and `site` is the reprocessor site address line 1, null for exporters.
- Each registration in the overview response now carries `reprocessingType`, so the assign form can filter and label candidate registrations without parsing the `processingType` display string. The rest of the registrations projection is unchanged.
- New `POST /v1/organisations/{organisationId}/accreditations/{accreditationId}/registration` with `{registrationId}`, scoped to `admin.write`. Deliberately not nested under a registration — an unlinked accreditation has none.
- The endpoint rejects with its own 422 per reason: the registration is not approved, the materials differ, the processing types differ, the reprocessor sites differ, the registration has no `reprocessingType`, the registration is already linked, or the accreditation is already linked. 404s cover an unknown organisation, accreditation or registration.
- On success one `replace()` sets `registration.accreditationId` and copies the registration's `reprocessingType` onto the accreditation, then audits the update via `auditOrganisationUpdate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAE-1816]: https://eaflood.atlassian.net/browse/PAE-1816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ