### PR TITLE
PAE-1823: Allow an admin to cancel an accepted PRN/PERN within the relevant year window

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -381,6 +381,12 @@ const baseConfig = {
       format: Boolean,
       default: false,
       env: 'FEATURE_FLAG_REPORT_DATA_COMPLETE_DIAGNOSTIC'
+    },
+    prnAdminCancellation: {
+      doc: 'Feature Flag: Allow an admin to cancel an accepted PRN/PERN (PAE-1823)',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_FLAG_PRN_ADMIN_CANCELLATION'
     }
   },
   formSubmissionOverrides: {

--- a/src/feature-flags/feature-flags.config.js
+++ b/src/feature-flags/feature-flags.config.js
@@ -19,5 +19,8 @@ export const createConfigFeatureFlags = (config) => ({
   },
   isReportDataCompleteDiagnosticEnabled() {
     return config.get('featureFlags.reportDataCompleteDiagnostic')
+  },
+  isPrnAdminCancellationEnabled() {
+    return config.get('featureFlags.prnAdminCancellation')
   }
 })

--- a/src/feature-flags/feature-flags.inmemory.js
+++ b/src/feature-flags/feature-flags.inmemory.js
@@ -20,5 +20,8 @@ export const createInMemoryFeatureFlags = (flags = {}) => ({
   },
   isReportDataCompleteDiagnosticEnabled() {
     return flags.reportDataCompleteDiagnostic ?? false
+  },
+  isPrnAdminCancellationEnabled() {
+    return flags.prnAdminCancellation ?? false
   }
 })

--- a/src/feature-flags/feature-flags.port.js
+++ b/src/feature-flags/feature-flags.port.js
@@ -6,6 +6,7 @@
  * @property {() => boolean} isStaleIssuedTonnageReportEnabled
  * @property {() => boolean} isReportDataValidationEnabled
  * @property {() => boolean} isReportDataCompleteDiagnosticEnabled
+ * @property {() => boolean} isPrnAdminCancellationEnabled
  */
 
 /**
@@ -16,6 +17,7 @@
  * @property {boolean} [staleIssuedTonnageReport]
  * @property {boolean} [reportDataValidation]
  * @property {boolean} [reportDataCompleteDiagnostic]
+ * @property {boolean} [prnAdminCancellation]
  */
 
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/packaging-recycling-notes/application/admin-prn-mapper.test.js
+++ b/src/packaging-recycling-notes/application/admin-prn-mapper.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+
+import { mapToAdminPrn } from './admin-prn-mapper.js'
+import { createMockIssuedPrn } from '#packaging-recycling-notes/routes/test-helpers.js'
+
+describe('mapToAdminPrn', () => {
+  it('maps core fields', () => {
+    const prn = createMockIssuedPrn()
+
+    const mapped = mapToAdminPrn(prn)
+
+    expect(mapped.id).toBe(prn.id)
+    expect(mapped.prnNumber).toBe(prn.prnNumber)
+    expect(mapped.status).toBe(prn.status.currentStatus)
+    expect(mapped.accreditationYear).toBe(prn.accreditation.accreditationYear)
+    expect(mapped.tonnage).toBe(prn.tonnage)
+    expect(mapped.organisationName).toBe(prn.organisation.name)
+  })
+})

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -75,6 +75,10 @@ const TRANSITION_TO_COMMAND = Object.freeze({
   [`${PRN_STATUS.AWAITING_CANCELLATION}|${PRN_STATUS.CANCELLED}`]: {
     method: 'cancelIssuedPrn',
     logOperation: 'credit_full'
+  },
+  [`${PRN_STATUS.ACCEPTED}|${PRN_STATUS.CANCELLED}`]: {
+    method: 'cancelIssuedPrn',
+    logOperation: 'credit_full'
   }
 })
 

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.test.js
@@ -108,6 +108,12 @@ describe('prnCommandFor', () => {
       PRN_STATUS.CANCELLED,
       'cancelIssuedPrn',
       'credit_full'
+    ],
+    [
+      PRN_STATUS.ACCEPTED,
+      PRN_STATUS.CANCELLED,
+      'cancelIssuedPrn',
+      'credit_full'
     ]
   ])(
     'maps %s -> %s to the %s command',

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -11,6 +11,7 @@ import {
   validateTransition,
   assertAccreditationCanIssue
 } from '#packaging-recycling-notes/domain/model.js'
+import { assertCancellationAllowed } from '#packaging-recycling-notes/domain/cancellation.js'
 import { generatePrnNumber } from '#packaging-recycling-notes/domain/prn-number-generator.js'
 import { PrnNumberConflictError } from '#packaging-recycling-notes/repository/port.js'
 import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
@@ -271,6 +272,12 @@ export async function updatePrnStatus({
 
   const currentStatus = prn.status.currentStatus
   validateTransition(currentStatus, newStatus, actor)
+  assertCancellationAllowed(
+    currentStatus,
+    newStatus,
+    prn.accreditation.accreditationYear,
+    updatedAt ?? new Date()
+  )
 
   const ctx = buildWriteContext({
     prnRepository,

--- a/src/packaging-recycling-notes/domain/cancellation.js
+++ b/src/packaging-recycling-notes/domain/cancellation.js
@@ -1,0 +1,28 @@
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { assertBeforeEndOfRelevantYear } from '#packaging-recycling-notes/domain/relevant-year.js'
+
+/**
+ * A PRN/PERN issued under an accreditation for relevant year Y must not be
+ * cancelled after 31 January of the following year (PAE-1823). Keyed on the
+ * transition itself, not the actor, so callers can run this unconditionally
+ * on any status change.
+ *
+ * @param {import('#packaging-recycling-notes/domain/model.js').PrnStatus} previousStatus
+ * @param {import('#packaging-recycling-notes/domain/model.js').PrnStatus} newStatus
+ * @param {number} accreditationYear
+ * @param {Date} now
+ * @throws {import('#packaging-recycling-notes/domain/relevant-year.js').RelevantYearWindowExpiredError} when the deadline has passed
+ */
+export function assertCancellationAllowed(
+  previousStatus,
+  newStatus,
+  accreditationYear,
+  now
+) {
+  const isAcceptedToCancelled =
+    previousStatus === PRN_STATUS.ACCEPTED && newStatus === PRN_STATUS.CANCELLED
+
+  if (isAcceptedToCancelled) {
+    assertBeforeEndOfRelevantYear(accreditationYear, now)
+  }
+}

--- a/src/packaging-recycling-notes/domain/cancellation.test.js
+++ b/src/packaging-recycling-notes/domain/cancellation.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+
+import { assertCancellationAllowed } from './cancellation.js'
+import { RelevantYearWindowExpiredError } from './relevant-year.js'
+import { PRN_STATUS } from './model.js'
+
+describe('assertCancellationAllowed', () => {
+  it('does not throw for accepted -> cancelled within the window', () => {
+    expect(() =>
+      assertCancellationAllowed(
+        PRN_STATUS.ACCEPTED,
+        PRN_STATUS.CANCELLED,
+        2026,
+        new Date('2027-01-31T23:59:59.999Z')
+      )
+    ).not.toThrow()
+  })
+
+  it('throws RelevantYearWindowExpiredError for accepted -> cancelled once the deadline has passed', () => {
+    expect(() =>
+      assertCancellationAllowed(
+        PRN_STATUS.ACCEPTED,
+        PRN_STATUS.CANCELLED,
+        2026,
+        new Date('2027-02-01T00:00:00.000Z')
+      )
+    ).toThrow(RelevantYearWindowExpiredError)
+  })
+
+  it('carries the relevant year on the error', () => {
+    let thrownError
+    try {
+      assertCancellationAllowed(
+        PRN_STATUS.ACCEPTED,
+        PRN_STATUS.CANCELLED,
+        2026,
+        new Date('2027-03-01T00:00:00.000Z')
+      )
+    } catch (e) {
+      thrownError = e
+    }
+
+    expect(thrownError).toBeInstanceOf(RelevantYearWindowExpiredError)
+    expect(thrownError?.relevantYear).toBe(2026)
+  })
+
+  it.each([
+    [
+      'awaiting_cancellation -> cancelled (signatory path, no deadline)',
+      PRN_STATUS.AWAITING_CANCELLATION,
+      PRN_STATUS.CANCELLED
+    ],
+    [
+      'awaiting_authorisation -> deleted',
+      PRN_STATUS.AWAITING_AUTHORISATION,
+      PRN_STATUS.DELETED
+    ],
+    ['draft -> discarded', PRN_STATUS.DRAFT, PRN_STATUS.DISCARDED]
+  ])(
+    'is a no-op for %s, even long past what would be the deadline',
+    (_label, previousStatus, newStatus) => {
+      expect(() =>
+        assertCancellationAllowed(
+          previousStatus,
+          newStatus,
+          2000,
+          new Date('2099-01-01T00:00:00.000Z')
+        )
+      ).not.toThrow()
+    }
+  )
+})

--- a/src/packaging-recycling-notes/domain/model.js
+++ b/src/packaging-recycling-notes/domain/model.js
@@ -35,7 +35,8 @@ export const CANCELLED_PRN_STATUSES = new Set([
 export const PRN_ACTOR = Object.freeze({
   REPROCESSOR_EXPORTER: 'reprocessor_exporter',
   SIGNATORY: 'signatory',
-  PRODUCER: 'producer'
+  PRODUCER: 'producer',
+  SERVICE_MAINTAINER: 'service_maintainer'
 })
 
 /**
@@ -63,7 +64,12 @@ export const PRN_STATUS_TRANSITIONS = Object.freeze({
     { status: PRN_STATUS.ACCEPTED, actors: [PRN_ACTOR.PRODUCER] },
     { status: PRN_STATUS.AWAITING_CANCELLATION, actors: [PRN_ACTOR.PRODUCER] }
   ],
-  [PRN_STATUS.ACCEPTED]: [],
+  [PRN_STATUS.ACCEPTED]: [
+    {
+      status: PRN_STATUS.CANCELLED,
+      actors: [PRN_ACTOR.SERVICE_MAINTAINER]
+    }
+  ],
   [PRN_STATUS.AWAITING_CANCELLATION]: [
     { status: PRN_STATUS.CANCELLED, actors: [PRN_ACTOR.SIGNATORY] }
   ],

--- a/src/packaging-recycling-notes/domain/model.test.js
+++ b/src/packaging-recycling-notes/domain/model.test.js
@@ -17,10 +17,15 @@ import {
 
 describe('PRN_STATUS_TRANSITIONS', () => {
   it('has empty array for terminal states', () => {
-    expect(PRN_STATUS_TRANSITIONS[PRN_STATUS.ACCEPTED]).toEqual([])
     expect(PRN_STATUS_TRANSITIONS[PRN_STATUS.CANCELLED]).toEqual([])
     expect(PRN_STATUS_TRANSITIONS[PRN_STATUS.DELETED]).toEqual([])
     expect(PRN_STATUS_TRANSITIONS[PRN_STATUS.DISCARDED]).toEqual([])
+  })
+
+  it('allows only accepted -> cancelled for a service maintainer (PAE-1823)', () => {
+    expect(PRN_STATUS_TRANSITIONS[PRN_STATUS.ACCEPTED]).toEqual([
+      { status: PRN_STATUS.CANCELLED, actors: [PRN_ACTOR.SERVICE_MAINTAINER] }
+    ])
   })
 
   it.each([
@@ -50,7 +55,8 @@ describe('PRN_STATUS_TRANSITIONS', () => {
       PRN_STATUS.AWAITING_CANCELLATION,
       PRN_STATUS.CANCELLED,
       PRN_ACTOR.SIGNATORY
-    ]
+    ],
+    [PRN_STATUS.ACCEPTED, PRN_STATUS.CANCELLED, PRN_ACTOR.SERVICE_MAINTAINER]
   ])('allows %s -> %s for %s', (from, to, actor) => {
     expect(isValidTransition(from, to, actor)).toBe(true)
   })
@@ -76,6 +82,10 @@ describe('PRN_STATUS_TRANSITIONS', () => {
     ],
     [PRN_STATUS.DRAFT, PRN_STATUS.ACCEPTED, PRN_ACTOR.PRODUCER],
     [PRN_STATUS.ACCEPTED, PRN_STATUS.DRAFT, PRN_ACTOR.PRODUCER],
+    [PRN_STATUS.ACCEPTED, PRN_STATUS.DELETED, PRN_ACTOR.SERVICE_MAINTAINER],
+    [PRN_STATUS.ACCEPTED, PRN_STATUS.CANCELLED, PRN_ACTOR.SIGNATORY],
+    [PRN_STATUS.ACCEPTED, PRN_STATUS.CANCELLED, PRN_ACTOR.PRODUCER],
+    [PRN_STATUS.ACCEPTED, PRN_STATUS.CANCELLED, PRN_ACTOR.REPROCESSOR_EXPORTER],
     [/** @type {PrnStatus} */ ('unknown'), PRN_STATUS.DRAFT, PRN_ACTOR.PRODUCER]
   ])('rejects %s -> %s for %s', (from, to, actor) => {
     expect(isValidTransition(from, to, actor)).toBe(false)

--- a/src/packaging-recycling-notes/domain/relevant-year.js
+++ b/src/packaging-recycling-notes/domain/relevant-year.js
@@ -1,0 +1,72 @@
+/**
+ * "Relevant year" is the Producer Responsibility Obligations (Packaging and
+ * Packaging Waste) Regulations 2024's term for the annual period a PRN/PERN,
+ * accreditation or compliance obligation relates to (reg 41(2)): several
+ * rules key off "31 January in the year immediately following the relevant
+ * year" — the PRN cancellation deadline (PAE-1823) is one instance, not the
+ * only one, so this module holds the general year-boundary arithmetic rather
+ * than anything cancellation-specific.
+ *
+ * Evaluated in UTC. There is no date library in this codebase, and every
+ * existing date helper (`#common/helpers/date-formatter.js`) is UTC-pinned.
+ * 31 January is in GMT every year (BST does not start until late March), so
+ * UTC and Europe/London name the same instant for this specific boundary.
+ */
+
+/**
+ * Thrown when an instant falls after the end of a relevant year's window.
+ */
+export class RelevantYearWindowExpiredError extends Error {
+  /**
+   * @param {number} relevantYear
+   */
+  constructor(relevantYear) {
+    const deadlineYear = relevantYear + 1
+    super(
+      `The deadline for a ${relevantYear} relevant year was 31 January ${deadlineYear}.`
+    )
+    this.relevantYear = relevantYear
+  }
+}
+
+/**
+ * The last instant (UTC) of 31 January in the year immediately following
+ * `relevantYear` — inclusive.
+ *
+ * @param {number} relevantYear
+ * @returns {Date}
+ */
+function endOfRelevantYear(relevantYear) {
+  if (!Number.isFinite(relevantYear)) {
+    throw new TypeError(
+      `Cannot compute the end of a relevant year: relevantYear must be a finite number, got ${relevantYear}`
+    )
+  }
+  // Month index 0 = January.
+  return new Date(Date.UTC(relevantYear + 1, 0, 31, 23, 59, 59, 999))
+}
+
+/**
+ * Whether `now` falls on or before the end of `relevantYear` (31 January of
+ * the following year, inclusive).
+ *
+ * @param {number} relevantYear
+ * @param {Date} now
+ * @returns {boolean}
+ */
+export function isBeforeEndOfRelevantYear(relevantYear, now) {
+  return now.getTime() <= endOfRelevantYear(relevantYear).getTime()
+}
+
+/**
+ * Asserts `now` falls on or before the end of `relevantYear`.
+ *
+ * @param {number} relevantYear
+ * @param {Date} now
+ * @throws {RelevantYearWindowExpiredError} when the deadline has passed
+ */
+export function assertBeforeEndOfRelevantYear(relevantYear, now) {
+  if (!isBeforeEndOfRelevantYear(relevantYear, now)) {
+    throw new RelevantYearWindowExpiredError(relevantYear)
+  }
+}

--- a/src/packaging-recycling-notes/domain/relevant-year.js
+++ b/src/packaging-recycling-notes/domain/relevant-year.js
@@ -29,6 +29,14 @@ export class RelevantYearWindowExpiredError extends Error {
   }
 }
 
+// Month index 0 = January.
+const JANUARY = 0
+const LAST_DAY_OF_JANUARY = 31
+const END_OF_DAY_HOURS = 23
+const END_OF_DAY_MINUTES = 59
+const END_OF_DAY_SECONDS = 59
+const END_OF_DAY_MILLISECONDS = 999
+
 /**
  * The last instant (UTC) of 31 January in the year immediately following
  * `relevantYear` — inclusive.
@@ -42,8 +50,17 @@ function endOfRelevantYear(relevantYear) {
       `Cannot compute the end of a relevant year: relevantYear must be a finite number, got ${relevantYear}`
     )
   }
-  // Month index 0 = January.
-  return new Date(Date.UTC(relevantYear + 1, 0, 31, 23, 59, 59, 999))
+  return new Date(
+    Date.UTC(
+      relevantYear + 1,
+      JANUARY,
+      LAST_DAY_OF_JANUARY,
+      END_OF_DAY_HOURS,
+      END_OF_DAY_MINUTES,
+      END_OF_DAY_SECONDS,
+      END_OF_DAY_MILLISECONDS
+    )
+  )
 }
 
 /**

--- a/src/packaging-recycling-notes/domain/relevant-year.test.js
+++ b/src/packaging-recycling-notes/domain/relevant-year.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+
+import { isBeforeEndOfRelevantYear } from './relevant-year.js'
+
+describe('isBeforeEndOfRelevantYear', () => {
+  it.each([
+    ['well inside the window', '2026-06-01T00:00:00.000Z', true],
+    [
+      'midnight at the start of the deadline day',
+      '2027-01-31T00:00:00.000Z',
+      true
+    ],
+    ['exactly the deadline instant', '2027-01-31T23:59:59.999Z', true],
+    ['one millisecond after the deadline', '2027-02-01T00:00:00.000Z', false],
+    ['well after the deadline', '2027-03-01T00:00:00.000Z', false]
+  ])('%s -> %s', (_label, isoNow, expected) => {
+    expect(isBeforeEndOfRelevantYear(2026, new Date(isoNow))).toBe(expected)
+  })
+
+  it('holds across a leap year boundary', () => {
+    expect(
+      isBeforeEndOfRelevantYear(2027, new Date('2028-01-31T23:59:59.999Z'))
+    ).toBe(true)
+    expect(
+      isBeforeEndOfRelevantYear(2027, new Date('2028-02-01T00:00:00.000Z'))
+    ).toBe(false)
+  })
+
+  it('throws for a non-finite relevant year', () => {
+    const now = new Date('2026-06-01T00:00:00.000Z')
+    expect(() => isBeforeEndOfRelevantYear(NaN, now)).toThrow(TypeError)
+    expect(() =>
+      isBeforeEndOfRelevantYear(
+        /** @type {number} */ (/** @type {*} */ (undefined)),
+        now
+      )
+    ).toThrow(TypeError)
+    expect(() =>
+      isBeforeEndOfRelevantYear(
+        /** @type {number} */ (/** @type {*} */ (null)),
+        now
+      )
+    ).toThrow(TypeError)
+  })
+})

--- a/src/packaging-recycling-notes/routes/admin-cancel.js
+++ b/src/packaging-recycling-notes/routes/admin-cancel.js
@@ -218,7 +218,7 @@ export const adminPackagingRecyclingNotesCancel = {
     const { packagingRecyclingNotesRepository, params, logger } = request
     const { id } = params
 
-    logger.debug({
+    logger.info({
       message: `Admin cancel requested: id=${id}`,
       event: {
         category: LOGGING_EVENT_CATEGORIES.SERVER,

--- a/src/packaging-recycling-notes/routes/admin-cancel.js
+++ b/src/packaging-recycling-notes/routes/admin-cancel.js
@@ -1,0 +1,210 @@
+import Boom from '@hapi/boom'
+import Joi from 'joi'
+import { StatusCodes } from 'http-status-codes'
+
+import {
+  LOGGING_EVENT_ACTIONS,
+  LOGGING_EVENT_CATEGORIES
+} from '#common/enums/index.js'
+import { SCOPES } from '#common/helpers/auth/constants.js'
+import { getAuthConfig } from '#common/helpers/auth/get-auth-config.js'
+import {
+  PRN_STATUS,
+  PRN_ACTOR
+} from '#packaging-recycling-notes/domain/model.js'
+import { RelevantYearWindowExpiredError } from '#packaging-recycling-notes/domain/relevant-year.js'
+import { updatePrnStatus } from '#packaging-recycling-notes/application/update-status.js'
+import { auditPrnStatusTransition } from '#packaging-recycling-notes/application/audit.js'
+
+/**
+ * @import { PackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/port.js'
+ * @import { HapiRequest, TypedLogger } from '#common/hapi-types.js'
+ * @import { OnPrnCancelled } from '#reports/application/prn-cancellation-events.js'
+ */
+
+export const adminPackagingRecyclingNotesCancelPath =
+  '/v1/admin/packaging-recycling-notes/{id}/cancel'
+
+/**
+ * Builds the acting user from admin request credentials. `HumanCredentials`
+ * guarantees `id` and `email`, but `name` is optional — Entra admin tokens
+ * carry no display name, so it falls back to the email to avoid stamping
+ * `'unknown'` on the PRN's `status.cancelled.by` and the ledger event's
+ * `createdBy` — the PRN actor summary (unlike the reports one) carries no
+ * `position` field, so it is not set here; the admin's role is still
+ * captured on the system log via `extractUserDetails`.
+ *
+ * @param {{ id: string, email: string, name?: string }} credentials
+ */
+const buildAdminUser = ({ id, email, name }) => ({
+  id,
+  name: name ?? email,
+  email
+})
+
+/**
+ * Maps a cancellation failure to the HTTP error it should surface as.
+ *
+ * `updatePrnStatus` is called with `providedPrn` set to the same document this
+ * handler already checked is `accepted`, so its internal `validateTransition`
+ * re-checks that identical status and can never disagree — `StatusConflictError`
+ * and `UnauthorisedTransitionError` are consequently unreachable here and are
+ * deliberately not special-cased; they would fall through to the generic 500
+ * below if the invariant above were ever broken.
+ * @param {*} error
+ * @param {string} path
+ * @param {string} id
+ * @param {TypedLogger} logger
+ */
+const mapAdminCancelError = (error, path, id, logger) => {
+  if (error instanceof RelevantYearWindowExpiredError) {
+    logger.info({
+      message: `Admin cancel refused: ${error.message}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.REQUEST_FAILURE,
+        reference: id
+      }
+    })
+    return Boom.conflict(error.message)
+  }
+
+  if (error.isBoom) {
+    return error
+  }
+
+  logger.error({
+    err: error,
+    message: `Admin cancel failed unexpectedly: id=${id}`,
+    event: {
+      category: LOGGING_EVENT_CATEGORIES.SERVER,
+      action: LOGGING_EVENT_ACTIONS.RESPONSE_FAILURE,
+      reference: id
+    }
+  })
+
+  return Boom.badImplementation(`Failure on ${path}`)
+}
+
+export const adminPackagingRecyclingNotesCancel = {
+  method: 'POST',
+  path: adminPackagingRecyclingNotesCancelPath,
+  options: {
+    auth: getAuthConfig([SCOPES.adminWrite]),
+    tags: ['api', 'admin'],
+    validate: {
+      params: Joi.object({
+        id: Joi.string().hex().length(24).required()
+      })
+    }
+  },
+  /**
+   * @param {HapiRequest & {
+   *   packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository,
+   *   params: { id: string },
+   *   prnEvents: { onCancelled: OnPrnCancelled }
+   * }} request
+   * @param {Object} h - Hapi response toolkit
+   */
+  handler: async (request, h) => {
+    const {
+      packagingRecyclingNotesRepository,
+      ledgerRepository,
+      organisationsRepository,
+      prnEvents,
+      params,
+      logger,
+      auth
+    } = request
+    const { id } = params
+
+    logger.debug({
+      message: `Admin cancel requested: id=${id}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS,
+        reference: id
+      }
+    })
+
+    try {
+      const previousPrn = await packagingRecyclingNotesRepository.findById(id)
+
+      if (!previousPrn) {
+        logger.info({
+          message: `Admin cancel refused: PRN not found: ${id}`,
+          event: {
+            category: LOGGING_EVENT_CATEGORIES.SERVER,
+            action: LOGGING_EVENT_ACTIONS.REQUEST_FAILURE,
+            reference: id
+          }
+        })
+        throw Boom.notFound(`PRN not found: ${id}`)
+      }
+
+      if (previousPrn.status.currentStatus !== PRN_STATUS.ACCEPTED) {
+        logger.info({
+          message: `Admin cancel refused: PRN ${id} is ${previousPrn.status.currentStatus}, not accepted`,
+          event: {
+            category: LOGGING_EVENT_CATEGORIES.SERVER,
+            action: LOGGING_EVENT_ACTIONS.REQUEST_FAILURE,
+            reference: id
+          }
+        })
+        throw Boom.conflict(
+          `Cannot cancel a PRN with status '${previousPrn.status.currentStatus}'; only an accepted PRN can be cancelled`
+        )
+      }
+
+      const user = buildAdminUser(
+        /** @type {{ id: string, email: string, name?: string }} */ (
+          auth.credentials
+        )
+      )
+
+      const updatedPrn = await updatePrnStatus({
+        prnRepository: packagingRecyclingNotesRepository,
+        ledgerRepository,
+        organisationsRepository,
+        prnEvents,
+        logger,
+        id,
+        organisationId: previousPrn.organisation.id,
+        registrationId: previousPrn.registrationId,
+        accreditationId: previousPrn.accreditation.id,
+        newStatus: PRN_STATUS.CANCELLED,
+        actor: PRN_ACTOR.SERVICE_MAINTAINER,
+        user,
+        providedPrn: previousPrn
+      })
+
+      await auditPrnStatusTransition(request, id, previousPrn, updatedPrn)
+
+      logger.info({
+        message: `Admin cancel succeeded: PRN ${id} is now cancelled`,
+        event: {
+          category: LOGGING_EVENT_CATEGORIES.SERVER,
+          action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS,
+          reference: id
+        }
+      })
+
+      return h
+        .response({
+          id: updatedPrn.id,
+          prnNumber: updatedPrn.prnNumber,
+          status: updatedPrn.status.currentStatus,
+          tonnage: updatedPrn.tonnage,
+          updatedAt: updatedPrn.updatedAt
+        })
+        .code(StatusCodes.OK)
+    } catch (error) {
+      throw mapAdminCancelError(
+        error,
+        adminPackagingRecyclingNotesCancelPath,
+        id,
+        logger
+      )
+    }
+  }
+}

--- a/src/packaging-recycling-notes/routes/admin-cancel.js
+++ b/src/packaging-recycling-notes/routes/admin-cancel.js
@@ -43,6 +43,114 @@ const buildAdminUser = ({ id, email, name }) => ({
 })
 
 /**
+ * Fetches the PRN and confirms it is in a cancellable state, logging and
+ * throwing the appropriate Boom error otherwise (404 if missing, 409 if not
+ * `accepted`).
+ *
+ * @param {PackagingRecyclingNotesRepository} repository
+ * @param {string} id
+ * @param {TypedLogger} logger
+ * @returns {Promise<*>} the `accepted` PRN
+ */
+const findAcceptedPrnOrThrow = async (repository, id, logger) => {
+  const previousPrn = await repository.findById(id)
+
+  if (!previousPrn) {
+    logger.info({
+      message: `Admin cancel refused: PRN not found: ${id}`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.REQUEST_FAILURE,
+        reference: id
+      }
+    })
+    throw Boom.notFound(`PRN not found: ${id}`)
+  }
+
+  if (previousPrn.status.currentStatus !== PRN_STATUS.ACCEPTED) {
+    logger.info({
+      message: `Admin cancel refused: PRN ${id} is ${previousPrn.status.currentStatus}, not accepted`,
+      event: {
+        category: LOGGING_EVENT_CATEGORIES.SERVER,
+        action: LOGGING_EVENT_ACTIONS.REQUEST_FAILURE,
+        reference: id
+      }
+    })
+    throw Boom.conflict(
+      `Cannot cancel a PRN with status '${previousPrn.status.currentStatus}'; only an accepted PRN can be cancelled`
+    )
+  }
+
+  return previousPrn
+}
+
+/**
+ * Transitions the given PRN to cancelled, audits the change, logs success and
+ * builds the 200 response body.
+ *
+ * @param {HapiRequest & {
+ *   packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository,
+ *   prnEvents: { onCancelled: OnPrnCancelled }
+ * }} request
+ * @param {*} previousPrn
+ * @param {string} id
+ * @param {Object} h - Hapi response toolkit
+ */
+const performCancellation = async (request, previousPrn, id, h) => {
+  const {
+    packagingRecyclingNotesRepository,
+    ledgerRepository,
+    organisationsRepository,
+    prnEvents,
+    logger,
+    auth
+  } = request
+
+  const user = buildAdminUser(
+    /** @type {{ id: string, email: string, name?: string }} */ (
+      auth.credentials
+    )
+  )
+
+  const updatedPrn = await updatePrnStatus({
+    prnRepository: packagingRecyclingNotesRepository,
+    ledgerRepository,
+    organisationsRepository,
+    prnEvents,
+    logger,
+    id,
+    organisationId: previousPrn.organisation.id,
+    registrationId: previousPrn.registrationId,
+    accreditationId: previousPrn.accreditation.id,
+    newStatus: PRN_STATUS.CANCELLED,
+    actor: PRN_ACTOR.SERVICE_MAINTAINER,
+    user,
+    providedPrn: previousPrn
+  })
+
+  await auditPrnStatusTransition(request, id, previousPrn, updatedPrn)
+
+  logger.info({
+    message: `Admin cancel succeeded: PRN ${id} is now cancelled`,
+    event: {
+      category: LOGGING_EVENT_CATEGORIES.SERVER,
+      action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS,
+      reference: id
+    }
+  })
+
+  return h
+    .response({
+      id: updatedPrn.id,
+      prnNumber: updatedPrn.prnNumber,
+      status: updatedPrn.status.currentStatus,
+      tonnage: updatedPrn.tonnage,
+      updatedAt: updatedPrn.updatedAt
+    })
+    .code(StatusCodes.OK)
+}
+
+/**
  * Maps a cancellation failure to the HTTP error it should surface as.
  *
  * `updatePrnStatus` is called with `providedPrn` set to the same document this
@@ -107,15 +215,7 @@ export const adminPackagingRecyclingNotesCancel = {
    * @param {Object} h - Hapi response toolkit
    */
   handler: async (request, h) => {
-    const {
-      packagingRecyclingNotesRepository,
-      ledgerRepository,
-      organisationsRepository,
-      prnEvents,
-      params,
-      logger,
-      auth
-    } = request
+    const { packagingRecyclingNotesRepository, params, logger } = request
     const { id } = params
 
     logger.debug({
@@ -128,76 +228,13 @@ export const adminPackagingRecyclingNotesCancel = {
     })
 
     try {
-      const previousPrn = await packagingRecyclingNotesRepository.findById(id)
-
-      if (!previousPrn) {
-        logger.info({
-          message: `Admin cancel refused: PRN not found: ${id}`,
-          event: {
-            category: LOGGING_EVENT_CATEGORIES.SERVER,
-            action: LOGGING_EVENT_ACTIONS.REQUEST_FAILURE,
-            reference: id
-          }
-        })
-        throw Boom.notFound(`PRN not found: ${id}`)
-      }
-
-      if (previousPrn.status.currentStatus !== PRN_STATUS.ACCEPTED) {
-        logger.info({
-          message: `Admin cancel refused: PRN ${id} is ${previousPrn.status.currentStatus}, not accepted`,
-          event: {
-            category: LOGGING_EVENT_CATEGORIES.SERVER,
-            action: LOGGING_EVENT_ACTIONS.REQUEST_FAILURE,
-            reference: id
-          }
-        })
-        throw Boom.conflict(
-          `Cannot cancel a PRN with status '${previousPrn.status.currentStatus}'; only an accepted PRN can be cancelled`
-        )
-      }
-
-      const user = buildAdminUser(
-        /** @type {{ id: string, email: string, name?: string }} */ (
-          auth.credentials
-        )
+      const previousPrn = await findAcceptedPrnOrThrow(
+        packagingRecyclingNotesRepository,
+        id,
+        logger
       )
 
-      const updatedPrn = await updatePrnStatus({
-        prnRepository: packagingRecyclingNotesRepository,
-        ledgerRepository,
-        organisationsRepository,
-        prnEvents,
-        logger,
-        id,
-        organisationId: previousPrn.organisation.id,
-        registrationId: previousPrn.registrationId,
-        accreditationId: previousPrn.accreditation.id,
-        newStatus: PRN_STATUS.CANCELLED,
-        actor: PRN_ACTOR.SERVICE_MAINTAINER,
-        user,
-        providedPrn: previousPrn
-      })
-
-      await auditPrnStatusTransition(request, id, previousPrn, updatedPrn)
-
-      logger.info({
-        message: `Admin cancel succeeded: PRN ${id} is now cancelled`,
-        event: {
-          category: LOGGING_EVENT_CATEGORIES.SERVER,
-          action: LOGGING_EVENT_ACTIONS.REQUEST_SUCCESS,
-          reference: id
-        }
-      })
-
-      return h
-        .response({
-          id: updatedPrn.id,
-          prnNumber: updatedPrn.prnNumber,
-          status: updatedPrn.status.currentStatus,
-          tonnage: updatedPrn.tonnage,
-          updatedAt: updatedPrn.updatedAt
-        })
-        .code(StatusCodes.OK)
+      return await performCancellation(request, previousPrn, id, h)
     } catch (error) {
       throw mapAdminCancelError(
         error,

--- a/src/packaging-recycling-notes/routes/admin-cancel.test.js
+++ b/src/packaging-recycling-notes/routes/admin-cancel.test.js
@@ -153,7 +153,7 @@ describe(`POST ${adminPackagingRecyclingNotesCancelPath}`, () => {
     vi.clearAllMocks()
   })
 
-  it('cancels an accepted PRN within the window, crediting the full tonnage back to both balances (Scenarios 1 and 3)', async () => {
+  it('cancels an accepted PRN within the window, crediting the full tonnage back to both balances', async () => {
     await startServer(buildAcceptedPrn({ tonnage: 500 }))
 
     const response = await server.inject({
@@ -259,7 +259,7 @@ describe(`POST ${adminPackagingRecyclingNotesCancelPath}`, () => {
     })
   })
 
-  it('allows cancellation exactly at the 31 January deadline instant (Scenario 5)', async () => {
+  it('allows cancellation exactly at the 31 January deadline instant', async () => {
     // Faking only Date leaves setTimeout/setInterval real, so Hapi's own
     // async request lifecycle (server.inject) is unaffected.
     vi.useFakeTimers({ toFake: ['Date'] })
@@ -277,7 +277,7 @@ describe(`POST ${adminPackagingRecyclingNotesCancelPath}`, () => {
     vi.useRealTimers()
   })
 
-  it('rejects cancellation one millisecond after the deadline (Scenario 2)', async () => {
+  it('rejects cancellation one millisecond after the deadline', async () => {
     vi.useFakeTimers({ toFake: ['Date'] })
     vi.setSystemTime(new Date('2027-02-01T00:00:00.000Z'))
 
@@ -335,7 +335,7 @@ describe(`POST ${adminPackagingRecyclingNotesCancelPath}`, () => {
     PRN_STATUS.CANCELLED,
     PRN_STATUS.DELETED,
     PRN_STATUS.DISCARDED
-  ])('rejects cancelling a %s PRN (Scenario 4)', async (currentStatus) => {
+  ])('rejects cancelling a %s PRN', async (currentStatus) => {
     await startServer(buildAcceptedPrn({ currentStatus }))
 
     const response = await server.inject({

--- a/src/packaging-recycling-notes/routes/admin-cancel.test.js
+++ b/src/packaging-recycling-notes/routes/admin-cancel.test.js
@@ -1,0 +1,465 @@
+import { StatusCodes } from 'http-status-codes'
+import { randomUUID } from 'node:crypto'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MATERIAL, REGULATOR } from '#domain/organisations/model.js'
+import { createInMemoryFeatureFlags } from '#feature-flags/feature-flags.inmemory.js'
+import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
+import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
+import { createInMemoryReportsRepository } from '#reports/repository/inmemory.js'
+import { buildCreateReportParams } from '#reports/repository/contract/test-data.js'
+import { createInMemoryLedgerRepository } from '#waste-balances/repository/ledger-inmemory.js'
+import { LEDGER_EVENT_KIND } from '#waste-balances/repository/ledger-schema.js'
+import { buildLedgerEvent } from '#waste-balances/repository/ledger-test-data.js'
+import { createMockLogger } from '#test/mock-logger.js'
+import { createTestServer } from '#test/create-test-server.js'
+import { partialMock } from '#test/type-helpers.js'
+import {
+  asServiceMaintainerWrite,
+  asServiceMaintainerRead,
+  asSupport,
+  asUnscopedAdminUser
+} from '#test/inject-auth.js'
+import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
+import { adminPackagingRecyclingNotesCancelPath } from './admin-cancel.js'
+
+/** @import { PackagingRecyclingNote, PrnStatus } from '#packaging-recycling-notes/domain/model.js' */
+
+const mockCdpAuditing = vi.fn()
+
+vi.mock('@defra/cdp-auditing', () => ({
+  audit: (...args) => mockCdpAuditing(...args)
+}))
+
+const prnId = '507f1f77bcf86cd799439011'
+// markActiveReportsStaleForPrnCancellation (ADR-0042) validates organisationId
+// and registrationId as 24-char hex ObjectIds, so these must be too — unlike
+// most PRN fixtures elsewhere that use plain strings.
+const organisationId = '507f1f77bcf86cd799439012'
+const registrationId = '507f1f77bcf86cd799439013'
+const accreditationId = '507f1f77bcf86cd799439014'
+
+const cancelUrl = `/v1/admin/packaging-recycling-notes/${prnId}/cancel`
+
+const SEED_BALANCE = { amount: 500, availableAmount: 500 }
+const ISSUED_AT = new Date('2026-01-15T10:00:00Z')
+
+/** @param {{ amount: number, availableAmount: number }} closingBalance */
+const openingBalanceEvent = (closingBalance = SEED_BALANCE) =>
+  buildLedgerEvent({
+    registrationId,
+    accreditationId,
+    organisationId,
+    number: 1,
+    payload: { summaryLogId: 'log-1', creditTotal: closingBalance.amount },
+    openingBalance: { amount: 0, availableAmount: 0 },
+    closingBalance
+  })
+
+/**
+ * @param {Object} [options]
+ * @param {PrnStatus} [options.currentStatus]
+ * @param {number} [options.accreditationYear]
+ * @param {number} [options.tonnage]
+ * @param {Date} [options.issuedAt]
+ */
+const buildAcceptedPrn = ({
+  currentStatus = PRN_STATUS.ACCEPTED,
+  accreditationYear = 2026,
+  tonnage = 500,
+  issuedAt = ISSUED_AT
+} = {}) => ({
+  id: prnId,
+  version: 1,
+  schemaVersion: 2,
+  organisation: { id: organisationId, name: 'Test Organisation' },
+  registrationId,
+  accreditation: {
+    id: accreditationId,
+    accreditationNumber: 'ACC-2026-001',
+    accreditationYear,
+    material: MATERIAL.PLASTIC,
+    submittedToRegulator: REGULATOR.EA
+  },
+  issuedToOrganisation: { id: 'producer-org-789', name: 'Producer Org' },
+  tonnage,
+  isExport: false,
+  isDecemberWaste: false,
+  createdAt: new Date('2026-01-10T10:00:00Z'),
+  createdBy: { id: 'user-123', name: 'Test User' },
+  updatedAt: new Date('2026-01-15T10:00:00Z'),
+  updatedBy: { id: 'user-issuer', name: 'Issuer User' },
+  status: {
+    currentStatus,
+    currentStatusAt: new Date('2026-01-15T10:00:00Z'),
+    issued: { at: issuedAt, by: { id: 'user-issuer', name: 'Issuer User' } },
+    accepted: {
+      at: new Date('2026-01-16T10:00:00Z'),
+      by: { id: 'producer-1', name: 'Producer Contact' }
+    },
+    history: []
+  }
+})
+
+let server
+let ledgerRepository
+let packagingRecyclingNotesRepository
+let reportsRepository
+
+/**
+ * @param {PackagingRecyclingNote | null} prn
+ * @param {Object} [options]
+ * @param {Map<string, object>} [options.reports]
+ * @param {{ amount: number, availableAmount: number } | null} [options.closingBalance]
+ * @param {boolean} [options.cancellationEnabled]
+ */
+const startServer = async (
+  prn,
+  {
+    reports = new Map(),
+    closingBalance = SEED_BALANCE,
+    cancellationEnabled = true
+  } = {}
+) => {
+  ledgerRepository = createInMemoryLedgerRepository(
+    closingBalance ? [partialMock(openingBalanceEvent(closingBalance))] : []
+  )()
+  const prnRepositoryFactory = createInMemoryPackagingRecyclingNotesRepository(
+    prn ? [prn] : []
+  )
+  packagingRecyclingNotesRepository = prnRepositoryFactory(createMockLogger())
+  const reportsRepositoryFactory = createInMemoryReportsRepository(reports)
+  reportsRepository = reportsRepositoryFactory()
+
+  server = await createTestServer({
+    repositories: {
+      packagingRecyclingNotesRepository: prnRepositoryFactory,
+      ledgerRepository: () => ledgerRepository,
+      organisationsRepository: () => ({}),
+      reportsRepository: reportsRepositoryFactory
+    },
+    featureFlags: createInMemoryFeatureFlags({
+      prnAdminCancellation: cancellationEnabled
+    })
+  })
+  return server
+}
+
+describe(`POST ${adminPackagingRecyclingNotesCancelPath}`, () => {
+  setupAuthContext()
+
+  afterEach(async () => {
+    await server.stop()
+    vi.clearAllMocks()
+  })
+
+  it('cancels an accepted PRN within the window, crediting the full tonnage back to both balances (Scenarios 1 and 3)', async () => {
+    await startServer(buildAcceptedPrn({ tonnage: 500 }))
+
+    const response = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+    const body = JSON.parse(response.payload)
+    expect(body.status).toBe(PRN_STATUS.CANCELLED)
+
+    const stored = await packagingRecyclingNotesRepository.findById(prnId)
+    expect(stored?.status.currentStatus).toBe(PRN_STATUS.CANCELLED)
+    expect(stored?.status.cancelled?.by).toEqual({
+      id: 'test-maintainer-id',
+      name: 'maintainer@example.com'
+    })
+    // Cancelled directly from `accepted`, bypassing the producer-rejection path
+    // (`awaiting_acceptance -> awaiting_cancellation`), so `status.rejected`
+    // must stay unset — otherwise the external API would report a
+    // `rejectedAt` for a PRN that was never rejected.
+    expect(stored?.status.rejected).toBeUndefined()
+
+    const latestEvent = await ledgerRepository.findLatestInLedger({
+      organisationId,
+      registrationId,
+      accreditationId
+    })
+    expect(latestEvent.kind).toBe(LEDGER_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE)
+    expect(latestEvent.payload).toEqual({ prnId, amount: 500 })
+    expect(latestEvent.closingBalance).toEqual({
+      amount: SEED_BALANCE.amount + 500,
+      availableAmount: SEED_BALANCE.availableAmount + 500
+    })
+
+    expect(mockCdpAuditing).toHaveBeenCalledTimes(1)
+    expect(
+      mockCdpAuditing.mock.calls[0][0].context.previous.status.currentStatus
+    ).toBe(PRN_STATUS.ACCEPTED)
+    expect(
+      mockCdpAuditing.mock.calls[0][0].context.next.status.currentStatus
+    ).toBe(PRN_STATUS.CANCELLED)
+  })
+
+  it('falls back to email when the admin credential carries no display name', async () => {
+    await startServer(buildAcceptedPrn())
+
+    await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite({ email: 'named.maintainer@example.com' })
+    })
+
+    const stored = await packagingRecyclingNotesRepository.findById(prnId)
+    expect(stored?.status.cancelled?.by.name).toBe(
+      'named.maintainer@example.com'
+    )
+  })
+
+  it('marks the active report for the PRN issuance period stale (ADR-0042, unchanged)', async () => {
+    const reportId = randomUUID()
+    const reports = new Map([
+      [
+        reportId,
+        {
+          ...buildCreateReportParams({ organisationId, registrationId }),
+          id: reportId,
+          version: 1,
+          schemaVersion: 1,
+          status: {
+            currentStatus: 'in_progress',
+            currentStatusAt: new Date().toISOString(),
+            created: { at: new Date().toISOString(), by: { id: 'user-1' } },
+            history: []
+          }
+        }
+      ]
+    ])
+
+    // buildCreateReportParams defaults to January 2024 (DEFAULT_REPORT_YEAR /
+    // DEFAULT_REPORT_PERIOD) — the PRN's issued.at must fall in that period for
+    // markActiveReportsStaleForPrnCancellation to find this report as active.
+    await startServer(
+      buildAcceptedPrn({ issuedAt: new Date('2024-01-15T10:00:00Z') }),
+      { reports }
+    )
+
+    const response = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const updatedReport = await reportsRepository.findReportById(reportId)
+    expect(updatedReport.stale).toEqual({
+      prnCancelled: {
+        occurredAt: expect.any(String),
+        prnId
+      }
+    })
+  })
+
+  it('allows cancellation exactly at the 31 January deadline instant (Scenario 5)', async () => {
+    // Faking only Date leaves setTimeout/setInterval real, so Hapi's own
+    // async request lifecycle (server.inject) is unaffected.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2027-01-31T23:59:59.999Z'))
+
+    await startServer(buildAcceptedPrn({ accreditationYear: 2026 }))
+
+    const response = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+    vi.useRealTimers()
+  })
+
+  it('rejects cancellation one millisecond after the deadline (Scenario 2)', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2027-02-01T00:00:00.000Z'))
+
+    await startServer(buildAcceptedPrn({ accreditationYear: 2026 }))
+
+    const response = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+    const payload = JSON.parse(response.payload)
+    expect(payload.message).toMatch(/2026/)
+    expect(payload.message).toMatch(/31 January 2027/)
+
+    const stored = await packagingRecyclingNotesRepository.findById(prnId)
+    expect(stored?.status.currentStatus).toBe(PRN_STATUS.ACCEPTED)
+
+    await expect(
+      ledgerRepository.findLatestInLedger({
+        organisationId,
+        registrationId,
+        accreditationId
+      })
+    ).resolves.toMatchObject({ kind: LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED })
+
+    vi.useRealTimers()
+  })
+
+  it('returns 500 when the accreditation year is missing (fails closed, cannot evaluate the window)', async () => {
+    await startServer(
+      buildAcceptedPrn({
+        accreditationYear: /** @type {number} */ (/** @type {*} */ (null))
+      })
+    )
+
+    const response = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+
+    const stored = await packagingRecyclingNotesRepository.findById(prnId)
+    expect(stored?.status.currentStatus).toBe(PRN_STATUS.ACCEPTED)
+  })
+
+  it.each([
+    PRN_STATUS.DRAFT,
+    PRN_STATUS.AWAITING_AUTHORISATION,
+    PRN_STATUS.AWAITING_ACCEPTANCE,
+    PRN_STATUS.AWAITING_CANCELLATION,
+    PRN_STATUS.CANCELLED,
+    PRN_STATUS.DELETED,
+    PRN_STATUS.DISCARDED
+  ])('rejects cancelling a %s PRN (Scenario 4)', async (currentStatus) => {
+    await startServer(buildAcceptedPrn({ currentStatus }))
+
+    const response = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+
+    const stored = await packagingRecyclingNotesRepository.findById(prnId)
+    expect(stored?.status.currentStatus).toBe(currentStatus)
+  })
+
+  it('returns 404 for an unknown PRN id', async () => {
+    await startServer(null)
+
+    const response = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+  })
+
+  it('returns 500 and logs when the repository throws an unexpected error', async () => {
+    const brokenRepository = {
+      findById: vi.fn().mockRejectedValue(new Error('connection reset'))
+    }
+
+    server = await createTestServer({
+      repositories: {
+        packagingRecyclingNotesRepository: () => brokenRepository,
+        ledgerRepository: () => createInMemoryLedgerRepository([])(),
+        organisationsRepository: () => ({}),
+        reportsRepository: () => createInMemoryReportsRepository()()
+      },
+      featureFlags: createInMemoryFeatureFlags({ prnAdminCancellation: true })
+    })
+
+    const response = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+  })
+
+  it('returns 422 for a malformed PRN id (Joi param validation)', async () => {
+    await startServer(buildAcceptedPrn())
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/v1/admin/packaging-recycling-notes/not-an-object-id/cancel',
+      ...asServiceMaintainerWrite()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY)
+  })
+
+  it('returns 401 with no credentials', async () => {
+    await startServer(buildAcceptedPrn())
+
+    const response = await server.inject({ method: 'POST', url: cancelUrl })
+
+    expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+  })
+
+  it.each([
+    ['a read-only service maintainer', asServiceMaintainerRead],
+    ['support', asSupport],
+    ['an unscoped admin user', asUnscopedAdminUser]
+  ])('returns 403 for %s (no admin.write)', async (_label, authAs) => {
+    await startServer(buildAcceptedPrn())
+
+    const response = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...authAs()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+  })
+
+  it('404s when the feature flag is off, even for a well-formed request', async () => {
+    await startServer(buildAcceptedPrn(), { cancellationEnabled: false })
+
+    const response = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+  })
+
+  it('rejects a second cancellation of the same PRN, crediting the balance only once', async () => {
+    await startServer(buildAcceptedPrn({ tonnage: 500 }))
+
+    const first = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite()
+    })
+    expect(first.statusCode).toBe(StatusCodes.OK)
+
+    const second = await server.inject({
+      method: 'POST',
+      url: cancelUrl,
+      ...asServiceMaintainerWrite()
+    })
+    expect(second.statusCode).toBe(StatusCodes.CONFLICT)
+
+    const latestEvent = await ledgerRepository.findLatestInLedger({
+      organisationId,
+      registrationId,
+      accreditationId
+    })
+    expect(latestEvent.kind).toBe(LEDGER_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE)
+    expect(latestEvent.closingBalance).toEqual({
+      amount: SEED_BALANCE.amount + 500,
+      availableAmount: SEED_BALANCE.availableAmount + 500
+    })
+  })
+})

--- a/src/packaging-recycling-notes/routes/status.test.js
+++ b/src/packaging-recycling-notes/routes/status.test.js
@@ -667,6 +667,41 @@ describe(`${packagingRecyclingNotesUpdateStatusPath} route`, () => {
         expect(response.payload).toContain('No transition exists from')
       })
 
+      it('returns 400 when an operator attempts to cancel an accepted PRN (PAE-1823, service-maintainer-only edge)', async () => {
+        // accepted -> cancelled is a real transition (INTERNAL_ACTOR_BY_STATUS
+        // has no entry for 'accepted', so the operator route can never resolve
+        // an actor for it) - only the admin route can drive it, as
+        // PRN_ACTOR.SERVICE_MAINTAINER, which this route can never supply.
+        const createdPrnId = '507f1f77bcf86cd799439044'
+        const createdPrn = createMockPrn({
+          id: createdPrnId,
+          status: {
+            currentStatus: PRN_STATUS.ACCEPTED,
+            history: [
+              {
+                status: PRN_STATUS.ACCEPTED,
+                at: new Date(),
+                by: { id: 'user-123', name: 'Test User' }
+              }
+            ]
+          }
+        })
+
+        packagingRecyclingNotesRepository.findById.mockResolvedValueOnce(
+          createdPrn
+        )
+
+        const response = await server.inject({
+          method: 'POST',
+          url: `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/${createdPrnId}/status`,
+          ...asOperator(),
+          payload: { status: PRN_STATUS.CANCELLED }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+        expect(response.payload).toContain('is not permitted')
+      })
+
       it('returns 400 when PRN has unknown current status', async () => {
         const unknownStatusPrnId = '507f1f77bcf86cd799439033'
         const unknownStatusPrn = createMockPrn({

--- a/src/packaging-recycling-notes/routes/test-helpers.js
+++ b/src/packaging-recycling-notes/routes/test-helpers.js
@@ -4,7 +4,7 @@
 import Jwt from '@hapi/jwt'
 import { generateKeyPairSync } from 'node:crypto'
 
-import { MATERIAL } from '#domain/organisations/model.js'
+import { MATERIAL, REGULATOR } from '#domain/organisations/model.js'
 import { PRN_STATUS } from '#packaging-recycling-notes/domain/model.js'
 
 /** @type {{ publicKey: JsonWebKey, privateKey: string }} */
@@ -84,6 +84,7 @@ export const generateExternalApiTokenWithoutClientId = () => {
 export const createMockIssuedPrn = (overrides = {}) => ({
   id: prnId,
   schemaVersion: 2,
+  version: 1,
   prnNumber,
   organisation: {
     id: 'org-123',
@@ -95,7 +96,7 @@ export const createMockIssuedPrn = (overrides = {}) => ({
     accreditationNumber: 'ACC-2026-001',
     accreditationYear: 2026,
     material: MATERIAL.PLASTIC,
-    submittedToRegulator: 'ea'
+    submittedToRegulator: REGULATOR.EA
   },
   issuedToOrganisation: {
     id: 'producer-org-789',
@@ -107,6 +108,7 @@ export const createMockIssuedPrn = (overrides = {}) => ({
   notes: 'Test notes',
   status: {
     currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+    currentStatusAt: new Date(issuedDate),
     created: {
       at: new Date(authorisedDate),
       by: creator

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -15,6 +15,7 @@ import * as wasteBalanceAvailabilityRoutes from '#routes/v1/waste-balance-availa
 import * as overseasSitesRoutes from '#overseas-sites/routes/index.js'
 import { packagingRecyclingNotesAccept } from '#packaging-recycling-notes/routes/accept.js'
 import { adminAccreditationPackagingRecyclingNotesList } from '#packaging-recycling-notes/routes/admin-accreditation-list.js'
+import { adminPackagingRecyclingNotesCancel } from '#packaging-recycling-notes/routes/admin-cancel.js'
 import { adminPackagingRecyclingNotesList } from '#packaging-recycling-notes/routes/admin-list.js'
 import { packagingRecyclingNotesList } from '#packaging-recycling-notes/routes/list.js'
 import { packagingRecyclingNotesReject } from '#packaging-recycling-notes/routes/reject.js'
@@ -44,6 +45,11 @@ const router = {
           ? Object.values(devRoutes)
           : []
 
+        const prnAdminCancellationRoutesBehindFeatureFlag =
+          featureFlags.isPrnAdminCancellationEnabled()
+            ? [adminPackagingRecyclingNotesCancel]
+            : []
+
         const { reportsUnsubmit: _unsubmit, ...coreReportsRoutes } =
           reportsRoutes
 
@@ -70,6 +76,7 @@ const router = {
           ...summaryLogUploadsReportRoutes,
           adminAccreditationPackagingRecyclingNotesList,
           adminPackagingRecyclingNotesList,
+          ...prnAdminCancellationRoutesBehindFeatureFlag,
           ...Object.values(overseasSitesRoutes),
           ...Object.values(coreReportsRoutes),
           reportsUnsubmit,


### PR DESCRIPTION
Ticket: [PAE-1823](https://eaflood.atlassian.net/browse/PAE-1823)
- Opens the `accepted -> cancelled` transition for a new `service_maintainer` actor, driven by a dedicated admin-only route (`POST /v1/admin/packaging-recycling-notes/{id}/cancel`), gated behind `FEATURE_FLAG_PRN_ADMIN_CANCELLATION`
- Reuses the existing `cancelIssuedPrn` ledger command, so cancelling credits the full tonnage back to both total and available waste balance immediately, same as the existing post-rejection cancellation path
- Enforces a cancellation deadline of 31 January of the year following the PRN's accreditation year, via a new generic `relevant-year.js` domain module (named after the statutory term in the PRO Regulations 2024) reusable by future relevant-year-anchored rules
- Adds a regression test pinning that an operator can never reach this transition through the normal operator-facing status endpoint — it is reachable only via the admin route's `service_maintainer` actor
- Records the cancellation with the same audit/system-log parity as every other PRN status transition

[PAE-1823]: https://eaflood.atlassian.net/browse/PAE-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ