### PR TITLE
PAE-1280: Prevent reprocessor report creation on incomplete summary log

### DIFF
--- a/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.js
@@ -3,7 +3,8 @@ import { SENT_ON_LOADS_FIELDS as FIELDS, ROW_ID_MINIMUMS } from './fields.js'
 import {
   createRowIdSchema,
   createUnboundedWeightFieldSchema,
-  createDateFieldSchema
+  createDateFieldSchema,
+  DROPDOWN_PLACEHOLDER
 } from '../shared/index.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { createRowTransformer } from '#domain/waste-records/row-transformers/create-row-transformer.js'
@@ -39,8 +40,16 @@ export const SENT_ON_LOADS = {
 
   /**
    * Per-field values that indicate "unfilled"
+   *
+   * The final-destination facility type is a dropdown ('Choose option,
+   * Exporter, Reprocessor, Other') on the Sent-on sheet, so a cell left on the
+   * placeholder counts as unfilled, matching the accredited schemas. Without
+   * this, an unselected facility type would read as a real value at upload and
+   * in the report-completeness gate (defra-h9hv twin).
    */
-  unfilledValues: {},
+  unfilledValues: {
+    [FIELDS.FINAL_DESTINATION_FACILITY_TYPE]: DROPDOWN_PLACEHOLDER
+  },
 
   /**
    * VAL010: Validation schema for filled fields

--- a/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.test.js
+++ b/src/domain/summary-logs/table-schemas/reprocessor-registered-only/sent-on-loads.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { TABLE_SCHEMAS } from './index.js'
+import { DROPDOWN_PLACEHOLDER } from '../shared/index.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
 const { SENT_ON_LOADS } = TABLE_SCHEMAS
@@ -52,8 +53,13 @@ describe('SENT_ON_LOADS (REPROCESSOR_REGISTERED_ONLY)', () => {
       })
     })
 
-    it('has unfilledValues object', () => {
-      expect(typeof schema.unfilledValues).toBe('object')
+    it('treats the final-destination facility type placeholder as unfilled', () => {
+      // The facility type is a 'Choose option' dropdown, so a cell left on the
+      // placeholder must count as unfilled — matching the accredited schemas so
+      // the report-completeness gate flags an unselected one (defra-h9hv twin).
+      expect(schema.unfilledValues).toEqual({
+        FINAL_DESTINATION_FACILITY_TYPE: DROPDOWN_PLACEHOLDER
+      })
     })
 
     it('has validationSchema with validate function', () => {

--- a/src/reports/domain/report-mandatory/index.js
+++ b/src/reports/domain/report-mandatory/index.js
@@ -41,6 +41,12 @@ import { REPROCESSOR_REGISTERED_ONLY_POLICY } from './policy/reprocessor-registe
  * are populated: the two exporter templates (PAE-1420) and the three reprocessor
  * templates (PAE-1280).
  *
+ * The three reprocessor policies are kept as separate modules even though their
+ * rule bodies currently coincide: each sources its fields from its own template
+ * schema and the templates may diverge (a mandatory field added or dropped for
+ * one variant). The policy test guards that their field names stay real, so a
+ * drift in one module fails in isolation rather than silently.
+ *
  * @type {Partial<Record<string, ReportMandatoryPolicy>>}
  */
 const POLICY_BY_PROCESSING_TYPE = Object.freeze({

--- a/src/reports/domain/report-mandatory/index.js
+++ b/src/reports/domain/report-mandatory/index.js
@@ -1,6 +1,9 @@
 import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { EXPORTER_POLICY } from './policy/exporter.js'
 import { EXPORTER_REGISTERED_ONLY_POLICY } from './policy/exporter-registered-only.js'
+import { REPROCESSOR_INPUT_POLICY } from './policy/reprocessor-input.js'
+import { REPROCESSOR_OUTPUT_POLICY } from './policy/reprocessor-output.js'
+import { REPROCESSOR_REGISTERED_ONLY_POLICY } from './policy/reprocessor-registered-only.js'
 
 /**
  * @import { RequiredByCode } from './reason-codes.js'
@@ -34,14 +37,19 @@ import { EXPORTER_REGISTERED_ONLY_POLICY } from './policy/exporter-registered-on
  */
 
 /**
- * Report-mandatory policy per processing type. Only the two exporter templates
- * are populated: the three reprocessor templates plug in under PAE-1280.
+ * Report-mandatory policy per processing type. All five summary-log templates
+ * are populated: the two exporter templates (PAE-1420) and the three reprocessor
+ * templates (PAE-1280).
  *
  * @type {Partial<Record<string, ReportMandatoryPolicy>>}
  */
 const POLICY_BY_PROCESSING_TYPE = Object.freeze({
   [PROCESSING_TYPES.EXPORTER]: EXPORTER_POLICY,
-  [PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY]: EXPORTER_REGISTERED_ONLY_POLICY
+  [PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY]: EXPORTER_REGISTERED_ONLY_POLICY,
+  [PROCESSING_TYPES.REPROCESSOR_INPUT]: REPROCESSOR_INPUT_POLICY,
+  [PROCESSING_TYPES.REPROCESSOR_OUTPUT]: REPROCESSOR_OUTPUT_POLICY,
+  [PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY]:
+    REPROCESSOR_REGISTERED_ONLY_POLICY
 })
 
 /**

--- a/src/reports/domain/report-mandatory/policy.test.js
+++ b/src/reports/domain/report-mandatory/policy.test.js
@@ -26,20 +26,25 @@ const ruleCases = POPULATED_TEMPLATES.flatMap((processingType) => {
   )
 })
 
-// Guards the schema-sourced layout the engine depends on: a rule whose required
-// field is not a real column would report `columnIndex: -1`, which the
-// integration tests do not notice because they assert the column index only as
-// an opaque number.
-describe('report-mandatory policy references only real table columns', () => {
+// Guards the schema-sourced layout the engine depends on. Two invariants: the
+// rule's `(processingType, wasteRecordType)` pair must resolve to a real schema
+// (the engine casts the lookup to non-null and dereferences `sheetName` and
+// `unfilledValues`, so a rule keyed under an unregistered record type would 500
+// the request), and every required field must be a real column (a phantom field
+// would report `columnIndex: -1`, which the integration tests miss because they
+// assert the column index only as an opaque number).
+describe('report-mandatory policy references only real table schemas', () => {
   it.each(ruleCases)(
     '$processingType/$wasteRecordType $rule.requiredBy',
     ({ processingType, wasteRecordType, rule }) => {
-      const headers =
-        findSchemaForProcessingType(processingType, wasteRecordType)
-          ?.requiredHeaders ?? []
+      const schema = findSchemaForProcessingType(
+        processingType,
+        wasteRecordType
+      )
+      expect(schema).not.toBeNull()
 
       for (const field of rule.requiredFields) {
-        expect(headers).toContain(field)
+        expect(schema?.requiredHeaders).toContain(field)
       }
     }
   )

--- a/src/reports/domain/report-mandatory/policy.test.js
+++ b/src/reports/domain/report-mandatory/policy.test.js
@@ -4,19 +4,22 @@ import { findSchemaForProcessingType } from '#domain/summary-logs/table-schemas/
 import { reportMandatoryPolicyFor } from './index.js'
 
 /**
- * Every populated exporter template. The three reprocessor templates are
- * deliberately unpopulated until PAE-1280 and resolve to a null policy.
+ * Every template with a populated report-mandatory policy: both exporter
+ * templates (PAE-1420) and the three reprocessor templates (PAE-1280).
  */
-const EXPORTER_TEMPLATES = [
+const POPULATED_TEMPLATES = [
   PROCESSING_TYPES.EXPORTER,
-  PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY
+  PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY,
+  PROCESSING_TYPES.REPROCESSOR_INPUT,
+  PROCESSING_TYPES.REPROCESSOR_OUTPUT,
+  PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY
 ]
 
 /**
  * Flattens each populated policy into one case per rule so a drifted field name
  * fails in isolation with a readable label.
  */
-const ruleCases = EXPORTER_TEMPLATES.flatMap((processingType) => {
+const ruleCases = POPULATED_TEMPLATES.flatMap((processingType) => {
   const policy = reportMandatoryPolicyFor(processingType) ?? {}
   return Object.entries(policy).flatMap(([wasteRecordType, rules]) =>
     rules.map((rule) => ({ processingType, wasteRecordType, rule }))
@@ -40,4 +43,10 @@ describe('report-mandatory policy references only real table columns', () => {
       }
     }
   )
+})
+
+describe('reportMandatoryPolicyFor', () => {
+  it('returns null for a processing type with no policy', () => {
+    expect(reportMandatoryPolicyFor('UNKNOWN_PROCESSING_TYPE')).toBeNull()
+  })
 })

--- a/src/reports/domain/report-mandatory/policy/reprocessor-input.js
+++ b/src/reports/domain/report-mandatory/policy/reprocessor-input.js
@@ -1,0 +1,59 @@
+import {
+  RECEIVED_LOADS_FIELDS,
+  SENT_ON_LOADS_FIELDS
+} from '#domain/summary-logs/table-schemas/reprocessor-input/fields.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { REQUIRED_BY } from '../reason-codes.js'
+import { tonnageOverZero } from '../triggers.js'
+
+/**
+ * @import { ReportMandatoryPolicy } from '../index.js'
+ */
+
+const RECEIVED = RECEIVED_LOADS_FIELDS
+const SENT_ON = SENT_ON_LOADS_FIELDS
+
+/**
+ * Report-mandatory policy for the accredited-on-input reprocessor template
+ * (PAE-1280 AC1, AC2).
+ *
+ * The reprocessor templates split the received and sent-on legs across separate
+ * tables (and sheets), so the supplier rule keys off the received record and the
+ * final-destination rule off the sent-on record. Reprocessor templates carry no
+ * overseas-site, export-date or interim concepts, so those exporter rules have
+ * no counterpart here.
+ *
+ * A rule fires for any row whose trigger holds, anywhere in the summary log — the
+ * gate checks the whole log, not just the rows the report aggregates. The field
+ * layout is read from the row's table schema rather than restated.
+ *
+ * @type {ReportMandatoryPolicy}
+ */
+export const REPROCESSOR_INPUT_POLICY = Object.freeze({
+  [WASTE_RECORD_TYPE.RECEIVED]: [
+    {
+      requiredBy: REQUIRED_BY.SUPPLIER_DETAILS,
+      trigger: tonnageOverZero(RECEIVED.TONNAGE_RECEIVED_FOR_RECYCLING),
+      requiredFields: [
+        RECEIVED.SUPPLIER_NAME,
+        RECEIVED.SUPPLIER_ADDRESS,
+        RECEIVED.SUPPLIER_POSTCODE,
+        RECEIVED.SUPPLIER_EMAIL,
+        RECEIVED.SUPPLIER_PHONE_NUMBER,
+        RECEIVED.ACTIVITIES_CARRIED_OUT_BY_SUPPLIER
+      ]
+    }
+  ],
+  [WASTE_RECORD_TYPE.SENT_ON]: [
+    {
+      requiredBy: REQUIRED_BY.FINAL_DESTINATION,
+      trigger: tonnageOverZero(SENT_ON.TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON),
+      requiredFields: [
+        SENT_ON.FINAL_DESTINATION_NAME,
+        SENT_ON.FINAL_DESTINATION_FACILITY_TYPE,
+        SENT_ON.FINAL_DESTINATION_ADDRESS,
+        SENT_ON.FINAL_DESTINATION_POSTCODE
+      ]
+    }
+  ]
+})

--- a/src/reports/domain/report-mandatory/policy/reprocessor-output.js
+++ b/src/reports/domain/report-mandatory/policy/reprocessor-output.js
@@ -1,0 +1,58 @@
+import {
+  RECEIVED_LOADS_FIELDS,
+  SENT_ON_LOADS_FIELDS
+} from '#domain/summary-logs/table-schemas/reprocessor-output/fields.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { REQUIRED_BY } from '../reason-codes.js'
+import { tonnageOverZero } from '../triggers.js'
+
+/**
+ * @import { ReportMandatoryPolicy } from '../index.js'
+ */
+
+const RECEIVED = RECEIVED_LOADS_FIELDS
+const SENT_ON = SENT_ON_LOADS_FIELDS
+
+/**
+ * Report-mandatory policy for the accredited-on-output reprocessor template
+ * (PAE-1280 AC1, AC2).
+ *
+ * Structurally identical to the accredited-on-input policy: the supplier rule
+ * keys off the received record and the final-destination rule off the sent-on
+ * record. The output template's received fields are shared with input; its
+ * sent-on fields are its own but carry the same final-destination columns.
+ *
+ * A rule fires for any row whose trigger holds, anywhere in the summary log — the
+ * gate checks the whole log, not just the rows the report aggregates. The field
+ * layout is read from the row's table schema rather than restated.
+ *
+ * @type {ReportMandatoryPolicy}
+ */
+export const REPROCESSOR_OUTPUT_POLICY = Object.freeze({
+  [WASTE_RECORD_TYPE.RECEIVED]: [
+    {
+      requiredBy: REQUIRED_BY.SUPPLIER_DETAILS,
+      trigger: tonnageOverZero(RECEIVED.TONNAGE_RECEIVED_FOR_RECYCLING),
+      requiredFields: [
+        RECEIVED.SUPPLIER_NAME,
+        RECEIVED.SUPPLIER_ADDRESS,
+        RECEIVED.SUPPLIER_POSTCODE,
+        RECEIVED.SUPPLIER_EMAIL,
+        RECEIVED.SUPPLIER_PHONE_NUMBER,
+        RECEIVED.ACTIVITIES_CARRIED_OUT_BY_SUPPLIER
+      ]
+    }
+  ],
+  [WASTE_RECORD_TYPE.SENT_ON]: [
+    {
+      requiredBy: REQUIRED_BY.FINAL_DESTINATION,
+      trigger: tonnageOverZero(SENT_ON.TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON),
+      requiredFields: [
+        SENT_ON.FINAL_DESTINATION_NAME,
+        SENT_ON.FINAL_DESTINATION_FACILITY_TYPE,
+        SENT_ON.FINAL_DESTINATION_ADDRESS,
+        SENT_ON.FINAL_DESTINATION_POSTCODE
+      ]
+    }
+  ]
+})

--- a/src/reports/domain/report-mandatory/policy/reprocessor-registered-only.js
+++ b/src/reports/domain/report-mandatory/policy/reprocessor-registered-only.js
@@ -1,0 +1,58 @@
+import {
+  RECEIVED_LOADS_FIELDS,
+  SENT_ON_LOADS_FIELDS
+} from '#domain/summary-logs/table-schemas/reprocessor-registered-only/fields.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { REQUIRED_BY } from '../reason-codes.js'
+import { tonnageOverZero } from '../triggers.js'
+
+/**
+ * @import { ReportMandatoryPolicy } from '../index.js'
+ */
+
+const RECEIVED = RECEIVED_LOADS_FIELDS
+const SENT_ON = SENT_ON_LOADS_FIELDS
+
+/**
+ * Report-mandatory policy for the registered-only reprocessor template
+ * (PAE-1280 AC1, AC2).
+ *
+ * Structurally identical to the accredited reprocessor policies: the supplier
+ * rule keys off the received record and the final-destination rule off the
+ * sent-on record. The registered-only template defines its own simplified field
+ * sets, but both rules reference the same canonical columns.
+ *
+ * A rule fires for any row whose trigger holds, anywhere in the summary log — the
+ * gate checks the whole log, not just the rows the report aggregates. The field
+ * layout is read from the row's table schema rather than restated.
+ *
+ * @type {ReportMandatoryPolicy}
+ */
+export const REPROCESSOR_REGISTERED_ONLY_POLICY = Object.freeze({
+  [WASTE_RECORD_TYPE.RECEIVED]: [
+    {
+      requiredBy: REQUIRED_BY.SUPPLIER_DETAILS,
+      trigger: tonnageOverZero(RECEIVED.TONNAGE_RECEIVED_FOR_RECYCLING),
+      requiredFields: [
+        RECEIVED.SUPPLIER_NAME,
+        RECEIVED.SUPPLIER_ADDRESS,
+        RECEIVED.SUPPLIER_POSTCODE,
+        RECEIVED.SUPPLIER_EMAIL,
+        RECEIVED.SUPPLIER_PHONE_NUMBER,
+        RECEIVED.ACTIVITIES_CARRIED_OUT_BY_SUPPLIER
+      ]
+    }
+  ],
+  [WASTE_RECORD_TYPE.SENT_ON]: [
+    {
+      requiredBy: REQUIRED_BY.FINAL_DESTINATION,
+      trigger: tonnageOverZero(SENT_ON.TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON),
+      requiredFields: [
+        SENT_ON.FINAL_DESTINATION_NAME,
+        SENT_ON.FINAL_DESTINATION_FACILITY_TYPE,
+        SENT_ON.FINAL_DESTINATION_ADDRESS,
+        SENT_ON.FINAL_DESTINATION_POSTCODE
+      ]
+    }
+  ]
+})

--- a/src/reports/routes/post.test.js
+++ b/src/reports/routes/post.test.js
@@ -1299,7 +1299,8 @@ describe(`POST ${reportsPostPath}`, () => {
     })
 
     // AC1: the six supplier fields a positive received-for-recycling tonnage
-    // makes mandatory, in the order the gate reports them.
+    // makes mandatory. Listed in the policy's declaration order so the expected
+    // issues below read naturally; the frontend does not depend on field order.
     const SUPPLIER_FIELDS = [
       'SUPPLIER_NAME',
       'SUPPLIER_ADDRESS',
@@ -1310,7 +1311,8 @@ describe(`POST ${reportsPostPath}`, () => {
     ]
 
     // AC2: the four final-destination fields a positive sent-on tonnage makes
-    // mandatory, in report order.
+    // mandatory. Listed in the policy's declaration order for readability; the
+    // frontend does not depend on field order.
     const DESTINATION_FIELDS = [
       'FINAL_DESTINATION_NAME',
       'FINAL_DESTINATION_FACILITY_TYPE',
@@ -1502,36 +1504,12 @@ describe(`POST ${reportsPostPath}`, () => {
       expect(response.statusCode).toBe(StatusCodes.CREATED)
     })
 
-    it('does not gate the report-detail retrieval path (GET) with the flag on', async () => {
-      const { server, organisationId, registrationId } = await createServer(
-        { wasteProcessingType: 'reprocessor', accreditationId: undefined },
-        {
-          featureFlags: gateEnabled,
-          rows: [
-            reprocessorRow(
-              PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY,
-              'row-1',
-              WASTE_RECORD_TYPE.RECEIVED,
-              { TONNAGE_RECEIVED_FOR_RECYCLING: 5 }
-            )
-          ]
-        }
-      )
-
-      const response = await server.inject({
-        method: 'GET',
-        url: makeUrl(organisationId, registrationId, 2025, 'quarterly', 1, 1),
-        ...asOperator()
-      })
-
-      expect(response.statusCode).toBe(StatusCodes.OK)
-      expect(JSON.parse(response.payload).reason).toBeUndefined()
-    })
-
-    it('treats a registered-only final-destination dropdown placeholder as unfilled when sent-on tonnage > 0 (defra-h9hv twin)', async () => {
+    it('blocks a registered-only placeholder facility type but never gates the GET retrieval path (defra-h9hv twin)', async () => {
       // The facility type is a 'Choose option' dropdown on the reprocessor
       // registered-only Sent-on sheet, so an unselected one must be flagged
-      // exactly as the accredited schemas do.
+      // exactly as the accredited schemas do. The same incomplete data must
+      // still return the on-the-fly report on GET: the gate lives only in
+      // report creation.
       const { server, organisationId, registrationId } = await createServer(
         { wasteProcessingType: 'reprocessor', accreditationId: undefined },
         {
@@ -1572,6 +1550,15 @@ describe(`POST ${reportsPostPath}`, () => {
           field: 'FINAL_DESTINATION_FACILITY_TYPE'
         })
       ])
+
+      const getResponse = await server.inject({
+        method: 'GET',
+        url: makeUrl(organisationId, registrationId, 2025, 'quarterly', 1, 1),
+        ...asOperator()
+      })
+
+      expect(getResponse.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(getResponse.payload).reason).toBeUndefined()
     })
   })
 })

--- a/src/reports/routes/post.test.js
+++ b/src/reports/routes/post.test.js
@@ -1073,30 +1073,6 @@ describe(`POST ${reportsPostPath}`, () => {
       expect(response.statusCode).toBe(StatusCodes.CREATED)
     })
 
-    it('does not gate rows whose processing type has no policy (reprocessor)', async () => {
-      const { server, organisationId, registrationId } = await createServer(
-        { wasteProcessingType: 'reprocessor', accreditationId: undefined },
-        {
-          featureFlags: gateEnabled,
-          rows: [
-            buildSummaryLogRowStateEntry({
-              rowId: 'row-1',
-              wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
-              processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
-              data: {
-                DATE_RECEIVED_FOR_REPROCESSING: '2025-01-10',
-                TONNAGE_RECEIVED_FOR_RECYCLING: 5
-              }
-            })
-          ]
-        }
-      )
-
-      const response = await postRegOnly(server, organisationId, registrationId)
-
-      expect(response.statusCode).toBe(StatusCodes.CREATED)
-    })
-
     it('blocks the report on an incomplete triggered row from outside the report period', async () => {
       // Whole-summary-log scoping (PAE-1420 pivot): export tonnage with a June
       // export date and a blank OSR_ID. The January report does not aggregate
@@ -1304,6 +1280,288 @@ describe(`POST ${reportsPostPath}`, () => {
       )
 
       const response = await postRegOnly(server, organisationId, registrationId)
+
+      expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+      const payload = JSON.parse(response.payload)
+      expect(payload.total).toBe(1)
+      expect(payload.issues).toEqual([
+        expect.objectContaining({
+          rowId: 'row-1',
+          field: 'FINAL_DESTINATION_FACILITY_TYPE'
+        })
+      ])
+    })
+  })
+
+  describe('reprocessor report data completeness gate (PAE-1280)', () => {
+    const gateEnabled = createInMemoryFeatureFlags({
+      reportDataValidation: true
+    })
+
+    // AC1: the six supplier fields a positive received-for-recycling tonnage
+    // makes mandatory, in the order the gate reports them.
+    const SUPPLIER_FIELDS = [
+      'SUPPLIER_NAME',
+      'SUPPLIER_ADDRESS',
+      'SUPPLIER_POSTCODE',
+      'SUPPLIER_EMAIL',
+      'SUPPLIER_PHONE_NUMBER',
+      'ACTIVITIES_CARRIED_OUT_BY_SUPPLIER'
+    ]
+
+    // AC2: the four final-destination fields a positive sent-on tonnage makes
+    // mandatory, in report order.
+    const DESTINATION_FIELDS = [
+      'FINAL_DESTINATION_NAME',
+      'FINAL_DESTINATION_FACILITY_TYPE',
+      'FINAL_DESTINATION_ADDRESS',
+      'FINAL_DESTINATION_POSTCODE'
+    ]
+
+    // Row states carry the canonical field names ingestion normalises every
+    // reprocessor template to; the gate reads only this data, never the template.
+    const reprocessorRow = (processingType, rowId, wasteRecordType, data) =>
+      buildSummaryLogRowStateEntry({
+        rowId,
+        wasteRecordType,
+        processingType,
+        data
+      })
+
+    // The payload is a flat list of issues, one per missing field. Each issue
+    // locates the field by sheet and row; the frontend maps the field to copy.
+    const issuesFor = (sheet, rowId, fields) =>
+      fields.map((field) => ({ sheet, rowId, field }))
+
+    // The three reprocessor templates share the same two rules but differ in
+    // registration shape and cadence: input and output are accredited (monthly),
+    // registered-only is quarterly. sheetNames are 'Received' and 'Sent on'
+    // across all three.
+    const TEMPLATES = [
+      {
+        name: 'accredited on input',
+        processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+        registration: { wasteProcessingType: 'reprocessor' },
+        accredited: true,
+        post: (server, orgId, regId) =>
+          makeRequest(server, orgId, regId, 2025, 'monthly', 1)
+      },
+      {
+        name: 'accredited on output',
+        processingType: PROCESSING_TYPES.REPROCESSOR_OUTPUT,
+        registration: { wasteProcessingType: 'reprocessor' },
+        accredited: true,
+        post: (server, orgId, regId) =>
+          makeRequest(server, orgId, regId, 2025, 'monthly', 1)
+      },
+      {
+        name: 'registered-only',
+        processingType: PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY,
+        registration: {
+          wasteProcessingType: 'reprocessor',
+          accreditationId: undefined
+        },
+        accredited: false,
+        post: (server, orgId, regId) =>
+          makeRequest(server, orgId, regId, 2025, 'quarterly', 1)
+      }
+    ]
+
+    describe.each(TEMPLATES)(
+      '$name',
+      ({ processingType, registration, accredited, post }) => {
+        it('blocks report creation when a received row is missing supplier details (AC1)', async () => {
+          const { server, organisationId, registrationId } = await createServer(
+            registration,
+            {
+              accredited,
+              featureFlags: gateEnabled,
+              rows: [
+                reprocessorRow(
+                  processingType,
+                  'row-1',
+                  WASTE_RECORD_TYPE.RECEIVED,
+                  { TONNAGE_RECEIVED_FOR_RECYCLING: 5 }
+                )
+              ]
+            }
+          )
+
+          const response = await post(server, organisationId, registrationId)
+
+          expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+          const payload = JSON.parse(response.payload)
+          expect(payload.reason).toBe('report_data_incomplete')
+          expect(payload.total).toBe(SUPPLIER_FIELDS.length)
+          expect(payload.issues).toEqual(
+            issuesFor('Received', 'row-1', SUPPLIER_FIELDS)
+          )
+        })
+
+        it('blocks report creation when a sent-on row is missing the final destination (AC2)', async () => {
+          const { server, organisationId, registrationId } = await createServer(
+            registration,
+            {
+              accredited,
+              featureFlags: gateEnabled,
+              rows: [
+                reprocessorRow(
+                  processingType,
+                  'row-1',
+                  WASTE_RECORD_TYPE.SENT_ON,
+                  { TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON: 2 }
+                )
+              ]
+            }
+          )
+
+          const response = await post(server, organisationId, registrationId)
+
+          expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+          const payload = JSON.parse(response.payload)
+          expect(payload.reason).toBe('report_data_incomplete')
+          expect(payload.total).toBe(DESTINATION_FIELDS.length)
+          expect(payload.issues).toEqual(
+            issuesFor('Sent on', 'row-1', DESTINATION_FIELDS)
+          )
+        })
+
+        it('creates the report when every triggered row is complete', async () => {
+          const { server, organisationId, registrationId } = await createServer(
+            registration,
+            {
+              accredited,
+              featureFlags: gateEnabled,
+              rows: [
+                reprocessorRow(
+                  processingType,
+                  'row-1',
+                  WASTE_RECORD_TYPE.RECEIVED,
+                  {
+                    TONNAGE_RECEIVED_FOR_RECYCLING: 5,
+                    SUPPLIER_NAME: 'Acme Waste Ltd',
+                    SUPPLIER_ADDRESS: '1 Depot Road',
+                    SUPPLIER_POSTCODE: 'AB1 2CD',
+                    SUPPLIER_EMAIL: 'ops@acme.example',
+                    SUPPLIER_PHONE_NUMBER: '01234 567890',
+                    ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Baling'
+                  }
+                ),
+                reprocessorRow(
+                  processingType,
+                  'row-2',
+                  WASTE_RECORD_TYPE.SENT_ON,
+                  {
+                    TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON: 2,
+                    FINAL_DESTINATION_NAME: 'Port Recyclers',
+                    FINAL_DESTINATION_FACILITY_TYPE: 'Reprocessor',
+                    FINAL_DESTINATION_ADDRESS: '2 Quay Street',
+                    FINAL_DESTINATION_POSTCODE: 'EF3 4GH'
+                  }
+                )
+              ]
+            }
+          )
+
+          const response = await post(server, organisationId, registrationId)
+
+          expect(response.statusCode).toBe(StatusCodes.CREATED)
+        })
+      }
+    )
+
+    it('does not gate a record type that carries no completeness rule', async () => {
+      // The reprocessed-loads (processed) record type has no report-mandatory
+      // rule, so the gate skips it: a processing type with a policy still leaves
+      // unruled record types untouched.
+      const { server, organisationId, registrationId } = await createServer(
+        { wasteProcessingType: 'reprocessor' },
+        {
+          accredited: true,
+          featureFlags: gateEnabled,
+          rows: [
+            reprocessorRow(
+              PROCESSING_TYPES.REPROCESSOR_INPUT,
+              'row-1',
+              WASTE_RECORD_TYPE.PROCESSED,
+              { PRODUCT_TONNAGE: 5 }
+            )
+          ]
+        }
+      )
+
+      const response = await makeRequest(
+        server,
+        organisationId,
+        registrationId,
+        2025,
+        'monthly',
+        1
+      )
+
+      expect(response.statusCode).toBe(StatusCodes.CREATED)
+    })
+
+    it('does not gate the report-detail retrieval path (GET) with the flag on', async () => {
+      const { server, organisationId, registrationId } = await createServer(
+        { wasteProcessingType: 'reprocessor', accreditationId: undefined },
+        {
+          featureFlags: gateEnabled,
+          rows: [
+            reprocessorRow(
+              PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY,
+              'row-1',
+              WASTE_RECORD_TYPE.RECEIVED,
+              { TONNAGE_RECEIVED_FOR_RECYCLING: 5 }
+            )
+          ]
+        }
+      )
+
+      const response = await server.inject({
+        method: 'GET',
+        url: makeUrl(organisationId, registrationId, 2025, 'quarterly', 1, 1),
+        ...asOperator()
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+      expect(JSON.parse(response.payload).reason).toBeUndefined()
+    })
+
+    it('treats a registered-only final-destination dropdown placeholder as unfilled when sent-on tonnage > 0 (defra-h9hv twin)', async () => {
+      // The facility type is a 'Choose option' dropdown on the reprocessor
+      // registered-only Sent-on sheet, so an unselected one must be flagged
+      // exactly as the accredited schemas do.
+      const { server, organisationId, registrationId } = await createServer(
+        { wasteProcessingType: 'reprocessor', accreditationId: undefined },
+        {
+          featureFlags: gateEnabled,
+          rows: [
+            reprocessorRow(
+              PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY,
+              'row-1',
+              WASTE_RECORD_TYPE.SENT_ON,
+              {
+                DATE_LOAD_LEFT_SITE: '2025-03-01',
+                TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON: 2,
+                FINAL_DESTINATION_NAME: 'Port Recyclers',
+                FINAL_DESTINATION_FACILITY_TYPE: 'Choose option',
+                FINAL_DESTINATION_ADDRESS: '2 Quay Street',
+                FINAL_DESTINATION_POSTCODE: 'EF3 4GH'
+              }
+            )
+          ]
+        }
+      )
+
+      const response = await makeRequest(
+        server,
+        organisationId,
+        registrationId,
+        2025,
+        'quarterly',
+        1
+      )
 
       expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
       const payload = JSON.parse(response.payload)

--- a/src/server/run-report-data-completeness-diagnostic.integration.test.js
+++ b/src/server/run-report-data-completeness-diagnostic.integration.test.js
@@ -127,8 +127,9 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
     })
   ]
 
-  // Ledger C: reprocessor, steel, an incomplete-looking row that has no
-  // completeness policy yet -> scanned but never flagged (PAE-1280).
+  // Ledger C: accredited reprocessor, steel. One Received row with received
+  // tonnage and no supplier details: now flagged by the reprocessor policy
+  // (PAE-1280) as one violating row with six missing supplier fields.
   const ledgerC = buildLedgerFixture({
     material: 'steel',
     processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
@@ -229,24 +230,35 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
     expect(lineB).toContain('accreditation registered-only')
     expect(lineB).toContain('1 incomplete row(s), 6 missing field(s)')
 
-    // The reprocessor summary log is scanned but has no policy, so it is not
-    // flagged.
-    expect(messages().find((m) => m.includes('sl-c'))).toBeUndefined()
+    // The reprocessor summary log is now flagged by the PAE-1280 policy: its
+    // Received row has tonnage but no supplier details.
+    const lineC = messages().find((m) => m.includes('sl-c'))
+    expect(lineC).toContain('template REPROCESSOR_INPUT,')
+    expect(lineC).toContain('material steel')
+    expect(lineC).toContain(ledgerC.ledgerId.organisationId)
+    expect(lineC).toContain(
+      `registration ${ledgerC.ledgerId.registrationId} (no. REG-000)`
+    )
+    expect(lineC).toContain(
+      `accreditation ${ledgerC.ledgerId.accreditationId} (no. `
+    )
+    expect(lineC).toContain('1 incomplete row(s), 6 missing field(s)')
 
     // (2) one line covering the evaluated templates.
     expect(messages()).toContain(
-      'Report-data diagnostic missing data by template: EXPORTER:1, EXPORTER_REGISTERED_ONLY:1'
+      'Report-data diagnostic missing data by template: REPROCESSOR_INPUT:1, REPROCESSOR_OUTPUT:0, EXPORTER:1, REPROCESSOR_REGISTERED_ONLY:0, EXPORTER_REGISTERED_ONLY:1'
     )
 
     // (3) one line covering every material, including those with no violations.
     expect(messages()).toContain(
-      'Report-data diagnostic missing data by material: aluminium:0, fibre:0, glass:1, paper:0, plastic:1, steel:0, wood:0'
+      'Report-data diagnostic missing data by material: aluminium:0, fibre:0, glass:1, paper:0, plastic:1, steel:1, wood:0'
     )
 
-    // (4) one line covering every missing field, most-missing first. OSR_ID is
-    // missing on both of ledger A's violating rows; each supplier field once.
+    // (4) one line covering every missing field, most-missing first, field name
+    // breaking ties. OSR_ID is missing on both of ledger A's violating rows; the
+    // six supplier fields are each missing twice (ledger B and ledger C).
     expect(messages()).toContain(
-      'Report-data diagnostic missing data by field: OSR_ID:2, ACTIVITIES_CARRIED_OUT_BY_SUPPLIER:1, SUPPLIER_ADDRESS:1, SUPPLIER_EMAIL:1, SUPPLIER_NAME:1, SUPPLIER_PHONE_NUMBER:1, SUPPLIER_POSTCODE:1'
+      'Report-data diagnostic missing data by field: ACTIVITIES_CARRIED_OUT_BY_SUPPLIER:2, OSR_ID:2, SUPPLIER_ADDRESS:2, SUPPLIER_EMAIL:2, SUPPLIER_NAME:2, SUPPLIER_PHONE_NUMBER:2, SUPPLIER_POSTCODE:2'
     )
 
     // (5) the estate-wide totals.
@@ -254,12 +266,12 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
       m.startsWith('Report-data diagnostic summary:')
     )
     expect(summary).toContain('scanned 3 summary log(s)')
-    expect(summary).toContain('2 with incomplete data (8 missing field(s))')
-    expect(summary).toContain('2 organisation(s)')
-    expect(summary).toContain('2 registration(s)')
-    expect(summary).toContain('1 accreditation(s)')
+    expect(summary).toContain('3 with incomplete data (14 missing field(s))')
+    expect(summary).toContain('3 organisation(s)')
+    expect(summary).toContain('3 registration(s)')
+    expect(summary).toContain('2 accreditation(s)')
     expect(summary).toContain(
-      'Evaluated templates: EXPORTER, EXPORTER_REGISTERED_ONLY'
+      'Evaluated templates: REPROCESSOR_INPUT, REPROCESSOR_OUTPUT, EXPORTER, REPROCESSOR_REGISTERED_ONLY, EXPORTER_REGISTERED_ONLY'
     )
 
     expect(lock).toHaveBeenCalledWith(LOCK_NAME)
@@ -343,7 +355,7 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
   })
 
   it('reports all-zero breakdowns when nothing would be blocked', async () => {
-    // A single reprocessor summary log: it has no completeness policy, so it is
+    // A single reprocessor summary log whose Received row is complete, so it is
     // scanned but never flagged. The rollups still report, all zero, and the
     // field line reads (none).
     const ledger = buildLedgerFixture({
@@ -360,7 +372,15 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
           rowId: 'row-z',
           wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
           processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
-          data: { TONNAGE_RECEIVED_FOR_RECYCLING: 5 }
+          data: {
+            TONNAGE_RECEIVED_FOR_RECYCLING: 5,
+            SUPPLIER_NAME: 'Acme Ltd',
+            SUPPLIER_ADDRESS: '1 Mill Road',
+            SUPPLIER_POSTCODE: 'AB1 2CD',
+            SUPPLIER_EMAIL: 'supplier@example.com',
+            SUPPLIER_PHONE_NUMBER: '01234 567890',
+            ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Sorting'
+          }
         })
       ],
       'sl-z'
@@ -399,7 +419,7 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
 
     expect(messages().find((m) => m.includes('sl-z'))).toBeUndefined()
     expect(messages()).toContain(
-      'Report-data diagnostic missing data by template: EXPORTER:0, EXPORTER_REGISTERED_ONLY:0'
+      'Report-data diagnostic missing data by template: REPROCESSOR_INPUT:0, REPROCESSOR_OUTPUT:0, EXPORTER:0, REPROCESSOR_REGISTERED_ONLY:0, EXPORTER_REGISTERED_ONLY:0'
     )
     expect(messages()).toContain(
       'Report-data diagnostic missing data by material: aluminium:0, fibre:0, glass:0, paper:0, plastic:0, steel:0, wood:0'


### PR DESCRIPTION
Ticket: [PAE-1280](https://eaflood.atlassian.net/browse/PAE-1280)
## What

Extends the report-data completeness gate to the three reprocessor summary-log templates (accredited on input, accredited on output, registered-only), behind the shared `FEATURE_FLAG_REPORT_DATA_VALIDATION` flag (off by default). When the flag is on, creating a reprocessor report is blocked if mandatory reporting data is missing anywhere in the summary log; the report stays Due/Over Due and a per-field 400 payload tells the frontend what is missing.

Two rules apply to every reprocessor template:

- **AC1 — supplier details.** When `tonnage_received_for_recycling > 0` on a received row, the six supplier fields (`supplier_name`, `supplier_address`, `supplier_postcode`, `supplier_email`, `supplier_phone_number`, `activities_carried_out_by_supplier`) must all be filled.
- **AC2 — final destination.** When `tonnage_of_uk_packaging_waste_sent_on > 0` on a sent-on row, `final_destination_name`, `final_destination_facility_type`, `final_destination_address` and `final_destination_postcode` must all be filled.

Reprocessor templates have no overseas-site, export-date or interim concepts, so the exporter's AC2/AC4/AC5 rules have no reprocessor counterpart.

## Changes

- Add three policy modules under `src/reports/domain/report-mandatory/policy/` (`reprocessor-input`, `reprocessor-output`, `reprocessor-registered-only`) and register them in `POLICY_BY_PROCESSING_TYPE`, which is now populated for all five templates. The whole-summary-log engine, triggers, reason codes and 400 payload contract are reused unchanged.
- Fix a registered-only sent-on schema bug: `final_destination_facility_type` is a "Choose option" dropdown, but its placeholder was not treated as unfilled, so an unselected value silently passed the gate. The schema now maps the placeholder to unfilled, matching the accredited schemas.
- Strengthen the policy test so it asserts each rule's `(processingType, wasteRecordType)` pair resolves to a real schema, not only that its fields are real columns: a rule keyed under an unregistered record type would otherwise fail the request at runtime rather than in a test.
- Replace the now-obsolete `does not gate rows whose processing type has no policy (reprocessor)` test — reprocessor rows are now gated, so that assertion is inverted by this change. Reprocessor gating is covered comprehensively by a new per-template test block, and a new test confirms a record type with no rule (reprocessed loads) is still not gated.

## Why

Regulators require that reprocessor reports cannot be generated with mandatory data missing from the summary log, validated at report creation rather than at upload. This is the reprocessor twin of PAE-1420 (exporter).

Jira: PAE-1280

[PAE-1280]: https://eaflood.atlassian.net/browse/PAE-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ