### PR TITLE
PAE-250: Fix nanoid infinite-loop vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9314,9 +9314,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## What

Bumps the transitive dependency **nanoid** from 3.3.17 to 3.3.18 (lockfile only, via `npm audit fix`).

## Why

nanoid 3.3.17 and earlier are affected by [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (high severity): when a custom alphabet generator is called with a size of zero, generation can loop indefinitely, causing a denial of service. 3.3.18 fixes this. nanoid is pulled in transitively, so no direct dependency change is needed — only the resolved version in the lockfile moves.

## Scope

- `package-lock.json` only. No `package.json` dependency or `overrides` changes.
- `npm audit` reports 0 vulnerabilities after the change.

## Notes for reviewers

While auditing this repo we also confirmed the existing `overrides` (`glob`, `joi`, `uuid`, and the two `@apidevtools/*` pins) are all still load-bearing — removing any of them either breaks peer resolution (hapi-swagger needs the `joi` override) or reintroduces a vulnerability (`uuid@8.3.2`, `inflight@1.0.6`), so none were pruned.

Two further issues in this repo are **not** addressed here and are being handled separately:
- `fast-uri` (patched in 3.1.6) is blocked by the repo's 7-day `min-release-age` cooldown until 30 Aug 2026.
- `exceljs` prototype-pollution has no released upstream fix (5.0.0 is unpublished) and needs a mitigation decision — tracked separately.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ