### PR TITLE
PAE-1712: Let a regulator search organisations

### DIFF
--- a/.vite/helpers/create-entra-id-test-tokens.js
+++ b/.vite/helpers/create-entra-id-test-tokens.js
@@ -13,6 +13,10 @@ const SERVICE_MAINTAINER_EMAIL = 'me@example.com'
 // token resolves to the read-only `service_maintainer` tier.
 const READ_ONLY_MAINTAINER_EMAIL = 'readonly@example.com'
 
+// Must match the support email list and no other, so this token resolves to
+// the lowest admin tier, `support`.
+const SUPPORT_EMAIL = 'support@example.com'
+
 // Must match no configured admin email list, so this token resolves through
 // the app role alone. Mirrors the regulator user the Entra stub serves.
 const REGULATOR_EMAIL = 'standard.regulator@test.gov.uk'
@@ -148,6 +152,19 @@ const generateEntraIdTokenForReadOnlyMaintainer = () => {
   return mockEntraIdToken
 }
 
+const generateEntraIdTokenForSupport = () => {
+  const mockEntraIdToken = Jwt.token.generate(
+    {
+      ...baseValidObject,
+      preferred_username: SUPPORT_EMAIL
+    },
+    validJwtSecretObject,
+    validGenerateTokenOptions
+  )
+
+  return mockEntraIdToken
+}
+
 const generateEntraIdTokenForRegulator = () => {
   const mockEntraIdToken = Jwt.token.generate(
     {
@@ -169,5 +186,6 @@ export const entraIdMockAuthTokens = {
   wrongAudienceToken: generateEntraIdTokenWithWrongAudience(),
   nonServiceMaintainerUserToken: generateEntraIdTokenForUnauthorisedUser(),
   readOnlyMaintainerToken: generateEntraIdTokenForReadOnlyMaintainer(),
+  supportToken: generateEntraIdTokenForSupport(),
   regulatorToken: generateEntraIdTokenForRegulator()
 }

--- a/.vite/setup-files.js
+++ b/.vite/setup-files.js
@@ -25,7 +25,9 @@ process.env.SERVICE_MAINTAINER_EMAILS =
   '["me@example.com", "you@example.com", "readonly@example.com"]'
 process.env.SERVICE_MAINTAINER_WRITE_EMAILS =
   '["me@example.com", "you@example.com"]'
-process.env.SUPPORT_EMAILS = '[]'
+// `support@example.com` is in no other list, so it resolves to the lowest
+// admin tier and tests can exercise `support` against read routes.
+process.env.SUPPORT_EMAILS = '["support@example.com"]'
 
 // AWS - test credentials
 process.env.AWS_ACCESS_KEY_ID = 'test'

--- a/src/common/helpers/auth/constants.js
+++ b/src/common/helpers/auth/constants.js
@@ -9,6 +9,7 @@ export const SCOPES = {
   organisationWrite: 'organisation.write',
   organisationLinkedRead: 'organisation.linked.read',
   organisationLinkedWrite: 'organisation.linked.write',
+  organisationSearch: 'organisation.search',
   regulator: 'regulator'
 }
 
@@ -34,13 +35,22 @@ export const REGULATOR_ROLE = 'regulator_standard'
  * regulator, and a read route written later admits one without its author
  * knowing regulators exist.
  *
+ * `organisation.search` is separate from `organisation.read` because a search
+ * enumerates the population of operators: the caller holds no organisation id
+ * yet, so the condition an operator's `organisation.read` carries — their own
+ * linked organisation — cannot apply.
+ *
  * `regulator` is coarse on purpose. It stands for the whole set of functions
  * only a regulator performs, and subdivides when caseworking functions
  * arrive.
  *
  * A regulator reads and changes nothing, so no write scope appears here.
  */
-export const REGULATOR_SCOPES = [SCOPES.organisationRead, SCOPES.regulator]
+export const REGULATOR_SCOPES = [
+  SCOPES.organisationRead,
+  SCOPES.organisationSearch,
+  SCOPES.regulator
+]
 
 /**
  * Admin role → scope-bundle map. Used internally by getEntraUserRoles to
@@ -51,8 +61,13 @@ export const ADMIN_ROLES = {
   service_maintainer_write: [
     SCOPES.adminRead,
     SCOPES.adminWrite,
-    SCOPES.adminDlqPurge
+    SCOPES.adminDlqPurge,
+    SCOPES.organisationSearch
   ],
-  service_maintainer: [SCOPES.adminRead, SCOPES.adminDlqPurge],
-  support: [SCOPES.adminRead]
+  service_maintainer: [
+    SCOPES.adminRead,
+    SCOPES.adminDlqPurge,
+    SCOPES.organisationSearch
+  ],
+  support: [SCOPES.adminRead, SCOPES.organisationSearch]
 }

--- a/src/common/helpers/auth/constants.test.js
+++ b/src/common/helpers/auth/constants.test.js
@@ -13,25 +13,38 @@ describe('ADMIN_ROLES', () => {
     expect(ADMIN_ROLES.service_maintainer_write).toEqual([
       SCOPES.adminRead,
       SCOPES.adminWrite,
-      SCOPES.adminDlqPurge
+      SCOPES.adminDlqPurge,
+      SCOPES.organisationSearch
     ])
   })
 
   test('service_maintainer carries admin.read and admin.dlq.purge but not admin.write', () => {
     expect(ADMIN_ROLES.service_maintainer).toEqual([
       SCOPES.adminRead,
-      SCOPES.adminDlqPurge
+      SCOPES.adminDlqPurge,
+      SCOPES.organisationSearch
     ])
     expect(ADMIN_ROLES.service_maintainer).not.toContain(SCOPES.adminWrite)
   })
 
-  test('support carries only admin.read', () => {
-    expect(ADMIN_ROLES.support).toEqual([SCOPES.adminRead])
+  test('support carries admin.read and no other admin scope', () => {
+    expect(ADMIN_ROLES.support).toEqual([
+      SCOPES.adminRead,
+      SCOPES.organisationSearch
+    ])
+    expect(ADMIN_ROLES.support).not.toContain(SCOPES.adminWrite)
+    expect(ADMIN_ROLES.support).not.toContain(SCOPES.adminDlqPurge)
   })
 
   test('every admin role includes admin.read so any tier can call read routes', () => {
     for (const scopes of Object.values(ADMIN_ROLES)) {
       expect(scopes).toContain(SCOPES.adminRead)
+    }
+  })
+
+  test('every tier that holds admin.read also holds organisation.search, so no role loses access it holds today', () => {
+    for (const scopes of Object.values(ADMIN_ROLES)) {
+      expect(scopes).toContain(SCOPES.organisationSearch)
     }
   })
 })
@@ -47,6 +60,10 @@ describe('the regulator role', () => {
 
   test('carries the coarse regulator scope for what only a regulator does', () => {
     expect(REGULATOR_SCOPES).toContain(SCOPES.regulator)
+  })
+
+  test('carries organisation.search, which enumerates operators the regulator holds no id for', () => {
+    expect(REGULATOR_SCOPES).toContain(SCOPES.organisationSearch)
   })
 
   test('carries no admin scope', () => {

--- a/src/common/helpers/auth/constants.test.js
+++ b/src/common/helpers/auth/constants.test.js
@@ -42,8 +42,12 @@ describe('ADMIN_ROLES', () => {
     }
   })
 
-  test('every tier that holds admin.read also holds organisation.search, so no role loses access it holds today', () => {
-    for (const scopes of Object.values(ADMIN_ROLES)) {
+  test('a tier that holds admin.read also holds organisation.search', () => {
+    const tiersWithAdminRead = Object.values(ADMIN_ROLES).filter((scopes) =>
+      scopes.includes(SCOPES.adminRead)
+    )
+
+    for (const scopes of tiersWithAdminRead) {
       expect(scopes).toContain(SCOPES.organisationSearch)
     }
   })

--- a/src/common/helpers/auth/get-jwt-strategy-config.test.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.test.js
@@ -351,7 +351,7 @@ describe('#getJwtStrategyConfig', () => {
       ])
     })
 
-    test('support tier credential carries only admin.read', async () => {
+    test('support tier credential carries the read scopes of that tier', async () => {
       mockGetEntraUserRoles.mockResolvedValue({
         role: 'support',
         scopes: [...ADMIN_ROLES.support]
@@ -372,7 +372,10 @@ describe('#getJwtStrategyConfig', () => {
 
       const result = await config.validate(artifacts)
 
-      expect(result.credentials.scope).toEqual([SCOPES.adminRead])
+      expect(result.credentials.scope).toEqual([
+        SCOPES.adminRead,
+        SCOPES.organisationSearch
+      ])
     })
 
     test('handles Entra ID token where user matches no admin tier (empty scope)', async () => {

--- a/src/overseas-sites/routes/post-import.test.js
+++ b/src/overseas-sites/routes/post-import.test.js
@@ -115,7 +115,12 @@ describe(`${orsImportCreatePath} route`, () => {
         expect(stored.createdBy).toEqual({
           id: 'test-maintainer-id',
           email: 'maintainer@example.com',
-          scope: ['admin.read', 'admin.write', 'admin.dlq.purge']
+          scope: [
+            'admin.read',
+            'admin.write',
+            'admin.dlq.purge',
+            'organisation.search'
+          ]
         })
       })
 

--- a/src/routes/v1/admin/me/get.test.js
+++ b/src/routes/v1/admin/me/get.test.js
@@ -59,7 +59,7 @@ describe('GET /v1/admin/me', () => {
   })
 
   describe('payload by tier', () => {
-    it('returns the write tier scope bundle (admin.read + admin.write + admin.dlq.purge)', async () => {
+    it('returns the write tier scope bundle (admin.read + admin.write + admin.dlq.purge + organisation.search)', async () => {
       const response = await server.inject({
         method: 'GET',
         url: ADMIN_ME_PATH,
@@ -68,11 +68,16 @@ describe('GET /v1/admin/me', () => {
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       expect(JSON.parse(response.payload)).toEqual({
-        scopes: [SCOPES.adminRead, SCOPES.adminWrite, SCOPES.adminDlqPurge]
+        scopes: [
+          SCOPES.adminRead,
+          SCOPES.adminWrite,
+          SCOPES.adminDlqPurge,
+          SCOPES.organisationSearch
+        ]
       })
     })
 
-    it('returns the maintainer tier scope bundle (admin.read + admin.dlq.purge)', async () => {
+    it('returns the maintainer tier scope bundle (admin.read + admin.dlq.purge + organisation.search)', async () => {
       const response = await server.inject({
         method: 'GET',
         url: ADMIN_ME_PATH,
@@ -81,11 +86,15 @@ describe('GET /v1/admin/me', () => {
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       expect(JSON.parse(response.payload)).toEqual({
-        scopes: [SCOPES.adminRead, SCOPES.adminDlqPurge]
+        scopes: [
+          SCOPES.adminRead,
+          SCOPES.adminDlqPurge,
+          SCOPES.organisationSearch
+        ]
       })
     })
 
-    it('returns the support tier scope bundle (admin.read only)', async () => {
+    it('returns the support tier scope bundle (admin.read + organisation.search)', async () => {
       const response = await server.inject({
         method: 'GET',
         url: ADMIN_ME_PATH,
@@ -94,7 +103,7 @@ describe('GET /v1/admin/me', () => {
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       expect(JSON.parse(response.payload)).toEqual({
-        scopes: [SCOPES.adminRead]
+        scopes: [SCOPES.adminRead, SCOPES.organisationSearch]
       })
     })
   })

--- a/src/routes/v1/me/get.test.js
+++ b/src/routes/v1/me/get.test.js
@@ -63,7 +63,12 @@ describe('GET /v1/me', () => {
       expect(response.statusCode).toBe(StatusCodes.OK)
       expect(JSON.parse(response.payload)).toEqual({
         role: 'service_maintainer_write',
-        scopes: [SCOPES.adminRead, SCOPES.adminWrite, SCOPES.adminDlqPurge]
+        scopes: [
+          SCOPES.adminRead,
+          SCOPES.adminWrite,
+          SCOPES.adminDlqPurge,
+          SCOPES.organisationSearch
+        ]
       })
     })
   })

--- a/src/routes/v1/organisations/get.js
+++ b/src/routes/v1/organisations/get.js
@@ -48,7 +48,7 @@ export const organisationsGetAll = {
   method: 'GET',
   path: organisationsGetAllPath,
   options: {
-    auth: getAuthConfig([SCOPES.adminRead]),
+    auth: getAuthConfig([SCOPES.organisationSearch]),
     tags: ['api', 'admin'],
     validate: {
       query: querySchema

--- a/src/routes/v1/organisations/get.test.js
+++ b/src/routes/v1/organisations/get.test.js
@@ -11,7 +11,10 @@ import { createTestServer } from '#test/create-test-server.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
 import { entraIdMockAuthTokens } from '#vite/helpers/create-entra-id-test-tokens.js'
 import { testInvalidTokenScenarios } from '#vite/helpers/test-invalid-token-scenarios.js'
-import { testOnlyServiceMaintainerCanAccess } from '#vite/helpers/test-invalid-roles-scenarios.js'
+import {
+  testOnlyServiceMaintainerCanAccess,
+  testRegulatorCanRead
+} from '#vite/helpers/test-invalid-roles-scenarios.js'
 
 const { validToken } = entraIdMockAuthTokens
 
@@ -399,27 +402,43 @@ describe('GET /v1/organisations', () => {
     })
   })
 
+  const makeListRequest = async () => {
+    await organisationsRepository.insert(buildOrganisation())
+    return {
+      method: 'GET',
+      url: '/v1/organisations?page=1&pageSize=10'
+    }
+  }
+
   testInvalidTokenScenarios({
     server: () => server,
-    makeRequest: async () => {
-      const org1 = buildOrganisation()
-      await organisationsRepository.insert(org1)
-      return {
-        method: 'GET',
-        url: `/v1/organisations/${org1.id}`
-      }
-    }
+    makeRequest: makeListRequest
   })
 
   testOnlyServiceMaintainerCanAccess({
     server: () => server,
-    makeRequest: async () => {
-      const org1 = buildOrganisation()
-      await organisationsRepository.insert(org1)
-      return {
-        method: 'GET',
-        url: `/v1/organisations/${org1.id}`
-      }
-    }
+    makeRequest: makeListRequest
+  })
+
+  describe('the organisation.search scope', () => {
+    testRegulatorCanRead({
+      server: () => server,
+      makeRequest: makeListRequest
+    })
+
+    it.each([
+      ['service_maintainer_write', entraIdMockAuthTokens.validToken],
+      ['service_maintainer', entraIdMockAuthTokens.readOnlyMaintainerToken],
+      ['support', entraIdMockAuthTokens.supportToken]
+    ])('returns 200 for an admin user on the %s tier', async (_tier, token) => {
+      const requestConfig = await makeListRequest()
+
+      const response = await server.inject({
+        ...requestConfig,
+        headers: { Authorization: `Bearer ${token}` }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+    })
   })
 })

--- a/src/routes/v1/organisations/put-by-id.test.js
+++ b/src/routes/v1/organisations/put-by-id.test.js
@@ -152,7 +152,8 @@ describe('PUT /v1/organisations/{id}', () => {
         expect(payload.scope).toEqual([
           'admin.read',
           'admin.write',
-          'admin.dlq.purge'
+          'admin.dlq.purge',
+          'organisation.search'
         ])
       }
 

--- a/src/routes/v1/organisations/unlink.test.js
+++ b/src/routes/v1/organisations/unlink.test.js
@@ -48,7 +48,12 @@ vi.mock(
 const ADMIN_USER = {
   id: 'test-maintainer-id',
   email: 'maintainer@example.com',
-  scope: [SCOPES.adminRead, SCOPES.adminWrite, SCOPES.adminDlqPurge]
+  scope: [
+    SCOPES.adminRead,
+    SCOPES.adminWrite,
+    SCOPES.adminDlqPurge,
+    SCOPES.organisationSearch
+  ]
 }
 
 describe('DELETE /v1/organisations/{organisationId}/link', () => {

--- a/src/test/inject-auth.js
+++ b/src/test/inject-auth.js
@@ -79,19 +79,20 @@ export const asServiceMaintainer = (overrides = {}) =>
   adminCredential('service_maintainer_write', { overrides })
 
 /**
- * Carries admin.read, admin.write, and admin.dlq.purge.
+ * Carries admin.read, admin.write, admin.dlq.purge and organisation.search.
  */
 export const asServiceMaintainerWrite = (overrides = {}) =>
   adminCredential('service_maintainer_write', { overrides })
 
 /**
- * Carries admin.read and admin.dlq.purge (no admin.write).
+ * Carries admin.read, admin.dlq.purge and organisation.search (no admin.write).
  */
 export const asServiceMaintainerRead = (overrides = {}) =>
   adminCredential('service_maintainer', { overrides })
 
 /**
- * Carries only admin.read.
+ * Carries admin.read and organisation.search, the read scopes of the lowest
+ * admin tier.
  */
 export const asSupport = (overrides = {}) =>
   adminCredential('support', {


### PR DESCRIPTION
Ticket: [PAE-1712](https://eaflood.atlassian.net/browse/PAE-1712)
A regulator can now call `GET /v1/organisations`. The route declares the new `organisation.search` scope in place of `admin.read`, and every admin tier that reached the route before still reaches it.

This is the backend precondition for PAE-1712, not the ticket itself. PAE-1712's acceptance criteria are all `epr-frontend` work: the regulator landing page offering an organisation option, the route to the search page, and the navigation to start a lookup. That page is tracked separately and cannot be built against a route that refuses a regulator credential, which is what this PR fixes. Nothing observable changes until the frontend lands: the route's only current consumer is the admin UI, and admin tiers already reached it.

The scope vocabulary comes from the operator and regulator authorisation ADR, which is **proposed, not accepted** — it is in review as DEFRA/epr-re-ex-service#423 and is not yet on that repo's `main`. If that ADR changes shape, this PR changes with it.

## Why a new scope rather than the regulator scope

The ADR's decision 4 separates reading in context from searching across. A search enumerates the population of operators: the caller holds no organisation id yet, so the condition that an operator's `organisation.read` carries — their own linked organisation — cannot apply. `organisation.search` is the scope that decision names for enumeration across operators.

The route therefore does not name a regulator. It declares a scope from the read vocabulary, and the identity that holds that scope is a matter for the role bundles. This keeps the rule that a route never names a population, and it is why the coarse `regulator` scope is not admitted here: the ADR says that scope gates nothing and stops existing once the read vocabulary lands.

## No role loses access

`organisation.search` joins `admin.read` in all three admin tiers — `service_maintainer_write`, `service_maintainer` and `support`. The admin UI's organisations page is the route's only non-test consumer, and a support-tier user reaches it exactly as before.

`admin.read` is untouched and no other route moves.

## `organisation.search` lands partly

The ADR defines `organisation.search` as enumeration across operators: the organisation list, the report submissions list, and the PRN lists. This PR moves the organisation list only. `src/reports/routes/submissions.js`, `src/packaging-recycling-notes/routes/admin-list.js` and `src/packaging-recycling-notes/routes/admin-accreditation-list.js` stay on `admin.read`, so a regulator holding `organisation.search` still gets a 403 from them. They move under their own ticket, once there is a regulator journey that needs them. The rest of the read vocabulary — the other four scopes — lands separately again.

The list route also keeps its unpaginated branch: a request carrying no recognised query parameter returns every organisation, unprojected. That predates this PR and the admin UI never triggers it, since it always sends `page` and `pageSize`. Bounding or removing it is tracked separately rather than folded in here.

<details>
<summary>File-by-file</summary>

**Production**

- `src/common/helpers/auth/constants.js` — adds `organisation.search` to `SCOPES`, to `REGULATOR_SCOPES`, and to all three admin tiers in `ADMIN_ROLES`. The comment above `REGULATOR_SCOPES` records why search is separate from read.
- `src/routes/v1/organisations/get.js` — the route declares `SCOPES.organisationSearch`.

**Test harness**

- `.vite/setup-files.js` — puts `support@example.com` in `SUPPORT_EMAILS`. The list was empty, so no token could resolve to the `support` tier through the real auth stack. The address is in no other list, so no existing credential changes tier.
- `.vite/helpers/create-entra-id-test-tokens.js` — adds `supportToken`, matching the read-tier credential added alongside the regulator work.
- `src/test/inject-auth.js` — comments only, so each tier helper still describes the bundle it injects.

**Tests**

- `src/routes/v1/organisations/get.test.js` — a regulator credential and each of the three admin tiers reach the route. The existing token and role scenarios in this file pointed at `/v1/organisations/{id}` rather than the list route they belong to; they now exercise the list route, which is where an operator credential is proved to be refused.
- `src/common/helpers/auth/constants.test.js` — states the invariant directly, so a fourth admin tier added later cannot hold `admin.read` without `organisation.search`.
- `src/common/helpers/auth/get-jwt-strategy-config.test.js`, `src/routes/v1/admin/me/get.test.js`, `src/routes/v1/me/get.test.js`, `src/routes/v1/organisations/put-by-id.test.js`, `src/routes/v1/organisations/unlink.test.js`, `src/overseas-sites/routes/post-import.test.js` — assertions that pin an admin scope bundle, updated for the added scope.

</details>


[PAE-1712]: https://eaflood.atlassian.net/browse/PAE-1712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ