### PR TITLE
PAE-1783: Break unexported-tonnage diagnostic figures down by material

### DIFF
--- a/src/common/enums/event.js
+++ b/src/common/enums/event.js
@@ -45,6 +45,7 @@ export const LOGGING_EVENT_ACTIONS = {
   UNEXPORTED_TONNAGE_RECOMPUTE_FAILED: 'unexported_tonnage_recompute_failed',
   UNEXPORTED_TONNAGE_LOOKUP_FAILED: 'unexported_tonnage_lookup_failed',
   UNEXPORTED_TONNAGE_BY_MONTH: 'unexported_tonnage_by_month',
+  UNEXPORTED_TONNAGE_BY_MATERIAL: 'unexported_tonnage_by_material',
   UNEXPORTED_TONNAGE_BY_STATUS: 'unexported_tonnage_by_status',
   UNEXPORTED_TONNAGE_LARGEST_DELTAS: 'unexported_tonnage_largest_deltas',
   UNEXPORTED_TONNAGE_SUMMARY: 'unexported_tonnage_summary'

--- a/src/reports/monitoring/unexported-tonnage.js
+++ b/src/reports/monitoring/unexported-tonnage.js
@@ -65,6 +65,7 @@ import { wasteRecordStatesForHead } from '#waste-records/application/read-summar
  *
  * @typedef {FindingIdentity & {
  *   kind: typeof FINDING_KIND.MISMATCH,
+ *   material: string,
  *   stored: number,
  *   recomputed: number,
  *   delta: number,
@@ -95,11 +96,19 @@ import { wasteRecordStatesForHead } from '#waste-records/application/read-summar
  *   | RecomputeFailedFinding
  *   | LookupFailedFinding} UnexportedTonnageFinding
  *
- * The rows a report was built from, or the reason they are not there. A reason
- * here means the data genuinely is not present, which a re-run will not change
- * — an error while reading is a `LOOKUP_FAILED` finding instead.
+ * The rows a report was built from together with the registration's material,
+ * or the reason the rows are not there. A reason here means the data genuinely
+ * is not present, which a re-run will not change — an error while reading is a
+ * `LOOKUP_FAILED` finding instead. The material rides through so a resolved
+ * report's mismatch lands in the right stream when the figures are split by
+ * material; an unresolved report carries none, contributing no mismatch to split.
  *
- * @typedef {{ states: WasteRecordState[] } | { unresolved: string }} SourceRowStates
+ * The resolved branch's `material` is optional: production always supplies it,
+ * but a direct caller diagnosing hand-built rows need not, and an absent one
+ * reads as `unknown`.
+ *
+ * @typedef {{ states: WasteRecordState[], material?: string }
+ *   | { unresolved: string }} SourceRowStates
  */
 
 /**
@@ -370,6 +379,7 @@ export const diagnoseReportRow = (row, sourceRowStates) => {
   return {
     kind: FINDING_KIND.MISMATCH,
     ...identityOf(row),
+    material: sourceRowStates.material ?? UNKNOWN_MATERIAL,
     stored: row.storedUnexported,
     recomputed: total,
     delta: toNumber(subtract(total, row.storedUnexported)),
@@ -453,6 +463,35 @@ const deltaTotalsOf = (mismatches) => {
   }
 }
 
+/**
+ * @typedef {{
+ *   material: string,
+ *   reports: number,
+ *   delta: number,
+ *   understated: number,
+ *   overstated: number
+ * }} MaterialBreakdown
+ */
+
+/**
+ * A set of mismatches broken down by the material their registration carries,
+ * alphabetically. The unit shared by the standalone by-material breakdown and the
+ * per-material split nested inside each month, so both read the tonnage the same
+ * way. Every mismatch carries a material — an absent one resolves to `unknown`
+ * upstream — so no mismatch falls out of the breakdown.
+ *
+ * @param {MismatchFinding[]} mismatches
+ * @returns {MaterialBreakdown[]}
+ */
+const byMaterialOf = (mismatches) =>
+  [...Map.groupBy(mismatches, ({ material }) => material).entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([material, group]) => ({
+      material,
+      reports: group.length,
+      ...deltaTotalsOf(group)
+    }))
+
 const MONTHS_IN_YEAR = 12
 
 /**
@@ -460,13 +499,18 @@ const MONTHS_IN_YEAR = 12
  * first — the shape the business asked the sizing run for. Only mismatches
  * carry a figure, so the other finding kinds contribute no months.
  *
+ * Each month carries a `byMaterial` split of its own mismatches, so a month's
+ * total can be read down to the stream it came from without crossing the whole
+ * estate against a second breakdown by hand.
+ *
  * @param {UnexportedTonnageFinding[]} findings
  * @returns {{
  *   month: string,
  *   reports: number,
  *   delta: number,
  *   understated: number,
- *   overstated: number
+ *   overstated: number,
+ *   byMaterial: MaterialBreakdown[]
  * }[]}
  */
 export const summariseUnexportedTonnageByMonth = (findings) =>
@@ -484,8 +528,22 @@ export const summariseUnexportedTonnageByMonth = (findings) =>
         mismatches[0].year
       ),
       reports: mismatches.length,
-      ...deltaTotalsOf(mismatches)
+      ...deltaTotalsOf(mismatches),
+      byMaterial: byMaterialOf(mismatches)
     }))
+
+/**
+ * The correctable tonnage broken down by the material each report's registration
+ * carries, alphabetically. The estate-wide counterpart to the per-material split
+ * nested inside each month, for reading the total against one stream at a time.
+ * Only mismatches carry a figure, so the other finding kinds contribute no
+ * materials.
+ *
+ * @param {UnexportedTonnageFinding[]} findings
+ * @returns {MaterialBreakdown[]}
+ */
+export const summariseUnexportedTonnageByMaterial = (findings) =>
+  byMaterialOf(mismatchesOf(findings))
 
 /**
  * The mismatches split by the status their report sits in. A submitted report
@@ -601,10 +659,16 @@ export const summariseUnexportedTonnageFindings = (findings) => {
  * Errors propagate: a registration that cannot be read is a fact about the run,
  * not about the exporter's data, and the caller records it as such.
  *
+ * Reads the registration's material off the same fetch, so a resolved report's
+ * mismatch can be split by stream without a second lookup.
+ *
  * @param {OrganisationsRepository} organisationsRepository
  * @param {string} organisationId
  * @param {string} registrationId
- * @returns {Promise<import('#waste-records/repository/port.js').WasteBalanceLedgerId[]>}
+ * @returns {Promise<{
+ *   ledgers: import('#waste-records/repository/port.js').WasteBalanceLedgerId[],
+ *   material: string
+ * }>}
  */
 const resolveLedgers = async (
   organisationsRepository,
@@ -620,15 +684,19 @@ const resolveLedgers = async (
     ? [null, registration.accreditationId]
     : [null]
 
-  return accreditationIds.map((accreditationId) => ({
-    organisationId,
-    registrationId,
-    accreditationId
-  }))
+  return {
+    ledgers: accreditationIds.map((accreditationId) => ({
+      organisationId,
+      registrationId,
+      accreditationId
+    })),
+    material: registration?.material ?? UNKNOWN_MATERIAL
+  }
 }
 
 const NO_SUMMARY_LOG = 'no source summary log recorded on the report'
 const NO_ROWS = 'no rows found under the registration ledgers'
+const UNKNOWN_MATERIAL = 'unknown'
 
 /**
  * The row states the report was built from, or the reason there are none. Both
@@ -654,7 +722,7 @@ const loadSourceRowStates = async (
     return { unresolved: NO_SUMMARY_LOG }
   }
 
-  const ledgers = await resolveLedgers(
+  const { ledgers, material } = await resolveLedgers(
     organisationsRepository,
     row.organisationId,
     row.registrationId
@@ -671,7 +739,7 @@ const loadSourceRowStates = async (
     )
   }
 
-  return states.length > 0 ? { states } : { unresolved: NO_ROWS }
+  return states.length > 0 ? { states, material } : { unresolved: NO_ROWS }
 }
 
 /**

--- a/src/reports/monitoring/unexported-tonnage.js
+++ b/src/reports/monitoring/unexported-tonnage.js
@@ -696,7 +696,14 @@ const resolveLedgers = async (
 
 const NO_SUMMARY_LOG = 'no source summary log recorded on the report'
 const NO_ROWS = 'no rows found under the registration ledgers'
-const UNKNOWN_MATERIAL = 'unknown'
+
+/**
+ * The bucket a mismatch lands in when its registration carries no material. A
+ * material is logged as its raw lowercase code (`plastic`, `steel`), so the
+ * sentinel is parenthesised to read plainly as "unresolved" rather than as a
+ * stream literally named that, and to sort clear of the real codes.
+ */
+const UNKNOWN_MATERIAL = '(material unknown)'
 
 /**
  * The row states the report was built from, or the reason there are none. Both

--- a/src/reports/monitoring/unexported-tonnage.test.js
+++ b/src/reports/monitoring/unexported-tonnage.test.js
@@ -705,7 +705,11 @@ describe('unexported-tonnage', () => {
   })
 
   describe('summariseUnexportedTonnageByMaterial', () => {
-    const mismatchOf = (material, delta) => ({ kind: 'mismatch', material, delta })
+    const mismatchOf = (material, delta) => ({
+      kind: 'mismatch',
+      material,
+      delta
+    })
 
     it('totals the correctable delta for each material, alphabetically, split understated and overstated', () => {
       const findings = /** @type {UnexportedTonnageFinding[]} */ (

--- a/src/reports/monitoring/unexported-tonnage.test.js
+++ b/src/reports/monitoring/unexported-tonnage.test.js
@@ -6,6 +6,7 @@ import {
   findReviewableReportRows,
   formatUnexportedTonnageFinding,
   largestUnexportedTonnageDeltas,
+  summariseUnexportedTonnageByMaterial,
   summariseUnexportedTonnageByMonth,
   summariseUnexportedTonnageByStatus,
   summariseUnexportedTonnageFindings
@@ -70,6 +71,7 @@ const mismatch = (overrides = {}) =>
   /** @type {UnexportedTonnageFinding} */ ({
     kind: 'mismatch',
     ...FEB_2026_IDENTITY,
+    material: 'unknown',
     stored: 0,
     recomputed: 0,
     delta: 0,
@@ -219,6 +221,20 @@ describe('unexported-tonnage', () => {
 
       expect(finding).toStrictEqual(
         mismatch({ recomputed: 29.19, delta: 29.19 })
+      )
+    })
+
+    it('carries the resolved material onto a mismatch, so its figure can be split by stream', () => {
+      const finding = diagnoseReportRow(
+        buildRow(),
+        /** @type {any} */ ({
+          states: [buildReceivedRow({ TONNAGE_RECEIVED_FOR_EXPORT: 29.19 })],
+          material: 'Plastic'
+        })
+      )
+
+      expect(finding).toStrictEqual(
+        mismatch({ material: 'Plastic', recomputed: 29.19, delta: 29.19 })
       )
     })
 
@@ -588,19 +604,20 @@ describe('unexported-tonnage', () => {
   })
 
   describe('summariseUnexportedTonnageByMonth', () => {
-    const mismatchIn = (year, period, delta) => ({
+    const mismatchIn = (year, period, delta, material = 'Plastic') => ({
       kind: 'mismatch',
       year,
       period,
-      delta
+      delta,
+      material
     })
 
-    it('totals the delta for each month a mismatch falls in, oldest first', () => {
+    it('totals the delta for each month a mismatch falls in, oldest first, split by material within the month', () => {
       const findings = /** @type {UnexportedTonnageFinding[]} */ (
         /** @type {unknown} */ ([
-          mismatchIn(2026, 3, 29.19),
-          mismatchIn(2025, 12, 4),
-          mismatchIn(2026, 3, 0.81)
+          mismatchIn(2026, 3, 29.19, 'Plastic'),
+          mismatchIn(2025, 12, 4, 'Steel'),
+          mismatchIn(2026, 3, 0.81, 'Steel')
         ])
       )
 
@@ -610,14 +627,39 @@ describe('unexported-tonnage', () => {
           reports: 1,
           delta: 4,
           understated: 4,
-          overstated: 0
+          overstated: 0,
+          byMaterial: [
+            {
+              material: 'Steel',
+              reports: 1,
+              delta: 4,
+              understated: 4,
+              overstated: 0
+            }
+          ]
         },
         {
           month: 'Mar 2026',
           reports: 2,
           delta: 30,
           understated: 30,
-          overstated: 0
+          overstated: 0,
+          byMaterial: [
+            {
+              material: 'Plastic',
+              reports: 1,
+              delta: 29.19,
+              understated: 29.19,
+              overstated: 0
+            },
+            {
+              material: 'Steel',
+              reports: 1,
+              delta: 0.81,
+              understated: 0.81,
+              overstated: 0
+            }
+          ]
         }
       ])
     })
@@ -636,7 +678,16 @@ describe('unexported-tonnage', () => {
           reports: 2,
           delta: 0,
           understated: 29.19,
-          overstated: 29.19
+          overstated: 29.19,
+          byMaterial: [
+            {
+              material: 'Plastic',
+              reports: 2,
+              delta: 0,
+              understated: 29.19,
+              overstated: 29.19
+            }
+          ]
         }
       ])
     })
@@ -650,6 +701,48 @@ describe('unexported-tonnage', () => {
       )
 
       expect(summariseUnexportedTonnageByMonth(findings)).toStrictEqual([])
+    })
+  })
+
+  describe('summariseUnexportedTonnageByMaterial', () => {
+    const mismatchOf = (material, delta) => ({ kind: 'mismatch', material, delta })
+
+    it('totals the correctable delta for each material, alphabetically, split understated and overstated', () => {
+      const findings = /** @type {UnexportedTonnageFinding[]} */ (
+        /** @type {unknown} */ ([
+          mismatchOf('Steel', 4),
+          mismatchOf('Plastic', 29.19),
+          mismatchOf('Plastic', -0.81)
+        ])
+      )
+
+      expect(summariseUnexportedTonnageByMaterial(findings)).toStrictEqual([
+        {
+          material: 'Plastic',
+          reports: 2,
+          delta: 28.38,
+          understated: 29.19,
+          overstated: 0.81
+        },
+        {
+          material: 'Steel',
+          reports: 1,
+          delta: 4,
+          understated: 4,
+          overstated: 0
+        }
+      ])
+    })
+
+    it('ignores findings with no figure to total', () => {
+      const findings = /** @type {UnexportedTonnageFinding[]} */ (
+        /** @type {unknown} */ ([
+          { kind: 'source-missing', material: 'Plastic' },
+          { kind: 'lookup-failed', material: 'Steel' }
+        ])
+      )
+
+      expect(summariseUnexportedTonnageByMaterial(findings)).toStrictEqual([])
     })
   })
 
@@ -798,6 +891,21 @@ describe('unexported-tonnage', () => {
         scanned: 1,
         findings: [mismatch({ recomputed: 12, delta: 12 })]
       })
+    })
+
+    it("carries the registration's material onto the mismatch it produces", async () => {
+      const { findings } = await scan(
+        buildDeps({
+          registration: /** @type {any} */ ({
+            accreditationId: 'acc-1',
+            material: 'Plastic'
+          })
+        })
+      )
+
+      expect(findings).toStrictEqual([
+        mismatch({ material: 'Plastic', recomputed: 12, delta: 12 })
+      ])
     })
 
     it('reads the rows at the summary log the report was built from, not the current head', async () => {

--- a/src/reports/monitoring/unexported-tonnage.test.js
+++ b/src/reports/monitoring/unexported-tonnage.test.js
@@ -71,7 +71,7 @@ const mismatch = (overrides = {}) =>
   /** @type {UnexportedTonnageFinding} */ ({
     kind: 'mismatch',
     ...FEB_2026_IDENTITY,
-    material: 'unknown',
+    material: '(material unknown)',
     stored: 0,
     recomputed: 0,
     delta: 0,
@@ -229,12 +229,12 @@ describe('unexported-tonnage', () => {
         buildRow(),
         /** @type {any} */ ({
           states: [buildReceivedRow({ TONNAGE_RECEIVED_FOR_EXPORT: 29.19 })],
-          material: 'Plastic'
+          material: 'plastic'
         })
       )
 
       expect(finding).toStrictEqual(
-        mismatch({ material: 'Plastic', recomputed: 29.19, delta: 29.19 })
+        mismatch({ material: 'plastic', recomputed: 29.19, delta: 29.19 })
       )
     })
 
@@ -604,7 +604,7 @@ describe('unexported-tonnage', () => {
   })
 
   describe('summariseUnexportedTonnageByMonth', () => {
-    const mismatchIn = (year, period, delta, material = 'Plastic') => ({
+    const mismatchIn = (year, period, delta, material = 'plastic') => ({
       kind: 'mismatch',
       year,
       period,
@@ -615,9 +615,9 @@ describe('unexported-tonnage', () => {
     it('totals the delta for each month a mismatch falls in, oldest first, split by material within the month', () => {
       const findings = /** @type {UnexportedTonnageFinding[]} */ (
         /** @type {unknown} */ ([
-          mismatchIn(2026, 3, 29.19, 'Plastic'),
-          mismatchIn(2025, 12, 4, 'Steel'),
-          mismatchIn(2026, 3, 0.81, 'Steel')
+          mismatchIn(2026, 3, 29.19, 'plastic'),
+          mismatchIn(2025, 12, 4, 'steel'),
+          mismatchIn(2026, 3, 0.81, 'steel')
         ])
       )
 
@@ -630,7 +630,7 @@ describe('unexported-tonnage', () => {
           overstated: 0,
           byMaterial: [
             {
-              material: 'Steel',
+              material: 'steel',
               reports: 1,
               delta: 4,
               understated: 4,
@@ -646,14 +646,14 @@ describe('unexported-tonnage', () => {
           overstated: 0,
           byMaterial: [
             {
-              material: 'Plastic',
+              material: 'plastic',
               reports: 1,
               delta: 29.19,
               understated: 29.19,
               overstated: 0
             },
             {
-              material: 'Steel',
+              material: 'steel',
               reports: 1,
               delta: 0.81,
               understated: 0.81,
@@ -681,7 +681,7 @@ describe('unexported-tonnage', () => {
           overstated: 29.19,
           byMaterial: [
             {
-              material: 'Plastic',
+              material: 'plastic',
               reports: 2,
               delta: 0,
               understated: 29.19,
@@ -710,22 +710,22 @@ describe('unexported-tonnage', () => {
     it('totals the correctable delta for each material, alphabetically, split understated and overstated', () => {
       const findings = /** @type {UnexportedTonnageFinding[]} */ (
         /** @type {unknown} */ ([
-          mismatchOf('Steel', 4),
-          mismatchOf('Plastic', 29.19),
-          mismatchOf('Plastic', -0.81)
+          mismatchOf('steel', 4),
+          mismatchOf('plastic', 29.19),
+          mismatchOf('plastic', -0.81)
         ])
       )
 
       expect(summariseUnexportedTonnageByMaterial(findings)).toStrictEqual([
         {
-          material: 'Plastic',
+          material: 'plastic',
           reports: 2,
           delta: 28.38,
           understated: 29.19,
           overstated: 0.81
         },
         {
-          material: 'Steel',
+          material: 'steel',
           reports: 1,
           delta: 4,
           understated: 4,
@@ -737,8 +737,8 @@ describe('unexported-tonnage', () => {
     it('ignores findings with no figure to total', () => {
       const findings = /** @type {UnexportedTonnageFinding[]} */ (
         /** @type {unknown} */ ([
-          { kind: 'source-missing', material: 'Plastic' },
-          { kind: 'lookup-failed', material: 'Steel' }
+          { kind: 'source-missing', material: 'plastic' },
+          { kind: 'lookup-failed', material: 'steel' }
         ])
       )
 
@@ -898,13 +898,13 @@ describe('unexported-tonnage', () => {
         buildDeps({
           registration: /** @type {any} */ ({
             accreditationId: 'acc-1',
-            material: 'Plastic'
+            material: 'plastic'
           })
         })
       )
 
       expect(findings).toStrictEqual([
-        mismatch({ material: 'Plastic', recomputed: 12, delta: 12 })
+        mismatch({ material: 'plastic', recomputed: 12, delta: 12 })
       ])
     })
 

--- a/src/server/run-unexported-tonnage-report.js
+++ b/src/server/run-unexported-tonnage-report.js
@@ -8,6 +8,7 @@ import {
   findUnexportedTonnageReports,
   formatUnexportedTonnageFinding,
   largestUnexportedTonnageDeltas,
+  summariseUnexportedTonnageByMaterial,
   summariseUnexportedTonnageByMonth,
   summariseUnexportedTonnageByStatus,
   summariseUnexportedTonnageFindings
@@ -15,7 +16,7 @@ import {
 
 /**
  * @import { StartedServer } from '#common/hapi-types.js'
- * @import { UnexportedTonnageFinding } from '#reports/monitoring/unexported-tonnage.js'
+ * @import { MaterialBreakdown, UnexportedTonnageFinding } from '#reports/monitoring/unexported-tonnage.js'
  */
 
 const LOCK_NAME = 'unexported-tonnage-report'
@@ -57,14 +58,39 @@ const log = (action, message, reference) =>
   })
 
 /**
+ * The compact per-material segment shared by the month lines, so a month's total
+ * reads down to the stream it came from on the same line.
+ *
+ * @param {MaterialBreakdown[]} byMaterial
+ * @returns {string}
+ */
+const materialSegment = (byMaterial) =>
+  byMaterial
+    .map(
+      ({ material, reports, delta }) =>
+        `${material} ${reports} report(s) delta ${delta}`
+    )
+    .join(', ')
+
+/**
  * @param {UnexportedTonnageFinding[]} findings
  */
 const logBreakdowns = (findings) => {
   summariseUnexportedTonnageByMonth(findings).forEach(
-    ({ month, reports, delta, understated, overstated }) =>
+    ({ month, reports, delta, understated, overstated, byMaterial }) =>
       log(
         LOGGING_EVENT_ACTIONS.UNEXPORTED_TONNAGE_BY_MONTH,
         `Unexported tonnage by month: ${month} - ${reports} report(s), ` +
+          `delta ${delta}, understated ${understated}, overstated ${overstated}; ` +
+          `by material: ${materialSegment(byMaterial)}`
+      )
+  )
+
+  summariseUnexportedTonnageByMaterial(findings).forEach(
+    ({ material, reports, delta, understated, overstated }) =>
+      log(
+        LOGGING_EVENT_ACTIONS.UNEXPORTED_TONNAGE_BY_MATERIAL,
+        `Unexported tonnage by material: ${material} - ${reports} report(s), ` +
           `delta ${delta}, understated ${understated}, overstated ${overstated}`
       )
   )

--- a/src/server/run-unexported-tonnage-report.test.js
+++ b/src/server/run-unexported-tonnage-report.test.js
@@ -320,14 +320,15 @@ describe('runUnexportedTonnageReport', () => {
         'unexported_tonnage_by_month',
         'Unexported tonnage by month: Feb 2026 - 1 report(s), delta 29.19, ' +
           'understated 29.19, overstated 0; ' +
-          'by material: unknown 1 report(s) delta 29.19'
+          'by material: (material unknown) 1 report(s) delta 29.19'
       )
     )
     expect(logger.info).toHaveBeenCalledWith(
       infoLine(
         'unexported_tonnage_by_month',
         'Unexported tonnage by month: Mar 2026 - 1 report(s), delta 4, ' +
-          'understated 4, overstated 0; by material: unknown 1 report(s) delta 4'
+          'understated 4, overstated 0; ' +
+          'by material: (material unknown) 1 report(s) delta 4'
       )
     )
   })
@@ -343,7 +344,7 @@ describe('runUnexportedTonnageReport', () => {
             reportId: 'report-2'
           })
         ],
-        { 'reg-1': 'Plastic', 'reg-2': 'Steel' }
+        { 'reg-1': 'plastic', 'reg-2': 'steel' }
       )
     )
 
@@ -352,14 +353,14 @@ describe('runUnexportedTonnageReport', () => {
     expect(logger.info).toHaveBeenCalledWith(
       infoLine(
         'unexported_tonnage_by_material',
-        'Unexported tonnage by material: Plastic - 1 report(s), delta 29.19, ' +
+        'Unexported tonnage by material: plastic - 1 report(s), delta 29.19, ' +
           'understated 29.19, overstated 0'
       )
     )
     expect(logger.info).toHaveBeenCalledWith(
       infoLine(
         'unexported_tonnage_by_material',
-        'Unexported tonnage by material: Steel - 1 report(s), delta 29.19, ' +
+        'Unexported tonnage by material: steel - 1 report(s), delta 29.19, ' +
           'understated 29.19, overstated 0'
       )
     )
@@ -368,7 +369,7 @@ describe('runUnexportedTonnageReport', () => {
         'unexported_tonnage_by_month',
         'Unexported tonnage by month: Feb 2026 - 2 report(s), delta 58.38, ' +
           'understated 58.38, overstated 0; ' +
-          'by material: Plastic 1 report(s) delta 29.19, Steel 1 report(s) delta 29.19'
+          'by material: plastic 1 report(s) delta 29.19, steel 1 report(s) delta 29.19'
       )
     )
   })

--- a/src/server/run-unexported-tonnage-report.test.js
+++ b/src/server/run-unexported-tonnage-report.test.js
@@ -100,6 +100,20 @@ const estateApp = (periodicReports, rowStates) => ({
   }
 })
 
+const estateAppWithMaterials = (periodicReports, materialByRegistration) => {
+  const app = estateApp(periodicReports, [])
+  app.summaryLogRowStatesRepository.findRowStatesForSummaryLog.mockResolvedValue(
+    [receivedRow(29.19)]
+  )
+  app.organisationsRepository.findRegistrationById.mockImplementation(
+    async (_organisationId, registrationId) => ({
+      accreditationId: null,
+      material: materialByRegistration[registrationId]
+    })
+  )
+  return app
+}
+
 const buildServer = (
   app,
   {
@@ -305,14 +319,56 @@ describe('runUnexportedTonnageReport', () => {
       infoLine(
         'unexported_tonnage_by_month',
         'Unexported tonnage by month: Feb 2026 - 1 report(s), delta 29.19, ' +
-          'understated 29.19, overstated 0'
+          'understated 29.19, overstated 0; ' +
+          'by material: unknown 1 report(s) delta 29.19'
       )
     )
     expect(logger.info).toHaveBeenCalledWith(
       infoLine(
         'unexported_tonnage_by_month',
         'Unexported tonnage by month: Mar 2026 - 1 report(s), delta 4, ' +
-          'understated 4, overstated 0'
+          'understated 4, overstated 0; by material: unknown 1 report(s) delta 4'
+      )
+    )
+  })
+
+  it('logs the delta broken down by material, and splits each month by material too', async () => {
+    const server = buildServer(
+      estateAppWithMaterials(
+        [
+          submittedFebReport({ registrationId: 'reg-1' }),
+          submittedFebReport({
+            organisationId: 'org-2',
+            registrationId: 'reg-2',
+            reportId: 'report-2'
+          })
+        ],
+        { 'reg-1': 'Plastic', 'reg-2': 'Steel' }
+      )
+    )
+
+    await runUnexportedTonnageReport(server)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      infoLine(
+        'unexported_tonnage_by_material',
+        'Unexported tonnage by material: Plastic - 1 report(s), delta 29.19, ' +
+          'understated 29.19, overstated 0'
+      )
+    )
+    expect(logger.info).toHaveBeenCalledWith(
+      infoLine(
+        'unexported_tonnage_by_material',
+        'Unexported tonnage by material: Steel - 1 report(s), delta 29.19, ' +
+          'understated 29.19, overstated 0'
+      )
+    )
+    expect(logger.info).toHaveBeenCalledWith(
+      infoLine(
+        'unexported_tonnage_by_month',
+        'Unexported tonnage by month: Feb 2026 - 2 report(s), delta 58.38, ' +
+          'understated 58.38, overstated 0; ' +
+          'by material: Plastic 1 report(s) delta 29.19, Steel 1 report(s) delta 29.19'
       )
     )
   })


### PR DESCRIPTION
Ticket: [PAE-1783](https://eaflood.atlassian.net/browse/PAE-1783)
## What

Extends the startup unexported-tonnage diagnostic so its correctable mismatch figures can be read by material stream, in two ways:

- **Standalone by-material breakdown** — one rolled-up line per material (`unexported_tonnage_by_material`), giving the mismatch report count and the delta split into understated/overstated tonnage.
- **Material within each month** — every existing by-month line now carries a per-material split as a suffix, so a month's total can be read down to the stream it came from on the same line.

## Why

The diagnostic already sizes the PAE-1783 miscalculation across the estate and breaks it down by month and report status. The business needs the same correctable tonnage attributable to the individual packaging material streams to weigh where the mismatch concentrates, which neither the by-month nor by-status breakdown answers on its own.

## Impact on the log lines

Material is logged as its raw lowercase registration code (`plastic`, `steel`, `aluminium`, ...). A mismatch whose registration carries no material falls into a parenthesised `(material unknown)` bucket, so it reads plainly as unresolved rather than as a stream named that, and sorts clear of the real codes.

New standalone breakdown (action `unexported_tonnage_by_material`), one line per material:

```
Unexported tonnage by material: plastic - 12 report(s), delta 340.5, understated 400, overstated 59.5
Unexported tonnage by material: steel - 3 report(s), delta 12, understated 12, overstated 0
```

Existing by-month line (action `unexported_tonnage_by_month`) gains a per-material suffix:

```
Unexported tonnage by month: Feb 2026 - 2 report(s), delta 58.38, understated 58.38, overstated 0; by material: plastic 1 report(s) delta 29.19, steel 1 report(s) delta 29.19
```

No material is displayed as a formatted label and glass is not split by recycling process: the raw code is what surfaces. All other existing lines (per-finding, by-status, largest-deltas, summary) are unchanged.

## How it fits together

- The registration's material is threaded from the organisations repository (already fetched while resolving a report's ledgers, so no extra lookup) through to each mismatch finding.
- A shared grouping helper backs both the standalone breakdown and the per-month split, so both total the tonnage identically and list materials alphabetically.
- A new `UNEXPORTED_TONNAGE_BY_MATERIAL` logging action makes the standalone line findable in OpenSearch without parsing message text, consistent with the existing per-breakdown actions.
- Only mismatch findings carry a material and feed the breakdowns — the source-missing, recompute-failed and lookup-failed kinds are unchanged, matching how the by-month and by-status breakdowns already behave.

Read-only throughout and gated by the existing `unexported-tonnage-report` feature flag; no behaviour changes when the flag is off.

[PAE-1783]: https://eaflood.atlassian.net/browse/PAE-1783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ