### PR TITLE
PAE-1420: Add report-completeness startup diagnostic

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -375,6 +375,12 @@ const baseConfig = {
       format: Boolean,
       default: false,
       env: 'FEATURE_FLAG_REPORT_DATA_VALIDATION'
+    },
+    reportDataCompleteDiagnostic: {
+      doc: 'Feature Flag: Run the estate-wide report-data completeness diagnostic on startup, logging which live summary logs would fail the report-completeness rules (defra-4ry0)',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_FLAG_REPORT_DATA_COMPLETE_DIAGNOSTIC'
     }
   },
   formSubmissionOverrides: {

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -16,5 +16,8 @@ export const createConfigFeatureFlags = (config) => ({
   },
   isReportDataValidationEnabled() {
     return config.get('featureFlags.reportDataValidation')
+  },
+  isReportDataCompleteDiagnosticEnabled() {
+    return config.get('featureFlags.reportDataCompleteDiagnostic')
   }
 })

--- a/src/feature-flags/feature-flags.config.test.js
+++ b/src/feature-flags/feature-flags.config.test.js
@@ -16,7 +16,11 @@ const FLAGS = [
     'isStaleIssuedTonnageReportEnabled',
     'featureFlags.staleIssuedTonnageReport'
   ],
-  ['isReportDataValidationEnabled', 'featureFlags.reportDataValidation']
+  ['isReportDataValidationEnabled', 'featureFlags.reportDataValidation'],
+  [
+    'isReportDataCompleteDiagnosticEnabled',
+    'featureFlags.reportDataCompleteDiagnostic'
+  ]
 ]
 
 describe('createConfigFeatureFlags', () => {

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -17,5 +17,8 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   },
   isReportDataValidationEnabled() {
     return flags.reportDataValidation ?? false
+  },
+  isReportDataCompleteDiagnosticEnabled() {
+    return flags.reportDataCompleteDiagnostic ?? false
   }
 })

--- a/src/feature-flags/feature-flags.inmemory.test.js
+++ b/src/feature-flags/feature-flags.inmemory.test.js
@@ -11,7 +11,8 @@ const FLAGS = [
   ['isDevEndpointsEnabled', 'devEndpoints'],
   ['isPreCpaResubmissionBackfillEnabled', 'preCpaResubmissionBackfill'],
   ['isPreCpaResubmissionReportEnabled', 'preCpaResubmissionReport'],
-  ['isStaleIssuedTonnageReportEnabled', 'staleIssuedTonnageReport']
+  ['isStaleIssuedTonnageReportEnabled', 'staleIssuedTonnageReport'],
+  ['isReportDataCompleteDiagnosticEnabled', 'reportDataCompleteDiagnostic']
 ]
 
 describe('createInMemoryFeatureFlags', () => {

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -5,6 +5,7 @@
  * @property {() => boolean} isPreCpaResubmissionReportEnabled
  * @property {() => boolean} isStaleIssuedTonnageReportEnabled
  * @property {() => boolean} isReportDataValidationEnabled
+ * @property {() => boolean} isReportDataCompleteDiagnosticEnabled
  */
 
 /**
@@ -14,6 +15,7 @@
  * @property {boolean} [preCpaResubmissionReport]
  * @property {boolean} [staleIssuedTonnageReport]
  * @property {boolean} [reportDataValidation]
+ * @property {boolean} [reportDataCompleteDiagnostic]
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/reports/monitoring/report-data-completeness-diagnostic.js
+++ b/src/reports/monitoring/report-data-completeness-diagnostic.js
@@ -17,7 +17,9 @@ import { MATERIAL } from '#domain/organisations/model.js'
  * @typedef {object} CompletenessFinding
  * @property {string} organisationId
  * @property {string} registrationId
+ * @property {string} registrationNumber - Human-facing registration number ('unknown' if the registration could not be resolved).
  * @property {string | null} accreditationId
+ * @property {string | null} accreditationNumber - Human-facing accreditation number; null for registered-only or unresolved.
  * @property {string} summaryLogId
  * @property {string} processingType - The SL's template (uniform across its rows).
  * @property {string} material
@@ -37,11 +39,12 @@ import { MATERIAL } from '#domain/organisations/model.js'
  */
 
 /**
- * Material reported for a violating summary log whose registration could not be
- * resolved. A real value would be one of the `MATERIAL` enum; this stands in so
- * the finding still counts toward the estate totals and the per-material rollup.
+ * Placeholder reported for a violating summary log whose registration could not
+ * be resolved, standing in for its material and its registration/accreditation
+ * numbers. The finding still counts toward the estate totals and the per-material
+ * rollup so the blast-radius numbers stay truthful.
  */
-export const UNKNOWN_MATERIAL = 'unknown'
+export const UNKNOWN = 'unknown'
 
 /**
  * The templates the completeness gate can evaluate today, derived from the
@@ -95,15 +98,21 @@ export const findReportDataCompletenessFindings = async ({
       fieldCounts.set(issue.field, (fieldCounts.get(issue.field) ?? 0) + 1)
     }
     // A deleted or re-versioned registration must not abort the estate scan:
-    // record it, report the material as unknown, and keep the finding so the
-    // blast-radius count stays truthful.
-    let material = UNKNOWN_MATERIAL
+    // record it, report the material and numbers as unknown, and keep the
+    // finding so the blast-radius count stays truthful.
+    let material = UNKNOWN
+    let registrationNumber = UNKNOWN
+    /** @type {string | null} */
+    let accreditationNumber = null
     try {
       const registration = await organisationsRepository.findRegistrationById(
         ledgerId.organisationId,
         ledgerId.registrationId
       )
       material = registration.material
+      registrationNumber = registration.registrationNumber ?? UNKNOWN
+      accreditationNumber =
+        registration.accreditation?.accreditationNumber ?? null
     } catch {
       unresolved.push({
         organisationId: ledgerId.organisationId,
@@ -114,7 +123,9 @@ export const findReportDataCompletenessFindings = async ({
     findings.push({
       organisationId: ledgerId.organisationId,
       registrationId: ledgerId.registrationId,
+      registrationNumber,
       accreditationId: ledgerId.accreditationId,
+      accreditationNumber,
       summaryLogId,
       processingType: rows[0].processingType,
       material,
@@ -135,11 +146,15 @@ export const findReportDataCompletenessFindings = async ({
  * @returns {string}
  */
 export const formatFinding = (finding) => {
-  const accreditation = finding.accreditationId ?? 'registered-only'
+  const accreditation =
+    finding.accreditationId === null
+      ? 'registered-only'
+      : `${finding.accreditationId} (no. ${finding.accreditationNumber ?? UNKNOWN})`
   return (
     `Report-data diagnostic: summary log ${finding.summaryLogId} ` +
     `(template ${finding.processingType}, material ${finding.material}) -- ` +
-    `org ${finding.organisationId} / registration ${finding.registrationId} / ` +
+    `org ${finding.organisationId} / ` +
+    `registration ${finding.registrationId} (no. ${finding.registrationNumber}) / ` +
     `accreditation ${accreditation} -- ${finding.violatingRows} incomplete row(s), ` +
     `${finding.missingFields} missing field(s)`
   )
@@ -219,7 +234,7 @@ export const formatUnresolved = ({
   summaryLogId
 }) =>
   `Report-data diagnostic: could not resolve registration ${registrationId} ` +
-  `(org ${organisationId}) for summary log ${summaryLogId}; material reported as ${UNKNOWN_MATERIAL}`
+  `(org ${organisationId}) for summary log ${summaryLogId}; material reported as ${UNKNOWN}`
 
 /**
  * @param {{ scanned: number, findings: CompletenessFinding[] }} result

--- a/src/reports/monitoring/report-data-completeness-diagnostic.js
+++ b/src/reports/monitoring/report-data-completeness-diagnostic.js
@@ -159,11 +159,13 @@ export const summariseByTemplate = (findings) =>
   }))
 
 /**
- * @param {{ processingType: string, count: number }} summary
+ * @param {{ processingType: string, count: number }[]} summaries
  * @returns {string}
  */
-export const formatTemplateSummary = ({ processingType, count }) =>
-  `Report-data diagnostic by template: ${processingType} -- ${count} summary log(s) with incomplete data`
+export const formatTemplateBreakdown = (summaries) =>
+  `Report-data diagnostic missing data by template: ${summaries
+    .map(({ processingType, count }) => `${processingType}:${count}`)
+    .join(', ')}`
 
 /**
  * Counts the violating summary logs per material, across every known material
@@ -185,18 +187,27 @@ export const summariseByMaterial = (findings) => {
 }
 
 /**
- * @param {{ material: string, count: number }} summary
+ * @param {{ material: string, count: number }[]} summaries
  * @returns {string}
  */
-export const formatMaterialSummary = ({ material, count }) =>
-  `Report-data diagnostic by material: ${material} -- ${count} summary log(s) with incomplete data`
+export const formatMaterialBreakdown = (summaries) =>
+  `Report-data diagnostic missing data by material: ${summaries
+    .map(({ material, count }) => `${material}:${count}`)
+    .join(', ')}`
 
 /**
- * @param {{ field: string, count: number }} summary
+ * One line listing how many times each field was missing, most-missing first,
+ * or `(none)` when nothing would be blocked.
+ *
+ * @param {{ field: string, count: number }[]} summaries
  * @returns {string}
  */
-export const formatFieldSummary = ({ field, count }) =>
-  `Report-data diagnostic by field: ${field} -- missing ${count} time(s)`
+export const formatFieldBreakdown = (summaries) =>
+  `Report-data diagnostic missing data by field: ${
+    summaries.length
+      ? summaries.map(({ field, count }) => `${field}:${count}`).join(', ')
+      : '(none)'
+  }`
 
 /**
  * @param {UnresolvedRegistration} unresolved

--- a/src/reports/monitoring/report-data-completeness-diagnostic.js
+++ b/src/reports/monitoring/report-data-completeness-diagnostic.js
@@ -1,0 +1,159 @@
+import { findIssues } from '#reports/application/report-mandatory/assert-report-data-complete.js'
+import { reportMandatoryPolicyFor } from '#reports/domain/report-mandatory/index.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { MATERIAL } from '#domain/organisations/model.js'
+
+/**
+ * @import { WasteBalanceLedgerRepository } from '#waste-balances/repository/ledger-port.js'
+ * @import { SummaryLogRowStatesRepository } from '#waste-records/repository/port.js'
+ * @import { OrganisationsRepository } from '#repositories/organisations/port.js'
+ */
+
+/**
+ * A summary log that would be blocked by the report-completeness gate, with the
+ * detail the diagnostic reports on: where it sits (org/registration/accreditation),
+ * how it was uploaded (template, material) and how much fails (violating rows).
+ *
+ * @typedef {object} CompletenessFinding
+ * @property {string} organisationId
+ * @property {string} registrationId
+ * @property {string | null} accreditationId
+ * @property {string} summaryLogId
+ * @property {string} processingType - The SL's template (uniform across its rows).
+ * @property {string} material
+ * @property {number} violatingRows - Distinct rows with at least one missing field.
+ */
+
+/**
+ * The templates the completeness gate can evaluate today, derived from the
+ * policy registry rather than hard-coded. When the reprocessor templates plug in
+ * (PAE-1280) they join automatically, so the diagnostic needs no change to work
+ * on the larger data set.
+ *
+ * @returns {string[]}
+ */
+export const evaluatedTemplates = () =>
+  Object.values(PROCESSING_TYPES).filter(
+    (processingType) => reportMandatoryPolicyFor(processingType) !== null
+  )
+
+/**
+ * Scans every live summary log across the estate and returns the ones that would
+ * fail the report-completeness rules. Reuses the gate's own `findIssues` so the
+ * diagnostic and the gate can never drift. Rows whose template has no policy
+ * produce no issues and are counted in `scanned` but never flagged. Read-only.
+ *
+ * @param {object} deps
+ * @param {WasteBalanceLedgerRepository} deps.ledgerRepository
+ * @param {SummaryLogRowStatesRepository} deps.summaryLogRowStatesRepository
+ * @param {OrganisationsRepository} deps.organisationsRepository
+ * @returns {Promise<{ scanned: number, findings: CompletenessFinding[] }>}
+ */
+export const findReportDataCompletenessFindings = async ({
+  ledgerRepository,
+  summaryLogRowStatesRepository,
+  organisationsRepository
+}) => {
+  const ledgers =
+    await ledgerRepository.findLatestSubmittedSummaryLogPerLedger()
+
+  /** @type {CompletenessFinding[]} */
+  const findings = []
+  for (const { ledgerId, summaryLogId } of ledgers) {
+    const rows = await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
+      ledgerId,
+      summaryLogId
+    )
+    const issues = findIssues(rows)
+    if (issues.length === 0) {
+      continue
+    }
+    const registration = await organisationsRepository.findRegistrationById(
+      ledgerId.organisationId,
+      ledgerId.registrationId
+    )
+    findings.push({
+      organisationId: ledgerId.organisationId,
+      registrationId: ledgerId.registrationId,
+      accreditationId: ledgerId.accreditationId,
+      summaryLogId,
+      processingType: rows[0].processingType,
+      material: registration.material,
+      violatingRows: new Set(issues.map((issue) => issue.rowId)).size
+    })
+  }
+  return { scanned: ledgers.length, findings }
+}
+
+/**
+ * @param {CompletenessFinding} finding
+ * @returns {string}
+ */
+export const formatFinding = (finding) => {
+  const accreditation = finding.accreditationId ?? 'registered-only'
+  return (
+    `Report-data diagnostic: summary log ${finding.summaryLogId} ` +
+    `(template ${finding.processingType}, material ${finding.material}) -- ` +
+    `org ${finding.organisationId} / registration ${finding.registrationId} / ` +
+    `accreditation ${accreditation} -- ${finding.violatingRows} incomplete row(s)`
+  )
+}
+
+/**
+ * Counts the violating summary logs per evaluated template (including templates
+ * with none, so absence of signal is explicit).
+ *
+ * @param {CompletenessFinding[]} findings
+ * @returns {{ processingType: string, count: number }[]}
+ */
+export const summariseByTemplate = (findings) =>
+  evaluatedTemplates().map((processingType) => ({
+    processingType,
+    count: findings.filter((f) => f.processingType === processingType).length
+  }))
+
+/**
+ * @param {{ processingType: string, count: number }} summary
+ * @returns {string}
+ */
+export const formatTemplateSummary = ({ processingType, count }) =>
+  `Report-data diagnostic by template: ${processingType} -- ${count} summary log(s) with incomplete data`
+
+/**
+ * Counts the violating summary logs per material, across every known material.
+ *
+ * @param {CompletenessFinding[]} findings
+ * @returns {{ material: string, count: number }[]}
+ */
+export const summariseByMaterial = (findings) =>
+  Object.values(MATERIAL).map((material) => ({
+    material,
+    count: findings.filter((f) => f.material === material).length
+  }))
+
+/**
+ * @param {{ material: string, count: number }} summary
+ * @returns {string}
+ */
+export const formatMaterialSummary = ({ material, count }) =>
+  `Report-data diagnostic by material: ${material} -- ${count} summary log(s) with incomplete data`
+
+/**
+ * @param {{ scanned: number, findings: CompletenessFinding[] }} result
+ * @returns {string}
+ */
+export const formatTotals = ({ scanned, findings }) => {
+  const distinct = (values) => new Set(values).size
+  const organisations = distinct(findings.map((f) => f.organisationId))
+  const registrations = distinct(findings.map((f) => f.registrationId))
+  const accreditations = distinct(
+    findings.map((f) => f.accreditationId).filter((id) => id !== null)
+  )
+  return (
+    `Report-data diagnostic summary: scanned ${scanned} summary log(s), ` +
+    `${findings.length} with incomplete data across ${organisations} organisation(s) / ` +
+    `${registrations} registration(s) / ${accreditations} accreditation(s). ` +
+    `Evaluated templates: ${evaluatedTemplates().join(', ')} ` +
+    `(other templates have no completeness rules yet).`
+  )
+}

--- a/src/reports/monitoring/report-data-completeness-diagnostic.js
+++ b/src/reports/monitoring/report-data-completeness-diagnostic.js
@@ -25,6 +25,24 @@ import { MATERIAL } from '#domain/organisations/model.js'
  */
 
 /**
+ * A violating summary log whose registration could not be resolved (deleted or
+ * re-versioned away), so its material is unknown. Reported separately so a single
+ * missing registration degrades one line rather than aborting the whole scan.
+ *
+ * @typedef {object} UnresolvedRegistration
+ * @property {string} organisationId
+ * @property {string} registrationId
+ * @property {string} summaryLogId
+ */
+
+/**
+ * Material reported for a violating summary log whose registration could not be
+ * resolved. A real value would be one of the `MATERIAL` enum; this stands in so
+ * the finding still counts toward the estate totals and the per-material rollup.
+ */
+export const UNKNOWN_MATERIAL = 'unknown'
+
+/**
  * The templates the completeness gate can evaluate today, derived from the
  * policy registry rather than hard-coded. When the reprocessor templates plug in
  * (PAE-1280) they join automatically, so the diagnostic needs no change to work
@@ -47,7 +65,7 @@ export const evaluatedTemplates = () =>
  * @param {WasteBalanceLedgerRepository} deps.ledgerRepository
  * @param {SummaryLogRowStatesRepository} deps.summaryLogRowStatesRepository
  * @param {OrganisationsRepository} deps.organisationsRepository
- * @returns {Promise<{ scanned: number, findings: CompletenessFinding[] }>}
+ * @returns {Promise<{ scanned: number, findings: CompletenessFinding[], unresolved: UnresolvedRegistration[] }>}
  */
 export const findReportDataCompletenessFindings = async ({
   ledgerRepository,
@@ -59,6 +77,8 @@ export const findReportDataCompletenessFindings = async ({
 
   /** @type {CompletenessFinding[]} */
   const findings = []
+  /** @type {UnresolvedRegistration[]} */
+  const unresolved = []
   for (const { ledgerId, summaryLogId } of ledgers) {
     const rows = await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
       ledgerId,
@@ -68,21 +88,34 @@ export const findReportDataCompletenessFindings = async ({
     if (issues.length === 0) {
       continue
     }
-    const registration = await organisationsRepository.findRegistrationById(
-      ledgerId.organisationId,
-      ledgerId.registrationId
-    )
+    // A deleted or re-versioned registration must not abort the estate scan:
+    // record it, report the material as unknown, and keep the finding so the
+    // blast-radius count stays truthful.
+    let material = UNKNOWN_MATERIAL
+    try {
+      const registration = await organisationsRepository.findRegistrationById(
+        ledgerId.organisationId,
+        ledgerId.registrationId
+      )
+      material = registration.material
+    } catch {
+      unresolved.push({
+        organisationId: ledgerId.organisationId,
+        registrationId: ledgerId.registrationId,
+        summaryLogId
+      })
+    }
     findings.push({
       organisationId: ledgerId.organisationId,
       registrationId: ledgerId.registrationId,
       accreditationId: ledgerId.accreditationId,
       summaryLogId,
       processingType: rows[0].processingType,
-      material: registration.material,
+      material,
       violatingRows: new Set(issues.map((issue) => issue.rowId)).size
     })
   }
-  return { scanned: ledgers.length, findings }
+  return { scanned: ledgers.length, findings, unresolved }
 }
 
 /**
@@ -120,16 +153,23 @@ export const formatTemplateSummary = ({ processingType, count }) =>
   `Report-data diagnostic by template: ${processingType} -- ${count} summary log(s) with incomplete data`
 
 /**
- * Counts the violating summary logs per material, across every known material.
+ * Counts the violating summary logs per material, across every known material
+ * plus any material actually seen that is not in the enum (legacy or drifted
+ * values, and the unknown-registration placeholder). Emitting the seen-but-
+ * unmodelled materials keeps this rollup reconcilable with the estate totals.
  *
  * @param {CompletenessFinding[]} findings
  * @returns {{ material: string, count: number }[]}
  */
-export const summariseByMaterial = (findings) =>
-  Object.values(MATERIAL).map((material) => ({
+export const summariseByMaterial = (findings) => {
+  const materials = [
+    ...new Set([...Object.values(MATERIAL), ...findings.map((f) => f.material)])
+  ]
+  return materials.map((material) => ({
     material,
     count: findings.filter((f) => f.material === material).length
   }))
+}
 
 /**
  * @param {{ material: string, count: number }} summary
@@ -137,6 +177,18 @@ export const summariseByMaterial = (findings) =>
  */
 export const formatMaterialSummary = ({ material, count }) =>
   `Report-data diagnostic by material: ${material} -- ${count} summary log(s) with incomplete data`
+
+/**
+ * @param {UnresolvedRegistration} unresolved
+ * @returns {string}
+ */
+export const formatUnresolved = ({
+  organisationId,
+  registrationId,
+  summaryLogId
+}) =>
+  `Report-data diagnostic: could not resolve registration ${registrationId} ` +
+  `(org ${organisationId}) for summary log ${summaryLogId}; material reported as ${UNKNOWN_MATERIAL}`
 
 /**
  * @param {{ scanned: number, findings: CompletenessFinding[] }} result

--- a/src/reports/monitoring/report-data-completeness-diagnostic.js
+++ b/src/reports/monitoring/report-data-completeness-diagnostic.js
@@ -22,6 +22,7 @@ import { MATERIAL } from '#domain/organisations/model.js'
  * @property {string} processingType - The SL's template (uniform across its rows).
  * @property {string} material
  * @property {number} violatingRows - Distinct rows with at least one missing field.
+ * @property {number} missingFields - Missing mandatory fields across all the SL's rows.
  */
 
 /**
@@ -65,7 +66,7 @@ export const evaluatedTemplates = () =>
  * @param {WasteBalanceLedgerRepository} deps.ledgerRepository
  * @param {SummaryLogRowStatesRepository} deps.summaryLogRowStatesRepository
  * @param {OrganisationsRepository} deps.organisationsRepository
- * @returns {Promise<{ scanned: number, findings: CompletenessFinding[], unresolved: UnresolvedRegistration[] }>}
+ * @returns {Promise<{ scanned: number, findings: CompletenessFinding[], unresolved: UnresolvedRegistration[], missingFieldCounts: { field: string, count: number }[] }>}
  */
 export const findReportDataCompletenessFindings = async ({
   ledgerRepository,
@@ -79,6 +80,8 @@ export const findReportDataCompletenessFindings = async ({
   const findings = []
   /** @type {UnresolvedRegistration[]} */
   const unresolved = []
+  /** @type {Map<string, number>} */
+  const fieldCounts = new Map()
   for (const { ledgerId, summaryLogId } of ledgers) {
     const rows = await summaryLogRowStatesRepository.findRowStatesForSummaryLog(
       ledgerId,
@@ -87,6 +90,9 @@ export const findReportDataCompletenessFindings = async ({
     const issues = findIssues(rows)
     if (issues.length === 0) {
       continue
+    }
+    for (const issue of issues) {
+      fieldCounts.set(issue.field, (fieldCounts.get(issue.field) ?? 0) + 1)
     }
     // A deleted or re-versioned registration must not abort the estate scan:
     // record it, report the material as unknown, and keep the finding so the
@@ -112,10 +118,16 @@ export const findReportDataCompletenessFindings = async ({
       summaryLogId,
       processingType: rows[0].processingType,
       material,
-      violatingRows: new Set(issues.map((issue) => issue.rowId)).size
+      violatingRows: new Set(issues.map((issue) => issue.rowId)).size,
+      missingFields: issues.length
     })
   }
-  return { scanned: ledgers.length, findings, unresolved }
+  // Most-missing first so the worst offenders lead; field name breaks ties for a
+  // deterministic order.
+  const missingFieldCounts = [...fieldCounts.entries()]
+    .map(([field, count]) => ({ field, count }))
+    .sort((a, b) => b.count - a.count || (a.field < b.field ? -1 : 1))
+  return { scanned: ledgers.length, findings, unresolved, missingFieldCounts }
 }
 
 /**
@@ -128,7 +140,8 @@ export const formatFinding = (finding) => {
     `Report-data diagnostic: summary log ${finding.summaryLogId} ` +
     `(template ${finding.processingType}, material ${finding.material}) -- ` +
     `org ${finding.organisationId} / registration ${finding.registrationId} / ` +
-    `accreditation ${accreditation} -- ${finding.violatingRows} incomplete row(s)`
+    `accreditation ${accreditation} -- ${finding.violatingRows} incomplete row(s), ` +
+    `${finding.missingFields} missing field(s)`
   )
 }
 
@@ -179,6 +192,13 @@ export const formatMaterialSummary = ({ material, count }) =>
   `Report-data diagnostic by material: ${material} -- ${count} summary log(s) with incomplete data`
 
 /**
+ * @param {{ field: string, count: number }} summary
+ * @returns {string}
+ */
+export const formatFieldSummary = ({ field, count }) =>
+  `Report-data diagnostic by field: ${field} -- missing ${count} time(s)`
+
+/**
  * @param {UnresolvedRegistration} unresolved
  * @returns {string}
  */
@@ -201,10 +221,12 @@ export const formatTotals = ({ scanned, findings }) => {
   const accreditations = distinct(
     findings.map((f) => f.accreditationId).filter((id) => id !== null)
   )
+  const missingFields = findings.reduce((sum, f) => sum + f.missingFields, 0)
   return (
     `Report-data diagnostic summary: scanned ${scanned} summary log(s), ` +
-    `${findings.length} with incomplete data across ${organisations} organisation(s) / ` +
-    `${registrations} registration(s) / ${accreditations} accreditation(s). ` +
+    `${findings.length} with incomplete data (${missingFields} missing field(s)) ` +
+    `across ${organisations} organisation(s) / ${registrations} registration(s) / ` +
+    `${accreditations} accreditation(s). ` +
     `Evaluated templates: ${evaluatedTemplates().join(', ')} ` +
     `(other templates have no completeness rules yet).`
   )

--- a/src/server/run-report-data-completeness-diagnostic.integration.test.js
+++ b/src/server/run-report-data-completeness-diagnostic.integration.test.js
@@ -69,27 +69,30 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
 
   const LOCK_NAME = 'report-data-complete-diagnostic'
 
-  // Ledger A: accredited exporter, plastic. One Exported row with export tonnage
+  // Ledger A: accredited exporter, plastic. Two Exported rows with export tonnage
   // but a blank OSR_ID (violating) alongside one fully complete Exported row, so
-  // exactly one row of the two is counted. This asserts the diagnostic counts
-  // only violating rows, not every row in the log. The specific rule that fires
-  // is the gate engine's concern and is covered by the gate's own tests.
+  // two of the three rows are counted (complete rows excluded) and OSR_ID is
+  // missing twice. The specific rule that fires is the gate engine's concern and
+  // is covered by the gate's own tests.
   const ledgerA = buildLedgerFixture({
     material: 'plastic',
     processingType: PROCESSING_TYPES.EXPORTER,
     summaryLogId: 'sl-a',
     accredited: true
   })
-  const rowsA = [
+  const incompleteExportedRow = (rowId) =>
     buildSummaryLogRowStateEntry({
-      rowId: 'row-a-incomplete',
+      rowId,
       wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
       processingType: PROCESSING_TYPES.EXPORTER,
       data: {
         DATE_OF_EXPORT: '2025-06-15',
         TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 3
       }
-    }),
+    })
+  const rowsA = [
+    incompleteExportedRow('row-a-incomplete-1'),
+    incompleteExportedRow('row-a-incomplete-2'),
     buildSummaryLogRowStateEntry({
       rowId: 'row-a-complete',
       wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
@@ -204,13 +207,13 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
     expect(lineA).toContain(ledgerA.ledgerId.organisationId)
     expect(lineA).toContain(ledgerA.ledgerId.registrationId)
     expect(lineA).toContain(ledgerA.ledgerId.accreditationId)
-    expect(lineA).toContain('1 incomplete row(s)')
+    expect(lineA).toContain('2 incomplete row(s), 2 missing field(s)')
 
     const lineB = messages().find((m) => m.includes('sl-b'))
     expect(lineB).toContain('template EXPORTER_REGISTERED_ONLY,')
     expect(lineB).toContain('material glass')
     expect(lineB).toContain('registered-only')
-    expect(lineB).toContain('1 incomplete row(s)')
+    expect(lineB).toContain('1 incomplete row(s), 6 missing field(s)')
 
     // The reprocessor summary log is scanned but has no policy, so it is not
     // flagged.
@@ -235,12 +238,21 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
       'Report-data diagnostic by material: aluminium -- 0 summary log(s) with incomplete data'
     )
 
-    // (4) the estate-wide totals.
+    // (4) one line per field that was missing, most-missing first. OSR_ID is
+    // missing on both of ledger A's violating rows; each supplier field once.
+    expect(messages()).toContain(
+      'Report-data diagnostic by field: OSR_ID -- missing 2 time(s)'
+    )
+    expect(messages()).toContain(
+      'Report-data diagnostic by field: SUPPLIER_NAME -- missing 1 time(s)'
+    )
+
+    // (5) the estate-wide totals.
     const summary = messages().find((m) =>
       m.startsWith('Report-data diagnostic summary:')
     )
     expect(summary).toContain('scanned 3 summary log(s)')
-    expect(summary).toContain('2 with incomplete data')
+    expect(summary).toContain('2 with incomplete data (8 missing field(s))')
     expect(summary).toContain('2 organisation(s)')
     expect(summary).toContain('2 registration(s)')
     expect(summary).toContain('1 accreditation(s)')
@@ -306,13 +318,13 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
 
     const lineD = messages().find((m) => m.includes('sl-d'))
     expect(lineD).toContain('material unknown')
-    expect(lineD).toContain('1 incomplete row(s)')
+    expect(lineD).toContain('1 incomplete row(s), 6 missing field(s)')
 
     // The finding still counts toward the estate totals and gets its own
     // material bucket, so the per-material rollup reconciles with the totals.
     expect(
       messages().find((m) => m.startsWith('Report-data diagnostic summary:'))
-    ).toContain('1 with incomplete data')
+    ).toContain('1 with incomplete data (6 missing field(s))')
     expect(messages()).toContain(
       'Report-data diagnostic by material: unknown -- 1 summary log(s) with incomplete data'
     )

--- a/src/server/run-report-data-completeness-diagnostic.integration.test.js
+++ b/src/server/run-report-data-completeness-diagnostic.integration.test.js
@@ -219,32 +219,20 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
     // flagged.
     expect(messages().find((m) => m.includes('sl-c'))).toBeUndefined()
 
-    // (2) one line per evaluated template.
+    // (2) one line covering the evaluated templates.
     expect(messages()).toContain(
-      'Report-data diagnostic by template: EXPORTER -- 1 summary log(s) with incomplete data'
-    )
-    expect(messages()).toContain(
-      'Report-data diagnostic by template: EXPORTER_REGISTERED_ONLY -- 1 summary log(s) with incomplete data'
+      'Report-data diagnostic missing data by template: EXPORTER:1, EXPORTER_REGISTERED_ONLY:1'
     )
 
-    // (3) one line per material, including materials with no violations.
+    // (3) one line covering every material, including those with no violations.
     expect(messages()).toContain(
-      'Report-data diagnostic by material: plastic -- 1 summary log(s) with incomplete data'
-    )
-    expect(messages()).toContain(
-      'Report-data diagnostic by material: glass -- 1 summary log(s) with incomplete data'
-    )
-    expect(messages()).toContain(
-      'Report-data diagnostic by material: aluminium -- 0 summary log(s) with incomplete data'
+      'Report-data diagnostic missing data by material: aluminium:0, fibre:0, glass:1, paper:0, plastic:1, steel:0, wood:0'
     )
 
-    // (4) one line per field that was missing, most-missing first. OSR_ID is
+    // (4) one line covering every missing field, most-missing first. OSR_ID is
     // missing on both of ledger A's violating rows; each supplier field once.
     expect(messages()).toContain(
-      'Report-data diagnostic by field: OSR_ID -- missing 2 time(s)'
-    )
-    expect(messages()).toContain(
-      'Report-data diagnostic by field: SUPPLIER_NAME -- missing 1 time(s)'
+      'Report-data diagnostic missing data by field: OSR_ID:2, ACTIVITIES_CARRIED_OUT_BY_SUPPLIER:1, SUPPLIER_ADDRESS:1, SUPPLIER_EMAIL:1, SUPPLIER_NAME:1, SUPPLIER_PHONE_NUMBER:1, SUPPLIER_POSTCODE:1'
     )
 
     // (5) the estate-wide totals.
@@ -321,18 +309,91 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
     expect(lineD).toContain('1 incomplete row(s), 6 missing field(s)')
 
     // The finding still counts toward the estate totals and gets its own
-    // material bucket, so the per-material rollup reconciles with the totals.
+    // material bucket appended after the known materials, so the per-material
+    // rollup reconciles with the totals.
     expect(
       messages().find((m) => m.startsWith('Report-data diagnostic summary:'))
     ).toContain('1 with incomplete data (6 missing field(s))')
     expect(messages()).toContain(
-      'Report-data diagnostic by material: unknown -- 1 summary log(s) with incomplete data'
+      'Report-data diagnostic missing data by material: aluminium:0, fibre:0, glass:0, paper:0, plastic:0, steel:0, wood:0, unknown:1'
     )
 
     // A warning names the registration that could not be resolved.
     const warning = warnings().find((m) => m.includes('sl-d'))
     expect(warning).toContain(ledgerId.registrationId)
     expect(warning).toContain('material reported as unknown')
+  })
+
+  it('reports all-zero breakdowns when nothing would be blocked', async () => {
+    // A single reprocessor summary log: it has no completeness policy, so it is
+    // scanned but never flagged. The rollups still report, all zero, and the
+    // field line reads (none).
+    const ledger = buildLedgerFixture({
+      material: 'steel',
+      processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+      summaryLogId: 'sl-z',
+      accredited: true
+    })
+    const rowStates = createInMemorySummaryLogRowStatesRepository()()
+    await rowStates.upsertSummaryLogRowStates(
+      ledger.ledgerId,
+      [
+        buildSummaryLogRowStateEntry({
+          rowId: 'row-z',
+          wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+          processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+          data: { TONNAGE_RECEIVED_FOR_RECYCLING: 5 }
+        })
+      ],
+      'sl-z'
+    )
+    const ledgerRepository = createInMemoryLedgerRepository([
+      partialMock(
+        buildLedgerEvent({
+          organisationId: ledger.ledgerId.organisationId,
+          registrationId: ledger.ledgerId.registrationId,
+          accreditationId: ledger.ledgerId.accreditationId,
+          payload: { summaryLogId: 'sl-z', creditTotal: 100 }
+        })
+      )
+    ])()
+    const server = /** @type {StartedServer} */ (
+      /** @type {unknown} */ (
+        await createTestServer({
+          featureFlags: createInMemoryFeatureFlags({
+            reportDataCompleteDiagnostic: true
+          }),
+          repositories: {
+            organisationsRepository: createInMemoryOrganisationsRepository([
+              partialMock(ledger.org)
+            ]),
+            ledgerRepository,
+            summaryLogRowStatesRepository: rowStates
+          }
+        })
+      )
+    )
+    server.locker = partialMock({
+      lock: vi.fn().mockResolvedValue({ free: vi.fn() })
+    })
+
+    await runReportDataCompletenessDiagnostic(server)
+
+    expect(messages().find((m) => m.includes('sl-z'))).toBeUndefined()
+    expect(messages()).toContain(
+      'Report-data diagnostic missing data by template: EXPORTER:0, EXPORTER_REGISTERED_ONLY:0'
+    )
+    expect(messages()).toContain(
+      'Report-data diagnostic missing data by material: aluminium:0, fibre:0, glass:0, paper:0, plastic:0, steel:0, wood:0'
+    )
+    expect(messages()).toContain(
+      'Report-data diagnostic missing data by field: (none)'
+    )
+    expect(
+      messages().find((m) => m.startsWith('Report-data diagnostic summary:'))
+    ).toContain(
+      'scanned 1 summary log(s), 0 with incomplete data (0 missing field(s))'
+    )
   })
 
   it('does nothing when the feature flag is off', async () => {

--- a/src/server/run-report-data-completeness-diagnostic.integration.test.js
+++ b/src/server/run-report-data-completeness-diagnostic.integration.test.js
@@ -69,8 +69,11 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
 
   const LOCK_NAME = 'report-data-complete-diagnostic'
 
-  // Ledger A: accredited exporter, plastic, one Exported row with export tonnage
-  // and a blank OSR_ID -> one violating row (AC2).
+  // Ledger A: accredited exporter, plastic. One Exported row with export tonnage
+  // but a blank OSR_ID (violating) alongside one fully complete Exported row, so
+  // exactly one row of the two is counted. This asserts the diagnostic counts
+  // only violating rows, not every row in the log. The specific rule that fires
+  // is the gate engine's concern and is covered by the gate's own tests.
   const ledgerA = buildLedgerFixture({
     material: 'plastic',
     processingType: PROCESSING_TYPES.EXPORTER,
@@ -79,18 +82,29 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
   })
   const rowsA = [
     buildSummaryLogRowStateEntry({
-      rowId: 'row-a',
+      rowId: 'row-a-incomplete',
       wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
       processingType: PROCESSING_TYPES.EXPORTER,
       data: {
         DATE_OF_EXPORT: '2025-06-15',
         TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 3
       }
+    }),
+    buildSummaryLogRowStateEntry({
+      rowId: 'row-a-complete',
+      wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+      processingType: PROCESSING_TYPES.EXPORTER,
+      data: {
+        DATE_OF_EXPORT: '2025-06-15',
+        TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 3,
+        OSR_ID: 'ORS-0001'
+      }
     })
   ]
 
-  // Ledger B: registered-only exporter, glass, one Received row with received
-  // tonnage and no supplier details -> one violating row (AC1).
+  // Ledger B: registered-only exporter, glass. One Received row with received
+  // tonnage and no supplier details: several missing fields on a single row,
+  // which the diagnostic counts as one violating row.
   const ledgerB = buildLedgerFixture({
     material: 'glass',
     processingType: PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY,
@@ -168,8 +182,12 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
   const messages = () =>
     /** @type {Mock} */ (logger.info).mock.calls.map((call) => call[0].message)
 
+  const warnings = () =>
+    /** @type {Mock} */ (logger.warn).mock.calls.map((call) => call[0].message)
+
   beforeEach(() => {
     vi.spyOn(logger, 'info').mockImplementation(() => logger)
+    vi.spyOn(logger, 'warn').mockImplementation(() => logger)
   })
 
   it('logs the estate-wide report-data completeness blast radius', async () => {
@@ -232,6 +250,77 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
 
     expect(lock).toHaveBeenCalledWith(LOCK_NAME)
     expect(free).toHaveBeenCalled()
+  })
+
+  it('keeps scanning and reports unknown material when a registration cannot be resolved', async () => {
+    // A violating summary log whose registration is absent from the org repo
+    // (deleted or re-versioned away). The scan must degrade this one line, not
+    // abort: the finding is still counted, its material reported as unknown.
+    const ledgerId = {
+      organisationId: new ObjectId().toString(),
+      registrationId: new ObjectId().toString(),
+      accreditationId: null
+    }
+    const rowStates = createInMemorySummaryLogRowStatesRepository()()
+    await rowStates.upsertSummaryLogRowStates(
+      ledgerId,
+      [
+        buildSummaryLogRowStateEntry({
+          rowId: 'row-d',
+          wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+          processingType: PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY,
+          data: { TONNAGE_RECEIVED_FOR_EXPORT: 5 }
+        })
+      ],
+      'sl-d'
+    )
+    const ledgerRepository = createInMemoryLedgerRepository([
+      partialMock(
+        buildLedgerEvent({
+          organisationId: ledgerId.organisationId,
+          registrationId: ledgerId.registrationId,
+          accreditationId: null,
+          payload: { summaryLogId: 'sl-d', creditTotal: 100 }
+        })
+      )
+    ])()
+    const server = /** @type {StartedServer} */ (
+      /** @type {unknown} */ (
+        await createTestServer({
+          featureFlags: createInMemoryFeatureFlags({
+            reportDataCompleteDiagnostic: true
+          }),
+          repositories: {
+            organisationsRepository: createInMemoryOrganisationsRepository([]),
+            ledgerRepository,
+            summaryLogRowStatesRepository: rowStates
+          }
+        })
+      )
+    )
+    server.locker = partialMock({
+      lock: vi.fn().mockResolvedValue({ free: vi.fn() })
+    })
+
+    await runReportDataCompletenessDiagnostic(server)
+
+    const lineD = messages().find((m) => m.includes('sl-d'))
+    expect(lineD).toContain('material unknown')
+    expect(lineD).toContain('1 incomplete row(s)')
+
+    // The finding still counts toward the estate totals and gets its own
+    // material bucket, so the per-material rollup reconciles with the totals.
+    expect(
+      messages().find((m) => m.startsWith('Report-data diagnostic summary:'))
+    ).toContain('1 with incomplete data')
+    expect(messages()).toContain(
+      'Report-data diagnostic by material: unknown -- 1 summary log(s) with incomplete data'
+    )
+
+    // A warning names the registration that could not be resolved.
+    const warning = warnings().find((m) => m.includes('sl-d'))
+    expect(warning).toContain(ledgerId.registrationId)
+    expect(warning).toContain('material reported as unknown')
   })
 
   it('does nothing when the feature flag is off', async () => {

--- a/src/server/run-report-data-completeness-diagnostic.integration.test.js
+++ b/src/server/run-report-data-completeness-diagnostic.integration.test.js
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ObjectId } from 'mongodb'
+
+import { createTestServer } from '#test/create-test-server.js'
+import { partialMock } from '#test/type-helpers.js'
+import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
+import { createInMemoryOrganisationsRepository } from '#repositories/organisations/inmemory.js'
+import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
+import { createInMemorySummaryLogRowStatesRepository } from '#waste-records/repository/inmemory.js'
+import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
+import { buildSummaryLogRowStateEntry } from '#waste-records/repository/test-data.js'
+import {
+  buildRegistration,
+  buildOrganisation,
+  buildOrganisationWithRegistration
+} from '#repositories/organisations/contract/test-data.js'
+import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { logger } from '#common/helpers/logging/logger.js'
+import { runReportDataCompletenessDiagnostic } from './run-report-data-completeness-diagnostic.js'
+
+/**
+ * @import { Mock } from 'vitest'
+ * @import { StartedServer } from '#common/hapi-types.js'
+ */
+
+/**
+ * Builds one ledger's worth of estate fixture: an organisation carrying a single
+ * registration (with a chosen material and template) plus the ledger id and the
+ * summary-log id the diagnostic will scan.
+ *
+ * @param {{ material: string, processingType: string, summaryLogId: string, accredited: boolean }} spec
+ */
+const buildLedgerFixture = ({
+  material,
+  processingType,
+  summaryLogId,
+  accredited
+}) => {
+  const wasteProcessingType =
+    processingType === PROCESSING_TYPES.REPROCESSOR_INPUT
+      ? 'reprocessor'
+      : 'exporter'
+  const accreditationId = accredited ? new ObjectId().toString() : undefined
+  const registration = buildRegistration({
+    wasteProcessingType,
+    material,
+    ...(accredited ? { accreditationId } : {})
+  })
+  const org = accredited
+    ? buildOrganisationWithRegistration(partialMock(registration), 'approved')
+    : buildOrganisation({ registrations: [registration] })
+
+  return {
+    org,
+    ledgerId: {
+      organisationId: org.id,
+      registrationId: registration.id,
+      accreditationId: registration.accreditationId ?? null
+    },
+    summaryLogId,
+    processingType
+  }
+}
+
+describe('runReportDataCompletenessDiagnostic (integration)', () => {
+  setupAuthContext()
+
+  const LOCK_NAME = 'report-data-complete-diagnostic'
+
+  // Ledger A: accredited exporter, plastic, one Exported row with export tonnage
+  // and a blank OSR_ID -> one violating row (AC2).
+  const ledgerA = buildLedgerFixture({
+    material: 'plastic',
+    processingType: PROCESSING_TYPES.EXPORTER,
+    summaryLogId: 'sl-a',
+    accredited: true
+  })
+  const rowsA = [
+    buildSummaryLogRowStateEntry({
+      rowId: 'row-a',
+      wasteRecordType: WASTE_RECORD_TYPE.EXPORTED,
+      processingType: PROCESSING_TYPES.EXPORTER,
+      data: {
+        DATE_OF_EXPORT: '2025-06-15',
+        TONNAGE_OF_UK_PACKAGING_WASTE_EXPORTED: 3
+      }
+    })
+  ]
+
+  // Ledger B: registered-only exporter, glass, one Received row with received
+  // tonnage and no supplier details -> one violating row (AC1).
+  const ledgerB = buildLedgerFixture({
+    material: 'glass',
+    processingType: PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY,
+    summaryLogId: 'sl-b',
+    accredited: false
+  })
+  const rowsB = [
+    buildSummaryLogRowStateEntry({
+      rowId: 'row-b',
+      wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+      processingType: PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY,
+      data: { TONNAGE_RECEIVED_FOR_EXPORT: 5 }
+    })
+  ]
+
+  // Ledger C: reprocessor, steel, an incomplete-looking row that has no
+  // completeness policy yet -> scanned but never flagged (PAE-1280).
+  const ledgerC = buildLedgerFixture({
+    material: 'steel',
+    processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+    summaryLogId: 'sl-c',
+    accredited: true
+  })
+  const rowsC = [
+    buildSummaryLogRowStateEntry({
+      rowId: 'row-c',
+      wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+      processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+      data: { TONNAGE_RECEIVED_FOR_RECYCLING: 5 }
+    })
+  ]
+
+  const buildServer = async (featureFlags) => {
+    const rowStates = createInMemorySummaryLogRowStatesRepository()()
+    await rowStates.upsertSummaryLogRowStates(ledgerA.ledgerId, rowsA, 'sl-a')
+    await rowStates.upsertSummaryLogRowStates(ledgerB.ledgerId, rowsB, 'sl-b')
+    await rowStates.upsertSummaryLogRowStates(ledgerC.ledgerId, rowsC, 'sl-c')
+
+    const ledgerRepository = createInMemoryLedgerRepository(
+      [ledgerA, ledgerB, ledgerC].map((l) =>
+        partialMock(
+          buildLedgerEvent({
+            organisationId: l.ledgerId.organisationId,
+            registrationId: l.ledgerId.registrationId,
+            accreditationId: l.ledgerId.accreditationId,
+            payload: { summaryLogId: l.summaryLogId, creditTotal: 100 }
+          })
+        )
+      )
+    )()
+
+    const server = await createTestServer({
+      featureFlags,
+      repositories: {
+        organisationsRepository: createInMemoryOrganisationsRepository([
+          partialMock(ledgerA.org),
+          partialMock(ledgerB.org),
+          partialMock(ledgerC.org)
+        ]),
+        ledgerRepository,
+        summaryLogRowStatesRepository: rowStates
+      }
+    })
+
+    const free = vi.fn()
+    const lock = vi.fn().mockResolvedValue({ free })
+    server.locker = partialMock({ lock })
+    return {
+      server: /** @type {StartedServer} */ (/** @type {unknown} */ (server)),
+      lock,
+      free
+    }
+  }
+
+  const messages = () =>
+    /** @type {Mock} */ (logger.info).mock.calls.map((call) => call[0].message)
+
+  beforeEach(() => {
+    vi.spyOn(logger, 'info').mockImplementation(() => logger)
+  })
+
+  it('logs the estate-wide report-data completeness blast radius', async () => {
+    const { server, lock, free } = await buildServer(
+      createInMemoryFeatureFlags({ reportDataCompleteDiagnostic: true })
+    )
+
+    await runReportDataCompletenessDiagnostic(server)
+
+    // (1) one line per violating summary log, with its counts and ids.
+    const lineA = messages().find((m) => m.includes('sl-a'))
+    expect(lineA).toContain('template EXPORTER,')
+    expect(lineA).toContain('material plastic')
+    expect(lineA).toContain(ledgerA.ledgerId.organisationId)
+    expect(lineA).toContain(ledgerA.ledgerId.registrationId)
+    expect(lineA).toContain(ledgerA.ledgerId.accreditationId)
+    expect(lineA).toContain('1 incomplete row(s)')
+
+    const lineB = messages().find((m) => m.includes('sl-b'))
+    expect(lineB).toContain('template EXPORTER_REGISTERED_ONLY,')
+    expect(lineB).toContain('material glass')
+    expect(lineB).toContain('registered-only')
+    expect(lineB).toContain('1 incomplete row(s)')
+
+    // The reprocessor summary log is scanned but has no policy, so it is not
+    // flagged.
+    expect(messages().find((m) => m.includes('sl-c'))).toBeUndefined()
+
+    // (2) one line per evaluated template.
+    expect(messages()).toContain(
+      'Report-data diagnostic by template: EXPORTER -- 1 summary log(s) with incomplete data'
+    )
+    expect(messages()).toContain(
+      'Report-data diagnostic by template: EXPORTER_REGISTERED_ONLY -- 1 summary log(s) with incomplete data'
+    )
+
+    // (3) one line per material, including materials with no violations.
+    expect(messages()).toContain(
+      'Report-data diagnostic by material: plastic -- 1 summary log(s) with incomplete data'
+    )
+    expect(messages()).toContain(
+      'Report-data diagnostic by material: glass -- 1 summary log(s) with incomplete data'
+    )
+    expect(messages()).toContain(
+      'Report-data diagnostic by material: aluminium -- 0 summary log(s) with incomplete data'
+    )
+
+    // (4) the estate-wide totals.
+    const summary = messages().find((m) =>
+      m.startsWith('Report-data diagnostic summary:')
+    )
+    expect(summary).toContain('scanned 3 summary log(s)')
+    expect(summary).toContain('2 with incomplete data')
+    expect(summary).toContain('2 organisation(s)')
+    expect(summary).toContain('2 registration(s)')
+    expect(summary).toContain('1 accreditation(s)')
+    expect(summary).toContain(
+      'Evaluated templates: EXPORTER, EXPORTER_REGISTERED_ONLY'
+    )
+
+    expect(lock).toHaveBeenCalledWith(LOCK_NAME)
+    expect(free).toHaveBeenCalled()
+  })
+
+  it('does nothing when the feature flag is off', async () => {
+    const { server, lock } = await buildServer(createInMemoryFeatureFlags())
+
+    await runReportDataCompletenessDiagnostic(server)
+
+    expect(lock).not.toHaveBeenCalled()
+    expect(
+      messages().filter((m) => m.startsWith('Report-data diagnostic'))
+    ).toHaveLength(0)
+  })
+})

--- a/src/server/run-report-data-completeness-diagnostic.integration.test.js
+++ b/src/server/run-report-data-completeness-diagnostic.integration.test.js
@@ -30,13 +30,14 @@ import { runReportDataCompletenessDiagnostic } from './run-report-data-completen
  * registration (with a chosen material and template) plus the ledger id and the
  * summary-log id the diagnostic will scan.
  *
- * @param {{ material: string, processingType: string, summaryLogId: string, accredited: boolean }} spec
+ * @param {{ material: string, processingType: string, summaryLogId: string, accredited: boolean, registrationNumber?: string }} spec
  */
 const buildLedgerFixture = ({
   material,
   processingType,
   summaryLogId,
-  accredited
+  accredited,
+  registrationNumber = 'REG-000'
 }) => {
   const wasteProcessingType =
     processingType === PROCESSING_TYPES.REPROCESSOR_INPUT
@@ -46,6 +47,7 @@ const buildLedgerFixture = ({
   const registration = buildRegistration({
     wasteProcessingType,
     material,
+    registrationNumber,
     ...(accredited ? { accreditationId } : {})
   })
   const org = accredited
@@ -78,7 +80,8 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
     material: 'plastic',
     processingType: PROCESSING_TYPES.EXPORTER,
     summaryLogId: 'sl-a',
-    accredited: true
+    accredited: true,
+    registrationNumber: 'REG-A-001'
   })
   const incompleteExportedRow = (rowId) =>
     buildSummaryLogRowStateEntry({
@@ -112,7 +115,8 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
     material: 'glass',
     processingType: PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY,
     summaryLogId: 'sl-b',
-    accredited: false
+    accredited: false,
+    registrationNumber: 'REG-B-002'
   })
   const rowsB = [
     buildSummaryLogRowStateEntry({
@@ -205,14 +209,24 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
     expect(lineA).toContain('template EXPORTER,')
     expect(lineA).toContain('material plastic')
     expect(lineA).toContain(ledgerA.ledgerId.organisationId)
-    expect(lineA).toContain(ledgerA.ledgerId.registrationId)
-    expect(lineA).toContain(ledgerA.ledgerId.accreditationId)
+    // The human-facing registration number is logged beside the mongo id, and
+    // the accreditation number beside the accreditation id.
+    expect(lineA).toContain(
+      `registration ${ledgerA.ledgerId.registrationId} (no. REG-A-001)`
+    )
+    expect(lineA).toContain(
+      `accreditation ${ledgerA.ledgerId.accreditationId} (no. `
+    )
     expect(lineA).toContain('2 incomplete row(s), 2 missing field(s)')
 
     const lineB = messages().find((m) => m.includes('sl-b'))
     expect(lineB).toContain('template EXPORTER_REGISTERED_ONLY,')
     expect(lineB).toContain('material glass')
-    expect(lineB).toContain('registered-only')
+    expect(lineB).toContain(
+      `registration ${ledgerB.ledgerId.registrationId} (no. REG-B-002)`
+    )
+    // Registered-only ledgers have no accreditation number.
+    expect(lineB).toContain('accreditation registered-only')
     expect(lineB).toContain('1 incomplete row(s), 6 missing field(s)')
 
     // The reprocessor summary log is scanned but has no policy, so it is not
@@ -306,6 +320,10 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
 
     const lineD = messages().find((m) => m.includes('sl-d'))
     expect(lineD).toContain('material unknown')
+    // With no registration to read, the registration number is unknown too.
+    expect(lineD).toContain(
+      `registration ${ledgerId.registrationId} (no. unknown)`
+    )
     expect(lineD).toContain('1 incomplete row(s), 6 missing field(s)')
 
     // The finding still counts toward the estate totals and gets its own
@@ -394,6 +412,73 @@ describe('runReportDataCompletenessDiagnostic (integration)', () => {
     ).toContain(
       'scanned 1 summary log(s), 0 with incomplete data (0 missing field(s))'
     )
+  })
+
+  it('reports the registration number as unknown when the registration carries none', async () => {
+    // A summary log submitted against a registration that no longer carries a
+    // registration number (a cancelled or rejected registration). The material
+    // still resolves; only the number is unknown.
+    const registration = buildRegistration({
+      wasteProcessingType: 'exporter',
+      material: 'plastic',
+      registrationNumber: undefined
+    })
+    const org = buildOrganisation({ registrations: [registration] })
+    const ledgerId = {
+      organisationId: org.id,
+      registrationId: registration.id,
+      accreditationId: null
+    }
+    const rowStates = createInMemorySummaryLogRowStatesRepository()()
+    await rowStates.upsertSummaryLogRowStates(
+      ledgerId,
+      [
+        buildSummaryLogRowStateEntry({
+          rowId: 'row-n',
+          wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+          processingType: PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY,
+          data: { TONNAGE_RECEIVED_FOR_EXPORT: 5 }
+        })
+      ],
+      'sl-n'
+    )
+    const ledgerRepository = createInMemoryLedgerRepository([
+      partialMock(
+        buildLedgerEvent({
+          organisationId: ledgerId.organisationId,
+          registrationId: ledgerId.registrationId,
+          accreditationId: null,
+          payload: { summaryLogId: 'sl-n', creditTotal: 100 }
+        })
+      )
+    ])()
+    const server = /** @type {StartedServer} */ (
+      /** @type {unknown} */ (
+        await createTestServer({
+          featureFlags: createInMemoryFeatureFlags({
+            reportDataCompleteDiagnostic: true
+          }),
+          repositories: {
+            organisationsRepository: createInMemoryOrganisationsRepository([
+              partialMock(org)
+            ]),
+            ledgerRepository,
+            summaryLogRowStatesRepository: rowStates
+          }
+        })
+      )
+    )
+    server.locker = partialMock({
+      lock: vi.fn().mockResolvedValue({ free: vi.fn() })
+    })
+
+    await runReportDataCompletenessDiagnostic(server)
+
+    const lineN = messages().find((m) => m.includes('sl-n'))
+    expect(lineN).toContain(
+      `registration ${ledgerId.registrationId} (no. unknown)`
+    )
+    expect(lineN).toContain('material plastic')
   })
 
   it('does nothing when the feature flag is off', async () => {

--- a/src/server/run-report-data-completeness-diagnostic.js
+++ b/src/server/run-report-data-completeness-diagnostic.js
@@ -3,10 +3,10 @@ import {
   findReportDataCompletenessFindings,
   formatFinding,
   summariseByTemplate,
-  formatTemplateSummary,
+  formatTemplateBreakdown,
   summariseByMaterial,
-  formatMaterialSummary,
-  formatFieldSummary,
+  formatMaterialBreakdown,
+  formatFieldBreakdown,
   formatTotals,
   formatUnresolved
 } from '#reports/monitoring/report-data-completeness-diagnostic.js'
@@ -33,15 +33,13 @@ const runDiagnostic = async (server) => {
   for (const finding of findings) {
     logger.info({ message: formatFinding(finding) })
   }
-  for (const summary of summariseByTemplate(findings)) {
-    logger.info({ message: formatTemplateSummary(summary) })
-  }
-  for (const summary of summariseByMaterial(findings)) {
-    logger.info({ message: formatMaterialSummary(summary) })
-  }
-  for (const summary of missingFieldCounts) {
-    logger.info({ message: formatFieldSummary(summary) })
-  }
+  logger.info({
+    message: formatTemplateBreakdown(summariseByTemplate(findings))
+  })
+  logger.info({
+    message: formatMaterialBreakdown(summariseByMaterial(findings))
+  })
+  logger.info({ message: formatFieldBreakdown(missingFieldCounts) })
   logger.info({ message: formatTotals({ scanned, findings }) })
 
   for (const item of unresolved) {

--- a/src/server/run-report-data-completeness-diagnostic.js
+++ b/src/server/run-report-data-completeness-diagnostic.js
@@ -1,0 +1,80 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import {
+  findReportDataCompletenessFindings,
+  formatFinding,
+  summariseByTemplate,
+  formatTemplateSummary,
+  summariseByMaterial,
+  formatMaterialSummary,
+  formatTotals
+} from '#reports/monitoring/report-data-completeness-diagnostic.js'
+
+/** @import { StartedServer } from '#common/hapi-types.js' */
+
+const LOCK_NAME = 'report-data-complete-diagnostic'
+
+/**
+ * Scans every live summary log and logs which would fail the report-completeness
+ * rules: one line per violating summary log, per-template and per-material
+ * rollups, then the estate-wide totals. Read-only.
+ *
+ * @param {StartedServer} server - Hapi server instance
+ */
+const runDiagnostic = async (server) => {
+  const { scanned, findings } = await findReportDataCompletenessFindings({
+    ledgerRepository: server.app.ledgerRepository,
+    summaryLogRowStatesRepository: server.app.summaryLogRowStatesRepository,
+    organisationsRepository: server.app.organisationsRepository
+  })
+
+  for (const finding of findings) {
+    logger.info({ message: formatFinding(finding) })
+  }
+  for (const summary of summariseByTemplate(findings)) {
+    logger.info({ message: formatTemplateSummary(summary) })
+  }
+  for (const summary of summariseByMaterial(findings)) {
+    logger.info({ message: formatMaterialSummary(summary) })
+  }
+  logger.info({ message: formatTotals({ scanned, findings }) })
+}
+
+/**
+ * Startup diagnostic (defra-4ry0) that surfaces how many live summary logs would
+ * be blocked by the report-data completeness gate, without changing any
+ * user-facing behaviour. Reuses the gate's own rules engine so the diagnostic
+ * can never drift from what the gate enforces. Runs under a cross-instance lock
+ * so a single pod per deploy executes and logs it.
+ *
+ * Gated by the reportDataCompleteDiagnostic feature flag, which is separate from
+ * the blocking gate's flag and off by default: with it off this returns before
+ * touching the locker or any repository.
+ *
+ * @param {StartedServer} server - Hapi server instance
+ */
+export const runReportDataCompletenessDiagnostic = async (server) => {
+  if (!server.featureFlags.isReportDataCompleteDiagnosticEnabled()) {
+    return
+  }
+
+  try {
+    const lock = await server.locker.lock(LOCK_NAME)
+    if (!lock) {
+      logger.info({
+        message:
+          'Unable to obtain lock, skipping report-data completeness diagnostic'
+      })
+      return
+    }
+    try {
+      await runDiagnostic(server)
+    } finally {
+      await lock.free()
+    }
+  } catch (error) {
+    logger.error({
+      err: error,
+      message: 'Failed to run report-data completeness diagnostic'
+    })
+  }
+}

--- a/src/server/run-report-data-completeness-diagnostic.js
+++ b/src/server/run-report-data-completeness-diagnostic.js
@@ -6,6 +6,7 @@ import {
   formatTemplateSummary,
   summariseByMaterial,
   formatMaterialSummary,
+  formatFieldSummary,
   formatTotals,
   formatUnresolved
 } from '#reports/monitoring/report-data-completeness-diagnostic.js'
@@ -22,7 +23,7 @@ const LOCK_NAME = 'report-data-complete-diagnostic'
  * @param {StartedServer} server - Hapi server instance
  */
 const runDiagnostic = async (server) => {
-  const { scanned, findings, unresolved } =
+  const { scanned, findings, unresolved, missingFieldCounts } =
     await findReportDataCompletenessFindings({
       ledgerRepository: server.app.ledgerRepository,
       summaryLogRowStatesRepository: server.app.summaryLogRowStatesRepository,
@@ -37,6 +38,9 @@ const runDiagnostic = async (server) => {
   }
   for (const summary of summariseByMaterial(findings)) {
     logger.info({ message: formatMaterialSummary(summary) })
+  }
+  for (const summary of missingFieldCounts) {
+    logger.info({ message: formatFieldSummary(summary) })
   }
   logger.info({ message: formatTotals({ scanned, findings }) })
 

--- a/src/server/run-report-data-completeness-diagnostic.js
+++ b/src/server/run-report-data-completeness-diagnostic.js
@@ -6,7 +6,8 @@ import {
   formatTemplateSummary,
   summariseByMaterial,
   formatMaterialSummary,
-  formatTotals
+  formatTotals,
+  formatUnresolved
 } from '#reports/monitoring/report-data-completeness-diagnostic.js'
 
 /** @import { StartedServer } from '#common/hapi-types.js' */
@@ -21,11 +22,12 @@ const LOCK_NAME = 'report-data-complete-diagnostic'
  * @param {StartedServer} server - Hapi server instance
  */
 const runDiagnostic = async (server) => {
-  const { scanned, findings } = await findReportDataCompletenessFindings({
-    ledgerRepository: server.app.ledgerRepository,
-    summaryLogRowStatesRepository: server.app.summaryLogRowStatesRepository,
-    organisationsRepository: server.app.organisationsRepository
-  })
+  const { scanned, findings, unresolved } =
+    await findReportDataCompletenessFindings({
+      ledgerRepository: server.app.ledgerRepository,
+      summaryLogRowStatesRepository: server.app.summaryLogRowStatesRepository,
+      organisationsRepository: server.app.organisationsRepository
+    })
 
   for (const finding of findings) {
     logger.info({ message: formatFinding(finding) })
@@ -37,6 +39,10 @@ const runDiagnostic = async (server) => {
     logger.info({ message: formatMaterialSummary(summary) })
   }
   logger.info({ message: formatTotals({ scanned, findings }) })
+
+  for (const item of unresolved) {
+    logger.warn({ message: formatUnresolved(item) })
+  }
 }
 
 /**

--- a/src/server/run-report-data-completeness-diagnostic.test.js
+++ b/src/server/run-report-data-completeness-diagnostic.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { partialMock } from '#test/type-helpers.js'
+import { logger } from '#common/helpers/logging/logger.js'
+import { runReportDataCompletenessDiagnostic } from './run-report-data-completeness-diagnostic.js'
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.enabled]
+ * @param {any} [options.lock]
+ * @param {Error} [options.lockError]
+ */
+const buildServer = ({ enabled = true, lock, lockError } = {}) =>
+  partialMock({
+    app: {},
+    featureFlags: { isReportDataCompleteDiagnosticEnabled: () => enabled },
+    locker: {
+      lock: lockError
+        ? vi.fn().mockRejectedValue(lockError)
+        : vi.fn().mockResolvedValue(lock)
+    }
+  })
+
+describe('runReportDataCompletenessDiagnostic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns without touching the locker when the flag is off', async () => {
+    const server = buildServer({ enabled: false })
+
+    await runReportDataCompletenessDiagnostic(server)
+
+    expect(server.locker.lock).not.toHaveBeenCalled()
+  })
+
+  it('logs and skips when the lock cannot be obtained', async () => {
+    const server = buildServer({ lock: null })
+
+    await runReportDataCompletenessDiagnostic(server)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Unable to obtain lock, skipping report-data completeness diagnostic'
+    })
+  })
+
+  it('logs the error when the run fails', async () => {
+    const lockError = new Error('locker down')
+    const server = buildServer({ lockError })
+
+    await runReportDataCompletenessDiagnostic(server)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: lockError,
+      message: 'Failed to run report-data completeness diagnostic'
+    })
+  })
+})

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -46,6 +46,7 @@ import { runFormsDataMigration } from '#server/run-forms-data-migration.js'
 import { runOrganisationValidationSweep } from '#server/run-organisation-validation-sweep.js'
 import { runStaleIssuedTonnageReport } from '#server/run-stale-issued-tonnage-report.js'
 import { runPreCpaResubmissionBackfill } from '#server/run-pre-cpa-resubmission-backfill.js'
+import { runReportDataCompletenessDiagnostic } from '#server/run-report-data-completeness-diagnostic.js'
 import { seedDatabase } from '#server/seed/seed-database.js'
 
 /** @import { Lifecycle } from '@hapi/hapi' */
@@ -229,6 +230,7 @@ async function createServer(options = {}) {
     runOrganisationValidationSweep(startedServer)
     runStaleIssuedTonnageReport(startedServer)
     runPreCpaResubmissionBackfill(startedServer)
+    runReportDataCompletenessDiagnostic(startedServer)
   })
 
   return server


### PR DESCRIPTION
## What

Adds a startup diagnostic that scans every live summary log across the estate on boot and logs which would fail the report-data completeness rules, without changing any user-facing behaviour. It sits behind its own feature flag `FEATURE_FLAG_REPORT_DATA_COMPLETE_DIAGNOSTIC` (default off), separate from the blocking gate's flag, so it can run in an environment independently of the gate. It runs under a cross-instance lock so a single pod per deploy executes and logs it.

When enabled it logs, message-only for cdp-logs to collate:

- one line per summary log that would be blocked: its template, material, organisation/registration/accreditation (with the human-facing registration and accreditation numbers alongside the ids), and its counts of incomplete rows and missing fields;
- one line breaking the blocked summary logs down by template;
- one line breaking them down by material, across every material;
- one line breaking down how many times each mandatory field was missing across the estate, most-missing first;
- estate-wide totals: summary logs scanned, how many would be blocked and the total missing fields, and the distinct organisations / registrations / accreditations affected, plus which templates were evaluated;
- a warning per summary log whose registration can no longer be resolved (deleted or re-versioned away): the finding is still counted, with its material and numbers reported as `unknown`, so one missing registration degrades one line rather than aborting the scan.

### Example log output

Each line below is the `message` field of a structured log record. For an estate of 128 submitted summary logs where two would be blocked: one accredited exporter carrying plastic (three rows missing an overseas-site id, one of them also missing the export date), and one registered-only exporter carrying glass (one row missing all six supplier fields):

```
Report-data diagnostic: summary log 66f0a1c3e4b0a2f1d3c40a11 (template EXPORTER, material plastic) -- org 66ef2b7a9c1d4e0012a3b456 / registration 66ef2b7a9c1d4e0012a3b789 (no. R1234567) / accreditation 66ef2b7a9c1d4e0012a3bccd (no. A7654321) -- 3 incomplete row(s), 4 missing field(s)
Report-data diagnostic: summary log 66f0a1c3e4b0a2f1d3c40a22 (template EXPORTER_REGISTERED_ONLY, material glass) -- org 66ef2b7a9c1d4e0012a3b999 / registration 66ef2b7a9c1d4e0012a3baaa (no. R7654321) / accreditation registered-only -- 1 incomplete row(s), 6 missing field(s)
Report-data diagnostic missing data by template: EXPORTER:1, EXPORTER_REGISTERED_ONLY:1
Report-data diagnostic missing data by material: aluminium:0, fibre:0, glass:1, paper:0, plastic:1, steel:0, wood:0
Report-data diagnostic missing data by field: OSR_ID:3, ACTIVITIES_CARRIED_OUT_BY_SUPPLIER:1, DATE_OF_EXPORT:1, SUPPLIER_ADDRESS:1, SUPPLIER_EMAIL:1, SUPPLIER_NAME:1, SUPPLIER_PHONE_NUMBER:1, SUPPLIER_POSTCODE:1
Report-data diagnostic summary: scanned 128 summary log(s), 2 with incomplete data (10 missing field(s)) across 2 organisation(s) / 2 registration(s) / 1 accreditation(s). Evaluated templates: EXPORTER, EXPORTER_REGISTERED_ONLY (other templates have no completeness rules yet).
```

When nothing would be blocked the breakdowns still report (all zero), and the field line reads `(none)`.

When a violating summary log's registration cannot be resolved, its per-summary-log line carries `material unknown` and `(no. unknown)`, an `unknown` entry is appended to the material breakdown, and an additional warning is logged:

```
Report-data diagnostic: could not resolve registration 66ef2b7a9c1d4e0012a3bfff (org 66ef2b7a9c1d4e0012a3beee) for summary log 66f0a1c3e4b0a2f1d3c40a33; material reported as unknown
```

## Why

The whole-summary-log completeness gate can now block report creation on incomplete rows anywhere in the summary log. Before enabling the blocking flag in an environment we need visibility of the blast radius on real data: how many operators, registrations and rows would newly be blocked, and which fields are most often missing. This diagnostic surfaces that on boot without touching user-facing behaviour.

It reuses the gate's own rules engine (`findIssues` from the report-mandatory policy) rather than reimplementing the checks, so the diagnostic and the gate can never drift. The evaluated-template set is derived from the policy registry, so when the reprocessor templates gain completeness rules (PAE-1280) the diagnostic reports on them with no further change.