### PR TITLE
PAE-1843: Allow December waste obligation year selection

### DIFF
--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.js
@@ -46,9 +46,16 @@ const applyEvent = (prn, event) => {
   // email (best-view enrichment on the stream), which the PRN document omits.
   const by = { id: event.createdBy.id, name: event.createdBy.name }
   const slotValue = { at: event.createdAt, by }
+  const obligationYear =
+    event.kind === LEDGER_EVENT_KIND.PRN_ACCEPTED &&
+    'obligationYear' in event.payload &&
+    event.payload.obligationYear !== undefined
+      ? { obligationYear: event.payload.obligationYear }
+      : {}
 
   return {
     ...prn,
+    ...obligationYear,
     updatedAt: event.createdAt,
     updatedBy: by,
     lastAppliedEventNumber: event.number,

--- a/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
+++ b/src/packaging-recycling-notes/application/fold-prn-from-tail-events.test.js
@@ -177,6 +177,22 @@ describe('foldPrnFromTailEvents', () => {
       })
     })
 
+    it('prn-accepted projects its selected obligation year', () => {
+      const prn = basePrn()
+      const event = {
+        ...buildEvent(
+          LEDGER_EVENT_KIND.PRN_ACCEPTED,
+          3,
+          '2026-02-03T12:00:00.000Z'
+        ),
+        payload: { prnId: 'prn-1', amount: 50, obligationYear: 2027 }
+      }
+
+      const result = foldPrnFromTailEvents(prn, [event])
+
+      expect(result.obligationYear).toBe(2027)
+    })
+
     it('prn-rejected sets currentStatus awaiting_cancellation and rejected slot', () => {
       const prn = basePrn()
       const event = buildEvent(

--- a/src/packaging-recycling-notes/application/update-status-balance-effects.js
+++ b/src/packaging-recycling-notes/application/update-status-balance-effects.js
@@ -139,20 +139,30 @@ const COMMANDS_REQUIRING_OPEN_LEDGER = Object.freeze(
  * @param {string} command.prnId
  * @param {number} command.tonnage
  * @param {import('#waste-balances/repository/ledger-schema.js').LedgerUserSummary} command.createdBy
+ * @param {number} [command.obligationYear]
  * @returns {Promise<Array<import('#waste-balances/repository/ledger-port.js').LedgerEvent>>}
  */
 export async function applyPrnBalanceCommand(
   service,
   logger,
-  { currentStatus, newStatus, ledgerId, prnId, tonnage, createdBy }
+  {
+    currentStatus,
+    newStatus,
+    ledgerId,
+    prnId,
+    tonnage,
+    createdBy,
+    obligationYear
+  }
 ) {
   const command = prnCommandFor(currentStatus, newStatus)
+  const payload = {
+    prnId,
+    amount: tonnage,
+    ...(obligationYear === undefined ? {} : { obligationYear })
+  }
 
-  const result = await service[command.method](
-    ledgerId,
-    { prnId, amount: tonnage },
-    createdBy
-  )
+  const result = await service[command.method](ledgerId, payload, createdBy)
 
   if (result.status === PRN_COMMAND_STATUS.REJECTED) {
     if (

--- a/src/packaging-recycling-notes/application/update-status-stream.test.js
+++ b/src/packaging-recycling-notes/application/update-status-stream.test.js
@@ -17,7 +17,8 @@ vi.mock('./metrics.js', () => ({
 }))
 
 const { updatePrnStatus } = await import('./update-status.js')
-const { getProjectedPrnByNumber } = await import('./get-projected-prn.js')
+const { getProjectedPrnByNumber, getProjectedPrnById } =
+  await import('./get-projected-prn.js')
 
 const ORG_ID = 'org-123'
 const ACC_ID = 'acc-456'
@@ -202,6 +203,46 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
         })
       })
     )
+  })
+
+  it('records an accepted December-waste PRN obligation year in the ledger event', async () => {
+    const storedPrn = buildPrn({
+      version: 1,
+      isDecemberWaste: true,
+      status: {
+        currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+        history: []
+      }
+    })
+    const packagingRecyclingNotesRepository =
+      createInMemoryPackagingRecyclingNotesRepository([storedPrn])(
+        buildLogger()
+      )
+    const ledgerRepository = buildSeededLedgerRepository()
+
+    await callUpdate({
+      prnRepository: packagingRecyclingNotesRepository,
+      ledgerRepository,
+      organisationsRepository: buildOrganisationsRepository(),
+      providedPrn: storedPrn,
+      newStatus: PRN_STATUS.ACCEPTED,
+      actor: PRN_ACTOR.PRODUCER,
+      obligationYear: 2027
+    })
+
+    const latest = await ledgerRepository.findLatestInLedger({
+      organisationId: ORG_ID,
+      registrationId: REG_ID,
+      accreditationId: ACC_ID
+    })
+    const reread = await packagingRecyclingNotesRepository.findById(PRN_ID)
+
+    expect(latest?.payload).toEqual({
+      prnId: PRN_ID,
+      amount: TONNAGE,
+      obligationYear: 2027
+    })
+    expect(reread?.obligationYear).toBe(2027)
   })
 
   it.each(['suspended', 'cancelled'])(
@@ -427,6 +468,55 @@ describe('updatePrnStatus on the ledger (event-first) path', () => {
     })
     expect(all).toHaveLength(2)
     expect(all.at(-1)?.kind).toBe(LEDGER_EVENT_KIND.PRN_ISSUED)
+  })
+
+  it('recovers an accepted December-waste obligation year from the stream when projection persistence fails', async () => {
+    const storedPrn = buildPrn({
+      version: 1,
+      isDecemberWaste: true,
+      lastAppliedEventNumber: SEED_NUMBER,
+      status: {
+        currentStatus: PRN_STATUS.AWAITING_ACCEPTANCE,
+        history: []
+      }
+    })
+    const packagingRecyclingNotesRepository =
+      createInMemoryPackagingRecyclingNotesRepository([storedPrn])(
+        buildLogger()
+      )
+    const prnRepository = {
+      findById: packagingRecyclingNotesRepository.findById,
+      persistProjection: vi
+        .fn()
+        .mockRejectedValue(new Error('doc write failed'))
+    }
+    const ledgerRepository = buildSeededLedgerRepository()
+
+    await expect(
+      callUpdate({
+        prnRepository,
+        ledgerRepository,
+        organisationsRepository: buildOrganisationsRepository(),
+        providedPrn: storedPrn,
+        newStatus: PRN_STATUS.ACCEPTED,
+        actor: PRN_ACTOR.PRODUCER,
+        obligationYear: 2027
+      })
+    ).rejects.toThrow('doc write failed')
+
+    const recovered = await getProjectedPrnById({
+      packagingRecyclingNotesRepository,
+      ledgerRepository,
+      prnId: PRN_ID
+    })
+
+    expect(recovered).toEqual(
+      expect.objectContaining({
+        obligationYear: 2027,
+        lastAppliedEventNumber: APPENDED_WATERMARK,
+        status: expect.objectContaining({ currentStatus: PRN_STATUS.ACCEPTED })
+      })
+    )
   })
 })
 

--- a/src/packaging-recycling-notes/application/update-status.js
+++ b/src/packaging-recycling-notes/application/update-status.js
@@ -13,6 +13,7 @@ import {
 } from '#packaging-recycling-notes/domain/model.js'
 import { assertCancellationAllowed } from '#packaging-recycling-notes/domain/cancellation.js'
 import { generatePrnNumber } from '#packaging-recycling-notes/domain/prn-number-generator.js'
+import { selectObligationYearForAcceptance } from '#packaging-recycling-notes/domain/obligation-year.js'
 import { PrnNumberConflictError } from '#packaging-recycling-notes/repository/port.js'
 import { createWasteBalanceService } from '#waste-balances/application/waste-balance-service.js'
 import { foldPrnFromTailEvents } from './fold-prn-from-tail-events.js'
@@ -74,7 +75,8 @@ async function notifyPrnCancelled(prnEvents, newStatus, updatedPrn) {
  *   user: { id: string, name: string, email?: string },
  *   currentStatus: PrnStatus,
  *   now: Date,
- *   id: string
+ *   id: string,
+ *   obligationYear?: number
  * }} PrnWriteContext
  */
 
@@ -141,7 +143,8 @@ async function performStreamWrite({
   registrationId,
   accreditationId,
   id,
-  user
+  user,
+  obligationYear
 }) {
   // The issuable check is hoisted ahead of the stream append so a suspended or
   // cancelled accreditation is never debited. The fetched accreditation is
@@ -155,13 +158,19 @@ async function performStreamWrite({
     assertAccreditationCanIssue(accreditation)
   }
 
+  const selectedObligationYear = selectObligationYearForAcceptance(
+    prn,
+    obligationYear
+  )
+
   const ledgerEvents = await applyPrnBalanceCommand(service, logger, {
     currentStatus,
     newStatus,
     ledgerId: { organisationId, registrationId, accreditationId },
     prnId: id,
     tonnage: prn.tonnage,
-    createdBy: user
+    createdBy: user,
+    obligationYear: selectedObligationYear
   })
 
   const projection = foldPrnFromTailEvents(prn, ledgerEvents)
@@ -244,6 +253,7 @@ const performDiscardWrite = async ({ prnRepository, updateParams }) => {
  * @param {{ id: string; name: string; email?: string }} params.user
  * @param {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote} [params.providedPrn] - Optional pre-fetched PRN to avoid duplicate fetch
  * @param {Date} [params.updatedAt] - Optional timestamp override (defaults to now)
+ * @param {number} [params.obligationYear] - Optional obligation year selected during external acceptance
  * @returns {Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote>}
  */
 export async function updatePrnStatus({
@@ -260,7 +270,8 @@ export async function updatePrnStatus({
   actor,
   user,
   providedPrn,
-  updatedAt
+  updatedAt,
+  obligationYear
 }) {
   const prn = await resolvePrnForUpdate({
     prnRepository,
@@ -292,7 +303,8 @@ export async function updatePrnStatus({
     accreditationId,
     user,
     id,
-    updatedAt
+    updatedAt,
+    obligationYear
   })
 
   const updatedPrn =
@@ -370,6 +382,7 @@ async function resolvePrnForUpdate({
  * @param {{ id: string; name: string; email?: string }} params.user
  * @param {string} params.id
  * @param {Date} [params.updatedAt]
+ * @param {number} [params.obligationYear]
  * @returns {PrnWriteContext}
  */
 function buildWriteContext({
@@ -385,7 +398,8 @@ function buildWriteContext({
   accreditationId,
   user,
   id,
-  updatedAt
+  updatedAt,
+  obligationYear
 }) {
   const now = updatedAt ?? new Date()
   const updateParams = {
@@ -411,6 +425,7 @@ function buildWriteContext({
     user,
     currentStatus,
     now,
-    id
+    id,
+    obligationYear
   }
 }

--- a/src/packaging-recycling-notes/domain/obligation-year.js
+++ b/src/packaging-recycling-notes/domain/obligation-year.js
@@ -1,0 +1,44 @@
+export class InvalidObligationYearError extends Error {
+  /**
+   * @param {number} accreditationYear
+   * @param {number} obligationYear
+   */
+  constructor(accreditationYear, obligationYear) {
+    super(
+      `obligationYear must be either accreditation year ${accreditationYear} or ${accreditationYear + 1} for a December waste PRN; received ${obligationYear}`
+    )
+    this.name = 'InvalidObligationYearError'
+  }
+}
+
+/**
+ * Returns the obligation year to apply during acceptance. An omitted value and
+ * any value supplied for a non-December PRN leave the stored value unchanged.
+ * December PRNs may be accepted against their accreditation year or its
+ * successor only.
+ *
+ * @param {{ isDecemberWaste: boolean, accreditation: { accreditationYear: number } }} prn
+ * @param {number} [providedObligationYear]
+ * @returns {number | undefined}
+ */
+export const selectObligationYearForAcceptance = (
+  prn,
+  providedObligationYear
+) => {
+  if (providedObligationYear === undefined || !prn.isDecemberWaste) {
+    return undefined
+  }
+
+  const { accreditationYear } = prn.accreditation
+  if (
+    providedObligationYear !== accreditationYear &&
+    providedObligationYear !== accreditationYear + 1
+  ) {
+    throw new InvalidObligationYearError(
+      accreditationYear,
+      providedObligationYear
+    )
+  }
+
+  return providedObligationYear
+}

--- a/src/packaging-recycling-notes/domain/obligation-year.test.js
+++ b/src/packaging-recycling-notes/domain/obligation-year.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  InvalidObligationYearError,
+  selectObligationYearForAcceptance
+} from './obligation-year.js'
+
+const buildPrn = ({ isDecemberWaste }) => ({
+  isDecemberWaste,
+  accreditation: { accreditationYear: 2026 }
+})
+
+describe('selectObligationYearForAcceptance', () => {
+  it('leaves the obligation year unchanged when none is supplied', () => {
+    expect(
+      selectObligationYearForAcceptance(buildPrn({ isDecemberWaste: true }))
+    ).toBeUndefined()
+  })
+
+  it('leaves the obligation year unchanged for a non-December PRN', () => {
+    expect(
+      selectObligationYearForAcceptance(
+        buildPrn({ isDecemberWaste: false }),
+        2027
+      )
+    ).toBeUndefined()
+  })
+
+  it.each([2026, 2027])(
+    'allows a December PRN to use obligation year %i',
+    (obligationYear) => {
+      expect(
+        selectObligationYearForAcceptance(
+          buildPrn({ isDecemberWaste: true }),
+          obligationYear
+        )
+      ).toBe(obligationYear)
+    }
+  )
+
+  it('rejects any other obligation year for a December PRN', () => {
+    expect(() =>
+      selectObligationYearForAcceptance(
+        buildPrn({ isDecemberWaste: true }),
+        2028
+      )
+    ).toThrow(InvalidObligationYearError)
+  })
+})

--- a/src/packaging-recycling-notes/routes/accept.js
+++ b/src/packaging-recycling-notes/routes/accept.js
@@ -13,7 +13,8 @@ export const packagingRecyclingNotesAcceptPath =
 const packagingRecyclingNotesAcceptPayloadSchema = Joi.object({
   acceptedAt: Joi.string().isoDate().optional().messages({
     'string.isoDate': 'acceptedAt must be a valid ISO 8601 date-time'
-  })
+  }),
+  obligationYear: Joi.number().integer().optional()
 }).allow(null)
 
 export const packagingRecyclingNotesAccept = {

--- a/src/packaging-recycling-notes/routes/accept.test.js
+++ b/src/packaging-recycling-notes/routes/accept.test.js
@@ -96,7 +96,10 @@ const startServer = async (prn) => {
  * @param {PrnStatus} [currentStatus]
  * @returns {PackagingRecyclingNote}
  */
-const buildPrn = (currentStatus = PRN_STATUS.AWAITING_ACCEPTANCE) => ({
+const buildPrn = (
+  currentStatus = PRN_STATUS.AWAITING_ACCEPTANCE,
+  { isDecemberWaste = false, obligationYear = 2026 } = {}
+) => ({
   id: prnId,
   schemaVersion: 2,
   version: 1,
@@ -110,11 +113,11 @@ const buildPrn = (currentStatus = PRN_STATUS.AWAITING_ACCEPTANCE) => ({
     material: MATERIAL.PLASTIC,
     submittedToRegulator: REGULATOR.EA
   },
-  obligationYear: 2026,
   issuedToOrganisation: { id: 'producer-org-789', name: 'Producer Org' },
   tonnage: 100,
   isExport: false,
-  isDecemberWaste: false,
+  isDecemberWaste,
+  obligationYear,
   createdAt: new Date('2026-01-10T10:00:00Z'),
   createdBy: { id: 'user-123', name: 'Test User' },
   updatedAt: new Date('2026-01-15T10:00:00Z'),
@@ -168,7 +171,7 @@ describe(`POST /v1/packaging-recycling-notes/{prnNumber}/accept`, () => {
     )
   })
 
-  it('honours a caller-provided acceptedAt timestamp in the payload', async () => {
+  it('does not change the obligation year when none is supplied', async () => {
     await startServer(buildPrn())
 
     const response = await server.inject({
@@ -181,6 +184,61 @@ describe(`POST /v1/packaging-recycling-notes/{prnNumber}/accept`, () => {
     expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
     const stored = await packagingRecyclingNotesRepository.findById(prnId)
     expect(stored?.status.currentStatus).toBe(PRN_STATUS.ACCEPTED)
+    expect(stored?.obligationYear).toBe(2026)
+  })
+
+  it('does not change a non-December PRN obligation year when one is supplied', async () => {
+    await startServer(buildPrn())
+
+    const response = await server.inject({
+      method: 'POST',
+      url: acceptUrl,
+      headers: authHeaders,
+      payload: { obligationYear: 2027 }
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
+    const stored = await packagingRecyclingNotesRepository.findById(prnId)
+    expect(stored?.obligationYear).toBe(2026)
+  })
+
+  it.each([2026, 2027])(
+    'sets a December PRN obligation year to %i',
+    async (obligationYear) => {
+      await startServer(
+        buildPrn(PRN_STATUS.AWAITING_ACCEPTANCE, {
+          isDecemberWaste: true
+        })
+      )
+
+      const response = await server.inject({
+        method: 'POST',
+        url: acceptUrl,
+        headers: authHeaders,
+        payload: { obligationYear }
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
+      const stored = await packagingRecyclingNotesRepository.findById(prnId)
+      expect(stored?.obligationYear).toBe(obligationYear)
+    }
+  )
+
+  it('rejects an invalid obligation year for a December PRN', async () => {
+    await startServer(
+      buildPrn(PRN_STATUS.AWAITING_ACCEPTANCE, { isDecemberWaste: true })
+    )
+
+    const response = await server.inject({
+      method: 'POST',
+      url: acceptUrl,
+      headers: authHeaders,
+      payload: { obligationYear: 2028 }
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+    const stored = await packagingRecyclingNotesRepository.findById(prnId)
+    expect(stored?.status.currentStatus).toBe(PRN_STATUS.AWAITING_ACCEPTANCE)
   })
 
   it.each([

--- a/src/packaging-recycling-notes/routes/admin-cancel.test.js
+++ b/src/packaging-recycling-notes/routes/admin-cancel.test.js
@@ -81,6 +81,7 @@ const buildAcceptedPrn = ({
     material: MATERIAL.PLASTIC,
     submittedToRegulator: REGULATOR.EA
   },
+  obligationYear: accreditationYear,
   issuedToOrganisation: { id: 'producer-org-789', name: 'Producer Org' },
   tonnage,
   isExport: false,

--- a/src/packaging-recycling-notes/routes/external-transition-handler.js
+++ b/src/packaging-recycling-notes/routes/external-transition-handler.js
@@ -10,6 +10,7 @@ import {
   StatusConflictError,
   UnauthorisedTransitionError
 } from '#packaging-recycling-notes/domain/model.js'
+import { InvalidObligationYearError } from '#packaging-recycling-notes/domain/obligation-year.js'
 import { updatePrnStatus } from '#packaging-recycling-notes/application/update-status.js'
 import { auditPrnStatusTransition } from '#packaging-recycling-notes/application/audit.js'
 import { getProjectedPrnByNumber } from '#packaging-recycling-notes/application/get-projected-prn.js'
@@ -48,6 +49,30 @@ function resolveTransitionContext(request, timestampField) {
   )
 
   return { timestamp, user: { id, name } }
+}
+
+/**
+ * Extracts the optional obligation year from a validated external request
+ * payload. Hapi's broad payload type also permits streams and buffers, which
+ * do not carry JSON properties.
+ *
+ * @param {ExternalTransitionRequest} request
+ * @returns {number | undefined}
+ */
+function resolveObligationYear(request) {
+  const { payload } = request
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    !('obligationYear' in payload)
+  ) {
+    return undefined
+  }
+
+  const { obligationYear } = /** @type {{ obligationYear?: number }} */ (
+    payload
+  )
+  return obligationYear
 }
 
 /**
@@ -114,7 +139,8 @@ export function createExternalTransitionHandler({
           actor: PRN_ACTOR.PRODUCER,
           user,
           providedPrn: prn,
-          updatedAt: timestamp
+          updatedAt: timestamp,
+          obligationYear: resolveObligationYear(request)
         })
 
         await auditPrnStatusTransition(request, prn.id, prn, updatedPrn)
@@ -137,6 +163,10 @@ export function createExternalTransitionHandler({
 }
 
 export function mapTransitionError(error, path, logger) {
+  if (error instanceof InvalidObligationYearError) {
+    return Boom.badRequest(error.message)
+  }
+
   if (error instanceof StatusConflictError) {
     return Boom.conflict(error.message)
   }

--- a/src/packaging-recycling-notes/routes/post.test.js
+++ b/src/packaging-recycling-notes/routes/post.test.js
@@ -127,6 +127,7 @@ describe(`${packagingRecyclingNotesCreatePath} route`, () => {
             organisation: expect.objectContaining({ id: organisationId }),
             registrationId,
             accreditation: expect.objectContaining({ id: accreditationId }),
+            obligationYear: 2026,
             issuedToOrganisation: validPayload.issuedToOrganisation
           })
         )

--- a/src/packaging-recycling-notes/routes/test-helpers.js
+++ b/src/packaging-recycling-notes/routes/test-helpers.js
@@ -98,6 +98,7 @@ export const createMockIssuedPrn = (overrides = {}) => ({
     material: MATERIAL.PLASTIC,
     submittedToRegulator: REGULATOR.EA
   },
+  obligationYear: 2026,
   issuedToOrganisation: {
     id: 'producer-org-789',
     name: 'Producer Org'

--- a/src/waste-balances/domain/commands.js
+++ b/src/waste-balances/domain/commands.js
@@ -23,7 +23,7 @@ import {
  *
  * @typedef {Object} BalanceEvent
  * @property {import('../repository/ledger-schema.js').LedgerEventKind} kind
- * @property {import('../repository/ledger-schema.js').SummaryLogSubmittedPayload | import('../repository/ledger-schema.js').PrnPayload} payload
+ * @property {import('../repository/ledger-schema.js').SummaryLogSubmittedPayload | import('../repository/ledger-schema.js').PrnPayload | import('../repository/ledger-schema.js').PrnAcceptedPayload} payload
  * @property {import('../repository/ledger-schema.js').LedgerBalanceSnapshot} openingBalance
  * @property {import('../repository/ledger-schema.js').LedgerBalanceSnapshot} closingBalance
  */
@@ -92,7 +92,7 @@ export const submitSummaryLog = (state, { summaryLogId, creditTotal }) => {
 /**
  * @param {import('../repository/ledger-schema.js').LedgerEventKind} kind
  * @param {import('../repository/ledger-schema.js').LedgerBalanceSnapshot} opening
- * @param {import('../repository/ledger-schema.js').PrnPayload} payload
+ * @param {import('../repository/ledger-schema.js').PrnPayload | import('../repository/ledger-schema.js').PrnAcceptedPayload} payload
  * @returns {PrnDecision}
  */
 const committed = (kind, opening, payload) => ({
@@ -166,7 +166,7 @@ export const cancelIssuedPrn = (balance, payload) =>
  * Record a PRN acceptance. No balance movement.
  *
  * @param {import('../repository/ledger-schema.js').LedgerBalanceSnapshot} balance
- * @param {import('../repository/ledger-schema.js').PrnPayload} payload
+ * @param {import('../repository/ledger-schema.js').PrnAcceptedPayload} payload
  * @returns {PrnDecision}
  */
 export const acceptPrn = (balance, payload) =>

--- a/src/waste-balances/repository/ledger-schema.js
+++ b/src/waste-balances/repository/ledger-schema.js
@@ -66,6 +66,14 @@ export const BACKFILL_ACTOR = Object.freeze({ id: 'system', name: 'backfill' })
  */
 
 /**
+ * The acceptance event may also carry the year selected by the accepter. It
+ * belongs in the event so a PRN projection can be recovered after an
+ * event-first write succeeds but its projection persistence fails.
+ *
+ * @typedef {PrnPayload & { obligationYear?: number }} PrnAcceptedPayload
+ */
+
+/**
  * The identity of an accreditation, or of a registration in its registered-only
  * phase (`accreditationId` null). An accreditation belongs to a registration,
  * which belongs to an organisation: all three ids are constitutive, and naming
@@ -104,7 +112,7 @@ export const BACKFILL_ACTOR = Object.freeze({ id: 'system', name: 'backfill' })
  *
  * @typedef {LedgerPosition & {
  *   kind: LedgerEventKind,
- *   payload: SummaryLogSubmittedPayload | PrnPayload,
+ *   payload: SummaryLogSubmittedPayload | PrnPayload | PrnAcceptedPayload,
  *   openingBalance: LedgerBalanceSnapshot,
  *   closingBalance: LedgerBalanceSnapshot,
  *   createdAt: Date,
@@ -140,6 +148,10 @@ const prnPayloadSchema = Joi.object({
   amount: Joi.number().required()
 })
 
+const prnAcceptedPayloadSchema = prnPayloadSchema.keys({
+  obligationYear: Joi.number().integer()
+})
+
 export const ledgerEventInsertSchema = Joi.object({
   registrationId: Joi.string().required(),
   accreditationId: Joi.string().allow(null).required(),
@@ -151,17 +163,21 @@ export const ledgerEventInsertSchema = Joi.object({
   payload: Joi.when('kind', {
     is: LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED,
     then: summaryLogPayloadSchema.required()
-  }).when('kind', {
-    is: Joi.string().valid(
-      LEDGER_EVENT_KIND.PRN_CREATED,
-      LEDGER_EVENT_KIND.PRN_ISSUED,
-      LEDGER_EVENT_KIND.PRN_CREATION_CANCELLED,
-      LEDGER_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
-      LEDGER_EVENT_KIND.PRN_ACCEPTED,
-      LEDGER_EVENT_KIND.PRN_REJECTED
-    ),
-    then: prnPayloadSchema.required()
-  }),
+  })
+    .when('kind', {
+      is: LEDGER_EVENT_KIND.PRN_ACCEPTED,
+      then: prnAcceptedPayloadSchema.required()
+    })
+    .when('kind', {
+      is: Joi.string().valid(
+        LEDGER_EVENT_KIND.PRN_CREATED,
+        LEDGER_EVENT_KIND.PRN_ISSUED,
+        LEDGER_EVENT_KIND.PRN_CREATION_CANCELLED,
+        LEDGER_EVENT_KIND.PRN_CANCELLED_AFTER_ISSUE,
+        LEDGER_EVENT_KIND.PRN_REJECTED
+      ),
+      then: prnPayloadSchema.required()
+    }),
   openingBalance: balanceSnapshotSchema.required(),
   closingBalance: balanceSnapshotSchema.required(),
   createdAt: Joi.date().required(),

--- a/src/waste-balances/repository/ledger-schema.test.js
+++ b/src/waste-balances/repository/ledger-schema.test.js
@@ -73,6 +73,16 @@ describe('ledger event insert schema', () => {
     expect(error).toBeUndefined()
   })
 
+  it('accepts a prn-accepted event with an obligation year', () => {
+    const { error } = validate(
+      buildLedgerEvent({
+        kind: LEDGER_EVENT_KIND.PRN_ACCEPTED,
+        payload: { prnId: 'prn-1', amount: 50, obligationYear: 2027 }
+      })
+    )
+    expect(error).toBeUndefined()
+  })
+
   it('accepts a valid prn-rejected event', () => {
     const { error } = validate(
       buildLedgerEvent({


### PR DESCRIPTION
Ticket: [PAE-1843](https://eaflood.atlassian.net/browse/PAE-1843)
## What

Allows a producer accepting a December-waste PRN through the external API to select the obligation year, subject to the accreditation-year rules. There is no feature flag.

## Changes

- Accept an optional integer `obligationYear` on the external PRN acceptance request.
- Preserve the existing obligation year when it is omitted. Reject a supplied year unless the PRN is December waste and it is the accreditation year or the following year.
- Default newly created PRNs to their accreditation year while allowing older documents without the field.
- Store a selected acceptance year in the authoritative `prn-accepted` ledger event and restore it through the normal stream-tail fold, so a failed PRN projection write cannot lose the selection.

## Why

PAE-1843 requires the producer to determine the obligation year when accepting December-waste evidence, while protecting non-December PRNs and maintaining the existing default behaviour.

## Data and rollout

- New PRNs write their accreditation year as the initial obligation year.
- Existing PRNs without the field remain readable. An acceptance that does not supply a year leaves their current value unchanged.
- No migration or feature flag is required.

## Scope boundaries

- This change does not introduce a user-interface control or change the operator/admin acceptance journeys.
- Review identified a separate reliability concern to discuss: after a PRN cancellation commits, report staleness is currently a best-effort effect. A failed handler can leave an affected report active, with no durable retry or reconciliation. Address this independently with a durable delivery or idempotent reconciliation design; it is deliberately not bundled into PAE-1843.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run lint:types`
- `npm run lint:types:tests`
- `npm test`
- Added domain and route coverage for all PAE-1843 acceptance criteria, ledger-schema coverage for the accepted-event payload, and stream-fold coverage including recovery after a projection persistence failure.

## Journey tests

Not required. The optional year is an external-API-only field with no new operator or administrator interaction. Backend validation, event persistence and recovery tests cover the observable behaviour. A journey change is needed if later work exposes the selection or its outcome in an operator/admin flow.


[PAE-1843]: https://eaflood.atlassian.net/browse/PAE-1843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ