### PR TITLE
PAE-1869: Fix negative-zero phantom adjustments on zero-tonnage sent-on rows

### DIFF
--- a/src/waste-records/application/project-summary-log-row-state.js
+++ b/src/waste-records/application/project-summary-log-row-state.js
@@ -6,6 +6,18 @@ import { coerceStoredTonnages } from './stored-tonnage-coercion.js'
  */
 
 /**
+ * Collapse negative zero to positive zero. `-0` and `+0` are distinct under
+ * `Object.is` (and therefore `util.isDeepStrictEqual`), yet MongoDB does not
+ * preserve `-0`: a persisted `-0` reads back as `+0`. A projected `-0` would
+ * thus never deep-equal its stored copy, producing an endless phantom
+ * "adjustment" when an identical row is resubmitted.
+ *
+ * @param {number} value
+ * @returns {number}
+ */
+const normaliseNegativeZero = (value) => (value === 0 ? 0 : value)
+
+/**
  * Project a waste record into its committed row state: classify it for the
  * waste balance and coerce the stored tonnages to two decimal places. These are
  * properties of the row-state value itself, so they
@@ -39,6 +51,12 @@ export const projectSummaryLogRowState = (
   return {
     ...classified,
     processingType,
+    classification: {
+      ...classified.classification,
+      transactionAmount: normaliseNegativeZero(
+        classified.classification.transactionAmount
+      )
+    },
     data: coerceStoredTonnages(data)
   }
 }

--- a/src/waste-records/application/project-summary-log-row-state.test.js
+++ b/src/waste-records/application/project-summary-log-row-state.test.js
@@ -5,8 +5,19 @@ import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 
 /** @typedef {import('#domain/waste-records/model.js').WasteRecord} WasteRecord */
 import { WASTE_BALANCE_OUTCOME } from '#waste-balances/domain/waste-balance-classification.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { buildAccreditation } from '#repositories/organisations/contract/test-data.js'
 
 const overseasSites = /** @type {any} */ (new Map())
+
+const accreditation = buildAccreditation({
+  validFrom: '2024-01-01',
+  validTo: '2024-12-31',
+  statusHistory: [
+    { status: 'created', updatedAt: '2023-12-01T00:00:00.000Z' },
+    { status: 'approved', updatedAt: '2023-12-15T00:00:00.000Z' }
+  ]
+})
 
 describe('projectSummaryLogRowState', () => {
   it('classifies the record and coerces its stored tonnages to two decimal places', () => {
@@ -103,6 +114,38 @@ describe('projectSummaryLogRowState', () => {
     expect(data.NET_WEIGHT).toBe(9.99)
     expect(data.NET_WEIGHT).toBe(
       data.GROSS_WEIGHT - data.TARE_WEIGHT - data.PALLET_WEIGHT
+    )
+  })
+
+  it('projects a zero-tonnage sent-on debit as positive zero, not negative zero', () => {
+    /** @type {WasteRecord} */
+    const record = {
+      organisationId: 'org-1',
+      registrationId: 'reg-1',
+      rowId: '5000',
+      type: WASTE_RECORD_TYPE.SENT_ON,
+      data: {
+        processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+        DATE_LOAD_LEFT_SITE: new Date('2024-06-15'),
+        TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON: 0
+      }
+    }
+
+    const projected = projectSummaryLogRowState(
+      record,
+      accreditation,
+      overseasSites
+    )
+
+    // A -0 debit does not survive the Mongo round-trip (it returns +0), so a
+    // resubmission of the identical row would read as an endless phantom
+    // adjustment. toBe uses Object.is, so -0 fails toBe(0).
+    expect(projected.classification.outcome).toBe(
+      WASTE_BALANCE_OUTCOME.INCLUDED
+    )
+    expect(projected.classification.transactionAmount).toBe(0)
+    expect(Object.is(projected.classification.transactionAmount, -0)).toBe(
+      false
     )
   })
 

--- a/src/waste-records/repository/mongodb.test.js
+++ b/src/waste-records/repository/mongodb.test.js
@@ -3,6 +3,12 @@ import { it as mongoIt } from '#vite/fixtures/mongo.js'
 import { MongoClient } from 'mongodb'
 
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
+import { ROW_OUTCOME } from '#domain/summary-logs/table-schemas/validation-pipeline.js'
+import { projectSummaryLogRowState } from '#waste-records/application/project-summary-log-row-state.js'
+import { classifyRecordChanges } from '#application/summary-logs/classify-record-changes.js'
+import { RECORD_CHANGE } from '#application/summary-logs/record-change.js'
+import { buildAccreditation } from '#repositories/organisations/contract/test-data.js'
 
 import {
   createMongoSummaryLogRowStatesRepository,
@@ -263,5 +269,82 @@ describe('write round-trip count', () => {
     const forFiftyRows = await roundTripsFor(50, 'log-50')
 
     expect(forFiftyRows).toBe(forOneRow)
+  })
+})
+
+describe('negative-zero classification survives the Mongo round-trip', () => {
+  /** @type {import('#domain/summary-logs/table-schemas/validation-pipeline.js').OverseasSitesContext} */
+  const overseasSites = {}
+
+  const accreditation = buildAccreditation({
+    validFrom: '2024-01-01',
+    validTo: '2024-12-31',
+    statusHistory: [
+      { status: 'created', updatedAt: '2023-12-01T00:00:00.000Z' },
+      { status: 'approved', updatedAt: '2023-12-15T00:00:00.000Z' }
+    ]
+  })
+
+  // A zero-tonnage sent-on debit projects transactionAmount `-0`. MongoDB does
+  // not preserve `-0` (it reads back `+0`), so without normalisation the fresh
+  // projection never deep-equals its stored copy and the identical resubmission
+  // is reported as an endless phantom adjustment.
+  /** @type {import('#domain/waste-records/model.js').WasteRecord} */
+  const zeroTonnageSentOn = {
+    organisationId: DEFAULT_LEDGER_ID.organisationId,
+    registrationId: DEFAULT_LEDGER_ID.registrationId,
+    accreditationId: DEFAULT_LEDGER_ID.accreditationId,
+    rowId: '5000',
+    type: WASTE_RECORD_TYPE.SENT_ON,
+    data: {
+      processingType: PROCESSING_TYPES.REPROCESSOR_INPUT,
+      DATE_LOAD_LEFT_SITE: new Date('2024-06-15'),
+      TONNAGE_OF_UK_PACKAGING_WASTE_SENT_ON: 0
+    }
+  }
+
+  /** @type {import('#application/waste-records/transform-from-summary-log.js').ValidatedWasteRecord} */
+  const currentUpload = {
+    record: zeroTonnageSentOn,
+    outcome: ROW_OUTCOME.INCLUDED,
+    tableName: 'SENT_ON_LOADS',
+    wasteRecordType: WASTE_RECORD_TYPE.SENT_ON
+  }
+
+  it('classifies an identical zero-tonnage sent-on resubmission as unchanged', async (/** @type {*} */ {
+    summaryLogRowStatesRepository
+  }) => {
+    const repository = summaryLogRowStatesRepository()
+
+    // First submission: project and persist the zero-debit sent-on row.
+    const entry = projectSummaryLogRowState(
+      zeroTonnageSentOn,
+      accreditation,
+      overseasSites
+    )
+    await repository.upsertSummaryLogRowStates(
+      DEFAULT_LEDGER_ID,
+      [entry],
+      'log-1'
+    )
+
+    // Read the submitted state back through Mongo, then compare the identical
+    // row's fresh projection against it — exactly what a resubmission does.
+    const submitted = await repository.findRowStatesForSummaryLog(
+      DEFAULT_LEDGER_ID,
+      'log-1'
+    )
+    const submittedRowStatesByKey = new Map(
+      submitted.map((doc) => [`${doc.wasteRecordType}:${doc.rowId}`, doc])
+    )
+
+    const changes = classifyRecordChanges({
+      wasteRecords: [currentUpload],
+      submittedRowStatesByKey,
+      accreditation,
+      overseasSites
+    })
+
+    expect(changes.get('sentOn:5000')).toBe(RECORD_CHANGE.UNCHANGED)
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1869](https://eaflood.atlassian.net/browse/PAE-1869)
## What

A reprocessor-input summary log containing a "Sent on" row with **zero tonnage** was reported as an *adjustment* in the resubmission "changes" view on every upload: including re-uploading the byte-identical file, and immediately after confirming a submission that contained it. The change was a phantom (zero tonnage delta, non-balance-affecting) that never cleared, so an operator could never reach a clean, zero-change resubmission while such a row existed.

## Why it happened

The `SENT_ON_LOADS` (reprocessor-input) balance classifier returns `transactionAmount: -roundToTwoDecimalPlaces(tonnage)`. For zero tonnage this evaluates to **negative zero (`-0`)**. MongoDB does not preserve `-0`: a persisted `-0` reads back as `+0`. The resubmission diff compares the freshly projected classification against the stored one with `util.isDeepStrictEqual`, which uses `Object.is` semantics, and `isDeepStrictEqual(-0, 0)` is `false`. So the freshly computed `-0` never matched the stored `+0`, and the row was marked adjusted on every upload.

## The fix

Normalise `-0` to `+0` at the single seam where a row state's `transactionAmount` is projected for storage and comparison: `projectSummaryLogRowState`. Every persisted row state and every resubmission diff flows through this projection, so this closes the whole class of bug (any classifier whose debit rounds to zero), not just sent-on. The balance-math path (`classifyRecordForWasteBalance` into ledger events) is untouched and keeps full precision; a `-0` there is harmless in sums.

Tests cover the projection producing `+0` for a zero-tonnage sent-on debit, and reproduce the MongoDB `-0` to `+0` round-trip asymmetry end-to-end against a real database.

[PAE-1869]: https://eaflood.atlassian.net/browse/PAE-1869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ