### PR TITLE
PAE-1844: Restore the duplicate ledger events startup diagnostic

### DIFF
--- a/src/server/run-waste-balance-duplicate-events-report.js
+++ b/src/server/run-waste-balance-duplicate-events-report.js
@@ -1,0 +1,78 @@
+import { logger } from '#common/helpers/logging/logger.js'
+import { findDuplicateBusinessEvents } from '#waste-balances/monitoring/duplicate-business-events.js'
+import { WASTE_BALANCE_EVENTS_COLLECTION_NAME } from '#waste-balances/repository/ledger-mongodb.js'
+
+/** @import { StartedServer } from '#common/hapi-types.js' */
+/** @import { DuplicateGroup } from '#waste-balances/monitoring/duplicate-business-events.js' */
+
+const LOCK_NAME = 'waste-balance-duplicate-events-report'
+
+/**
+ * A stored write time that is absent, or present but unparseable, reads as
+ * `unknown`. `toISOString` throws on an invalid date, and one such event must
+ * not take down the whole report.
+ *
+ * @param {Date} [createdAt]
+ */
+const writtenAt = (createdAt) => {
+  const at = createdAt && new Date(createdAt)
+  return at && !Number.isNaN(at.getTime()) ? at.toISOString() : 'unknown'
+}
+
+/** @param {DuplicateGroup} group */
+const formatFinding = (group) => {
+  const identity = Object.entries(group._id)
+    .map(([field, value]) => `${field}=${value}`)
+    .join(' ')
+  const slots = group.entries
+    .map(({ number, createdAt }) => `${number}@${writtenAt(createdAt)}`)
+    .join(',')
+  return `Duplicate waste-balance event: ${identity} organisationIds=[${group.organisationIds.join(',')}] count=${group.count} slots=[${slots}]`
+}
+
+/** @param {StartedServer} server */
+const runReport = async (server) => {
+  const collection = server.db.collection(WASTE_BALANCE_EVENTS_COLLECTION_NAME)
+  const { prn, summaryLog } = await findDuplicateBusinessEvents(collection)
+
+  for (const group of [...prn, ...summaryLog]) {
+    logger.info({ message: formatFinding(group) })
+  }
+
+  logger.info({
+    message: `Waste-balance duplicate events report: prnDuplicates=${prn.length} summaryLogDuplicates=${summaryLog.length}`
+  })
+}
+
+/**
+ * Startup diagnostic for duplicate waste-balance events. Read-only, and safe
+ * under live traffic.
+ *
+ * Findings are logged at info, not warn: they are for a human to confirm, and
+ * info keeps them out of the OpenSearch alerts. It reports and does not correct
+ * — the ledger is append-only, so a duplicate credit needs a correcting entry.
+ *
+ * @param {StartedServer} server
+ */
+export const runWasteBalanceDuplicateEventsReport = async (server) => {
+  try {
+    const lock = await server.locker.lock(LOCK_NAME)
+    if (!lock) {
+      logger.info({
+        message:
+          'Unable to obtain lock, skipping waste-balance duplicate events report'
+      })
+      return
+    }
+    try {
+      await runReport(server)
+    } finally {
+      await lock.free()
+    }
+  } catch (error) {
+    logger.error({
+      err: error,
+      message: 'Failed to run waste-balance duplicate events report'
+    })
+  }
+}

--- a/src/server/run-waste-balance-duplicate-events-report.test.js
+++ b/src/server/run-waste-balance-duplicate-events-report.test.js
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { logger } from '#common/helpers/logging/logger.js'
+import { findDuplicateBusinessEvents } from '#waste-balances/monitoring/duplicate-business-events.js'
+
+import { runWasteBalanceDuplicateEventsReport } from './run-waste-balance-duplicate-events-report.js'
+
+/** @import { DuplicateGroup } from '#waste-balances/monitoring/duplicate-business-events.js' */
+
+vi.mock('#common/helpers/logging/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+vi.mock('#waste-balances/monitoring/duplicate-business-events.js', () => ({
+  findDuplicateBusinessEvents: vi.fn()
+}))
+
+/**
+ * @param {{ prn?: DuplicateGroup[], summaryLog?: DuplicateGroup[] }} [findings]
+ */
+const seedFindings = ({ prn = [], summaryLog = [] } = {}) => {
+  vi.mocked(findDuplicateBusinessEvents).mockResolvedValue({ prn, summaryLog })
+}
+
+describe('runWasteBalanceDuplicateEventsReport', () => {
+  /** @type {*} */
+  let mockServer
+  /** @type {*} */
+  let mockLock
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockLock = { free: vi.fn().mockResolvedValue(undefined) }
+    mockServer = {
+      db: { collection: vi.fn().mockReturnValue({}) },
+      locker: {
+        lock: vi.fn().mockResolvedValue(mockLock)
+      }
+    }
+  })
+
+  it('acquires a lock scoped to the report and releases it afterwards', async () => {
+    seedFindings()
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(mockServer.locker.lock).toHaveBeenCalledWith(
+      'waste-balance-duplicate-events-report'
+    )
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('reads the waste-balance-events collection', async () => {
+    seedFindings()
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(mockServer.db.collection).toHaveBeenCalledWith(
+      'waste-balance-events'
+    )
+  })
+
+  it('skips the report when the lock is held by another instance', async () => {
+    mockServer.locker.lock.mockResolvedValue(null)
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(findDuplicateBusinessEvents).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Unable to obtain lock, skipping waste-balance duplicate events report'
+    })
+  })
+
+  it('logs a zero-duplicate summary for a clean ledger', async () => {
+    seedFindings()
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledTimes(1)
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-balance duplicate events report: prnDuplicates=0 summaryLogDuplicates=0'
+    })
+  })
+
+  it('logs a PRN duplicate finding at info with its identity, count and slot numbers', async () => {
+    seedFindings({
+      prn: [
+        {
+          _id: {
+            registrationId: 'reg-1',
+            accreditationId: 'acc-1',
+            prnId: 'prn-1',
+            kind: 'prn-cancelled-after-issue'
+          },
+          count: 2,
+          entries: [
+            { number: 4, createdAt: new Date('2026-01-15T10:00:00.000Z') },
+            { number: 5, createdAt: new Date('2026-01-15T10:00:00.050Z') }
+          ],
+          organisationIds: ['org-1']
+        }
+      ]
+    })
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Duplicate waste-balance event: registrationId=reg-1 accreditationId=acc-1 prnId=prn-1 kind=prn-cancelled-after-issue organisationIds=[org-1] count=2 slots=[4@2026-01-15T10:00:00.000Z,5@2026-01-15T10:00:00.050Z]'
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-balance duplicate events report: prnDuplicates=1 summaryLogDuplicates=0'
+    })
+  })
+
+  it('logs a summary-log duplicate finding for a registered-only (null accreditation) ledger', async () => {
+    seedFindings({
+      summaryLog: [
+        {
+          _id: {
+            registrationId: 'reg-1',
+            accreditationId: null,
+            summaryLogId: 'log-1'
+          },
+          count: 3,
+          entries: [
+            { number: 1, createdAt: new Date('2026-01-15T10:00:00.000Z') },
+            { number: 2, createdAt: new Date('2026-01-15T10:00:00.020Z') },
+            { number: 3, createdAt: new Date('2026-01-15T10:00:00.040Z') }
+          ],
+          organisationIds: ['org-1']
+        }
+      ]
+    })
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Duplicate waste-balance event: registrationId=reg-1 accreditationId=null summaryLogId=log-1 organisationIds=[org-1] count=3 slots=[1@2026-01-15T10:00:00.000Z,2@2026-01-15T10:00:00.020Z,3@2026-01-15T10:00:00.040Z]'
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-balance duplicate events report: prnDuplicates=0 summaryLogDuplicates=1'
+    })
+  })
+
+  it('names every organisation, and reports an event with no write time as unknown', async () => {
+    seedFindings({
+      prn: [
+        {
+          _id: {
+            registrationId: 'reg-1',
+            accreditationId: 'acc-1',
+            prnId: 'prn-1',
+            kind: 'prn-created'
+          },
+          count: 2,
+          entries: [
+            { number: 1 },
+            { number: 2, createdAt: new Date('2026-01-15T10:00:00.050Z') }
+          ],
+          organisationIds: ['org-1', 'org-2']
+        }
+      ]
+    })
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Duplicate waste-balance event: registrationId=reg-1 accreditationId=acc-1 prnId=prn-1 kind=prn-created organisationIds=[org-1,org-2] count=2 slots=[1@unknown,2@2026-01-15T10:00:00.050Z]'
+    })
+  })
+
+  it('reports an unparseable write time as unknown rather than failing the run', async () => {
+    seedFindings({
+      prn: [
+        {
+          _id: { registrationId: 'reg-1', kind: 'prn-created' },
+          count: 2,
+          entries: [
+            { number: 1, createdAt: /** @type {*} */ ('not-a-date') },
+            { number: 2, createdAt: new Date('2026-01-15T10:00:00.050Z') }
+          ],
+          organisationIds: ['org-1']
+        }
+      ]
+    })
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.error).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Duplicate waste-balance event: registrationId=reg-1 kind=prn-created organisationIds=[org-1] count=2 slots=[1@unknown,2@2026-01-15T10:00:00.050Z]'
+    })
+    expect(logger.info).toHaveBeenCalledWith({
+      message:
+        'Waste-balance duplicate events report: prnDuplicates=1 summaryLogDuplicates=0'
+    })
+  })
+
+  it('releases the lock and logs an error when the scan throws', async () => {
+    const error = new Error('mongo unavailable')
+    vi.mocked(findDuplicateBusinessEvents).mockRejectedValue(error)
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run waste-balance duplicate events report'
+    })
+    expect(mockLock.free).toHaveBeenCalled()
+  })
+
+  it('tolerates the locker itself throwing', async () => {
+    const error = new Error('locker unavailable')
+    mockServer.locker.lock.mockRejectedValue(error)
+
+    await runWasteBalanceDuplicateEventsReport(mockServer)
+
+    expect(logger.error).toHaveBeenCalledWith({
+      err: error,
+      message: 'Failed to run waste-balance duplicate events report'
+    })
+  })
+})

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -46,6 +46,7 @@ import { runFormsDataMigration } from '#server/run-forms-data-migration.js'
 import { runOrganisationValidationSweep } from '#server/run-organisation-validation-sweep.js'
 import { runStaleIssuedTonnageReport } from '#server/run-stale-issued-tonnage-report.js'
 import { runPreCpaResubmissionBackfill } from '#server/run-pre-cpa-resubmission-backfill.js'
+import { runWasteBalanceDuplicateEventsReport } from '#server/run-waste-balance-duplicate-events-report.js'
 import { seedDatabase } from '#server/seed/seed-database.js'
 
 /** @import { Lifecycle } from '@hapi/hapi' */
@@ -229,6 +230,7 @@ async function createServer(options = {}) {
     runOrganisationValidationSweep(startedServer)
     runStaleIssuedTonnageReport(startedServer)
     runPreCpaResubmissionBackfill(startedServer)
+    runWasteBalanceDuplicateEventsReport(startedServer)
   })
 
   return server

--- a/src/waste-balances/monitoring/duplicate-business-events.js
+++ b/src/waste-balances/monitoring/duplicate-business-events.js
@@ -1,0 +1,121 @@
+import {
+  PRN_KINDS,
+  LEDGER_EVENT_KIND
+} from '#waste-balances/repository/ledger-schema.js'
+
+/**
+ * A business event should occupy one slot in its ledger: `(prnId, kind)` arises
+ * at most once, and a summary-log submission carries a distinct id.
+ *
+ * A detection heuristic, not an invariant. Do not reuse it on the write path,
+ * where it would forbid a transition a future state machine allows.
+ */
+const DUPLICATE_THRESHOLD = 1
+
+/**
+ * @typedef {Object} DuplicateEntry
+ * @property {number} number - the ledger slot the event occupies
+ * @property {Date} [createdAt] - absent when the stored document carries none
+ */
+
+/**
+ * @typedef {Object} DuplicateGroup
+ * @property {Record<string, string | null>} _id - the identity that repeated
+ * @property {number} count - how many slots carry that identity
+ * @property {DuplicateEntry[]} entries - ascending by slot number
+ * @property {string[]} organisationIds - the organisations its events were written under
+ */
+
+/**
+ * `entries` pushes one document rather than two parallel arrays: `$push` of a
+ * field path contributes nothing when the field is missing, so parallel arrays
+ * can differ in length and pair a slot with another slot's write time.
+ *
+ * `organisationId` is reported, not grouped by. It is not part of the slot
+ * identity, and grouping by it would split a duplicate group wherever two
+ * events disagreed on it.
+ */
+const groupByIdentityStages = (
+  /** @type {Record<string, string>} */ identity
+) => [
+  {
+    $group: {
+      _id: identity,
+      count: { $sum: 1 },
+      entries: { $push: { number: '$number', createdAt: '$createdAt' } },
+      organisationIds: { $addToSet: '$organisationId' }
+    }
+  },
+  { $match: { count: { $gt: DUPLICATE_THRESHOLD } } },
+  { $sort: { count: -1 } }
+]
+
+/** Every PRN event kind is covered identically. */
+const duplicatePrnEventsPipeline = () => [
+  { $match: { kind: { $in: [...PRN_KINDS] } } },
+  ...groupByIdentityStages({
+    registrationId: '$registrationId',
+    accreditationId: '$accreditationId',
+    prnId: '$payload.prnId',
+    kind: '$kind'
+  })
+]
+
+const duplicateSummaryLogEventsPipeline = () => [
+  { $match: { kind: LEDGER_EVENT_KIND.SUMMARY_LOG_SUBMITTED } },
+  ...groupByIdentityStages({
+    registrationId: '$registrationId',
+    accreditationId: '$accreditationId',
+    summaryLogId: '$payload.summaryLogId'
+  })
+]
+
+/**
+ * `DuplicateGroup` is declared here, not validated: the diagnostic has to
+ * survive whatever it finds. `allowDiskUse` because the `$group` accumulates
+ * every distinct identity before the count filter, on a collection that grows
+ * without bound.
+ *
+ * @param {Pick<import('mongodb').Collection, 'aggregate'>} collection
+ * @param {object[]} pipeline
+ * @returns {Promise<DuplicateGroup[]>}
+ */
+const runPipeline = async (collection, pipeline) => {
+  const groups = await collection
+    .aggregate(pipeline, { allowDiskUse: true })
+    .toArray()
+  return /** @type {DuplicateGroup[]} */ (groups)
+}
+
+/**
+ * The aggregation returns `$push`ed arrays in scan order, and `$addToSet` is
+ * unordered.
+ *
+ * @param {DuplicateGroup} group
+ * @returns {DuplicateGroup}
+ */
+const inSlotOrder = (group) => ({
+  ...group,
+  entries: [...group.entries].sort((a, b) => a.number - b.number),
+  organisationIds: [...group.organisationIds].sort((a, b) => a.localeCompare(b))
+})
+
+/**
+ * Read-only sweep for two events written for one action, which on a PRN
+ * cancellation credits the balance twice. The `partition_number` index does not
+ * cover this: it stops two writers taking the same slot, not one that folds the
+ * ledger after a competing append and takes the next.
+ *
+ * @param {Pick<import('mongodb').Collection, 'aggregate'>} collection - the waste-balance-events collection
+ * @returns {Promise<{ prn: DuplicateGroup[], summaryLog: DuplicateGroup[] }>}
+ */
+export const findDuplicateBusinessEvents = async (collection) => {
+  const [prn, summaryLog] = await Promise.all([
+    runPipeline(collection, duplicatePrnEventsPipeline()),
+    runPipeline(collection, duplicateSummaryLogEventsPipeline())
+  ])
+  return {
+    prn: prn.map(inSlotOrder),
+    summaryLog: summaryLog.map(inSlotOrder)
+  }
+}

--- a/src/waste-balances/monitoring/duplicate-business-events.test.js
+++ b/src/waste-balances/monitoring/duplicate-business-events.test.js
@@ -1,0 +1,331 @@
+import { describe, beforeEach, expect } from 'vitest'
+import { it as mongoIt } from '#vite/fixtures/mongo.js'
+import { MongoClient } from 'mongodb'
+
+import {
+  ensureLedgerCollection,
+  WASTE_BALANCE_EVENTS_COLLECTION_NAME
+} from '#waste-balances/repository/ledger-mongodb.js'
+import {
+  buildLedgerEvent,
+  buildPrnCreatedEvent,
+  buildPrnIssuedEvent
+} from '#waste-balances/repository/ledger-test-data.js'
+
+import { findDuplicateBusinessEvents } from './duplicate-business-events.js'
+
+const DATABASE_NAME = 'epr-backend'
+
+const it = mongoIt.extend({
+  mongoClient: async (/** @type {*} */ { db }, use) => {
+    const client = await MongoClient.connect(db)
+    await use(client)
+    await client.close()
+  },
+
+  ledgerCollection: async (/** @type {*} */ { mongoClient }, use) => {
+    const database = mongoClient.db(DATABASE_NAME)
+    await ensureLedgerCollection(database)
+    await use(database.collection(WASTE_BALANCE_EVENTS_COLLECTION_NAME))
+  }
+})
+
+describe('findDuplicateBusinessEvents', () => {
+  beforeEach(async (/** @type {*} */ { ledgerCollection }) => {
+    await ledgerCollection.deleteMany({})
+  })
+
+  it('flags a PRN business event that appears more than once in a ledger', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    await ledgerCollection.insertMany([
+      buildPrnCreatedEvent({
+        number: 1,
+        payload: { prnId: 'prn-1', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        number: 2,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    ])
+
+    const { prn } = await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(prn.map((group) => group._id)).toEqual([
+      {
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1',
+        prnId: 'prn-1',
+        kind: 'prn-created'
+      }
+    ])
+    expect(prn).toMatchObject([
+      {
+        count: 2,
+        entries: [{ number: 1 }, { number: 2 }],
+        organisationIds: ['org-1']
+      }
+    ])
+  })
+
+  it('flags a cancellation credited twice — the double credit this exists to find', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    await ledgerCollection.insertMany([
+      buildLedgerEvent({
+        kind: 'prn-cancelled-after-issue',
+        number: 4,
+        payload: { prnId: 'prn-1', amount: 50 }
+      }),
+      buildLedgerEvent({
+        kind: 'prn-cancelled-after-issue',
+        number: 5,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    ])
+
+    const { prn } = await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(prn).toMatchObject([
+      {
+        _id: { kind: 'prn-cancelled-after-issue' },
+        entries: [{ number: 4 }, { number: 5 }]
+      }
+    ])
+  })
+
+  it('pairs each slot with its own write time, even when a stored event has none', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    const duplicated = { prnId: 'prn-1', amount: 50 }
+    const { createdAt: _omittedCreatedAt, ...withoutCreatedAt } =
+      buildPrnCreatedEvent({ number: 2, payload: duplicated })
+    await ledgerCollection.insertMany([
+      buildPrnCreatedEvent({
+        number: 1,
+        createdAt: new Date('2026-01-15T10:00:01.000Z'),
+        payload: duplicated
+      }),
+      withoutCreatedAt,
+      buildPrnCreatedEvent({
+        number: 3,
+        createdAt: new Date('2026-01-15T10:00:03.000Z'),
+        payload: duplicated
+      })
+    ])
+
+    const { prn } = await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(prn.map((group) => group.entries)).toEqual([
+      [
+        { number: 1, createdAt: new Date('2026-01-15T10:00:01.000Z') },
+        { number: 2 },
+        { number: 3, createdAt: new Date('2026-01-15T10:00:03.000Z') }
+      ]
+    ])
+    expect(prn).toMatchObject([{ count: 3 }])
+  })
+
+  it('reports every organisation a repeated identity was written under', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    await ledgerCollection.insertMany([
+      buildPrnCreatedEvent({
+        organisationId: 'org-2',
+        number: 1,
+        payload: { prnId: 'prn-1', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        organisationId: 'org-1',
+        number: 2,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    ])
+
+    const { prn } = await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(prn).toMatchObject([{ organisationIds: ['org-1', 'org-2'] }])
+  })
+
+  it('does not flag a single occurrence of a PRN business event', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    await ledgerCollection.insertOne(
+      buildPrnCreatedEvent({
+        number: 1,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    )
+
+    const { prn } = await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(prn).toHaveLength(0)
+  })
+
+  it('does not conflate different lifecycle kinds for the same PRN', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    await ledgerCollection.insertMany([
+      buildPrnCreatedEvent({
+        number: 1,
+        payload: { prnId: 'prn-1', amount: 50 }
+      }),
+      buildPrnIssuedEvent({
+        number: 2,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    ])
+
+    const { prn } = await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(prn).toHaveLength(0)
+  })
+
+  it('does not flag the same PRN event kind across different ledgers', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    await ledgerCollection.insertMany([
+      buildPrnCreatedEvent({
+        registrationId: 'reg-1',
+        number: 1,
+        payload: { prnId: 'prn-1', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        registrationId: 'reg-2',
+        number: 1,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    ])
+
+    const { prn } = await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(prn).toHaveLength(0)
+  })
+
+  it('sorts findings by descending count so the worst duplication surfaces first', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    await ledgerCollection.insertMany([
+      buildPrnCreatedEvent({
+        number: 1,
+        payload: { prnId: 'prn-twice', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        number: 2,
+        payload: { prnId: 'prn-twice', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        number: 3,
+        payload: { prnId: 'prn-thrice', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        number: 4,
+        payload: { prnId: 'prn-thrice', amount: 50 }
+      }),
+      buildPrnCreatedEvent({
+        number: 5,
+        payload: { prnId: 'prn-thrice', amount: 50 }
+      })
+    ])
+
+    const { prn } = await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(prn.map((group) => [group._id.prnId, group.count])).toEqual([
+      ['prn-thrice', 3],
+      ['prn-twice', 2]
+    ])
+  })
+
+  it('flags a summary-log submission that appears more than once in a ledger', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    await ledgerCollection.insertMany([
+      buildLedgerEvent({
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      }),
+      buildLedgerEvent({
+        number: 2,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      })
+    ])
+
+    const { summaryLog } = await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(summaryLog.map((group) => group._id)).toEqual([
+      {
+        registrationId: 'reg-1',
+        accreditationId: 'acc-1',
+        summaryLogId: 'log-1'
+      }
+    ])
+    expect(summaryLog).toMatchObject([{ count: 2, organisationIds: ['org-1'] }])
+  })
+
+  it('flags duplicate summary-log submissions in a registered-only (null accreditation) ledger', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    await ledgerCollection.insertMany([
+      buildLedgerEvent({
+        accreditationId: null,
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      }),
+      buildLedgerEvent({
+        accreditationId: null,
+        number: 2,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      })
+    ])
+
+    const { summaryLog } = await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(summaryLog).toMatchObject([{ _id: { accreditationId: null } }])
+  })
+
+  it('does not flag the same summary-log id across different ledgers', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    await ledgerCollection.insertMany([
+      buildLedgerEvent({
+        registrationId: 'reg-1',
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      }),
+      buildLedgerEvent({
+        registrationId: 'reg-2',
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      })
+    ])
+
+    const { summaryLog } = await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(summaryLog).toHaveLength(0)
+  })
+
+  it('returns no findings for a clean ledger', async (/** @type {*} */ {
+    ledgerCollection
+  }) => {
+    await ledgerCollection.insertMany([
+      buildLedgerEvent({
+        number: 1,
+        payload: { summaryLogId: 'log-1', creditTotal: 100 }
+      }),
+      buildPrnCreatedEvent({
+        number: 2,
+        payload: { prnId: 'prn-1', amount: 50 }
+      }),
+      buildPrnIssuedEvent({
+        number: 3,
+        payload: { prnId: 'prn-1', amount: 50 }
+      })
+    ])
+
+    const { prn, summaryLog } =
+      await findDuplicateBusinessEvents(ledgerCollection)
+
+    expect(prn).toHaveLength(0)
+    expect(summaryLog).toHaveLength(0)
+  })
+})

--- a/src/waste-balances/repository/ledger-schema.js
+++ b/src/waste-balances/repository/ledger-schema.js
@@ -16,7 +16,13 @@ export const LEDGER_EVENT_KIND = Object.freeze({
 
 const kindValues = Object.values(LEDGER_EVENT_KIND)
 
-const PRN_KINDS = new Set([
+/**
+ * Every kind of ledger event raised by a PRN. Frozen, and an array rather than
+ * a `Set`, because it is exported: `Object.freeze` does not stop `.add()` on a
+ * `Set`, and this list gates write-path validation below, so a consumer that
+ * mutated it would silently change what the ledger accepts.
+ */
+export const PRN_KINDS = Object.freeze([
   LEDGER_EVENT_KIND.PRN_CREATED,
   LEDGER_EVENT_KIND.PRN_ISSUED,
   LEDGER_EVENT_KIND.PRN_CREATION_CANCELLED,
@@ -183,7 +189,7 @@ export const ledgerEventInsertSchema = Joi.object({
   createdAt: Joi.date().required(),
   createdBy: userSummarySchema.required()
 }).custom((value, helpers) => {
-  if (value.accreditationId === null && PRN_KINDS.has(value.kind)) {
+  if (value.accreditationId === null && PRN_KINDS.includes(value.kind)) {
     return helpers.error('any.custom', {
       message:
         'PRN events are invalid in registered-only ledgers (accreditationId is null)'


### PR DESCRIPTION
Ticket: [PAE-1844](https://eaflood.atlassian.net/browse/PAE-1844)

**Detection only.** The ticket's acceptance criteria are all about prevention, and [#1657](https://github.com/DEFRA/epr-backend/pull/1657) carries that work. This restores the diagnostic that finds the defect where it has already happened, so neither PR depends on the other.

Restores the startup scan for duplicate business events on the waste balance ledger, added in [#1408](https://github.com/DEFRA/epr-backend/pull/1408) and removed a day later in [#1422](https://github.com/DEFRA/epr-backend/pull/1422). The removal argued that the unique `partition_number` index prevented recurrence. It does not: that index stops two writers taking the *same* slot, and does nothing about a writer that folds the ledger after a competing append and takes the *next* one.

Two read-only server-side aggregations run at `onPostStart` under a cross-instance lock. PRN events group by `(registrationId, accreditationId, payload.prnId, kind)`, covering every PRN event kind; summary-log submissions group by `(registrationId, accreditationId, payload.summaryLogId)`. Anything holding more than one slot for the same identity is logged, one line per group, then a summary line:

```
Duplicate waste-balance event: registrationId=… accreditationId=… prnId=… kind=prn-cancelled-after-issue organisationIds=[…] count=2 slots=[4@2026-01-15T10:00:00.000Z,5@2026-01-15T10:00:00.050Z]
Waste-balance duplicate events report: prnDuplicates=1 summaryLogDuplicates=0
```

## What it does not catch

A single cancellation whose ledger event landed but whose PRN projection did not leaves one event, not two, so this is blind to it until a second cancellation lands. The scan also runs only at startup, so detection lags the deploy cadence. A clean report is not proof the ledger is sound.

## Differences from the original

It is a port, not a revert: the modules were renamed (`stream-*` → `ledger-*`, `STREAM_EVENT_KIND` → `LEDGER_EVENT_KIND`), and three things have moved on.

**Ledger events now carry `organisationId`,** so each finding names the whole organisation → registration → accreditation chain. It is reported rather than part of the group key: the ledger's slot identity is `(registrationId, accreditationId, number)`, the organisation is a denormalised ancestor, and grouping by it would split a duplicate group wherever two events disagreed.

**Each slot number is pushed together with its own write time,** as one document rather than two parallel arrays. `$push` of a field path contributes nothing when the field is missing, so parallel arrays can come back different lengths and pair a slot with another slot's write time. That matters because near-simultaneous timestamps are what distinguish one action written twice from two legitimate events, and this reads a collection's whole history rather than only rows the current write path produced. A write time that is missing, or present but unparseable, reads as `unknown` rather than dropping the slot or failing the run.

**Slot numbers are ordered before they are logged.** The aggregation returns them in scan order, which is not slot order. A group holds two or three entries, so they are ordered on the way out rather than by a blocking server-side `$sort`.

`PRN_KINDS` is exported from the ledger schema for the detector, as a frozen array rather than the `Set` it was: `Object.freeze` does not stop `.add()` on a `Set`, and that list gates write-path validation, so a mutable exported handle would let a consumer silently change what the ledger accepts.


[PAE-1844]: https://eaflood.atlassian.net/browse/PAE-1844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ