### PR TITLE
PAE-1420: Surface incomplete summary log rows on report-detail GET preview

### DIFF
--- a/src/reports/application/report-mandatory/assert-report-data-complete.js
+++ b/src/reports/application/report-mandatory/assert-report-data-complete.js
@@ -94,6 +94,29 @@ export const findIssues = (rows) =>
 export const MAX_ISSUES_REPORTED = 100
 
 /**
+ * Summarises missing mandatory fields across the whole summary log without
+ * throwing, for the GET report-detail preview. Returns `null` when nothing is
+ * missing, so callers attach the field only when there is something to report.
+ *
+ * Mirrors the payload {@link assertReportDataComplete} throws on the POST:
+ * `total` is the true number of missing fields; `issues` is capped at
+ * `MAX_ISSUES_REPORTED`, so `total` can exceed `issues.length`. The frontend
+ * consumes the same `{ total, issues }` shape whether it arrives in this 200
+ * body field or the 400 error payload.
+ *
+ * @param {CompletenessRow[]} rows
+ * @returns {{ total: number, issues: Issue[] } | null}
+ */
+export const summariseIncompleteData = (rows) => {
+  const issues = findIssues(rows)
+  const total = issues.length
+  if (!total) {
+    return null
+  }
+  return { total, issues: issues.slice(0, MAX_ISSUES_REPORTED) }
+}
+
+/**
  * Throws a 400 Boom enriched with `code=report_data_incomplete` and a flat
  * `issues` payload if any mandatory field is missing anywhere in the summary
  * log. On success it returns silently and the report is created.

--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -12,7 +12,10 @@ import {
 } from './create-report-validation.js'
 import { canRequestResubmission } from './resubmission-service.js'
 import { findReportIdBySubmissionNumber } from './submission-lookup.js'
-import { assertReportDataComplete } from './report-mandatory/assert-report-data-complete.js'
+import {
+  assertReportDataComplete,
+  summariseIncompleteData
+} from './report-mandatory/assert-report-data-complete.js'
 
 /**
  * @import { Registration, RegistrationAddress } from '#domain/organisations/registration.js'
@@ -133,6 +136,29 @@ function buildReportData(aggregated, registration) {
 }
 
 /**
+ * Wraps a stored report with its `canRequestResubmission` flag for the
+ * fetch-or-generate result. The completeness signal is a preview-only concern,
+ * so the stored branch never carries it.
+ *
+ * @param {import('#reports/repository/port.js').Report} storedReport
+ * @param {PeriodicReport[]} periodicReports
+ * @returns {import('#reports/repository/port.js').Report & { canRequestResubmission: boolean }}
+ */
+function buildStoredReportResult(storedReport, periodicReports) {
+  return {
+    ...storedReport,
+    canRequestResubmission: canRequestResubmission(periodicReports, {
+      status: storedReport.status.currentStatus,
+      resubmissionRequired: storedReport.resubmissionRequired,
+      year: storedReport.year,
+      cadence: /** @type {Cadence} */ (storedReport.cadence),
+      period: storedReport.period,
+      submissionNumber: storedReport.submissionNumber
+    })
+  }
+}
+
+/**
  * Finds the report for a given period with PRN tonnage. Returns the stored
  * report if one exists, otherwise computes one from waste records.
  *
@@ -149,7 +175,8 @@ function buildReportData(aggregated, registration) {
  * @param {Cadence} params.cadence
  * @param {number} params.period
  * @param {number} params.submissionNumber
- * @returns {Promise<(import('#reports/repository/port.js').Report | import('#reports/domain/aggregation/aggregate-report-detail.js').AggregatedReportDetail) & { canRequestResubmission: boolean }>}
+ * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags} [params.featureFlags]
+ * @returns {Promise<(import('#reports/repository/port.js').Report | import('#reports/domain/aggregation/aggregate-report-detail.js').AggregatedReportDetail) & { canRequestResubmission: boolean, incompleteSummaryLogRows?: { total: number, issues: import('./report-mandatory/assert-report-data-complete.js').Issue[] } }>}
  */
 export async function fetchOrGenerateReportForPeriod({
   reportsRepository,
@@ -163,7 +190,8 @@ export async function fetchOrGenerateReportForPeriod({
   year,
   cadence,
   period,
-  submissionNumber
+  submissionNumber,
+  featureFlags
 }) {
   const periodicReports = await reportsRepository.findPeriodicReports({
     organisationId,
@@ -183,17 +211,7 @@ export async function fetchOrGenerateReportForPeriod({
     : null
 
   if (storedReport) {
-    return {
-      ...storedReport,
-      canRequestResubmission: canRequestResubmission(periodicReports, {
-        status: storedReport.status.currentStatus,
-        resubmissionRequired: storedReport.resubmissionRequired,
-        year: storedReport.year,
-        cadence: /** @type {Cadence} */ (storedReport.cadence),
-        period: storedReport.period,
-        submissionNumber: storedReport.submissionNumber
-      })
-    }
+    return buildStoredReportResult(storedReport, periodicReports)
   }
 
   const operatorCategory = getOperatorCategory(registration)
@@ -222,7 +240,21 @@ export async function fetchOrGenerateReportForPeriod({
     latestSubmission
   })
 
-  return { ...aggregatedReportDetail, canRequestResubmission: false }
+  // Attached on every generate-branch preview (any period without a stored
+  // report), not only Due/Over Due ones: a not-yet-ended period resolves to a
+  // null period status yet still generates. The frontend gates the
+  // validation-error screen on Due/Over Due, so this signal is broader than the
+  // screen by design (PAE-1420).
+  const incompleteSummaryLogRows = summariseIncompleteDataIfEnabled(
+    featureFlags,
+    wasteRecordStates
+  )
+
+  return {
+    ...aggregatedReportDetail,
+    canRequestResubmission: false,
+    ...(incompleteSummaryLogRows && { incompleteSummaryLogRows })
+  }
 }
 
 /**
@@ -404,6 +436,24 @@ function assertReportDataCompleteIfEnabled(
   if (featureFlags?.isReportDataValidationEnabled()) {
     assertReportDataComplete(wasteRecordStates, reference)
   }
+}
+
+/**
+ * Summarises incomplete summary-log rows for the GET report-detail preview when
+ * the feature flag is on, mirroring the POST gate's issue payload without
+ * throwing. Returns `null` when the flag is off — or on but nothing is missing —
+ * so the generate branch attaches the field only when there is something to
+ * report.
+ *
+ * @param {import('#feature-flags/feature-flags.port.js').FeatureFlags | undefined} featureFlags
+ * @param {import('#waste-records/application/read-summary-log-row-states.js').WasteRecordState[]} wasteRecordStates
+ * @returns {{ total: number, issues: import('./report-mandatory/assert-report-data-complete.js').Issue[] } | null}
+ */
+function summariseIncompleteDataIfEnabled(featureFlags, wasteRecordStates) {
+  if (!featureFlags?.isReportDataValidationEnabled()) {
+    return null
+  }
+  return summariseIncompleteData(wasteRecordStates)
 }
 
 /**

--- a/src/reports/application/report-service.test.js
+++ b/src/reports/application/report-service.test.js
@@ -15,6 +15,7 @@ import {
 } from '#packaging-recycling-notes/repository/contract/test-data.js'
 import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
 import { createInMemoryOverseasSitesRepository } from '#overseas-sites/repository/inmemory.plugin.js'
+import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
 import {
   fetchOrGenerateReportForPeriod,
   createReportForPeriod,
@@ -22,6 +23,7 @@ import {
   createReportsService
 } from './report-service.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { MAX_ISSUES_REPORTED } from './report-mandatory/assert-report-data-complete.js'
 
 /**
  * @import { Registration } from '#domain/organisations/registration.js'
@@ -382,6 +384,150 @@ describe('report-service', () => {
       expect(report.recyclingActivity?.suppliers[0]?.supplierName).toBe(
         'Supplier A'
       )
+    })
+
+    describe('incompleteSummaryLogRows (PAE-1420)', () => {
+      const gateEnabled = createInMemoryFeatureFlags({
+        reportDataValidation: true
+      })
+
+      // A received row whose positive tonnage triggers the supplier rule but
+      // carries none of the six mandatory supplier fields: six missing fields.
+      const incompleteReceivedEntry = () =>
+        buildSummaryLogRowStateEntry({
+          rowId: 'row-1',
+          wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+          data: { TONNAGE_RECEIVED_FOR_RECYCLING: 5 }
+        })
+
+      const completeReceivedEntry = () =>
+        buildSummaryLogRowStateEntry({
+          rowId: 'row-1',
+          wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+          data: {
+            TONNAGE_RECEIVED_FOR_RECYCLING: 5,
+            SUPPLIER_NAME: 'Acme Waste Ltd',
+            SUPPLIER_ADDRESS: '1 Depot Road',
+            SUPPLIER_POSTCODE: 'AB1 2CD',
+            SUPPLIER_EMAIL: 'ops@acme.example',
+            SUPPLIER_PHONE_NUMBER: '01234 567890',
+            ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Baling'
+          }
+        })
+
+      const generate = async (entries, featureFlags) => {
+        const params = defaultParams()
+        const { ledgerRepository, summaryLogRowStatesRepository } =
+          await seedState(params, entries)
+        return fetchOrGenerateReportForPeriod({
+          reportsRepository: createInMemoryReportsRepository()(),
+          ledgerRepository,
+          summaryLogRowStatesRepository,
+          packagingRecyclingNotesRepository: createPrnRepo(),
+          ...params,
+          featureFlags
+        })
+      }
+
+      it('attaches incompleteSummaryLogRows on the generate branch when the flag is on and data is incomplete', async () => {
+        const report = await generate([incompleteReceivedEntry()], gateEnabled)
+
+        const { incompleteSummaryLogRows } = report
+        expect(incompleteSummaryLogRows?.total).toBe(6)
+        expect(incompleteSummaryLogRows?.issues).toHaveLength(6)
+        expect(incompleteSummaryLogRows?.issues).toContainEqual(
+          expect.objectContaining({ rowId: 'row-1', field: 'SUPPLIER_NAME' })
+        )
+      })
+
+      it('caps issues at MAX_ISSUES_REPORTED while total stays truthful', async () => {
+        // Each incomplete received row contributes six missing supplier fields,
+        // so enough rows breach the display cap. total stays truthful; issues
+        // is capped.
+        const FIELDS_PER_ROW = 6
+        const rowCount = Math.ceil((MAX_ISSUES_REPORTED + 1) / FIELDS_PER_ROW)
+        const entries = Array.from({ length: rowCount }, (_, index) =>
+          buildSummaryLogRowStateEntry({
+            rowId: `row-${index + 1}`,
+            wasteRecordType: WASTE_RECORD_TYPE.RECEIVED,
+            data: { TONNAGE_RECEIVED_FOR_RECYCLING: 5 }
+          })
+        )
+
+        const report = await generate(entries, gateEnabled)
+
+        const { incompleteSummaryLogRows } = report
+        expect(incompleteSummaryLogRows?.total).toBe(rowCount * FIELDS_PER_ROW)
+        expect(incompleteSummaryLogRows?.total).toBeGreaterThan(
+          MAX_ISSUES_REPORTED
+        )
+        expect(incompleteSummaryLogRows?.issues).toHaveLength(
+          MAX_ISSUES_REPORTED
+        )
+      })
+
+      it('omits incompleteSummaryLogRows when the flag is off despite incomplete data', async () => {
+        const report = await generate(
+          [incompleteReceivedEntry()],
+          createInMemoryFeatureFlags()
+        )
+
+        expect(report).not.toHaveProperty('incompleteSummaryLogRows')
+      })
+
+      it('omits incompleteSummaryLogRows when the flag is on but data is complete', async () => {
+        const report = await generate([completeReceivedEntry()], gateEnabled)
+
+        expect(report).not.toHaveProperty('incompleteSummaryLogRows')
+      })
+
+      it('never attaches incompleteSummaryLogRows on the stored-report branch', async () => {
+        const params = defaultParams()
+        const { ledgerRepository, summaryLogRowStatesRepository } =
+          await seedState(params, [incompleteReceivedEntry()])
+        const reportsRepository = createInMemoryReportsRepository()()
+        const changedBy = { id: 'user-1', name: 'Alice', position: 'Officer' }
+
+        await reportsRepository.createReport({
+          organisationId: params.organisationId,
+          registrationId: params.registrationId,
+          year: 2024,
+          cadence: 'monthly',
+          period: 1,
+          submissionNumber: 1,
+          startDate: '2024-01-01',
+          endDate: '2024-01-31',
+          dueDate: '2024-02-15',
+          changedBy,
+          material: 'plastic',
+          wasteProcessingType: 'reprocessor',
+          source: { summaryLogId: 'sl-1', lastUploadedAt: null },
+          prn: null,
+          recyclingActivity: {
+            suppliers: [],
+            totalTonnageReceived: 0,
+            tonnageRecycled: null,
+            tonnageNotRecycled: null
+          },
+          wasteSent: {
+            tonnageSentToReprocessor: 0,
+            tonnageSentToExporter: 0,
+            tonnageSentToAnotherSite: 0,
+            finalDestinations: []
+          }
+        })
+
+        const report = await fetchOrGenerateReportForPeriod({
+          reportsRepository,
+          ledgerRepository,
+          summaryLogRowStatesRepository,
+          packagingRecyclingNotesRepository: createPrnRepo(),
+          ...params,
+          featureFlags: gateEnabled
+        })
+
+        expect(report).not.toHaveProperty('incompleteSummaryLogRows')
+      })
     })
   })
 

--- a/src/reports/routes/get-detail.js
+++ b/src/reports/routes/get-detail.js
@@ -88,6 +88,7 @@ export const reportsGetDetail = {
       packagingRecyclingNotesRepository,
       reportsRepository,
       overseasSitesRepository,
+      featureFlags,
       params
     } = request
     const {
@@ -116,7 +117,8 @@ export const reportsGetDetail = {
       year,
       cadence,
       period,
-      submissionNumber
+      submissionNumber,
+      featureFlags
     })
 
     warnIfWasteRecordsExcluded(request, report, organisationId, registrationId)

--- a/src/reports/routes/get-detail.test.js
+++ b/src/reports/routes/get-detail.test.js
@@ -87,7 +87,8 @@ describe(`GET ${reportsGetDetailPath}`, () => {
     const createServer = async (
       registrationOverrides = {},
       wasteRecordOverrides = [],
-      accreditationStatus
+      accreditationStatus,
+      featureFlags = createInMemoryFeatureFlags()
     ) => {
       const registration = /** @type {Registration} */ (
         buildRegistration(registrationOverrides)
@@ -113,7 +114,7 @@ describe(`GET ${reportsGetDetailPath}`, () => {
           ledgerRepository,
           summaryLogRowStatesRepository
         },
-        featureFlags: createInMemoryFeatureFlags()
+        featureFlags
       })
 
       return {
@@ -1605,6 +1606,99 @@ describe(`GET ${reportsGetDetailPath}`, () => {
         })
 
         expect(response.statusCode).toBe(StatusCodes.OK)
+      })
+    })
+
+    describe('incompleteSummaryLogRows (PAE-1420)', () => {
+      const gateEnabled = createInMemoryFeatureFlags({
+        reportDataValidation: true
+      })
+
+      // A received row whose positive tonnage triggers the supplier rule but
+      // carries none of the six mandatory supplier fields.
+      const incompleteReceived = {
+        type: WASTE_RECORD_TYPE.RECEIVED,
+        data: {
+          MONTH_RECEIVED_FOR_REPROCESSING: '2026-01',
+          TONNAGE_RECEIVED_FOR_RECYCLING: 5
+        }
+      }
+
+      it('returns 200 carrying incompleteSummaryLogRows on the generate branch when the flag is on and data is incomplete', async () => {
+        const { server, organisationId, registrationId } = await createServer(
+          { wasteProcessingType: 'reprocessor', accreditationId: undefined },
+          [incompleteReceived],
+          undefined,
+          gateEnabled
+        )
+
+        const response = await makeRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(payload.incompleteSummaryLogRows.total).toBe(6)
+        expect(payload.incompleteSummaryLogRows.issues).toHaveLength(6)
+        expect(payload.incompleteSummaryLogRows.issues[0]).toEqual(
+          expect.objectContaining({
+            sheet: expect.any(String),
+            rowId: 'row-0',
+            field: expect.any(String)
+          })
+        )
+      })
+
+      it('omits incompleteSummaryLogRows when the same data is complete', async () => {
+        const { server, organisationId, registrationId } = await createServer(
+          { wasteProcessingType: 'reprocessor', accreditationId: undefined },
+          [
+            {
+              type: WASTE_RECORD_TYPE.RECEIVED,
+              data: {
+                MONTH_RECEIVED_FOR_REPROCESSING: '2026-01',
+                TONNAGE_RECEIVED_FOR_RECYCLING: 5,
+                SUPPLIER_NAME: 'Acme Waste Ltd',
+                SUPPLIER_ADDRESS: '1 Depot Road',
+                SUPPLIER_POSTCODE: 'AB1 2CD',
+                SUPPLIER_EMAIL: 'ops@acme.example',
+                SUPPLIER_PHONE_NUMBER: '01234 567890',
+                ACTIVITIES_CARRIED_OUT_BY_SUPPLIER: 'Baling'
+              }
+            }
+          ],
+          undefined,
+          gateEnabled
+        )
+
+        const response = await makeRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(payload.incompleteSummaryLogRows).toBeUndefined()
+      })
+
+      it('omits incompleteSummaryLogRows when the flag is off despite incomplete data', async () => {
+        const { server, organisationId, registrationId } = await createServer(
+          { wasteProcessingType: 'reprocessor', accreditationId: undefined },
+          [incompleteReceived]
+        )
+
+        const response = await makeRequest(
+          server,
+          organisationId,
+          registrationId
+        )
+        const payload = JSON.parse(response.payload)
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(payload.incompleteSummaryLogRows).toBeUndefined()
       })
     })
   })

--- a/src/reports/routes/response.schema.js
+++ b/src/reports/routes/response.schema.js
@@ -72,6 +72,25 @@ export const reportDetailResponseSchema = Joi.object({
   })
     .unknown(true)
     .optional(),
+  // Present only on the generate branch (uncreated preview) when the report
+  // data validation flag is on and mandatory data is missing (PAE-1420). Same
+  // { total, issues } shape the POST create gate throws, so the frontend
+  // consumes it unchanged.
+  incompleteSummaryLogRows: Joi.object({
+    total: Joi.number().integer().required(),
+    issues: Joi.array()
+      .items(
+        // `.unknown(true)` keeps the field additive, matching the sibling
+        // sections above: a future locator added to an issue must not fail
+        // response validation and 500 a read for existing consumers.
+        Joi.object({
+          sheet: Joi.string().required(),
+          rowId: Joi.string().required(),
+          field: Joi.string().required()
+        }).unknown(true)
+      )
+      .required()
+  }).optional(),
   operatorCategory: Joi.string().optional(),
   period: periodSchema.optional(),
   prn: prnSchema.allow(null),

--- a/src/reports/routes/response.schema.test.js
+++ b/src/reports/routes/response.schema.test.js
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import { PERIOD_STATUS } from '#reports/domain/period-status.js'
-import { reportsCalendarResponseSchema } from './response.schema.js'
+import {
+  reportDetailResponseSchema,
+  reportsCalendarResponseSchema
+} from './response.schema.js'
 
 const validReport = {
   id: 'report-1',
@@ -81,6 +84,59 @@ describe('reportsCalendarResponseSchema', () => {
     }
 
     const { error } = reportsCalendarResponseSchema.validate(response)
+
+    expect(error).toBeDefined()
+  })
+})
+
+describe('reportDetailResponseSchema incompleteSummaryLogRows (PAE-1420)', () => {
+  const validDetail = {
+    details: { material: 'plastic', site: null },
+    recyclingActivity: { suppliers: [], totalTonnageReceived: 0 },
+    source: { lastUploadedAt: null, summaryLogId: null },
+    wasteSent: {
+      finalDestinations: [],
+      tonnageSentToAnotherSite: 0,
+      tonnageSentToExporter: 0,
+      tonnageSentToReprocessor: 0
+    }
+  }
+
+  it('accepts a well-formed incompleteSummaryLogRows', () => {
+    const { error } = reportDetailResponseSchema.validate({
+      ...validDetail,
+      incompleteSummaryLogRows: {
+        total: 2,
+        issues: [
+          { sheet: 'Received', rowId: 'row-1', field: 'SUPPLIER_NAME' },
+          { sheet: 'Received', rowId: 'row-1', field: 'SUPPLIER_ADDRESS' }
+        ]
+      }
+    })
+
+    expect(error).toBeUndefined()
+  })
+
+  it('rejects an incompleteSummaryLogRows whose total is not a number', () => {
+    const { error } = reportDetailResponseSchema.validate({
+      ...validDetail,
+      incompleteSummaryLogRows: {
+        total: 'two',
+        issues: [{ sheet: 'Received', rowId: 'row-1', field: 'SUPPLIER_NAME' }]
+      }
+    })
+
+    expect(error).toBeDefined()
+  })
+
+  it('rejects an issue missing the field locator', () => {
+    const { error } = reportDetailResponseSchema.validate({
+      ...validDetail,
+      incompleteSummaryLogRows: {
+        total: 1,
+        issues: [{ sheet: 'Received', rowId: 'row-1' }]
+      }
+    })
 
     expect(error).toBeDefined()
   })


### PR DESCRIPTION
Ticket: [PAE-1420](https://eaflood.atlassian.net/browse/PAE-1420)
## What

The `report_data_incomplete` gate previously ran only on the report-creation POST. 

This PR adds a **passive** incompleteness signal to the report-detail GET preview so the frontend can trigger the validation-error screen on the "Select entry / Create draft" CTA (a GET), per the AC: *"Screen is triggered on the Select CTA for reports in Due/Over Due status."*

- `assert-report-data-complete.js`: new non-throwing `summariseIncompleteData(rows) → { total, issues } | null`, reusing `findIssues` + `MAX_ISSUES_REPORTED`. The POST gate (`assertReportDataComplete`) is untouched.
- `report-service.js`: `fetchOrGenerateReportForPeriod` takes an optional `featureFlags`; attaches `incompleteSummaryLogRows` **on the generate branch only** when the flag is on and mandatory data is missing. The stored-report branch stays ungated (check-your-answers unaffected). Stored-report result construction extracted to `buildStoredReportResult` to keep the function within the length limit.
- `get-detail.js`: passes `request.featureFlags` through to the service.
- `response.schema.js`: optional `incompleteSummaryLogRows { total, issues: [{ sheet, rowId, field }] }`.

Gated behind `FEATURE_FLAG_REPORT_DATA_VALIDATION` (off by default). Omitted when the flag is off, when data is complete, or when a stored report exists.

## Why 200-with-field, not a non-200

The GET returns 200 with an optional field rather than mirroring the POST's 400:

- **Shared endpoint** — the GET serves `organisationRead` and `adminRead` plus the stored-report branch. A non-200 on the generate branch would turn a previously-successful read into an error for admin and every other GET consumer; a 200 field is additive and safely ignorable.
- **Read semantics** — the preview *was* computed successfully. A 4xx on a successful read misleads caches, client HTTP wrappers, and error dashboards.
- **Payload reuse preserved** — `incompleteSummaryLogRows` carries the same `{ total, issues }` shape the POST throws, so the frontend's `buildReportDataIncompleteView` consumes it unchanged. Only the transport envelope differs.

## Why this isn't redundant with the POST gate

The two guards cover **different journey steps**, not the same check twice:

- The GET signal gates *entering* the draft flow (the Select CTA).
- The POST gate gates *committing* the resource (the confirm CTA), and remains the authoritative server-side enforcement — a client can POST directly, the data can change between GET and POST, and the endpoint is shared. The GET signal is a UX affordance; the POST is the integrity boundary.

Dropping the GET signal would defer the error until after the user has walked the entire preview (the UX the ticket exists to prevent); dropping the POST gate would remove enforcement. Both responses share one payload shape so the frontend keeps a single view-builder.

## Tests

Covers the service generate branch (attaches when flag on and data incomplete; omits when flag off, when complete, and on the stored branch), the get-detail route (200 carrying the field; omitted when complete or flag off), and the response schema (accepts a well-formed field, rejects a malformed one).

Frontend counterpart: defra-07a6 (epr-frontend PR #1064).


[PAE-1420]: https://eaflood.atlassian.net/browse/PAE-1420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ