### PR TITLE
PAE-1826: Remove the regulator scope

### DIFF
--- a/src/common/helpers/auth/constants.js
+++ b/src/common/helpers/auth/constants.js
@@ -10,8 +10,7 @@ export const SCOPES = {
   organisationLinkedRead: 'organisation.linked.read',
   organisationLinkedWrite: 'organisation.linked.write',
   organisationSearch: 'organisation.search',
-  wasteBalanceLedgerRead: 'waste-balance.ledger.read',
-  regulator: 'regulator'
+  wasteBalanceLedgerRead: 'waste-balance.ledger.read'
 }
 
 /**
@@ -50,17 +49,12 @@ export const REGULATOR_ROLE = 'regulator_standard'
  * So a ledger route requires both scopes: `organisation.read` for the
  * organisation, and `waste-balance.ledger.read` for the ledger behind it.
  *
- * `regulator` is coarse on purpose. It stands for the whole set of functions
- * only a regulator performs, and subdivides when caseworking functions
- * arrive.
- *
  * A regulator reads and changes nothing, so no write scope appears here.
  */
 export const REGULATOR_SCOPES = [
   SCOPES.organisationRead,
   SCOPES.organisationSearch,
-  SCOPES.wasteBalanceLedgerRead,
-  SCOPES.regulator
+  SCOPES.wasteBalanceLedgerRead
 ]
 
 /**

--- a/src/common/helpers/auth/constants.test.js
+++ b/src/common/helpers/auth/constants.test.js
@@ -75,10 +75,6 @@ describe('the regulator role', () => {
     expect(REGULATOR_SCOPES).toContain(SCOPES.organisationRead)
   })
 
-  test('carries the coarse regulator scope for what only a regulator does', () => {
-    expect(REGULATOR_SCOPES).toContain(SCOPES.regulator)
-  })
-
   test('carries organisation.search, which enumerates operators the regulator holds no id for', () => {
     expect(REGULATOR_SCOPES).toContain(SCOPES.organisationSearch)
   })

--- a/src/common/helpers/auth/get-jwt-strategy-config.test.js
+++ b/src/common/helpers/auth/get-jwt-strategy-config.test.js
@@ -252,7 +252,7 @@ describe('#getJwtStrategyConfig', () => {
     test('credential carries the scope the Entra resolver returned for a regulator', async () => {
       mockGetEntraUserRoles.mockResolvedValue({
         role: 'regulator_standard',
-        scopes: [SCOPES.organisationRead, SCOPES.regulator]
+        scopes: [SCOPES.organisationRead, SCOPES.organisationSearch]
       })
       const config = createStrategyConfig(mockOidcConfigs)
 
@@ -273,7 +273,7 @@ describe('#getJwtStrategyConfig', () => {
       expect(result.credentials.role).toBe('regulator_standard')
       expect(result.credentials.scope).toEqual([
         SCOPES.organisationRead,
-        SCOPES.regulator
+        SCOPES.organisationSearch
       ])
     })
 


### PR DESCRIPTION
`regulator` is a role, not a scope. The role is already carried by `REGULATOR_ROLE`, so the entry in `SCOPES` duplicated it in a list that exists to name capabilities, and no route gated on it. This removes it from `SCOPES` and from the regulator's scope bundle. It was verified dead across epr-backend, epr-frontend, epr-re-ex-admin-frontend, epr-re-ex-journey-tests and cdp-app-config: nothing reads it as an authorisation decision, and epr-frontend's `src/server/auth/scopes.js` already records that it gates no route there. The regulator's other scopes and both role constants are untouched, so nothing a regulator can reach changes.

No journey-test change accompanies this. The scope gated nothing, so no scenario can observe its removal, and no journey fixture mints it into a token.
