### PR TITLE
PAE-1826: Require both organisation.read and a new ledger scope on the waste balance ledger routes

### DIFF
--- a/src/common/helpers/auth/constants.js
+++ b/src/common/helpers/auth/constants.js
@@ -10,6 +10,7 @@ export const SCOPES = {
   organisationLinkedRead: 'organisation.linked.read',
   organisationLinkedWrite: 'organisation.linked.write',
   organisationSearch: 'organisation.search',
+  wasteBalanceLedgerRead: 'waste-balance.ledger.read',
   regulator: 'regulator'
 }
 
@@ -40,6 +41,13 @@ export const REGULATOR_ROLE = 'regulator_standard'
  * yet, so the condition an operator's `organisation.read` carries — their own
  * linked organisation — cannot apply.
  *
+ * `waste-balance.ledger.read` is separate from `organisation.read` because an
+ * operator earns `organisation.read` for the organisation named in the path,
+ * and the ledger routes carry an `{organisationId}`. A route that admits
+ * `organisation.read` therefore admits an operator reading their own ledger.
+ * The ledger is a supervisory view of a balance, so only a regulator and the
+ * admin tiers may read it.
+ *
  * `regulator` is coarse on purpose. It stands for the whole set of functions
  * only a regulator performs, and subdivides when caseworking functions
  * arrive.
@@ -49,6 +57,7 @@ export const REGULATOR_ROLE = 'regulator_standard'
 export const REGULATOR_SCOPES = [
   SCOPES.organisationRead,
   SCOPES.organisationSearch,
+  SCOPES.wasteBalanceLedgerRead,
   SCOPES.regulator
 ]
 

--- a/src/common/helpers/auth/constants.js
+++ b/src/common/helpers/auth/constants.js
@@ -45,9 +45,10 @@ export const REGULATOR_ROLE = 'regulator_standard'
  * service's own record of how the balance moved, event by event. An operator
  * reads the balance, and does not read the ledger.
  *
- * `organisation.read` cannot draw that line. An operator earns it for the
- * organisation named in the request, and the ledger routes name one, so a
- * ledger route that admits `organisation.read` admits the operator too.
+ * `organisation.read` cannot draw that line on its own. An operator earns it
+ * for the organisation named in the request, and the ledger routes name one.
+ * So a ledger route requires both scopes: `organisation.read` for the
+ * organisation, and `waste-balance.ledger.read` for the ledger behind it.
  *
  * `regulator` is coarse on purpose. It stands for the whole set of functions
  * only a regulator performs, and subdivides when caseworking functions
@@ -66,18 +67,31 @@ export const REGULATOR_SCOPES = [
  * Admin role → scope-bundle map. Used internally by getEntraUserRoles to
  * resolve an email-list match to its scope set; role names do not flow onto
  * credentials or out over the wire.
+ *
+ * Every tier reads, so every tier holds `organisation.read` and
+ * `waste-balance.ledger.read`. A tier reaches a route by holding the scopes
+ * that route requires, never by the route naming the tier.
  */
 export const ADMIN_ROLES = {
   service_maintainer_write: [
     SCOPES.adminRead,
     SCOPES.adminWrite,
     SCOPES.adminDlqPurge,
-    SCOPES.organisationSearch
+    SCOPES.organisationSearch,
+    SCOPES.organisationRead,
+    SCOPES.wasteBalanceLedgerRead
   ],
   service_maintainer: [
     SCOPES.adminRead,
     SCOPES.adminDlqPurge,
-    SCOPES.organisationSearch
+    SCOPES.organisationSearch,
+    SCOPES.organisationRead,
+    SCOPES.wasteBalanceLedgerRead
   ],
-  support: [SCOPES.adminRead, SCOPES.organisationSearch]
+  support: [
+    SCOPES.adminRead,
+    SCOPES.organisationSearch,
+    SCOPES.organisationRead,
+    SCOPES.wasteBalanceLedgerRead
+  ]
 }

--- a/src/common/helpers/auth/constants.js
+++ b/src/common/helpers/auth/constants.js
@@ -41,12 +41,13 @@ export const REGULATOR_ROLE = 'regulator_standard'
  * yet, so the condition an operator's `organisation.read` carries — their own
  * linked organisation — cannot apply.
  *
- * `waste-balance.ledger.read` is separate from `organisation.read` because an
- * operator earns `organisation.read` for the organisation named in the path,
- * and the ledger routes carry an `{organisationId}`. A route that admits
- * `organisation.read` therefore admits an operator reading their own ledger.
- * The ledger is a supervisory view of a balance, so only a regulator and the
- * admin tiers may read it.
+ * `waste-balance.ledger.read` covers the ledger behind a waste balance: the
+ * service's own record of how the balance moved, event by event. An operator
+ * reads the balance, and does not read the ledger.
+ *
+ * `organisation.read` cannot draw that line. An operator earns it for the
+ * organisation named in the request, and the ledger routes name one, so a
+ * ledger route that admits `organisation.read` admits the operator too.
  *
  * `regulator` is coarse on purpose. It stands for the whole set of functions
  * only a regulator performs, and subdivides when caseworking functions

--- a/src/common/helpers/auth/constants.test.js
+++ b/src/common/helpers/auth/constants.test.js
@@ -42,7 +42,7 @@ describe('ADMIN_ROLES', () => {
     }
   })
 
-  test('no tier holds waste-balance.ledger.read, because admin.read admits a tier to a ledger', () => {
+  test('no tier holds waste-balance.ledger.read, which names a regulator bundle', () => {
     for (const scopes of Object.values(ADMIN_ROLES)) {
       expect(scopes).not.toContain(SCOPES.wasteBalanceLedgerRead)
     }
@@ -78,6 +78,10 @@ describe('the regulator role', () => {
 
   test('carries waste-balance.ledger.read, which organisation.read must not admit', () => {
     expect(REGULATOR_SCOPES).toContain(SCOPES.wasteBalanceLedgerRead)
+  })
+
+  test('spells that scope the way the frontend declares it on its own gate', () => {
+    expect(SCOPES.wasteBalanceLedgerRead).toBe('waste-balance.ledger.read')
   })
 
   test('carries no admin scope', () => {

--- a/src/common/helpers/auth/constants.test.js
+++ b/src/common/helpers/auth/constants.test.js
@@ -42,7 +42,7 @@ describe('ADMIN_ROLES', () => {
     expect(ADMIN_ROLES.support).not.toContain(SCOPES.adminDlqPurge)
   })
 
-  test('every admin role includes admin.read, which the read routes declare', () => {
+  test('every admin role includes admin.read', () => {
     for (const scopes of Object.values(ADMIN_ROLES)) {
       expect(scopes).toContain(SCOPES.adminRead)
     }

--- a/src/common/helpers/auth/constants.test.js
+++ b/src/common/helpers/auth/constants.test.js
@@ -87,7 +87,7 @@ describe('the regulator role', () => {
     expect(REGULATOR_SCOPES).toContain(SCOPES.wasteBalanceLedgerRead)
   })
 
-  test('spells that scope the way the frontend declares it on its own gate', () => {
+  test('pins the exact string the ledger routes require', () => {
     expect(SCOPES.wasteBalanceLedgerRead).toBe('waste-balance.ledger.read')
   })
 

--- a/src/common/helpers/auth/constants.test.js
+++ b/src/common/helpers/auth/constants.test.js
@@ -14,7 +14,9 @@ describe('ADMIN_ROLES', () => {
       SCOPES.adminRead,
       SCOPES.adminWrite,
       SCOPES.adminDlqPurge,
-      SCOPES.organisationSearch
+      SCOPES.organisationSearch,
+      SCOPES.organisationRead,
+      SCOPES.wasteBalanceLedgerRead
     ])
   })
 
@@ -22,7 +24,9 @@ describe('ADMIN_ROLES', () => {
     expect(ADMIN_ROLES.service_maintainer).toEqual([
       SCOPES.adminRead,
       SCOPES.adminDlqPurge,
-      SCOPES.organisationSearch
+      SCOPES.organisationSearch,
+      SCOPES.organisationRead,
+      SCOPES.wasteBalanceLedgerRead
     ])
     expect(ADMIN_ROLES.service_maintainer).not.toContain(SCOPES.adminWrite)
   })
@@ -30,21 +34,24 @@ describe('ADMIN_ROLES', () => {
   test('support carries admin.read and no other admin scope', () => {
     expect(ADMIN_ROLES.support).toEqual([
       SCOPES.adminRead,
-      SCOPES.organisationSearch
+      SCOPES.organisationSearch,
+      SCOPES.organisationRead,
+      SCOPES.wasteBalanceLedgerRead
     ])
     expect(ADMIN_ROLES.support).not.toContain(SCOPES.adminWrite)
     expect(ADMIN_ROLES.support).not.toContain(SCOPES.adminDlqPurge)
   })
 
-  test('every admin role includes admin.read so any tier can call read routes', () => {
+  test('every admin role includes admin.read, which the read routes declare', () => {
     for (const scopes of Object.values(ADMIN_ROLES)) {
       expect(scopes).toContain(SCOPES.adminRead)
     }
   })
 
-  test('no tier holds waste-balance.ledger.read, which names a regulator bundle', () => {
+  test('every tier reads, so every tier holds both scopes a ledger route requires', () => {
     for (const scopes of Object.values(ADMIN_ROLES)) {
-      expect(scopes).not.toContain(SCOPES.wasteBalanceLedgerRead)
+      expect(scopes).toContain(SCOPES.organisationRead)
+      expect(scopes).toContain(SCOPES.wasteBalanceLedgerRead)
     }
   })
 

--- a/src/common/helpers/auth/constants.test.js
+++ b/src/common/helpers/auth/constants.test.js
@@ -42,6 +42,12 @@ describe('ADMIN_ROLES', () => {
     }
   })
 
+  test('no tier holds waste-balance.ledger.read, because admin.read admits a tier to a ledger', () => {
+    for (const scopes of Object.values(ADMIN_ROLES)) {
+      expect(scopes).not.toContain(SCOPES.wasteBalanceLedgerRead)
+    }
+  })
+
   test('a tier that holds admin.read also holds organisation.search', () => {
     const tiersWithAdminRead = Object.values(ADMIN_ROLES).filter((scopes) =>
       scopes.includes(SCOPES.adminRead)
@@ -68,6 +74,10 @@ describe('the regulator role', () => {
 
   test('carries organisation.search, which enumerates operators the regulator holds no id for', () => {
     expect(REGULATOR_SCOPES).toContain(SCOPES.organisationSearch)
+  })
+
+  test('carries waste-balance.ledger.read, which organisation.read must not admit', () => {
+    expect(REGULATOR_SCOPES).toContain(SCOPES.wasteBalanceLedgerRead)
   })
 
   test('carries no admin scope', () => {

--- a/src/common/helpers/auth/get-jwt-strategy-config.test.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.test.js
@@ -372,12 +372,7 @@ describe('#getJwtStrategyConfig', () => {
 
       const result = await config.validate(artifacts)
 
-      expect(result.credentials.scope).toEqual([
-        SCOPES.adminRead,
-        SCOPES.organisationSearch,
-        SCOPES.organisationRead,
-        SCOPES.wasteBalanceLedgerRead
-      ])
+      expect(result.credentials.scope).toEqual([...ADMIN_ROLES.support])
     })
 
     test('handles Entra ID token where user matches no admin tier (empty scope)', async () => {

--- a/src/common/helpers/auth/get-jwt-strategy-config.test.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.test.js
@@ -374,7 +374,9 @@ describe('#getJwtStrategyConfig', () => {
 
       expect(result.credentials.scope).toEqual([
         SCOPES.adminRead,
-        SCOPES.organisationSearch
+        SCOPES.organisationSearch,
+        SCOPES.organisationRead,
+        SCOPES.wasteBalanceLedgerRead
       ])
     })
 

--- a/src/overseas-sites/routes/post-import.test.js
+++ b/src/overseas-sites/routes/post-import.test.js
@@ -119,7 +119,9 @@ describe(`${orsImportCreatePath} route`, () => {
             'admin.read',
             'admin.write',
             'admin.dlq.purge',
-            'organisation.search'
+            'organisation.search',
+            'organisation.read',
+            'waste-balance.ledger.read'
           ]
         })
       })

--- a/src/routes/v1/admin/me/get.test.js
+++ b/src/routes/v1/admin/me/get.test.js
@@ -59,7 +59,7 @@ describe('GET /v1/admin/me', () => {
   })
 
   describe('payload by tier', () => {
-    it('returns the write tier scope bundle (admin.read + admin.write + admin.dlq.purge + organisation.search)', async () => {
+    it('returns the write tier scope bundle', async () => {
       const response = await server.inject({
         method: 'GET',
         url: ADMIN_ME_PATH,
@@ -72,12 +72,14 @@ describe('GET /v1/admin/me', () => {
           SCOPES.adminRead,
           SCOPES.adminWrite,
           SCOPES.adminDlqPurge,
-          SCOPES.organisationSearch
+          SCOPES.organisationSearch,
+          SCOPES.organisationRead,
+          SCOPES.wasteBalanceLedgerRead
         ]
       })
     })
 
-    it('returns the maintainer tier scope bundle (admin.read + admin.dlq.purge + organisation.search)', async () => {
+    it('returns the maintainer tier scope bundle', async () => {
       const response = await server.inject({
         method: 'GET',
         url: ADMIN_ME_PATH,
@@ -89,12 +91,14 @@ describe('GET /v1/admin/me', () => {
         scopes: [
           SCOPES.adminRead,
           SCOPES.adminDlqPurge,
-          SCOPES.organisationSearch
+          SCOPES.organisationSearch,
+          SCOPES.organisationRead,
+          SCOPES.wasteBalanceLedgerRead
         ]
       })
     })
 
-    it('returns the support tier scope bundle (admin.read + organisation.search)', async () => {
+    it('returns the support tier scope bundle', async () => {
       const response = await server.inject({
         method: 'GET',
         url: ADMIN_ME_PATH,
@@ -103,7 +107,12 @@ describe('GET /v1/admin/me', () => {
 
       expect(response.statusCode).toBe(StatusCodes.OK)
       expect(JSON.parse(response.payload)).toEqual({
-        scopes: [SCOPES.adminRead, SCOPES.organisationSearch]
+        scopes: [
+          SCOPES.adminRead,
+          SCOPES.organisationSearch,
+          SCOPES.organisationRead,
+          SCOPES.wasteBalanceLedgerRead
+        ]
       })
     })
   })

--- a/src/routes/v1/admin/organisations/registrations/accreditations/ledger-events/get.js
+++ b/src/routes/v1/admin/organisations/registrations/accreditations/ledger-events/get.js
@@ -11,7 +11,10 @@ export const accreditationLedgerEventsGet = {
   path: accreditationLedgerEventsGetPath,
   options: {
     auth: {
-      scope: [SCOPES.adminRead, SCOPES.wasteBalanceLedgerRead]
+      scope: [
+        `+${SCOPES.organisationRead}`,
+        `+${SCOPES.wasteBalanceLedgerRead}`
+      ]
     },
     tags: ['api', 'admin']
   },

--- a/src/routes/v1/admin/organisations/registrations/accreditations/ledger-events/get.js
+++ b/src/routes/v1/admin/organisations/registrations/accreditations/ledger-events/get.js
@@ -11,7 +11,7 @@ export const accreditationLedgerEventsGet = {
   path: accreditationLedgerEventsGetPath,
   options: {
     auth: {
-      scope: [SCOPES.adminRead, SCOPES.organisationRead]
+      scope: [SCOPES.adminRead, SCOPES.wasteBalanceLedgerRead]
     },
     tags: ['api', 'admin']
   },

--- a/src/routes/v1/admin/organisations/registrations/ledger-events-test-helpers.js
+++ b/src/routes/v1/admin/organisations/registrations/ledger-events-test-helpers.js
@@ -17,11 +17,15 @@ const ANOTHER_ORGANISATION_ID = 'another-organisation-id'
  * Exercises who may read a waste balance ledger over the full auth stack.
  *
  * Real tokens are the point. `server.inject({ auth })` attaches credentials
- * directly, so it cannot show which scopes a caller actually earns. An
- * operator earns `organisation.read` for the organisation named in the path,
- * and the admin path carries an `{organisationId}`, so a route that admits
- * `organisation.read` admits an operator reading their own ledger. The case
- * that pins that down is the operator refused their own organisation.
+ * directly, so it cannot show which scopes a caller actually earns. Only a
+ * real Defra ID token shows that the operator resolver grants nothing that
+ * opens a ledger, and the case that pins that down is the operator refused
+ * their own organisation.
+ *
+ * The three operator cases are one assertion held three ways. An operator
+ * earns no ledger scope in any of them, so the organisation in the request no
+ * longer changes the answer. They stay because a later change to the operator
+ * resolver must break all three, not one.
  *
  * @param {{ makeUrl: (organisationId: string) => string }} options
  */

--- a/src/routes/v1/admin/organisations/registrations/ledger-events-test-helpers.js
+++ b/src/routes/v1/admin/organisations/registrations/ledger-events-test-helpers.js
@@ -17,10 +17,11 @@ const ANOTHER_ORGANISATION_ID = 'another-organisation-id'
  * Exercises who may read a waste balance ledger over the full auth stack.
  *
  * Real tokens are the point. `server.inject({ auth })` attaches credentials
- * directly, so it cannot show that an operator holds `organisation.read` only
- * for the organisation named in the path. The pair that pins that down is the
- * operator reading their own organisation and the same token refused another
- * one.
+ * directly, so it cannot show which scopes a caller actually earns. An
+ * operator earns `organisation.read` for the organisation named in the path,
+ * and the admin path carries an `{organisationId}`, so a route that admits
+ * `organisation.read` admits an operator reading their own ledger. The case
+ * that pins that down is the operator refused their own organisation.
  *
  * @param {{ makeUrl: (organisationId: string) => string }} options
  */
@@ -71,10 +72,24 @@ export const testLedgerEventsAccess = ({ makeUrl }) => {
       expect(response.statusCode).toBe(StatusCodes.OK)
     })
 
-    it('returns 200 for an operator linked to the organisation in the path', async () => {
-      const response = await getWithToken(defraIdMockAuthTokens.validToken)
+    it('returns 200 for a read-only service maintainer', async () => {
+      const response = await getWithToken(
+        entraIdMockAuthTokens.readOnlyMaintainerToken
+      )
 
       expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+
+    it('returns 200 for the support tier, the lowest tier that holds admin.read', async () => {
+      const response = await getWithToken(entraIdMockAuthTokens.supportToken)
+
+      expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+
+    it('returns 403 for an operator linked to the organisation in the path', async () => {
+      const response = await getWithToken(defraIdMockAuthTokens.validToken)
+
+      expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
     })
 
     it('returns 403 for an operator asked for an organisation that is not their own', async () => {

--- a/src/routes/v1/admin/organisations/registrations/ledger-events-test-helpers.js
+++ b/src/routes/v1/admin/organisations/registrations/ledger-events-test-helpers.js
@@ -27,6 +27,11 @@ const ANOTHER_ORGANISATION_ID = 'another-organisation-id'
  * longer changes the answer. They stay because a later change to the operator
  * resolver must break all three, not one.
  *
+ * The first of them also pins the shape of the route's scope array. That
+ * operator holds `organisation.read` for the organisation in the path, so a
+ * route that admitted either scope would answer 200. The 403 is what shows
+ * the route requires both.
+ *
  * @param {{ makeUrl: (organisationId: string) => string }} options
  */
 export const testLedgerEventsAccess = ({ makeUrl }) => {
@@ -84,13 +89,13 @@ export const testLedgerEventsAccess = ({ makeUrl }) => {
       expect(response.statusCode).toBe(StatusCodes.OK)
     })
 
-    it('returns 200 for the support tier, the lowest tier that holds admin.read', async () => {
+    it('returns 200 for the support tier, the narrowest admin bundle', async () => {
       const response = await getWithToken(entraIdMockAuthTokens.supportToken)
 
       expect(response.statusCode).toBe(StatusCodes.OK)
     })
 
-    it('returns 403 for an operator linked to the organisation in the path', async () => {
+    it('returns 403 for an operator who holds organisation.read for the organisation in the path but no ledger scope', async () => {
       const response = await getWithToken(defraIdMockAuthTokens.validToken)
 
       expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)

--- a/src/routes/v1/admin/organisations/registrations/ledger-events-test-helpers.js
+++ b/src/routes/v1/admin/organisations/registrations/ledger-events-test-helpers.js
@@ -29,8 +29,10 @@ const ANOTHER_ORGANISATION_ID = 'another-organisation-id'
  *
  * The first of them also pins the shape of the route's scope array. That
  * operator holds `organisation.read` for the organisation in the path, so a
- * route that admitted either scope would answer 200. The 403 is what shows
- * the route requires both.
+ * route that admitted either scope would answer 200. The 403 shows the ledger
+ * scope is required rather than merely accepted. No identity holds the ledger
+ * scope without `organisation.read`, so no case here shows the first entry is
+ * enforced.
  *
  * @param {{ makeUrl: (organisationId: string) => string }} options
  */

--- a/src/routes/v1/admin/organisations/registrations/ledger-events/get.js
+++ b/src/routes/v1/admin/organisations/registrations/ledger-events/get.js
@@ -11,7 +11,7 @@ export const registrationLedgerEventsGet = {
   path: registrationLedgerEventsGetPath,
   options: {
     auth: {
-      scope: [SCOPES.adminRead, SCOPES.organisationRead]
+      scope: [SCOPES.adminRead, SCOPES.wasteBalanceLedgerRead]
     },
     tags: ['api', 'admin']
   },

--- a/src/routes/v1/admin/organisations/registrations/ledger-events/get.js
+++ b/src/routes/v1/admin/organisations/registrations/ledger-events/get.js
@@ -11,7 +11,10 @@ export const registrationLedgerEventsGet = {
   path: registrationLedgerEventsGetPath,
   options: {
     auth: {
-      scope: [SCOPES.adminRead, SCOPES.wasteBalanceLedgerRead]
+      scope: [
+        `+${SCOPES.organisationRead}`,
+        `+${SCOPES.wasteBalanceLedgerRead}`
+      ]
     },
     tags: ['api', 'admin']
   },

--- a/src/routes/v1/me/get.test.js
+++ b/src/routes/v1/me/get.test.js
@@ -67,7 +67,9 @@ describe('GET /v1/me', () => {
           SCOPES.adminRead,
           SCOPES.adminWrite,
           SCOPES.adminDlqPurge,
-          SCOPES.organisationSearch
+          SCOPES.organisationSearch,
+          SCOPES.organisationRead,
+          SCOPES.wasteBalanceLedgerRead
         ]
       })
     })

--- a/src/routes/v1/organisations/put-by-id.test.js
+++ b/src/routes/v1/organisations/put-by-id.test.js
@@ -153,7 +153,9 @@ describe('PUT /v1/organisations/{id}', () => {
           'admin.read',
           'admin.write',
           'admin.dlq.purge',
-          'organisation.search'
+          'organisation.search',
+          'organisation.read',
+          'waste-balance.ledger.read'
         ])
       }
 

--- a/src/routes/v1/organisations/unlink.test.js
+++ b/src/routes/v1/organisations/unlink.test.js
@@ -52,7 +52,9 @@ const ADMIN_USER = {
     SCOPES.adminRead,
     SCOPES.adminWrite,
     SCOPES.adminDlqPurge,
-    SCOPES.organisationSearch
+    SCOPES.organisationSearch,
+    SCOPES.organisationRead,
+    SCOPES.wasteBalanceLedgerRead
   ]
 }
 

--- a/src/routes/v1/organisations/unlink.test.js
+++ b/src/routes/v1/organisations/unlink.test.js
@@ -1,4 +1,4 @@
-import { SCOPES } from '#common/helpers/auth/constants.js'
+import { ADMIN_ROLES } from '#common/helpers/auth/constants.js'
 import { ORGANISATION_STATUS } from '#domain/organisations/model.js'
 import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import {
@@ -48,14 +48,7 @@ vi.mock(
 const ADMIN_USER = {
   id: 'test-maintainer-id',
   email: 'maintainer@example.com',
-  scope: [
-    SCOPES.adminRead,
-    SCOPES.adminWrite,
-    SCOPES.adminDlqPurge,
-    SCOPES.organisationSearch,
-    SCOPES.organisationRead,
-    SCOPES.wasteBalanceLedgerRead
-  ]
+  scope: [...ADMIN_ROLES.service_maintainer_write]
 }
 
 describe('DELETE /v1/organisations/{organisationId}/link', () => {


### PR DESCRIPTION
Ticket: [PAE-1826](https://eaflood.atlassian.net/browse/PAE-1826)

An operator can read their own organisation's full waste balance ledger over the API today. This branch adds a `waste-balance.ledger.read` scope and makes both ledger routes require it as well as `organisation.read`, so the regulator and the three admin tiers still get 200 and an operator now gets 403.

- The `+` prefix on the scope array is what makes it AND — a bare hapi scope array is OR.
- `admin.read` comes off these two routes. Granting the admin tiers `organisation.read` also admits them to the summary-log and PRN read routes, which declare that scope alone.

[PAE-1826]: https://eaflood.atlassian.net/browse/PAE-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
