### PR TITLE
PAE-1856: State a note's number on a waste balance ledger event

### DIFF
--- a/src/packaging-recycling-notes/repository/contract/find.contract.js
+++ b/src/packaging-recycling-notes/repository/contract/find.contract.js
@@ -229,5 +229,79 @@ export const testFindBehaviour = (it) => {
         expect(result[0].tonnage).toBe(100)
       })
     })
+
+    describe('findByIds', () => {
+      it('reads the notes the ids name', async () => {
+        const accreditation = buildAccreditationId()
+        const wanted = await repository.create(
+          buildDraftPrn(underAccreditation(accreditation, { tonnage: 100 }))
+        )
+        await repository.create(
+          buildDraftPrn(underAccreditation(accreditation, { tonnage: 200 }))
+        )
+
+        const result = await repository.findByIds({
+          ...accreditation,
+          ids: [wanted.id]
+        })
+
+        expect(result).toHaveLength(1)
+        expect(result[0].id).toBe(wanted.id)
+        expect(result[0].tonnage).toBe(100)
+      })
+
+      it('reads nothing when no ids are named', async () => {
+        const accreditation = buildAccreditationId()
+        await repository.create(
+          buildDraftPrn(underAccreditation(accreditation))
+        )
+
+        const result = await repository.findByIds({ ...accreditation, ids: [] })
+
+        expect(result).toEqual([])
+      })
+
+      it('reads nothing for a note another accreditation holds', async () => {
+        const accreditation = buildAccreditationId()
+        const elsewhere = await repository.create(
+          buildDraftPrn(underAccreditation(buildAccreditationId()))
+        )
+
+        const result = await repository.findByIds({
+          ...accreditation,
+          ids: [elsewhere.id]
+        })
+
+        expect(result).toEqual([])
+      })
+
+      it('reads nothing for an id no note is stored under', async () => {
+        const accreditation = buildAccreditationId()
+        await repository.create(
+          buildDraftPrn(underAccreditation(accreditation))
+        )
+
+        const result = await repository.findByIds({
+          ...accreditation,
+          ids: ['a note that was never stored']
+        })
+
+        expect(result).toEqual([])
+      })
+
+      it('does not return deleted PRNs (soft delete)', async () => {
+        const accreditation = buildAccreditationId()
+        const deleted = await repository.create(
+          buildDeletedPrn(underAccreditation(accreditation))
+        )
+
+        const result = await repository.findByIds({
+          ...accreditation,
+          ids: [deleted.id]
+        })
+
+        expect(result).toEqual([])
+      })
+    })
   })
 }

--- a/src/packaging-recycling-notes/repository/inmemory.plugin.js
+++ b/src/packaging-recycling-notes/repository/inmemory.plugin.js
@@ -97,6 +97,25 @@ const performFindByAccreditation =
     return results
   }
 
+const performFindByIds =
+  (storage) =>
+  async ({ organisationId, registrationId, accreditationId, ids }) => {
+    const wanted = new Set(ids)
+    const results = []
+    for (const prn of storage.values()) {
+      if (
+        wanted.has(prn.id) &&
+        prn.organisation?.id === organisationId &&
+        prn.registrationId === registrationId &&
+        prn.accreditation?.id === accreditationId &&
+        prn.status?.currentStatus !== PRN_STATUS.DELETED
+      ) {
+        results.push(structuredClone(prn))
+      }
+    }
+    return results
+  }
+
 /**
  * @param {PackagingRecyclingNote['status']['currentStatusAt'] | undefined} statusAt
  * @param {FindByStatusParams['dateFrom']} dateFrom
@@ -331,6 +350,7 @@ export function createInMemoryPackagingRecyclingNotesRepository(
   return (/** @type {TypedLogger} */ logger) => ({
     create: performCreate(storage),
     findByAccreditation: performFindByAccreditation(storage),
+    findByIds: performFindByIds(storage),
     findById: performFindById(storage),
     findByPrnNumber: performFindByPrnNumber(storage),
     findByStatus: performFindByStatus(storage, excludeOrganisationIds),

--- a/src/packaging-recycling-notes/repository/mongodb.js
+++ b/src/packaging-recycling-notes/repository/mongodb.js
@@ -13,7 +13,7 @@ import { throwWatermarkRegression } from './watermark-guard.js'
 /** @import { Collection, Db, Document, Filter, WithId } from 'mongodb' */
 /** @import { Organisation } from '#domain/organisations/model.js' */
 /** @import { PackagingRecyclingNote } from '#packaging-recycling-notes/domain/model.js' */
-/** @import { FindByStatusParams, PackagingRecyclingNotesRepositoryFactory, PaginatedResult, PersistProjectionParams, UpdateStatusParams } from './port.js' */
+/** @import { FindByIdsParams, FindByStatusParams, PackagingRecyclingNotesRepositoryFactory, PaginatedResult, PersistProjectionParams, UpdateStatusParams } from './port.js' */
 /** @import { TypedLogger } from '#common/hapi-types.js' */
 
 const COLLECTION_NAME = 'packaging-recycling-notes'
@@ -177,6 +177,50 @@ const performFindByAccreditation = async (
   const docs = await db
     .collection(COLLECTION_NAME)
     .find({
+      'organisation.id': organisationId,
+      registrationId,
+      'accreditation.id': accreditationId,
+      'status.currentStatus': { $ne: PRN_STATUS.DELETED }
+    })
+    .toArray()
+
+  return docs.map((doc) =>
+    validatePrnRead({ ...doc, id: doc._id.toHexString() })
+  )
+}
+
+/**
+ * A note id reaches this repository from a stored waste-balance ledger event,
+ * whose schema constrains the id to a string and no further. Anything that is
+ * not a document id cannot name a stored note, so it is dropped rather than
+ * handed to the driver, which would throw on it.
+ *
+ * @param {string} id
+ * @returns {boolean}
+ */
+const isDocumentId = (id) => /^[0-9a-f]{24}$/i.test(id)
+
+/**
+ * @param {Db} db
+ * @param {FindByIdsParams} params
+ * @returns {Promise<PackagingRecyclingNote[]>}
+ */
+const performFindByIds = async (
+  db,
+  { organisationId, registrationId, accreditationId, ids }
+) => {
+  const documentIds = ids
+    .filter(isDocumentId)
+    .map((id) => ObjectId.createFromHexString(id))
+
+  if (documentIds.length === 0) {
+    return []
+  }
+
+  const docs = await db
+    .collection(COLLECTION_NAME)
+    .find({
+      _id: { $in: documentIds },
       'organisation.id': organisationId,
       registrationId,
       'accreditation.id': accreditationId,
@@ -488,6 +532,7 @@ export const createPackagingRecyclingNotesRepository = async (
     create: (prn) => performCreate(db, prn),
     findByAccreditation: (accreditationId) =>
       performFindByAccreditation(db, accreditationId),
+    findByIds: (params) => performFindByIds(db, params),
     findById: (id) => performFindById(db, id),
     findByPrnNumber: (prnNumber) => performFindByPrnNumber(db, prnNumber),
     findByStatus: performFindByStatus(db, excludeOrganisationIds),

--- a/src/packaging-recycling-notes/repository/port.js
+++ b/src/packaging-recycling-notes/repository/port.js
@@ -50,6 +50,18 @@ export const PRN_VERSION_CONFLICT = 'prn-version-conflict'
  */
 
 /**
+ * Names the notes a ledger read wants, scoped to the accreditation whose ledger
+ * it is reading. The scope is what keeps a note belonging to another
+ * accreditation from being read here, so it is required rather than optional.
+ *
+ * @typedef {Object} FindByIdsParams
+ * @property {string} organisationId
+ * @property {string} registrationId
+ * @property {string} accreditationId
+ * @property {string[]} ids
+ */
+
+/**
  * @typedef {Object} PaginatedResult
  * @property {import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote[]} items
  * @property {string | null} nextCursor
@@ -73,6 +85,7 @@ export const PRN_VERSION_CONFLICT = 'prn-version-conflict'
  * @property {(prnNumber: string) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote | null>} findByPrnNumber
  * @property {(prn: Omit<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote, 'id'>) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote>} create
  * @property {(accreditationId: AccreditationId) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote[]>} findByAccreditation
+ * @property {(params: FindByIdsParams) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote[]>} findByIds
  * @property {(params: FindByStatusParams) => Promise<PaginatedResult>} findByStatus
  * @property {(params: UpdateStatusParams) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote | null>} updateStatus
  * @property {(params: PersistProjectionParams) => Promise<import('#packaging-recycling-notes/domain/model.js').PackagingRecyclingNote | null>} persistProjection

--- a/src/routes/v1/organisations/registrations/accreditations/waste-balance-ledger/get.js
+++ b/src/routes/v1/organisations/registrations/accreditations/waste-balance-ledger/get.js
@@ -4,6 +4,7 @@ import { readLedger } from '#waste-balances/application/read-ledger.js'
 import { wasteBalanceLedgerResponseSchema } from '../../waste-balance-ledger-response.schema.js'
 
 /** @import { HapiRequest, HapiResponseToolkit } from '#common/hapi-types.js' */
+/** @import { LedgerNoteReader } from '#waste-balances/application/read-ledger.js' */
 
 export const accreditationWasteBalanceLedgerGetPath =
   '/v1/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/waste-balance-ledger'
@@ -25,19 +26,24 @@ export const accreditationWasteBalanceLedgerGet = {
   },
   /**
    * @param {HapiRequest & {
+   *   packagingRecyclingNotesRepository: LedgerNoteReader,
    *   params: { organisationId: string, registrationId: string, accreditationId: string }
    * }} request
    * @param {HapiResponseToolkit} h
    */
   handler: async (request, h) => {
-    const { ledgerRepository } = request
+    const { ledgerRepository, packagingRecyclingNotesRepository } = request
     const { organisationId, registrationId, accreditationId } = request.params
 
-    const ledger = await readLedger(ledgerRepository, {
-      organisationId,
-      registrationId,
-      accreditationId
-    })
+    const ledger = await readLedger(
+      ledgerRepository,
+      packagingRecyclingNotesRepository,
+      {
+        organisationId,
+        registrationId,
+        accreditationId
+      }
+    )
 
     return h.response(ledger).code(StatusCodes.OK)
   }

--- a/src/routes/v1/organisations/registrations/accreditations/waste-balance-ledger/get.js
+++ b/src/routes/v1/organisations/registrations/accreditations/waste-balance-ledger/get.js
@@ -4,7 +4,7 @@ import { readLedger } from '#waste-balances/application/read-ledger.js'
 import { wasteBalanceLedgerResponseSchema } from '../../waste-balance-ledger-response.schema.js'
 
 /** @import { HapiRequest, HapiResponseToolkit } from '#common/hapi-types.js' */
-/** @import { LedgerNoteReader } from '#waste-balances/application/read-ledger.js' */
+/** @import { PackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/port.js' */
 
 export const accreditationWasteBalanceLedgerGetPath =
   '/v1/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/waste-balance-ledger'
@@ -26,7 +26,7 @@ export const accreditationWasteBalanceLedgerGet = {
   },
   /**
    * @param {HapiRequest & {
-   *   packagingRecyclingNotesRepository: LedgerNoteReader,
+   *   packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository,
    *   params: { organisationId: string, registrationId: string, accreditationId: string }
    * }} request
    * @param {HapiResponseToolkit} h

--- a/src/routes/v1/organisations/registrations/accreditations/waste-balance-ledger/get.test.js
+++ b/src/routes/v1/organisations/registrations/accreditations/waste-balance-ledger/get.test.js
@@ -5,6 +5,8 @@ import {
   buildLedgerEvent,
   buildPrnCreatedEvent
 } from '#waste-balances/repository/ledger-test-data.js'
+import { createInMemoryPackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/inmemory.plugin.js'
+import { createMockIssuedPrn } from '#packaging-recycling-notes/routes/test-helpers.js'
 import { createTestServer } from '#test/create-test-server.js'
 import { asServiceMaintainer } from '#test/inject-auth.js'
 import { setupAuthContext } from '#vite/helpers/setup-auth-mocking.js'
@@ -109,7 +111,48 @@ describe(`GET ${accreditationWasteBalanceLedgerGetPath}`, () => {
         opening: { total: 100, available: 100 },
         closing: { total: 100, available: 50 }
       },
-      prn: { id: 'prn-1', tonnage: 50 }
+      prn: { id: 'prn-1', prnNumber: null, tonnage: 50 }
+    })
+  })
+
+  it('gives a PRN event the number its note is known by', async () => {
+    const note = createMockIssuedPrn({
+      id: 'prn-numbered',
+      prnNumber: 'EA26000123',
+      organisation: { id: 'org-note', name: 'A reprocessor' },
+      registrationId: 'reg-note',
+      accreditation: {
+        ...createMockIssuedPrn().accreditation,
+        id: 'acc-note'
+      }
+    })
+    const serverHoldingTheNote = await createTestServer({
+      repositories: {
+        packagingRecyclingNotesRepository:
+          createInMemoryPackagingRecyclingNotesRepository([note], [])
+      }
+    })
+    await serverHoldingTheNote.app.ledgerRepository.appendEvents([
+      buildPrnCreatedEvent({
+        organisationId: 'org-note',
+        registrationId: 'reg-note',
+        accreditationId: 'acc-note',
+        number: 1,
+        payload: { prnId: 'prn-numbered', amount: 50 }
+      })
+    ])
+
+    const response = await serverHoldingTheNote.inject({
+      method: 'GET',
+      url: makePath('org-note', 'reg-note', 'acc-note'),
+      ...asServiceMaintainer()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+    expect(JSON.parse(response.payload).events[0].prn).toEqual({
+      id: 'prn-numbered',
+      prnNumber: 'EA26000123',
+      tonnage: 50
     })
   })
 

--- a/src/routes/v1/organisations/registrations/accreditations/waste-balance-ledger/get.test.js
+++ b/src/routes/v1/organisations/registrations/accreditations/waste-balance-ledger/get.test.js
@@ -156,6 +156,50 @@ describe(`GET ${accreditationWasteBalanceLedgerGetPath}`, () => {
     })
   })
 
+  it('gives no number for a note the accreditation does not hold', async () => {
+    const noteOfAnotherAccreditation = createMockIssuedPrn({
+      id: 'prn-elsewhere',
+      prnNumber: 'EA26000456',
+      organisation: { id: 'org-note', name: 'A reprocessor' },
+      registrationId: 'reg-note',
+      accreditation: {
+        ...createMockIssuedPrn().accreditation,
+        id: 'acc-elsewhere'
+      }
+    })
+    const serverHoldingTheNote = await createTestServer({
+      repositories: {
+        packagingRecyclingNotesRepository:
+          createInMemoryPackagingRecyclingNotesRepository(
+            [noteOfAnotherAccreditation],
+            []
+          )
+      }
+    })
+    await serverHoldingTheNote.app.ledgerRepository.appendEvents([
+      buildPrnCreatedEvent({
+        organisationId: 'org-note',
+        registrationId: 'reg-note',
+        accreditationId: 'acc-note',
+        number: 1,
+        payload: { prnId: 'prn-elsewhere', amount: 50 }
+      })
+    ])
+
+    const response = await serverHoldingTheNote.inject({
+      method: 'GET',
+      url: makePath('org-note', 'reg-note', 'acc-note'),
+      ...asServiceMaintainer()
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+    expect(JSON.parse(response.payload).events[0].prn).toEqual({
+      id: 'prn-elsewhere',
+      prnNumber: null,
+      tonnage: 50
+    })
+  })
+
   it('returns events ordered by number ascending', async () => {
     await ledgerRepository.appendEvents([
       buildLedgerEvent({

--- a/src/routes/v1/organisations/registrations/waste-balance-ledger-response.schema.js
+++ b/src/routes/v1/organisations/registrations/waste-balance-ledger-response.schema.js
@@ -39,10 +39,8 @@ const summaryLogSchema = Joi.object({
 })
 
 /**
- * `prnNumber` is the note's own number, the reference it is known by outside
- * the service. It is null wherever the note holds no number the read can see.
- * A reader cannot take null to mean the note is unissued: `LedgerEventResource`
- * in `src/waste-balances/application/read-ledger.js` states the cases.
+ * `prnNumber` is null wherever the read sees no number on the note. Null does
+ * not mean the note is unissued.
  *
  * `tonnage` is the tonnage of the note itself, not the amount the balance
  * moved. Accepting or rejecting a note moves neither total.

--- a/src/routes/v1/organisations/registrations/waste-balance-ledger-response.schema.js
+++ b/src/routes/v1/organisations/registrations/waste-balance-ledger-response.schema.js
@@ -40,8 +40,9 @@ const summaryLogSchema = Joi.object({
 
 /**
  * `prnNumber` is the note's own number, the reference it is known by outside
- * the service. It is null on the events of a note that holds none: a note is
- * numbered as it is issued, and a ledger records the events before that.
+ * the service. It is null wherever the note holds no number the read can see.
+ * A reader cannot take null to mean the note is unissued: `LedgerEventResource`
+ * in `src/waste-balances/application/read-ledger.js` states the cases.
  *
  * `tonnage` is the tonnage of the note itself, not the amount the balance
  * moved. Accepting or rejecting a note moves neither total.

--- a/src/routes/v1/organisations/registrations/waste-balance-ledger-response.schema.js
+++ b/src/routes/v1/organisations/registrations/waste-balance-ledger-response.schema.js
@@ -39,11 +39,16 @@ const summaryLogSchema = Joi.object({
 })
 
 /**
+ * `prnNumber` is the note's own number, the reference it is known by outside
+ * the service. It is null on the events of a note that holds none: a note is
+ * numbered as it is issued, and a ledger records the events before that.
+ *
  * `tonnage` is the tonnage of the note itself, not the amount the balance
  * moved. Accepting or rejecting a note moves neither total.
  */
 const prnSchema = Joi.object({
   id: Joi.string().required(),
+  prnNumber: Joi.string().allow(null).required(),
   tonnage: Joi.number().required()
 })
 

--- a/src/routes/v1/organisations/registrations/waste-balance-ledger-response.schema.test.js
+++ b/src/routes/v1/organisations/registrations/waste-balance-ledger-response.schema.test.js
@@ -23,7 +23,7 @@ const summaryLogEvent = (overrides = {}) => ({
 const prnEvent = (overrides = {}) => ({
   ...commonKeys(),
   kind: LEDGER_EVENT_KIND.PRN_CREATED,
-  prn: { id: 'prn-1', tonnage: 50 },
+  prn: { id: 'prn-1', prnNumber: 'EX123456789', tonnage: 50 },
   ...overrides
 })
 
@@ -68,6 +68,22 @@ describe('the waste balance ledger response schema', () => {
     expect(errorFrom(ledgerOf([prnEvent()]))).toBeUndefined()
   })
 
+  it('accepts an event whose note holds no number yet', () => {
+    expect(
+      errorFrom(
+        ledgerOf([
+          prnEvent({ prn: { id: 'prn-1', prnNumber: null, tonnage: 50 } })
+        ])
+      )
+    ).toBeUndefined()
+  })
+
+  it('refuses a note that states no number either way', () => {
+    const event = prnEvent({ prn: { id: 'prn-1', tonnage: 50 } })
+
+    expect(refusalOf(event)).toContain('"events[0].prn.prnNumber" is required')
+  })
+
   it('accepts a ledger holding no events', () => {
     expect(errorFrom(ledgerOf([]))).toBeUndefined()
   })
@@ -83,7 +99,9 @@ describe('the waste balance ledger response schema', () => {
   })
 
   it('refuses an event that names both a summary log and a note', () => {
-    const event = summaryLogEvent({ prn: { id: 'prn-1', tonnage: 50 } })
+    const event = summaryLogEvent({
+      prn: { id: 'prn-1', prnNumber: 'EX123456789', tonnage: 50 }
+    })
 
     expect(refusalOf(event)).toContain('"events[0].prn" is not allowed')
     expect(

--- a/src/routes/v1/organisations/registrations/waste-balance-ledger/get.js
+++ b/src/routes/v1/organisations/registrations/waste-balance-ledger/get.js
@@ -4,6 +4,7 @@ import { readLedger } from '#waste-balances/application/read-ledger.js'
 import { wasteBalanceLedgerResponseSchema } from '../waste-balance-ledger-response.schema.js'
 
 /** @import { HapiRequest, HapiResponseToolkit } from '#common/hapi-types.js' */
+/** @import { LedgerNoteReader } from '#waste-balances/application/read-ledger.js' */
 
 export const registrationWasteBalanceLedgerGetPath =
   '/v1/organisations/{organisationId}/registrations/{registrationId}/waste-balance-ledger'
@@ -25,19 +26,24 @@ export const registrationWasteBalanceLedgerGet = {
   },
   /**
    * @param {HapiRequest & {
+   *   packagingRecyclingNotesRepository: LedgerNoteReader,
    *   params: { organisationId: string, registrationId: string }
    * }} request
    * @param {HapiResponseToolkit} h
    */
   handler: async (request, h) => {
-    const { ledgerRepository } = request
+    const { ledgerRepository, packagingRecyclingNotesRepository } = request
     const { organisationId, registrationId } = request.params
 
-    const ledger = await readLedger(ledgerRepository, {
-      organisationId,
-      registrationId,
-      accreditationId: null
-    })
+    const ledger = await readLedger(
+      ledgerRepository,
+      packagingRecyclingNotesRepository,
+      {
+        organisationId,
+        registrationId,
+        accreditationId: null
+      }
+    )
 
     return h.response(ledger).code(StatusCodes.OK)
   }

--- a/src/routes/v1/organisations/registrations/waste-balance-ledger/get.js
+++ b/src/routes/v1/organisations/registrations/waste-balance-ledger/get.js
@@ -4,7 +4,7 @@ import { readLedger } from '#waste-balances/application/read-ledger.js'
 import { wasteBalanceLedgerResponseSchema } from '../waste-balance-ledger-response.schema.js'
 
 /** @import { HapiRequest, HapiResponseToolkit } from '#common/hapi-types.js' */
-/** @import { LedgerNoteReader } from '#waste-balances/application/read-ledger.js' */
+/** @import { PackagingRecyclingNotesRepository } from '#packaging-recycling-notes/repository/port.js' */
 
 export const registrationWasteBalanceLedgerGetPath =
   '/v1/organisations/{organisationId}/registrations/{registrationId}/waste-balance-ledger'
@@ -26,7 +26,7 @@ export const registrationWasteBalanceLedgerGet = {
   },
   /**
    * @param {HapiRequest & {
-   *   packagingRecyclingNotesRepository: LedgerNoteReader,
+   *   packagingRecyclingNotesRepository: PackagingRecyclingNotesRepository,
    *   params: { organisationId: string, registrationId: string }
    * }} request
    * @param {HapiResponseToolkit} h

--- a/src/test/mock-repositories.js
+++ b/src/test/mock-repositories.js
@@ -107,6 +107,7 @@ export const createMockPackagingRecyclingNotesRepository = (
   findByPrnNumber: vi.fn(),
   create: vi.fn(),
   findByAccreditation: vi.fn(),
+  findByIds: vi.fn(),
   findByStatus: vi.fn(),
   updateStatus: vi.fn(),
   persistProjection: vi.fn(),

--- a/src/test/mock-repositories.test.js
+++ b/src/test/mock-repositories.test.js
@@ -73,6 +73,7 @@ describe('mock-repositories', () => {
         'findByPrnNumber',
         'create',
         'findByAccreditation',
+        'findByIds',
         'findByStatus',
         'updateStatus',
         'persistProjection'

--- a/src/waste-balances/application/read-ledger.js
+++ b/src/waste-balances/application/read-ledger.js
@@ -79,6 +79,11 @@
  */
 
 /**
+ * Reads the notes an accreditation holds. Deleted notes are not among them, and
+ * their absence costs a ledger read nothing: a note can only be deleted before
+ * it is issued, and only issue gives it a number. A note this reader omits has
+ * no number to state.
+ *
  * @typedef {Object} LedgerNoteReader
  * @property {(accreditation: WasteBalanceLedgerId & { accreditationId: string }) => Promise<Array<{ id: string, prnNumber?: string | null }>>} findByAccreditation
  */
@@ -129,9 +134,13 @@ const creditsASummaryLog = (payload) => 'summaryLogId' in payload
 const noteNumbersById = async (noteReader, ledgerId, events) => {
   const { accreditationId } = ledgerId
 
+  if (accreditationId === null) {
+    return new Map()
+  }
+
   const namesNoNote = events.every((event) => creditsASummaryLog(event.payload))
 
-  if (accreditationId === null || namesNoNote) {
+  if (namesNoNote) {
     return new Map()
   }
 

--- a/src/waste-balances/application/read-ledger.js
+++ b/src/waste-balances/application/read-ledger.js
@@ -79,13 +79,13 @@
  */
 
 /**
- * Reads the notes an accreditation holds. Deleted notes are not among them, and
- * their absence costs a ledger read nothing: a note can only be deleted before
- * it is issued, and only issue gives it a number. A note this reader omits has
- * no number to state.
+ * Reads the notes an accreditation holds, among the ids asked for. Deleted
+ * notes are not among them, and their absence costs a ledger read nothing: a
+ * note can only be deleted before it is issued, and only issue gives it a
+ * number. A note this reader omits has no number to state.
  *
  * @typedef {Object} LedgerNoteReader
- * @property {(accreditation: WasteBalanceLedgerId & { accreditationId: string }) => Promise<Array<{ id: string, prnNumber?: string | null }>>} findByAccreditation
+ * @property {(params: WasteBalanceLedgerId & { accreditationId: string, ids: string[] }) => Promise<Array<{ id: string, prnNumber?: string | null }>>} findByIds
  */
 
 /**
@@ -138,15 +138,18 @@ const noteNumbersById = async (noteReader, ledgerId, events) => {
     return new Map()
   }
 
-  const namesNoNote = events.every((event) => creditsASummaryLog(event.payload))
+  const noteIds = events.flatMap((event) =>
+    creditsASummaryLog(event.payload) ? [] : [event.payload.prnId]
+  )
 
-  if (namesNoNote) {
+  if (noteIds.length === 0) {
     return new Map()
   }
 
-  const notes = await noteReader.findByAccreditation({
+  const notes = await noteReader.findByIds({
     ...ledgerId,
-    accreditationId
+    accreditationId,
+    ids: noteIds
   })
 
   return new Map(notes.map((note) => [note.id, note.prnNumber ?? null]))

--- a/src/waste-balances/application/read-ledger.js
+++ b/src/waste-balances/application/read-ledger.js
@@ -47,9 +47,19 @@
 
 /**
  * `prnNumber` is the note's own number, the reference it is known by outside
- * the service. A note holds none until it is issued, and a ledger records the
- * events that precede issuance, so the number is null on some events of a note
- * that carries one on others.
+ * the service. It is null wherever the note holds no number the read can see,
+ * which is not only the pre-issuance case:
+ *
+ * - The note is not yet issued. A number is stamped as a note is issued, and a
+ *   ledger records the events before that, so a note carries a number on some
+ *   of its events and none on the earlier ones.
+ * - The note has been deleted. The note read excludes a deleted note, and a
+ *   note reaches `deleted` only from `awaiting_authorisation`, so one that is
+ *   deleted never held a number.
+ * - The issuance has not finished. The write appends the event before it
+ *   persists the number, and the read-side catch-up projects status without
+ *   restoring a number, so an issued event can be read before its note carries
+ *   one.
  *
  * `tonnage` is the tonnage of the note itself, not the amount the balance
  * moved. Accepting or rejecting a note moves neither total.

--- a/src/waste-balances/application/read-ledger.js
+++ b/src/waste-balances/application/read-ledger.js
@@ -46,11 +46,16 @@
  */
 
 /**
+ * `prnNumber` is the note's own number, the reference it is known by outside
+ * the service. A note holds none until it is issued, and a ledger records the
+ * events that precede issuance, so the number is null on some events of a note
+ * that carries one on others.
+ *
  * `tonnage` is the tonnage of the note itself, not the amount the balance
  * moved. Accepting or rejecting a note moves neither total.
  *
  * @typedef {LedgerEventCommon & {
- *   prn: { id: string, tonnage: number },
+ *   prn: { id: string, prnNumber: string | null, tonnage: number },
  *   summaryLog?: never
  * }} PrnEventResource
  */
@@ -76,6 +81,18 @@
  * @typedef {Object} LedgerResource
  * @property {WasteBalanceLedgerId} ledger
  * @property {LedgerEventResource[]} events
+ */
+
+/**
+ * Reads the notes of one accreditation, so a ledger read can state each note's
+ * own number beside the id its events carry.
+ *
+ * Stated here as what a ledger read needs of a note, rather than taken from the
+ * note module, so `waste-balances` depends on nothing above it. A
+ * `PackagingRecyclingNotesRepository` satisfies it, and the routes pass one.
+ *
+ * @typedef {Object} LedgerNoteReader
+ * @property {(accreditation: WasteBalanceLedgerId & { accreditationId: string }) => Promise<Array<{ id: string, prnNumber?: string | null }>>} findByAccreditation
  */
 
 /**
@@ -116,10 +133,45 @@ const toActor = ({ id, name, email }) => ({ id, name, email })
 const creditsASummaryLog = (payload) => 'summaryLogId' in payload
 
 /**
+ * The number of every note the ledger's events can name, by note id.
+ *
+ * A ledger is keyed by the accreditation its notes belong to — the write path
+ * refuses an event whose note names another accreditation, and refuses a note
+ * event on a registered-only ledger at all — so one read of that accreditation
+ * covers every note the events name.
+ *
+ * Empty where the ledger names no note: a registered-only ledger holds none,
+ * and an accreditation ledger that has seen no note decision has nothing to
+ * look up.
+ *
+ * @param {LedgerNoteReader} noteReader
+ * @param {WasteBalanceLedgerId} ledgerId
+ * @param {LedgerEvent[]} events
+ * @returns {Promise<Map<string, string | null>>}
+ */
+const noteNumbersById = async (noteReader, ledgerId, events) => {
+  const { accreditationId } = ledgerId
+
+  const namesNoNote = events.every((event) => creditsASummaryLog(event.payload))
+
+  if (accreditationId === null || namesNoNote) {
+    return new Map()
+  }
+
+  const notes = await noteReader.findByAccreditation({
+    ...ledgerId,
+    accreditationId
+  })
+
+  return new Map(notes.map((note) => [note.id, note.prnNumber ?? null]))
+}
+
+/**
  * @param {LedgerEvent} event
+ * @param {Map<string, string | null>} noteNumbers
  * @returns {LedgerEventResource}
  */
-const toEventResource = (event) => {
+const toEventResource = (event, noteNumbers) => {
   const common = {
     number: event.number,
     kind: event.kind,
@@ -141,7 +193,11 @@ const toEventResource = (event) => {
       }
     : {
         ...common,
-        prn: { id: event.payload.prnId, tonnage: event.payload.amount }
+        prn: {
+          id: event.payload.prnId,
+          prnNumber: noteNumbers.get(event.payload.prnId) ?? null,
+          tonnage: event.payload.amount
+        }
       }
 }
 
@@ -157,14 +213,21 @@ const toEventResource = (event) => {
  * the size of the service. The `events` key leaves room to page it later
  * without changing the shape.
  *
+ * A note event names its note by id. The number that note is known by is held
+ * on the note itself, so the read states it from there.
+ *
  * @param {WasteBalanceLedgerRepository} ledgerRepository
+ * @param {LedgerNoteReader} noteReader
  * @param {WasteBalanceLedgerId} ledgerId - The registration or accreditation
  *   whose ledger is read.
  * @returns {Promise<LedgerResource>}
  */
-export const readLedger = async (ledgerRepository, ledgerId) => ({
-  ledger: toLedger(ledgerId),
-  events: (await ledgerRepository.findAllInLedger(ledgerId)).map(
-    toEventResource
-  )
-})
+export const readLedger = async (ledgerRepository, noteReader, ledgerId) => {
+  const events = await ledgerRepository.findAllInLedger(ledgerId)
+  const noteNumbers = await noteNumbersById(noteReader, ledgerId, events)
+
+  return {
+    ledger: toLedger(ledgerId),
+    events: events.map((event) => toEventResource(event, noteNumbers))
+  }
+}

--- a/src/waste-balances/application/read-ledger.js
+++ b/src/waste-balances/application/read-ledger.js
@@ -46,21 +46,6 @@
  */
 
 /**
- * `prnNumber` is the note's own number, the reference it is known by outside
- * the service. It is null wherever the note holds no number the read can see,
- * which is not only the pre-issuance case:
- *
- * - The note is not yet issued. A number is stamped as a note is issued, and a
- *   ledger records the events before that, so a note carries a number on some
- *   of its events and none on the earlier ones.
- * - The note has been deleted. The note read excludes a deleted note, and a
- *   note reaches `deleted` only from `awaiting_authorisation`, so one that is
- *   deleted never held a number.
- * - The issuance has not finished. The write appends the event before it
- *   persists the number, and the read-side catch-up projects status without
- *   restoring a number, so an issued event can be read before its note carries
- *   one.
- *
  * `tonnage` is the tonnage of the note itself, not the amount the balance
  * moved. Accepting or rejecting a note moves neither total.
  *
@@ -94,13 +79,6 @@
  */
 
 /**
- * Reads the notes of one accreditation, so a ledger read can state each note's
- * own number beside the id its events carry.
- *
- * Stated here as what a ledger read needs of a note, rather than taken from the
- * note module, so `waste-balances` depends on nothing above it. A
- * `PackagingRecyclingNotesRepository` satisfies it, and the routes pass one.
- *
  * @typedef {Object} LedgerNoteReader
  * @property {(accreditation: WasteBalanceLedgerId & { accreditationId: string }) => Promise<Array<{ id: string, prnNumber?: string | null }>>} findByAccreditation
  */
@@ -143,17 +121,6 @@ const toActor = ({ id, name, email }) => ({ id, name, email })
 const creditsASummaryLog = (payload) => 'summaryLogId' in payload
 
 /**
- * The number of every note the ledger's events can name, by note id.
- *
- * A ledger is keyed by the accreditation its notes belong to — the write path
- * refuses an event whose note names another accreditation, and refuses a note
- * event on a registered-only ledger at all — so one read of that accreditation
- * covers every note the events name.
- *
- * Empty where the ledger names no note: a registered-only ledger holds none,
- * and an accreditation ledger that has seen no note decision has nothing to
- * look up.
- *
  * @param {LedgerNoteReader} noteReader
  * @param {WasteBalanceLedgerId} ledgerId
  * @param {LedgerEvent[]} events
@@ -222,9 +189,6 @@ const toEventResource = (event, noteNumbers) => {
  * PRN decision, so the count follows the operator's own activity rather than
  * the size of the service. The `events` key leaves room to page it later
  * without changing the shape.
- *
- * A note event names its note by id. The number that note is known by is held
- * on the note itself, so the read states it from there.
  *
  * @param {WasteBalanceLedgerRepository} ledgerRepository
  * @param {LedgerNoteReader} noteReader

--- a/src/waste-balances/application/read-ledger.test.js
+++ b/src/waste-balances/application/read-ledger.test.js
@@ -174,18 +174,6 @@ describe('reading a waste balance ledger', () => {
     expect(noteReader.findByAccreditation).not.toHaveBeenCalled()
   })
 
-  it('reads the notes of the accreditation whose ledger it is reading', async () => {
-    await ledgerRepository.appendEvents([buildPrnAcceptedEvent()])
-
-    await readLedger(ledgerRepository, noteReader, buildLedgerId())
-
-    expect(noteReader.findByAccreditation).toHaveBeenCalledWith({
-      organisationId: 'org-1',
-      registrationId: 'reg-1',
-      accreditationId: 'acc-1'
-    })
-  })
-
   it('carries an actor the source knows only the id of', async () => {
     await ledgerRepository.appendEvents([
       buildLedgerEvent({ createdBy: { id: 'user-9' } })

--- a/src/waste-balances/application/read-ledger.test.js
+++ b/src/waste-balances/application/read-ledger.test.js
@@ -12,7 +12,7 @@ import { readLedger } from './read-ledger.js'
  * @param {Array<{ id: string, prnNumber?: string | null }>} notes
  */
 const noteReaderHolding = (notes) => ({
-  findByAccreditation: vi.fn(async () => notes)
+  findByIds: vi.fn(async () => notes)
 })
 
 describe('reading a waste balance ledger', () => {
@@ -160,7 +160,7 @@ describe('reading a waste balance ledger', () => {
 
     await readLedger(ledgerRepository, noteReader, buildLedgerId())
 
-    expect(noteReader.findByAccreditation).not.toHaveBeenCalled()
+    expect(noteReader.findByIds).not.toHaveBeenCalled()
   })
 
   it('reads no note for a registered-only ledger', async () => {
@@ -171,7 +171,7 @@ describe('reading a waste balance ledger', () => {
 
     await readLedger(ledgerRepository, noteReader, ledgerId)
 
-    expect(noteReader.findByAccreditation).not.toHaveBeenCalled()
+    expect(noteReader.findByIds).not.toHaveBeenCalled()
   })
 
   it('carries an actor the source knows only the id of', async () => {

--- a/src/waste-balances/application/read-ledger.test.js
+++ b/src/waste-balances/application/read-ledger.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 import { createInMemoryLedgerRepository } from '../repository/ledger-inmemory.js'
 import {
@@ -8,16 +8,30 @@ import {
 } from '../repository/ledger-test-data.js'
 import { readLedger } from './read-ledger.js'
 
+/**
+ * @param {Array<{ id: string, prnNumber?: string | null }>} notes
+ */
+const noteReaderHolding = (notes) => ({
+  findByAccreditation: vi.fn(async () => notes)
+})
+
 describe('reading a waste balance ledger', () => {
   /** @type {import('../repository/ledger-port.js').WasteBalanceLedgerRepository} */
   let ledgerRepository
+  /** @type {ReturnType<typeof noteReaderHolding>} */
+  let noteReader
 
   beforeEach(() => {
     ledgerRepository = createInMemoryLedgerRepository()()
+    noteReader = noteReaderHolding([])
   })
 
   it('names the ledger the events belong to', async () => {
-    const result = await readLedger(ledgerRepository, buildLedgerId())
+    const result = await readLedger(
+      ledgerRepository,
+      noteReader,
+      buildLedgerId()
+    )
 
     expect(result.ledger).toEqual({
       organisationId: 'org-1',
@@ -29,13 +43,17 @@ describe('reading a waste balance ledger', () => {
   it('names a registered-only ledger by its null accreditation', async () => {
     const ledgerId = buildLedgerId({ accreditationId: null })
 
-    const result = await readLedger(ledgerRepository, ledgerId)
+    const result = await readLedger(ledgerRepository, noteReader, ledgerId)
 
     expect(result.ledger.accreditationId).toBeNull()
   })
 
   it('returns no events for a ledger that holds none', async () => {
-    const result = await readLedger(ledgerRepository, buildLedgerId())
+    const result = await readLedger(
+      ledgerRepository,
+      noteReader,
+      buildLedgerId()
+    )
 
     expect(result.events).toEqual([])
   })
@@ -48,7 +66,11 @@ describe('reading a waste balance ledger', () => {
       })
     ])
 
-    const result = await readLedger(ledgerRepository, buildLedgerId())
+    const result = await readLedger(
+      ledgerRepository,
+      noteReader,
+      buildLedgerId()
+    )
 
     expect(result.events).toEqual([
       expect.objectContaining({
@@ -65,7 +87,11 @@ describe('reading a waste balance ledger', () => {
       buildLedgerEvent({ payload: { summaryLogId: 'log-7', creditTotal: 250 } })
     ])
 
-    const result = await readLedger(ledgerRepository, buildLedgerId())
+    const result = await readLedger(
+      ledgerRepository,
+      noteReader,
+      buildLedgerId()
+    )
 
     expect(result.events).toEqual([
       expect.objectContaining({ summaryLog: { id: 'log-7', creditTotal: 250 } })
@@ -76,12 +102,88 @@ describe('reading a waste balance ledger', () => {
     await ledgerRepository.appendEvents([
       buildPrnAcceptedEvent({ payload: { prnId: 'prn-9', amount: 40 } })
     ])
+    noteReader = noteReaderHolding([{ id: 'prn-9', prnNumber: 'EX123456789' }])
 
-    const result = await readLedger(ledgerRepository, buildLedgerId())
+    const result = await readLedger(
+      ledgerRepository,
+      noteReader,
+      buildLedgerId()
+    )
 
     expect(result.events).toEqual([
-      expect.objectContaining({ prn: { id: 'prn-9', tonnage: 40 } })
+      expect.objectContaining({
+        prn: { id: 'prn-9', prnNumber: 'EX123456789', tonnage: 40 }
+      })
     ])
+  })
+
+  it('gives a PRN event no number while the note it names holds none', async () => {
+    await ledgerRepository.appendEvents([
+      buildPrnAcceptedEvent({ payload: { prnId: 'prn-9', amount: 40 } })
+    ])
+    noteReader = noteReaderHolding([{ id: 'prn-9' }])
+
+    const result = await readLedger(
+      ledgerRepository,
+      noteReader,
+      buildLedgerId()
+    )
+
+    expect(result.events).toEqual([
+      expect.objectContaining({
+        prn: { id: 'prn-9', prnNumber: null, tonnage: 40 }
+      })
+    ])
+  })
+
+  it('gives a PRN event no number when the note reader no longer holds the note', async () => {
+    await ledgerRepository.appendEvents([
+      buildPrnAcceptedEvent({ payload: { prnId: 'prn-9', amount: 40 } })
+    ])
+    noteReader = noteReaderHolding([{ id: 'a-different-note' }])
+
+    const result = await readLedger(
+      ledgerRepository,
+      noteReader,
+      buildLedgerId()
+    )
+
+    expect(result.events).toEqual([
+      expect.objectContaining({
+        prn: { id: 'prn-9', prnNumber: null, tonnage: 40 }
+      })
+    ])
+  })
+
+  it('reads no note for a ledger whose events name none', async () => {
+    await ledgerRepository.appendEvents([buildLedgerEvent()])
+
+    await readLedger(ledgerRepository, noteReader, buildLedgerId())
+
+    expect(noteReader.findByAccreditation).not.toHaveBeenCalled()
+  })
+
+  it('reads no note for a registered-only ledger', async () => {
+    const ledgerId = buildLedgerId({ accreditationId: null })
+    await ledgerRepository.appendEvents([
+      buildLedgerEvent({ accreditationId: null })
+    ])
+
+    await readLedger(ledgerRepository, noteReader, ledgerId)
+
+    expect(noteReader.findByAccreditation).not.toHaveBeenCalled()
+  })
+
+  it('reads the notes of the accreditation whose ledger it is reading', async () => {
+    await ledgerRepository.appendEvents([buildPrnAcceptedEvent()])
+
+    await readLedger(ledgerRepository, noteReader, buildLedgerId())
+
+    expect(noteReader.findByAccreditation).toHaveBeenCalledWith({
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      accreditationId: 'acc-1'
+    })
   })
 
   it('carries an actor the source knows only the id of', async () => {
@@ -89,7 +191,11 @@ describe('reading a waste balance ledger', () => {
       buildLedgerEvent({ createdBy: { id: 'user-9' } })
     ])
 
-    const result = await readLedger(ledgerRepository, buildLedgerId())
+    const result = await readLedger(
+      ledgerRepository,
+      noteReader,
+      buildLedgerId()
+    )
 
     expect(result.events).toEqual([
       expect.objectContaining({ createdBy: { id: 'user-9' } })
@@ -103,7 +209,11 @@ describe('reading a waste balance ledger', () => {
       })
     ])
 
-    const result = await readLedger(ledgerRepository, buildLedgerId())
+    const result = await readLedger(
+      ledgerRepository,
+      noteReader,
+      buildLedgerId()
+    )
 
     expect(result.events).toEqual([
       expect.objectContaining({
@@ -119,7 +229,11 @@ describe('reading a waste balance ledger', () => {
   it('addresses an event by its number and repeats no ledger id on it', async () => {
     await ledgerRepository.appendEvents([buildLedgerEvent()])
 
-    const result = await readLedger(ledgerRepository, buildLedgerId())
+    const result = await readLedger(
+      ledgerRepository,
+      noteReader,
+      buildLedgerId()
+    )
 
     expect(result.events.map((event) => Object.keys(event).sort())).toEqual([
       ['balance', 'createdAt', 'createdBy', 'kind', 'number', 'summaryLog']
@@ -133,7 +247,11 @@ describe('reading a waste balance ledger', () => {
       buildLedgerEvent({ accreditationId: null, number: 1 })
     ])
 
-    const result = await readLedger(ledgerRepository, buildLedgerId())
+    const result = await readLedger(
+      ledgerRepository,
+      noteReader,
+      buildLedgerId()
+    )
 
     expect(result.events.map((event) => event.number)).toEqual([1, 2])
   })


### PR DESCRIPTION
Ticket: [PAE-1856](https://eaflood.atlassian.net/browse/PAE-1856)

PAE-1856 takes a regulator from a movement on an operator's waste balance ledger to the PRN behind it. A PRN event named its note by internal id alone, so nothing a regulator read there identified the note. Each PRN event now states the note's `prnNumber` as well.

The number is read from the note rather than stored on the event: a note is numbered as it is issued, and the ledger records the events leading up to that, so an immutable `prn-created` event would carry null for ever. A ledger read fetches only the notes its own events name, scoped to the accreditation whose ledger it is, and `prnNumber` reads as null wherever the note has no number.

Both ledger routes require `waste-balance.ledger.read`, which only regulator and admin identities hold, so no operator sees any of this.

[PAE-1856]: https://eaflood.atlassian.net/browse/PAE-1856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
