### PR TITLE
PAE-1783: net off only in-period exports in unexported-tonnage diagnostic

### DIFF
--- a/src/reports/monitoring/unexported-tonnage.js
+++ b/src/reports/monitoring/unexported-tonnage.js
@@ -39,10 +39,13 @@ import { wasteRecordStatesForHead } from '#waste-records/application/read-summar
  * The live calculation drops any received load whose DATE_OF_EXPORT falls in the
  * reporting period and sums column S for the rest, so a load carrying an export
  * date but no exported tonnage reads as fully exported and contributes nothing.
- * The AC's rule is per load: column S minus column T. This module recomputes
- * under that rule, deliberately reimplementing it rather than calling the live
- * path, so it is valid both before the fix (as sizing) and after it (as the
- * remediation verifier).
+ * The AC's rule is per load: column S minus the tonnage exported within the
+ * period — column T when the load's DATE_OF_EXPORT falls in the period, nothing
+ * otherwise (so a blank export date, or one in a later period, leaves the whole
+ * column S standing as not yet exported). This module recomputes under that
+ * rule, deliberately reimplementing it rather than calling the live path, so it
+ * is valid both before the fix (as sizing) and after it (as the remediation
+ * verifier).
  *
  * Read-only throughout, and safe under live traffic.
  *
@@ -206,7 +209,14 @@ export const findReviewableReportRows = (periodicReports) =>
 
 /**
  * A load's contribution to the figure: the tonnage received for export that has
- * not yet been exported, and what is wrong with the row if anything.
+ * not yet been exported within the period, and what is wrong with the row if
+ * anything.
+ *
+ * Only tonnage that actually left within the period is subtracted: a load's
+ * exported tonnage counts only when its `DATE_OF_EXPORT` falls in the period.
+ * A load with no export date, or one whose export lands in a later period, has
+ * exported nothing this period, so its whole received tonnage reads as not yet
+ * exported — it only stops counting in the period the export lands in.
  *
  * Every field on the exporter received-loads table is optional, so a blank
  * received tonnage is possible and reads as zero. Left alone that row would
@@ -220,14 +230,18 @@ export const findReviewableReportRows = (periodicReports) =>
  * counts the rows so the decision has a number behind it.
  *
  * @param {Record<string, any>} data
+ * @param {string} startDate
+ * @param {string} endDate
  * @returns {{
  *   notExported: import('#common/helpers/rounded-tonnage.js').RoundedTonnage,
  *   overExported: boolean,
  *   missingReceived: boolean
  * }}
  */
-const classifyLoad = (data) => {
-  const exported = toRoundedTonnage(data[TONNAGE_EXPORTED_FIELD])
+const classifyLoad = (data, startDate, endDate) => {
+  const exported = isDateInRange(data[EXPORT_DATE_FIELD], startDate, endDate)
+    ? toRoundedTonnage(data[TONNAGE_EXPORTED_FIELD])
+    : ZERO_TONNAGE
   if (isNil(data[TONNAGE_RECEIVED_FIELD])) {
     return {
       notExported: ZERO_TONNAGE,
@@ -279,8 +293,11 @@ const liveContribution = (data, startDate, endDate) =>
 
 /**
  * The corrected figure for a period: per load received in that period, column S
- * minus column T, summed. Unlike the live calculation, no load is dropped for
- * carrying an export date.
+ * minus the tonnage it exported within the period (column T when its
+ * `DATE_OF_EXPORT` falls in the period, nothing otherwise), summed. Unlike the
+ * live calculation, a load is never dropped whole for carrying an export date —
+ * only the tonnage that actually left within the period is netted off, so a
+ * load exported in a later period still counts its full column S here.
  *
  * Reports the rows behind the figure alongside it, so a finding says how much
  * data a backfill would move and not only how much tonnage.
@@ -297,7 +314,7 @@ const recomputeUnexported = (wasteRecordStates, startDate, endDate) => {
     startDate,
     endDate
   ).map(({ data }) => ({
-    ...classifyLoad(data),
+    ...classifyLoad(data, startDate, endDate),
     live: liveContribution(data, startDate, endDate)
   }))
 

--- a/src/reports/monitoring/unexported-tonnage.test.js
+++ b/src/reports/monitoring/unexported-tonnage.test.js
@@ -238,9 +238,10 @@ describe('unexported-tonnage', () => {
       )
     })
 
-    it('reports the unexported remainder of a partly exported load', () => {
+    it('reports the unexported remainder of a load partly exported in the period', () => {
       const finding = diagnoseWithRows(buildRow(), [
         buildReceivedRow({
+          DATE_OF_EXPORT: '2026-02-16',
           TONNAGE_RECEIVED_FOR_EXPORT: 10,
           TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 6
         })
@@ -251,9 +252,33 @@ describe('unexported-tonnage', () => {
       )
     })
 
-    it('returns nothing when a fully exported load already agrees with the stored zero', () => {
+    it('counts the full received tonnage when the export lands in a later period', () => {
       const finding = diagnoseWithRows(buildRow(), [
         buildReceivedRow({
+          DATE_OF_EXPORT: '2026-03-05',
+          TONNAGE_RECEIVED_FOR_EXPORT: 10,
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 10
+        })
+      ])
+
+      expect(finding).toStrictEqual(mismatch({ recomputed: 10, delta: 10 }))
+    })
+
+    it('counts the full received tonnage when a load carries exported tonnage but no export date', () => {
+      const finding = diagnoseWithRows(buildRow(), [
+        buildReceivedRow({
+          TONNAGE_RECEIVED_FOR_EXPORT: 10,
+          TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 10
+        })
+      ])
+
+      expect(finding).toStrictEqual(mismatch({ recomputed: 10, delta: 10 }))
+    })
+
+    it('returns nothing when a load fully exported in the period agrees with the stored zero', () => {
+      const finding = diagnoseWithRows(buildRow(), [
+        buildReceivedRow({
+          DATE_OF_EXPORT: '2026-02-16',
           TONNAGE_RECEIVED_FOR_EXPORT: 10,
           TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 10
         })
@@ -262,13 +287,15 @@ describe('unexported-tonnage', () => {
       expect(finding).toBeNull()
     })
 
-    it('clamps a row exporting more than it received rather than crediting it back', () => {
+    it('clamps a row exporting more than it received in the period rather than crediting it back', () => {
       const finding = diagnoseWithRows(buildRow({ storedUnexported: 5 }), [
         buildReceivedRow({
+          DATE_OF_EXPORT: '2026-02-16',
           TONNAGE_RECEIVED_FOR_EXPORT: 10,
           TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 12
         }),
         buildReceivedRow({
+          DATE_OF_EXPORT: '2026-02-16',
           TONNAGE_RECEIVED_FOR_EXPORT: 8,
           TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 5
         })
@@ -282,18 +309,19 @@ describe('unexported-tonnage', () => {
           rowsInPeriod: 2,
           rowsUnexported: 1,
           rowsOverExported: 1,
-          rowsMiscounted: 2
+          rowsMiscounted: 1
         })
       )
     })
 
-    it('counts a row with no received tonnage apart from one that over-exported', () => {
+    it('counts a row with no received tonnage apart from one that over-exported in the period', () => {
       const finding = diagnoseWithRows(buildRow({ storedUnexported: 5 }), [
         buildReceivedRow({
           TONNAGE_RECEIVED_FOR_EXPORT: null,
           TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 7
         }),
         buildReceivedRow({
+          DATE_OF_EXPORT: '2026-02-16',
           TONNAGE_RECEIVED_FOR_EXPORT: 10,
           TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 12
         })
@@ -308,7 +336,7 @@ describe('unexported-tonnage', () => {
           rowsUnexported: 0,
           rowsOverExported: 1,
           rowsMissingReceived: 1,
-          rowsMiscounted: 1
+          rowsMiscounted: 0
         })
       )
     })
@@ -337,6 +365,7 @@ describe('unexported-tonnage', () => {
       const finding = diagnoseWithRows(buildRow(), [
         buildReceivedRow({ TONNAGE_RECEIVED_FOR_EXPORT: 10 }),
         buildReceivedRow({
+          DATE_OF_EXPORT: '2026-02-16',
           TONNAGE_RECEIVED_FOR_EXPORT: 8,
           TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 8
         }),
@@ -353,7 +382,7 @@ describe('unexported-tonnage', () => {
           rowsInPeriod: 2,
           rowsUnexported: 1,
           rowsOverExported: 0,
-          rowsMiscounted: 1
+          rowsMiscounted: 0
         })
       )
     })

--- a/src/server/run-unexported-tonnage-report.test.js
+++ b/src/server/run-unexported-tonnage-report.test.js
@@ -67,6 +67,7 @@ const partlyExportedRow = (tonnageReceived, tonnageExported) => ({
   ...receivedRow(tonnageReceived),
   data: {
     ...receivedRow(tonnageReceived).data,
+    DATE_OF_EXPORT: '2026-02-16',
     TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: tonnageExported
   }
 })


### PR DESCRIPTION
Ticket: [PAE-1783](https://eaflood.atlassian.net/browse/PAE-1783)
## What

Changes the corrected rule in the `unexported-tonnage` startup diagnostic (`src/reports/monitoring/unexported-tonnage.js`) — the rule it recomputes each accredited-exporter report under and diffs against the stored **live** figure.

**New per-load rule** (loads received in the period):
```
notExported = max(0, received − exportedInPeriod)
exportedInPeriod = TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED, but only if DATE_OF_EXPORT is in the period; otherwise 0
```

So a load's exported tonnage is netted off **only when the export lands within the reporting period**. A blank export date, or an export in a later period, leaves the full received tonnage standing as not-yet-exported — it only stops counting in the period the export actually lands in.

Previously the diagnostic subtracted column T regardless of when the export happened.

## Why

SME clarification on PAE-1783: 'received but not exported' should reflect what actually left **within the period**. If no material was exported this period, the whole received tonnage is still not-exported.

Worked example — received 141.65 t on 10 June, exported 1.21 t on 20 June → in-period export → `141.65 − 1.21` = **140.44 t** not exported.

## Scope

- **Production live calculation is unchanged** — only the diagnostic's shadow/compare rule changes.
- Implementation: gate `exported` in `classifyLoad` on `isDateInRange(DATE_OF_EXPORT)`; pass the period dates through from `recomputeUnexported`. Row-count denominators unchanged; `rowsMiscounted` now flags only in-period-export loads where received ≠ exported.

## Tests

- 2 new cases drive the change (later-period export → full received; exported tonnage with no date → full received).
- Existing partial/over-export fixtures gained an in-period `DATE_OF_EXPORT` so their intent survives.
- Full suite green via pre-commit (100% coverage); both type configs clean on touched files.

Jira: PAE-1783 · bead defra-acgl

🤖 Draft — the rule is still under discussion; a counter-argument for different behaviour is being weighed.

[PAE-1783]: https://eaflood.atlassian.net/browse/PAE-1783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ