### PR TITLE
PAE-1420: Correct completeness-signal gating comment

### DIFF
--- a/src/reports/application/report-service.js
+++ b/src/reports/application/report-service.js
@@ -241,10 +241,13 @@ export async function fetchOrGenerateReportForPeriod({
   })
 
   // Attached on every generate-branch preview (any period without a stored
-  // report), not only Due/Over Due ones: a not-yet-ended period resolves to a
-  // null period status yet still generates. The frontend gates the
-  // validation-error screen on Due/Over Due, so this signal is broader than the
-  // screen by design (PAE-1420).
+  // report) regardless of period status: a not-yet-ended period resolves to a
+  // null period status yet still generates. The frontend controller redirects
+  // to the validation-error screen unconditionally on this signal, with no
+  // period-status check. What keeps a not-yet-ended period off that screen is
+  // the reports list upstream, which only offers a link into the generate
+  // branch for Due/Over Due (or requires-resubmission) periods, never a future
+  // one (PAE-1420).
   const incompleteSummaryLogRows = summariseIncompleteDataIfEnabled(
     featureFlags,
     wasteRecordStates


### PR DESCRIPTION
Ticket: [PAE-1420](https://eaflood.atlassian.net/browse/PAE-1420)
## What

Corrects an inaccurate code comment in `report-service.js` (`fetchOrGenerateReportForPeriod`) describing how the `incompleteSummaryLogRows` completeness signal is gated on the frontend. No behaviour change — documentation only.

## Why

The old comment claimed:

> The frontend gates the validation-error screen on Due/Over Due, so this signal is broader than the screen by design.

That is wrong. Verified against the frontend:

- `detail-controller.js` redirects to `/report-data-incomplete` **unconditionally** whenever `incompleteSummaryLogRows` is present — there is no period-status check in the controller.
- What actually keeps a not-yet-ended (future) period off that screen is upstream in the **reports list**: `report-action.js` `ACTION_BY_STATUS` only maps `DUE`/`OVERDUE` to create-draft and `REQUIRES_RESUBMISSION` to review-and-create-draft, so the list never offers a link into the generate branch for a future period.

The corrected comment states that the signal is attached on every generate-branch preview regardless of period status, the controller redirects unconditionally on it, and it is the list — not the controller — that withholds the link for a future period.

Raised from Tony Bruce's verification comment on PAE-1420; relates to PAE-1280.

[PAE-1420]: https://eaflood.atlassian.net/browse/PAE-1420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ