### PR TITLE
PAE-1832: Enforce the type checks that already run

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -41,8 +41,8 @@ jobs:
             console.log(`Documentation-only changes: ${docsOnly}`);
             console.log(`Changed files: ${files.map(f => f.filename).join(', ')}`)
 
-  pr-validator:
-    name: Run Pull Request Checks
+  test-and-scan:
+    name: Test and Scan
     runs-on: ubuntu-latest
     needs: pr-prep
     if: needs.pr-prep.outputs.docs-only != 'true'
@@ -95,6 +95,43 @@ jobs:
       - uses: DEFRA/epr-re-ex-service/.github/actions/lint-types@main
         with:
           fail-on: all
+
+  # The one context the branch ruleset requires from this workflow, so every
+  # blocking job must appear in `needs` below. Two jobs are left out on purpose:
+  # test-journey, because `Run Journey Tests` is separately required, and
+  # typecheck-burndown, because it is advisory (continue-on-error).
+  pr-checks:
+    name: Run Pull Request Checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - pr-prep
+      - test-and-scan
+      - type-check-prod
+      - type-check-tests
+      - dependency-review
+    if: always()
+    steps:
+      - name: Check results
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+          EXPECTED: 5
+        run: |
+          echo "$RESULTS"
+          COUNT=$(echo "$RESULTS" | jq -r 'length')
+          if [ "$COUNT" -ne "$EXPECTED" ]; then
+            echo "Expected $EXPECTED jobs in needs, found $COUNT: update EXPECTED when you add a job"
+            exit 1
+          fi
+          NOT_PASSED=$(echo "$RESULTS" | jq -r 'to_entries
+            | map(select(.value.result != "success" and .value.result != "skipped"))
+            | .[] | "\(.key)=\(.value.result)"')
+          if [ -n "$NOT_PASSED" ]; then
+            echo "Did not pass: $(echo "$NOT_PASSED" | tr '\n' ' ')"
+            exit 1
+          fi
+          echo "Every pull request check passed"
 
   typecheck-burndown:
     name: Typecheck strictness burndown

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
   build:
     if: github.run_number != 1
     name: CDP-build-workflow
+    needs: lint-types
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -38,3 +39,28 @@ jobs:
         uses: DEFRA/cdp-build-action/build@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  lint-types:
+    name: Lint Types
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint types (Prod)
+        run: npm run lint:types
+
+      - name: Lint types (Tests)
+        if: ${{ !cancelled() }}
+        run: npm run lint:types:tests


### PR DESCRIPTION
Ticket: [PAE-1832](https://eaflood.atlassian.net/browse/PAE-1832)
Both `Lint Types` jobs run on every pull request, and neither is in the branch ruleset's required status checks, so a red one does not block a merge. That is how thirteen `obligationYear` type errors reached `main`, where `Lint Types - Tests` fails on any error in the run and turns every open pull request in this repository red regardless of what it changed.

`Run Pull Request Checks` is the one context this workflow contributes to the required set, so it becomes an aggregating job over every blocking job in the workflow: preparation, test and scan, both type checks and dependency review. This follows the pattern `Run Journey Tests` already uses for its matrix. The jobs still run in parallel and report individually, the required context name is unchanged so the ruleset needs no edit, and the gate fails if a job is dropped from its `needs` list rather than silently narrowing. `test-journey` and `typecheck-burndown` are left out on purpose, for the reasons in the comment above the job.

`main` itself is never type-checked today, so the publish workflow gains the same two checks and the build depends on them. A type error on `main` now stops the deployment rather than shipping quietly; `publish-hotfix.yml` remains available by manual dispatch if something has to go out regardless.

This branch is expected to fail `Lint Types - Tests`, and therefore `Run Pull Request Checks`, until the fixes for the `obligationYear` errors land on `main`. That failure is the change working: it is the first pull request in this repository where a red type check blocks the merge. Update the branch once those fixes are in and it should go green.

One check stays unenforced and this branch cannot reach it: the SonarCloud quality gate. Its scan step carries `continue-on-error: true` in the shared `test-and-scan` action, added on 2026-07-16 as a temporary measure while SonarCloud was unavailable, so the gate cannot block a merge regardless of the ruleset. That is a change for `epr-re-ex-service`.

[PAE-1832]: https://eaflood.atlassian.net/browse/PAE-1832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ